### PR TITLE
feat(input): add input backend and channel integrations

### DIFF
--- a/pkg/input/advanced_test.go
+++ b/pkg/input/advanced_test.go
@@ -1,0 +1,42 @@
+package input
+
+import "testing"
+
+func TestChannelPairingListPairedReturnsEmptySlice(t *testing.T) {
+	cp := NewChannelPairing()
+
+	paired := cp.ListPaired()
+
+	if paired == nil {
+		t.Fatal("expected empty slice, got nil")
+	}
+	if len(paired) != 0 {
+		t.Fatalf("expected no paired devices, got %d", len(paired))
+	}
+}
+
+func TestContactDirectoryListReturnsEmptySlice(t *testing.T) {
+	cd := NewContactDirectory()
+
+	contacts := cd.List("wechat")
+
+	if contacts == nil {
+		t.Fatal("expected empty slice, got nil")
+	}
+	if len(contacts) != 0 {
+		t.Fatalf("expected no contacts, got %d", len(contacts))
+	}
+}
+
+func TestContactDirectorySearchReturnsEmptySlice(t *testing.T) {
+	cd := NewContactDirectory()
+
+	contacts := cd.Search("alice")
+
+	if contacts == nil {
+		t.Fatal("expected empty slice, got nil")
+	}
+	if len(contacts) != 0 {
+		t.Fatalf("expected no contacts, got %d", len(contacts))
+	}
+}

--- a/pkg/input/channels/channels_test.go
+++ b/pkg/input/channels/channels_test.go
@@ -1,0 +1,88 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestDiscordPolledMessageDecodesMessageReference(t *testing.T) {
+	var msg discordPolledMessage
+	raw := []byte(`{
+		"id":"m1",
+		"content":"hello",
+		"guild_id":"g1",
+		"author":{"id":"u1","username":"alice"},
+		"message_reference":{"message_id":"parent-123","channel_id":"c1"}
+	}`)
+
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal discord message: %v", err)
+	}
+	if msg.MessageReference.MessageID != "parent-123" {
+		t.Fatalf("expected parent message id to decode, got %q", msg.MessageReference.MessageID)
+	}
+}
+
+func TestSignalFindAudioAttachmentMatchesByMIMEWithoutURL(t *testing.T) {
+	adapter := &SignalAdapter{}
+	attachments := []struct {
+		ContentType string `json:"contentType"`
+		Filename    string `json:"filename"`
+	}{
+		{ContentType: "audio/ogg", Filename: ""},
+	}
+
+	audioURL, audioMIME, hasAudio := adapter.findAudioAttachment(attachments)
+	if !hasAudio {
+		t.Fatal("expected audio attachment to be detected")
+	}
+	if audioMIME != "audio/ogg" {
+		t.Fatalf("expected audio MIME to be preserved, got %q", audioMIME)
+	}
+	if audioURL != "" {
+		t.Fatalf("expected empty audio URL when attachment has no filename, got %q", audioURL)
+	}
+}
+
+func TestSlackPollOnceReturnsAPIErrorWhenOKFalse(t *testing.T) {
+	adapter := &SlackAdapter{
+		config: config.SlackChannelConfig{
+			DefaultChannel: "C123",
+		},
+		client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if !strings.Contains(req.URL.String(), "conversations.history") {
+					t.Fatalf("unexpected request URL: %s", req.URL.String())
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"ok":false,"error":"invalid_auth"}`)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+
+	err := adapter.pollOnce(context.Background(), func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		t.Fatal("handler should not be called on Slack API failure")
+		return "", "", nil
+	})
+	if err == nil {
+		t.Fatal("expected slack API error")
+	}
+	if !strings.Contains(err.Error(), "invalid_auth") {
+		t.Fatalf("expected invalid_auth error, got %v", err)
+	}
+}

--- a/pkg/input/channels/channels_test.go
+++ b/pkg/input/channels/channels_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/1024XEngineer/anyclaw/pkg/config"
 )
@@ -84,5 +85,144 @@ func TestSlackPollOnceReturnsAPIErrorWhenOKFalse(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid_auth") {
 		t.Fatalf("expected invalid_auth error, got %v", err)
+	}
+}
+
+func TestSlackSendStreamingMessageFallsBackToThreadedFinalPost(t *testing.T) {
+	var bodies []string
+	adapter := &SlackAdapter{
+		config: config.SlackChannelConfig{
+			DefaultChannel: "C123",
+		},
+		client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				payload, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("read request body: %v", err)
+				}
+				bodies = append(bodies, string(payload))
+				switch len(bodies) {
+				case 1:
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"ok":true,"ts":""}`)),
+						Header:     make(http.Header),
+					}, nil
+				case 2:
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"ok":true,"ts":"123.456"}`)),
+						Header:     make(http.Header),
+					}, nil
+				default:
+					t.Fatalf("unexpected additional request: %s", req.URL.String())
+					return nil, nil
+				}
+			}),
+		},
+	}
+
+	err := adapter.sendStreamingMessage(context.Background(), "thread-1", func(onChunk func(chunk string)) error {
+		onChunk("hello from stream")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("send streaming message: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 postMessage calls, got %d", len(bodies))
+	}
+	if !strings.Contains(bodies[1], `"thread_ts":"thread-1"`) {
+		t.Fatalf("expected fallback post to preserve thread_ts, got %s", bodies[1])
+	}
+	if !strings.Contains(bodies[1], `"text":"hello from stream"`) {
+		t.Fatalf("expected fallback post to include final text, got %s", bodies[1])
+	}
+}
+
+func TestTelegramSendMessageReturnsAPIErrorWhenOKFalse(t *testing.T) {
+	adapter := &TelegramAdapter{
+		baseURL: "https://telegram.example/bot-token",
+		client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if !strings.HasSuffix(req.URL.String(), "/sendMessage") {
+					t.Fatalf("unexpected request URL: %s", req.URL.String())
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"ok":false,"description":"chat not found"}`)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+
+	err := adapter.sendMessage(context.Background(), "42", "hello")
+	if err == nil {
+		t.Fatal("expected telegram API error")
+	}
+	if !strings.Contains(err.Error(), "chat not found") {
+		t.Fatalf("expected chat not found error, got %v", err)
+	}
+}
+
+func TestDiscordPollOnceRepliesToChannelInsteadOfParentMessageID(t *testing.T) {
+	var postedURL string
+	var postedBody string
+	adapter := &DiscordAdapter{
+		config: config.DiscordChannelConfig{
+			DefaultChannel: "c1",
+		},
+		apiBaseURL: "https://discord.example/api/v10",
+		client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.Method {
+				case http.MethodGet:
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`[
+							{
+								"id":"m1",
+								"channel_id":"c1",
+								"content":"hello",
+								"guild_id":"g1",
+								"author":{"id":"u1","username":"alice","bot":false},
+								"message_reference":{"message_id":"parent-123","channel_id":"c1"}
+							}
+						]`)),
+						Header: make(http.Header),
+					}, nil
+				case http.MethodPost:
+					body, err := io.ReadAll(req.Body)
+					if err != nil {
+						t.Fatalf("read request body: %v", err)
+					}
+					postedURL = req.URL.String()
+					postedBody = string(body)
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"id":"reply-1"}`)),
+						Header:     make(http.Header),
+					}, nil
+				default:
+					t.Fatalf("unexpected method: %s", req.Method)
+					return nil, nil
+				}
+			}),
+		},
+		processed: make(map[string]time.Time),
+	}
+
+	err := adapter.pollOnce(context.Background(), func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		return "", "reply", nil
+	})
+	if err != nil {
+		t.Fatalf("pollOnce failed: %v", err)
+	}
+	if !strings.Contains(postedURL, "/channels/c1/messages") {
+		t.Fatalf("expected reply to post to channel c1, got %s", postedURL)
+	}
+	if !strings.Contains(postedBody, `"message_reference":{"message_id":"parent-123"}`) {
+		t.Fatalf("expected reply to preserve parent message reference, got %s", postedBody)
 	}
 }

--- a/pkg/input/channels/contracts.go
+++ b/pkg/input/channels/contracts.go
@@ -1,0 +1,14 @@
+package channels
+
+import inputlayer "github.com/1024XEngineer/anyclaw/pkg/input"
+
+type InboundHandler = inputlayer.InboundHandler
+type StreamChunkHandler = inputlayer.StreamChunkHandler
+type StreamAdapter = inputlayer.StreamAdapter
+type Status = inputlayer.Status
+type Adapter = inputlayer.Adapter
+type BaseAdapter = inputlayer.BaseAdapter
+type Manager = inputlayer.Manager
+
+var NewBaseAdapter = inputlayer.NewBaseAdapter
+var NewManager = inputlayer.NewManager

--- a/pkg/input/channels/contracts.go
+++ b/pkg/input/channels/contracts.go
@@ -1,6 +1,10 @@
 package channels
 
-import inputlayer "github.com/1024XEngineer/anyclaw/pkg/input"
+import (
+	"strings"
+
+	inputlayer "github.com/1024XEngineer/anyclaw/pkg/input"
+)
 
 type InboundHandler = inputlayer.InboundHandler
 type StreamChunkHandler = inputlayer.StreamChunkHandler
@@ -12,3 +16,22 @@ type Manager = inputlayer.Manager
 
 var NewBaseAdapter = inputlayer.NewBaseAdapter
 var NewManager = inputlayer.NewManager
+
+func streamWithMessageFallback(streamFn func(onChunk func(chunk string)) error, sendFinal func(text string) error) error {
+	var accumulated strings.Builder
+	err := streamFn(func(chunk string) {
+		accumulated.WriteString(chunk)
+	})
+
+	final := accumulated.String()
+	if err != nil {
+		if strings.TrimSpace(final) != "" {
+			_ = sendFinal(final + "\n\n[Error: " + err.Error() + "]")
+		}
+		return err
+	}
+	if strings.TrimSpace(final) == "" {
+		return nil
+	}
+	return sendFinal(final)
+}

--- a/pkg/input/channels/discord.go
+++ b/pkg/input/channels/discord.go
@@ -27,6 +27,13 @@ type DiscordAdapter struct {
 	processed   map[string]time.Time
 }
 
+type discordGatewayPacket struct {
+	Op int             `json:"op"`
+	T  string          `json:"t"`
+	S  *int            `json:"s"`
+	D  json.RawMessage `json:"d"`
+}
+
 func (a *DiscordAdapter) VerifyInteraction(r *http.Request, body []byte) bool {
 	publicKeyHex := strings.TrimSpace(a.config.PublicKey)
 	if publicKeyHex == "" {
@@ -80,7 +87,17 @@ func (a *DiscordAdapter) HandleInteraction(ctx context.Context, body []byte, han
 			message = fmt.Sprintf("%v", opt.Value)
 		}
 	}
-	respSession, response, err := handle(ctx, "", message, map[string]string{"channel": "discord", "channel_id": payload.ChannelID, "guild_id": payload.GuildID, "user_id": payload.Member.User.ID, "username": payload.Member.User.Username, "reply_target": payload.ChannelID, "message_id": fmt.Sprintf("interaction:%d", time.Now().UnixNano())})
+	respSession, response, err := handle(ctx, "", message, map[string]string{
+		"channel":      "discord",
+		"channel_id":   payload.ChannelID,
+		"guild_id":     payload.GuildID,
+		"user_id":      payload.Member.User.ID,
+		"username":     payload.Member.User.Username,
+		"reply_target": payload.ChannelID,
+		"message_id":   fmt.Sprintf("interaction:%d", time.Now().UnixNano()),
+		"channel_type": discordChannelType(payload.GuildID),
+		"is_group":     boolString(strings.TrimSpace(payload.GuildID) != ""),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -155,6 +172,15 @@ func (a *DiscordAdapter) Run(ctx context.Context, handle InboundHandler) error {
 }
 
 func (a *DiscordAdapter) runGatewayWS(ctx context.Context, handle InboundHandler) error {
+	return a.runGateway(ctx, func(ctx context.Context, packet discordGatewayPacket) error {
+		if packet.T == "MESSAGE_CREATE" || packet.T == "THREAD_CREATE" || packet.T == "TYPING_START" || packet.T == "PRESENCE_UPDATE" || packet.T == "INTERACTION_CREATE" {
+			return a.handleGatewayEvent(ctx, packet.T, packet.D, handle)
+		}
+		return nil
+	})
+}
+
+func (a *DiscordAdapter) runGateway(ctx context.Context, handlePacket func(context.Context, discordGatewayPacket) error) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://discord.com/api/gateway/bot", nil)
 	if err != nil {
 		return err
@@ -179,27 +205,114 @@ func (a *DiscordAdapter) runGatewayWS(ctx context.Context, handle InboundHandler
 		return err
 	}
 	defer conn.Close()
-	_ = conn.WriteJSON(map[string]any{"op": 2, "d": map[string]any{"token": a.config.BotToken, "intents": 4609, "properties": map[string]string{"$os": "windows", "$browser": "anyclaw", "$device": "anyclaw"}}})
-	for {
-		select {
-		case <-ctx.Done():
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
+
+	var writeMu sync.Mutex
+	send := func(payload map[string]any) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return conn.WriteJSON(payload)
+	}
+
+	var (
+		identified    bool
+		heartbeatStop chan struct{}
+		seqMu         sync.RWMutex
+		lastSeq       int
+		hasSeq        bool
+	)
+	defer func() {
+		if heartbeatStop != nil {
+			close(heartbeatStop)
+		}
+	}()
+
+	currentSeq := func() any {
+		seqMu.RLock()
+		defer seqMu.RUnlock()
+		if !hasSeq {
 			return nil
-		default:
 		}
-		var packet struct {
-			Op int             `json:"op"`
-			T  string          `json:"t"`
-			D  json.RawMessage `json:"d"`
-		}
+		return lastSeq
+	}
+
+	for {
+		var packet discordGatewayPacket
 		if err := conn.ReadJSON(&packet); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
 			return err
 		}
+		if packet.S != nil {
+			seqMu.Lock()
+			lastSeq = *packet.S
+			hasSeq = true
+			seqMu.Unlock()
+		}
 		if packet.Op == 10 {
-			_ = conn.WriteJSON(map[string]any{"op": 1, "d": nil})
+			var hello struct {
+				HeartbeatInterval int `json:"heartbeat_interval"`
+			}
+			if err := json.Unmarshal(packet.D, &hello); err != nil {
+				return err
+			}
+			if hello.HeartbeatInterval <= 0 {
+				return fmt.Errorf("discord heartbeat interval missing")
+			}
+			if heartbeatStop != nil {
+				close(heartbeatStop)
+			}
+			heartbeatStop = make(chan struct{})
+			go func(interval time.Duration, stop <-chan struct{}) {
+				ticker := time.NewTicker(interval)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-stop:
+						return
+					case <-ticker.C:
+						_ = send(map[string]any{"op": 1, "d": currentSeq()})
+					}
+				}
+			}(time.Duration(hello.HeartbeatInterval)*time.Millisecond, heartbeatStop)
+			if err := send(map[string]any{"op": 1, "d": currentSeq()}); err != nil {
+				return err
+			}
+			if !identified {
+				if err := send(map[string]any{
+					"op": 2,
+					"d": map[string]any{
+						"token":   a.config.BotToken,
+						"intents": 4609,
+						"properties": map[string]string{
+							"$os":      "windows",
+							"$browser": "anyclaw",
+							"$device":  "anyclaw",
+						},
+					},
+				}); err != nil {
+					return err
+				}
+				identified = true
+			}
 			continue
 		}
-		if packet.T == "MESSAGE_CREATE" || packet.T == "THREAD_CREATE" || packet.T == "TYPING_START" || packet.T == "PRESENCE_UPDATE" || packet.T == "INTERACTION_CREATE" {
-			_ = a.handleGatewayEvent(ctx, packet.T, packet.D, handle)
+		if packet.Op == 11 {
+			continue
+		}
+		if packet.Op == 7 {
+			return fmt.Errorf("discord requested reconnect")
+		}
+		if handlePacket != nil {
+			if err := handlePacket(ctx, packet); err != nil {
+				return err
+			}
 		}
 	}
 }
@@ -246,6 +359,8 @@ func (a *DiscordAdapter) handleGatewayEvent(ctx context.Context, eventType strin
 			"reply_target": msg.ChannelID,
 			"message_id":   msg.ID,
 			"sender":       msg.Author.Username,
+			"channel_type": discordChannelType(msg.GuildID),
+			"is_group":     boolString(strings.TrimSpace(msg.GuildID) != ""),
 		}
 
 		audioURL, audioMIME := a.findAudioAttachment(msg.Attachments)
@@ -262,7 +377,7 @@ func (a *DiscordAdapter) handleGatewayEvent(ctx context.Context, eventType strin
 				return err
 			}
 			_ = respSession
-			return a.sendMessage(ctx, msg.ChannelID, "", response)
+			return a.sendMessage(ctx, msg.ChannelID, strings.TrimSpace(msg.MessageReference.MessageID), response)
 		}
 
 		if strings.TrimSpace(msg.Content) == "" {
@@ -274,7 +389,7 @@ func (a *DiscordAdapter) handleGatewayEvent(ctx context.Context, eventType strin
 			return err
 		}
 		_ = respSession
-		return a.sendMessage(ctx, msg.ChannelID, "", response)
+		return a.sendMessage(ctx, msg.ChannelID, strings.TrimSpace(msg.MessageReference.MessageID), response)
 	}
 	return nil
 }
@@ -329,10 +444,11 @@ type discordMessageReference struct {
 }
 
 type discordPolledMessage struct {
-	ID      string `json:"id"`
-	Content string `json:"content"`
-	GuildID string `json:"guild_id"`
-	Author  struct {
+	ID        string `json:"id"`
+	ChannelID string `json:"channel_id"`
+	Content   string `json:"content"`
+	GuildID   string `json:"guild_id"`
+	Author    struct {
 		ID       string `json:"id"`
 		Username string `json:"username"`
 		Bot      bool   `json:"bot"`
@@ -375,16 +491,23 @@ func (a *DiscordAdapter) pollOnce(ctx context.Context, handle InboundHandler) er
 			continue
 		}
 		a.latestID = msg.ID
+		targetChannel := strings.TrimSpace(msg.ChannelID)
+		if targetChannel == "" {
+			targetChannel = strings.TrimSpace(a.config.DefaultChannel)
+		}
+		replyMessageID := strings.TrimSpace(msg.MessageReference.MessageID)
 
 		meta := map[string]string{
 			"channel":      "discord",
-			"channel_id":   a.config.DefaultChannel,
+			"channel_id":   targetChannel,
 			"guild_id":     msg.GuildID,
 			"user_id":      msg.Author.ID,
 			"username":     msg.Author.Username,
-			"reply_target": a.config.DefaultChannel,
+			"reply_target": targetChannel,
 			"message_id":   msg.ID,
 			"sender":       msg.Author.Username,
+			"channel_type": discordChannelType(msg.GuildID),
+			"is_group":     boolString(strings.TrimSpace(msg.GuildID) != ""),
 		}
 
 		audioURL, audioMIME := a.findAudioAttachment(msg.Attachments)
@@ -396,17 +519,11 @@ func (a *DiscordAdapter) pollOnce(ctx context.Context, handle InboundHandler) er
 				meta["caption"] = strings.TrimSpace(msg.Content)
 			}
 
-			threadID := strings.TrimSpace(msg.MessageReference.MessageID)
-			replyTarget := a.config.DefaultChannel
-			if threadID != "" {
-				replyTarget = threadID
-			}
-
 			sessionID, response, err := handle(ctx, "", audioURL, meta)
 			if err != nil {
 				return err
 			}
-			if err := a.sendMessage(ctx, replyTarget, threadID, response); err != nil {
+			if err := a.sendMessage(ctx, targetChannel, replyMessageID, response); err != nil {
 				return err
 			}
 			a.base.MarkActivity()
@@ -425,16 +542,11 @@ func (a *DiscordAdapter) pollOnce(ctx context.Context, handle InboundHandler) er
 			continue
 		}
 
-		threadID := strings.TrimSpace(msg.MessageReference.MessageID)
-		replyTarget := a.config.DefaultChannel
-		if threadID != "" {
-			replyTarget = threadID
-		}
 		sessionID, response, err := handle(ctx, "", msg.Content, meta)
 		if err != nil {
 			return err
 		}
-		if err := a.sendMessage(ctx, replyTarget, threadID, response); err != nil {
+		if err := a.sendMessage(ctx, targetChannel, replyMessageID, response); err != nil {
 			return err
 		}
 		a.base.MarkActivity()
@@ -448,14 +560,14 @@ func (a *DiscordAdapter) pollOnce(ctx context.Context, handle InboundHandler) er
 	return nil
 }
 
-func (a *DiscordAdapter) sendMessage(ctx context.Context, target string, threadID string, text string) error {
+func (a *DiscordAdapter) sendMessage(ctx context.Context, target string, replyMessageID string, text string) error {
 	target = strings.TrimSpace(target)
 	if target == "" {
 		target = strings.TrimSpace(a.config.DefaultChannel)
 	}
 	bodyMap := map[string]any{"content": text}
-	if strings.TrimSpace(threadID) != "" && threadID != target {
-		bodyMap["message_reference"] = map[string]any{"message_id": threadID}
+	if strings.TrimSpace(replyMessageID) != "" {
+		bodyMap["message_reference"] = map[string]any{"message_id": replyMessageID}
 	}
 	body, _ := json.Marshal(bodyMap)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/channels/%s/messages", a.apiBaseURL, target), bytes.NewReader(body))
@@ -494,18 +606,20 @@ func (a *DiscordAdapter) seen(id string) bool {
 	return false
 }
 
-func (a *DiscordAdapter) sendStreamingMessage(ctx context.Context, target string, threadID string, streamFn func(onChunk func(chunk string)) error) error {
+func (a *DiscordAdapter) sendStreamingMessage(ctx context.Context, target string, replyMessageID string, streamFn func(onChunk func(chunk string)) error) error {
 	streamInterval := time.Duration(a.config.StreamInterval) * time.Millisecond
 	if streamInterval <= 0 {
 		streamInterval = 500 * time.Millisecond
 	}
 
-	initialMsgID, err := a.sendMessageWithResult(ctx, target, threadID, "\u200B")
+	initialMsgID, err := a.sendMessageWithResult(ctx, target, replyMessageID, "\u200B")
 	if err != nil {
 		return err
 	}
 	if initialMsgID == "" {
-		return streamFn(func(chunk string) {})
+		return streamWithMessageFallback(streamFn, func(final string) error {
+			return a.sendMessage(ctx, target, replyMessageID, final)
+		})
 	}
 
 	var accumulated strings.Builder
@@ -544,14 +658,14 @@ func (a *DiscordAdapter) sendStreamingMessage(ctx context.Context, target string
 	return nil
 }
 
-func (a *DiscordAdapter) sendMessageWithResult(ctx context.Context, target string, threadID string, text string) (string, error) {
+func (a *DiscordAdapter) sendMessageWithResult(ctx context.Context, target string, replyMessageID string, text string) (string, error) {
 	target = strings.TrimSpace(target)
 	if target == "" {
 		target = strings.TrimSpace(a.config.DefaultChannel)
 	}
 	bodyMap := map[string]any{"content": text}
-	if strings.TrimSpace(threadID) != "" && threadID != target {
-		bodyMap["message_reference"] = map[string]any{"message_id": threadID}
+	if strings.TrimSpace(replyMessageID) != "" {
+		bodyMap["message_reference"] = map[string]any{"message_id": replyMessageID}
 	}
 	body, _ := json.Marshal(bodyMap)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/channels/%s/messages", a.apiBaseURL, target), bytes.NewReader(body))
@@ -640,53 +754,12 @@ func (a *DiscordAdapter) RunStream(ctx context.Context, handle StreamChunkHandle
 }
 
 func (a *DiscordAdapter) runGatewayWSStream(ctx context.Context, handle StreamChunkHandler) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://discord.com/api/gateway/bot", nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
-	resp, err := a.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	var gateway struct {
-		URL string `json:"url"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&gateway); err != nil {
-		return err
-	}
-	if strings.TrimSpace(gateway.URL) == "" {
-		return fmt.Errorf("discord gateway URL missing")
-	}
-	conn, _, err := websocket.DefaultDialer.DialContext(ctx, gateway.URL+"?v=10&encoding=json", nil)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-	_ = conn.WriteJSON(map[string]any{"op": 2, "d": map[string]any{"token": a.config.BotToken, "intents": 4609, "properties": map[string]string{"$os": "windows", "$browser": "anyclaw", "$device": "anyclaw"}}})
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
-		}
-		var packet struct {
-			Op int             `json:"op"`
-			T  string          `json:"t"`
-			D  json.RawMessage `json:"d"`
-		}
-		if err := conn.ReadJSON(&packet); err != nil {
-			return err
-		}
-		if packet.Op == 10 {
-			_ = conn.WriteJSON(map[string]any{"op": 1, "d": nil})
-			continue
-		}
+	return a.runGateway(ctx, func(ctx context.Context, packet discordGatewayPacket) error {
 		if packet.T == "MESSAGE_CREATE" || packet.T == "THREAD_CREATE" {
-			_ = a.handleGatewayEventStream(ctx, packet.T, packet.D, handle)
+			return a.handleGatewayEventStream(ctx, packet.T, packet.D, handle)
 		}
-	}
+		return nil
+	})
 }
 
 func (a *DiscordAdapter) handleGatewayEventStream(ctx context.Context, eventType string, raw json.RawMessage, handle StreamChunkHandler) error {
@@ -725,10 +798,13 @@ func (a *DiscordAdapter) handleGatewayEventStream(ctx context.Context, eventType
 			"reply_target": msg.ChannelID,
 			"message_id":   msg.ID,
 			"sender":       msg.Author.Username,
+			"channel_type": discordChannelType(msg.GuildID),
+			"is_group":     boolString(strings.TrimSpace(msg.GuildID) != ""),
 		}
+		replyMessageID := strings.TrimSpace(msg.MessageReference.MessageID)
 
 		sessionID := ""
-		err := a.sendStreamingMessage(ctx, msg.ChannelID, "", func(onChunk func(chunk string)) error {
+		err := a.sendStreamingMessage(ctx, msg.ChannelID, replyMessageID, func(onChunk func(chunk string)) error {
 			var err error
 			sessionID, err = handle(ctx, sessionID, msg.Content, meta, func(chunk string) error {
 				onChunk(chunk)
@@ -772,6 +848,11 @@ func (a *DiscordAdapter) pollOnceStream(ctx context.Context, handle StreamChunkH
 			continue
 		}
 		a.latestID = msg.ID
+		targetChannel := strings.TrimSpace(msg.ChannelID)
+		if targetChannel == "" {
+			targetChannel = strings.TrimSpace(a.config.DefaultChannel)
+		}
+		replyMessageID := strings.TrimSpace(msg.MessageReference.MessageID)
 
 		if strings.TrimSpace(msg.Content) == "" {
 			continue
@@ -779,23 +860,20 @@ func (a *DiscordAdapter) pollOnceStream(ctx context.Context, handle StreamChunkH
 
 		meta := map[string]string{
 			"channel":      "discord",
-			"channel_id":   a.config.DefaultChannel,
+			"channel_id":   targetChannel,
 			"guild_id":     msg.GuildID,
 			"user_id":      msg.Author.ID,
 			"username":     msg.Author.Username,
-			"reply_target": a.config.DefaultChannel,
+			"reply_target": targetChannel,
 			"message_id":   msg.ID,
 			"sender":       msg.Author.Username,
+			"channel_type": discordChannelType(msg.GuildID),
+			"is_group":     boolString(strings.TrimSpace(msg.GuildID) != ""),
 		}
 
-		threadID := strings.TrimSpace(msg.MessageReference.MessageID)
-		replyTarget := a.config.DefaultChannel
-		if threadID != "" {
-			replyTarget = threadID
-		}
 		sessionID := ""
 
-		err := a.sendStreamingMessage(ctx, replyTarget, threadID, func(onChunk func(chunk string)) error {
+		err := a.sendStreamingMessage(ctx, targetChannel, replyMessageID, func(onChunk func(chunk string)) error {
 			var err error
 			sessionID, err = handle(ctx, sessionID, msg.Content, meta, func(chunk string) error {
 				onChunk(chunk)
@@ -816,4 +894,11 @@ func (a *DiscordAdapter) pollOnceStream(ctx context.Context, handle StreamChunkH
 		})
 	}
 	return nil
+}
+
+func discordChannelType(guildID string) string {
+	if strings.TrimSpace(guildID) != "" {
+		return "guild"
+	}
+	return "private"
 }

--- a/pkg/input/channels/discord.go
+++ b/pkg/input/channels/discord.go
@@ -323,6 +323,31 @@ func (a *DiscordAdapter) findAudioAttachment(attachments []struct {
 	return "", ""
 }
 
+type discordMessageReference struct {
+	MessageID string `json:"message_id"`
+	ChannelID string `json:"channel_id"`
+}
+
+type discordPolledMessage struct {
+	ID      string `json:"id"`
+	Content string `json:"content"`
+	GuildID string `json:"guild_id"`
+	Author  struct {
+		ID       string `json:"id"`
+		Username string `json:"username"`
+		Bot      bool   `json:"bot"`
+	} `json:"author"`
+	MessageReference discordMessageReference `json:"message_reference"`
+	Attachments      []struct {
+		ID          string `json:"id"`
+		URL         string `json:"url"`
+		ProxyURL    string `json:"proxy_url"`
+		Filename    string `json:"filename"`
+		ContentType string `json:"content_type"`
+		Size        int    `json:"size"`
+	} `json:"attachments"`
+}
+
 func (a *DiscordAdapter) pollOnce(ctx context.Context, handle InboundHandler) error {
 	url := fmt.Sprintf("%s/channels/%s/messages?limit=20", a.apiBaseURL, a.config.DefaultChannel)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -339,25 +364,7 @@ func (a *DiscordAdapter) pollOnce(ctx context.Context, handle InboundHandler) er
 		return fmt.Errorf("discord fetch failed: %s", resp.Status)
 	}
 
-	var messages []struct {
-		ID       string `json:"id"`
-		Content  string `json:"content"`
-		GuildID  string `json:"guild_id"`
-		ParentID string `json:"message_reference.message_id"`
-		Author   struct {
-			ID       string `json:"id"`
-			Username string `json:"username"`
-			Bot      bool   `json:"bot"`
-		} `json:"author"`
-		Attachments []struct {
-			ID          string `json:"id"`
-			URL         string `json:"url"`
-			ProxyURL    string `json:"proxy_url"`
-			Filename    string `json:"filename"`
-			ContentType string `json:"content_type"`
-			Size        int    `json:"size"`
-		} `json:"attachments"`
-	}
+	var messages []discordPolledMessage
 	if err := json.NewDecoder(resp.Body).Decode(&messages); err != nil {
 		return err
 	}
@@ -389,7 +396,7 @@ func (a *DiscordAdapter) pollOnce(ctx context.Context, handle InboundHandler) er
 				meta["caption"] = strings.TrimSpace(msg.Content)
 			}
 
-			threadID := strings.TrimSpace(msg.ParentID)
+			threadID := strings.TrimSpace(msg.MessageReference.MessageID)
 			replyTarget := a.config.DefaultChannel
 			if threadID != "" {
 				replyTarget = threadID
@@ -418,7 +425,7 @@ func (a *DiscordAdapter) pollOnce(ctx context.Context, handle InboundHandler) er
 			continue
 		}
 
-		threadID := strings.TrimSpace(msg.ParentID)
+		threadID := strings.TrimSpace(msg.MessageReference.MessageID)
 		replyTarget := a.config.DefaultChannel
 		if threadID != "" {
 			replyTarget = threadID
@@ -754,17 +761,7 @@ func (a *DiscordAdapter) pollOnceStream(ctx context.Context, handle StreamChunkH
 		return fmt.Errorf("discord fetch failed: %s", resp.Status)
 	}
 
-	var messages []struct {
-		ID       string `json:"id"`
-		Content  string `json:"content"`
-		GuildID  string `json:"guild_id"`
-		ParentID string `json:"message_reference.message_id"`
-		Author   struct {
-			ID       string `json:"id"`
-			Username string `json:"username"`
-			Bot      bool   `json:"bot"`
-		} `json:"author"`
-	}
+	var messages []discordPolledMessage
 	if err := json.NewDecoder(resp.Body).Decode(&messages); err != nil {
 		return err
 	}
@@ -791,7 +788,7 @@ func (a *DiscordAdapter) pollOnceStream(ctx context.Context, handle StreamChunkH
 			"sender":       msg.Author.Username,
 		}
 
-		threadID := strings.TrimSpace(msg.ParentID)
+		threadID := strings.TrimSpace(msg.MessageReference.MessageID)
 		replyTarget := a.config.DefaultChannel
 		if threadID != "" {
 			replyTarget = threadID

--- a/pkg/input/channels/discord.go
+++ b/pkg/input/channels/discord.go
@@ -1,0 +1,822 @@
+package channels
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	"github.com/gorilla/websocket"
+)
+
+type DiscordAdapter struct {
+	base        BaseAdapter
+	config      config.DiscordChannelConfig
+	client      *http.Client
+	appendEvent func(eventType string, sessionID string, payload map[string]any)
+	latestID    string
+	apiBaseURL  string
+	processed   map[string]time.Time
+}
+
+func (a *DiscordAdapter) VerifyInteraction(r *http.Request, body []byte) bool {
+	publicKeyHex := strings.TrimSpace(a.config.PublicKey)
+	if publicKeyHex == "" {
+		return false
+	}
+	publicKey, err := hex.DecodeString(publicKeyHex)
+	if err != nil || len(publicKey) != ed25519.PublicKeySize {
+		return false
+	}
+	sigHex := strings.TrimSpace(r.Header.Get("X-Signature-Ed25519"))
+	ts := strings.TrimSpace(r.Header.Get("X-Signature-Timestamp"))
+	if sigHex == "" || ts == "" {
+		return false
+	}
+	sig, err := hex.DecodeString(sigHex)
+	if err != nil {
+		return false
+	}
+	message := append([]byte(ts), body...)
+	return ed25519.Verify(ed25519.PublicKey(publicKey), message, sig)
+}
+
+func (a *DiscordAdapter) HandleInteraction(ctx context.Context, body []byte, handle InboundHandler) (map[string]any, error) {
+	var payload struct {
+		Type int `json:"type"`
+		Data struct {
+			Name    string `json:"name"`
+			Options []struct {
+				Name  string `json:"name"`
+				Value any    `json:"value"`
+			} `json:"options"`
+		} `json:"data"`
+		ChannelID string `json:"channel_id"`
+		GuildID   string `json:"guild_id"`
+		Member    struct {
+			User struct {
+				ID       string `json:"id"`
+				Username string `json:"username"`
+			} `json:"user"`
+		} `json:"member"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	if payload.Type == 1 {
+		return map[string]any{"type": 1}, nil
+	}
+	message := payload.Data.Name
+	for _, opt := range payload.Data.Options {
+		if strings.EqualFold(opt.Name, "message") {
+			message = fmt.Sprintf("%v", opt.Value)
+		}
+	}
+	respSession, response, err := handle(ctx, "", message, map[string]string{"channel": "discord", "channel_id": payload.ChannelID, "guild_id": payload.GuildID, "user_id": payload.Member.User.ID, "username": payload.Member.User.Username, "reply_target": payload.ChannelID, "message_id": fmt.Sprintf("interaction:%d", time.Now().UnixNano())})
+	if err != nil {
+		return nil, err
+	}
+	_ = respSession
+	return map[string]any{"type": 4, "data": map[string]any{"content": response}}, nil
+}
+
+func ReadBody(r *http.Request) ([]byte, error) {
+	defer r.Body.Close()
+	return io.ReadAll(r.Body)
+}
+
+func NewDiscordAdapter(cfg config.DiscordChannelConfig, appendEvent func(eventType string, sessionID string, payload map[string]any)) *DiscordAdapter {
+	apiBaseURL := strings.TrimRight(strings.TrimSpace(cfg.APIBaseURL), "/")
+	if apiBaseURL == "" {
+		apiBaseURL = "https://discord.com/api/v10"
+	}
+	return &DiscordAdapter{
+		base:        NewBaseAdapter("discord", cfg.Enabled && cfg.BotToken != ""),
+		config:      cfg,
+		client:      &http.Client{Timeout: 20 * time.Second},
+		appendEvent: appendEvent,
+		apiBaseURL:  apiBaseURL,
+		processed:   make(map[string]time.Time),
+	}
+}
+
+func (a *DiscordAdapter) Name() string {
+	return "discord"
+}
+
+func (a *DiscordAdapter) Enabled() bool {
+	return a.config.Enabled && strings.TrimSpace(a.config.BotToken) != "" && strings.TrimSpace(a.config.DefaultChannel) != ""
+}
+
+func (a *DiscordAdapter) Status() Status {
+	status := a.base.Status()
+	status.Enabled = a.Enabled()
+	return status
+}
+
+func (a *DiscordAdapter) Run(ctx context.Context, handle InboundHandler) error {
+	a.base.SetRunning(true)
+	defer a.base.SetRunning(false)
+	if a.config.UseGatewayWS {
+		if err := a.runGatewayWS(ctx, handle); err == nil {
+			return nil
+		} else {
+			a.append("channel.discord.gateway.error", "", map[string]any{"error": err.Error()})
+		}
+	}
+	interval := time.Duration(a.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := a.pollOnce(ctx, handle); err != nil {
+			a.base.SetError(err)
+			a.append("channel.discord.error", "", map[string]any{"error": err.Error()})
+		} else {
+			a.base.SetError(nil)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *DiscordAdapter) runGatewayWS(ctx context.Context, handle InboundHandler) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://discord.com/api/gateway/bot", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var gateway struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&gateway); err != nil {
+		return err
+	}
+	if strings.TrimSpace(gateway.URL) == "" {
+		return fmt.Errorf("discord gateway URL missing")
+	}
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, gateway.URL+"?v=10&encoding=json", nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_ = conn.WriteJSON(map[string]any{"op": 2, "d": map[string]any{"token": a.config.BotToken, "intents": 4609, "properties": map[string]string{"$os": "windows", "$browser": "anyclaw", "$device": "anyclaw"}}})
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+		var packet struct {
+			Op int             `json:"op"`
+			T  string          `json:"t"`
+			D  json.RawMessage `json:"d"`
+		}
+		if err := conn.ReadJSON(&packet); err != nil {
+			return err
+		}
+		if packet.Op == 10 {
+			_ = conn.WriteJSON(map[string]any{"op": 1, "d": nil})
+			continue
+		}
+		if packet.T == "MESSAGE_CREATE" || packet.T == "THREAD_CREATE" || packet.T == "TYPING_START" || packet.T == "PRESENCE_UPDATE" || packet.T == "INTERACTION_CREATE" {
+			_ = a.handleGatewayEvent(ctx, packet.T, packet.D, handle)
+		}
+	}
+}
+
+func (a *DiscordAdapter) handleGatewayEvent(ctx context.Context, eventType string, raw json.RawMessage, handle InboundHandler) error {
+	a.append("channel.discord.gateway.event", "", map[string]any{"event": eventType})
+	if eventType == "MESSAGE_CREATE" {
+		var msg struct {
+			ID        string `json:"id"`
+			Content   string `json:"content"`
+			ChannelID string `json:"channel_id"`
+			GuildID   string `json:"guild_id"`
+			Author    struct {
+				ID       string `json:"id"`
+				Username string `json:"username"`
+				Bot      bool   `json:"bot"`
+			} `json:"author"`
+			Attachments []struct {
+				ID          string `json:"id"`
+				URL         string `json:"url"`
+				ProxyURL    string `json:"proxy_url"`
+				Filename    string `json:"filename"`
+				ContentType string `json:"content_type"`
+				Size        int    `json:"size"`
+			} `json:"attachments"`
+			MessageReference struct {
+				MessageID string `json:"message_id"`
+				ChannelID string `json:"channel_id"`
+			} `json:"message_reference"`
+		}
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			return err
+		}
+		if msg.Author.Bot || a.seen(msg.ID) {
+			return nil
+		}
+
+		meta := map[string]string{
+			"channel":      "discord",
+			"channel_id":   msg.ChannelID,
+			"guild_id":     msg.GuildID,
+			"user_id":      msg.Author.ID,
+			"username":     msg.Author.Username,
+			"reply_target": msg.ChannelID,
+			"message_id":   msg.ID,
+			"sender":       msg.Author.Username,
+		}
+
+		audioURL, audioMIME := a.findAudioAttachment(msg.Attachments)
+		if audioURL != "" {
+			meta["message_type"] = "voice_note"
+			meta["audio_url"] = audioURL
+			meta["audio_mime"] = audioMIME
+			if strings.TrimSpace(msg.Content) != "" {
+				meta["caption"] = strings.TrimSpace(msg.Content)
+			}
+
+			respSession, response, err := handle(ctx, "", audioURL, meta)
+			if err != nil {
+				return err
+			}
+			_ = respSession
+			return a.sendMessage(ctx, msg.ChannelID, "", response)
+		}
+
+		if strings.TrimSpace(msg.Content) == "" {
+			return nil
+		}
+
+		respSession, response, err := handle(ctx, "", msg.Content, meta)
+		if err != nil {
+			return err
+		}
+		_ = respSession
+		return a.sendMessage(ctx, msg.ChannelID, "", response)
+	}
+	return nil
+}
+
+func (a *DiscordAdapter) findAudioAttachment(attachments []struct {
+	ID          string `json:"id"`
+	URL         string `json:"url"`
+	ProxyURL    string `json:"proxy_url"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type"`
+	Size        int    `json:"size"`
+}) (string, string) {
+	for _, att := range attachments {
+		ct := strings.ToLower(att.ContentType)
+		fn := strings.ToLower(att.Filename)
+		if strings.HasPrefix(ct, "audio/") {
+			url := att.URL
+			if url == "" {
+				url = att.ProxyURL
+			}
+			return url, att.ContentType
+		}
+		if strings.HasSuffix(fn, ".ogg") || strings.HasSuffix(fn, ".mp3") || strings.HasSuffix(fn, ".wav") || strings.HasSuffix(fn, ".flac") || strings.HasSuffix(fn, ".m4a") || strings.HasSuffix(fn, ".webm") {
+			url := att.URL
+			if url == "" {
+				url = att.ProxyURL
+			}
+			mime := "audio/unknown"
+			switch {
+			case strings.HasSuffix(fn, ".ogg"):
+				mime = "audio/ogg"
+			case strings.HasSuffix(fn, ".mp3"):
+				mime = "audio/mpeg"
+			case strings.HasSuffix(fn, ".wav"):
+				mime = "audio/wav"
+			case strings.HasSuffix(fn, ".flac"):
+				mime = "audio/flac"
+			case strings.HasSuffix(fn, ".m4a"):
+				mime = "audio/mp4"
+			case strings.HasSuffix(fn, ".webm"):
+				mime = "audio/webm"
+			}
+			return url, mime
+		}
+	}
+	return "", ""
+}
+
+func (a *DiscordAdapter) pollOnce(ctx context.Context, handle InboundHandler) error {
+	url := fmt.Sprintf("%s/channels/%s/messages?limit=20", a.apiBaseURL, a.config.DefaultChannel)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("discord fetch failed: %s", resp.Status)
+	}
+
+	var messages []struct {
+		ID       string `json:"id"`
+		Content  string `json:"content"`
+		GuildID  string `json:"guild_id"`
+		ParentID string `json:"message_reference.message_id"`
+		Author   struct {
+			ID       string `json:"id"`
+			Username string `json:"username"`
+			Bot      bool   `json:"bot"`
+		} `json:"author"`
+		Attachments []struct {
+			ID          string `json:"id"`
+			URL         string `json:"url"`
+			ProxyURL    string `json:"proxy_url"`
+			Filename    string `json:"filename"`
+			ContentType string `json:"content_type"`
+			Size        int    `json:"size"`
+		} `json:"attachments"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&messages); err != nil {
+		return err
+	}
+
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.ID == "" || msg.ID == a.latestID || msg.Author.Bot || a.seen(msg.ID) {
+			continue
+		}
+		a.latestID = msg.ID
+
+		meta := map[string]string{
+			"channel":      "discord",
+			"channel_id":   a.config.DefaultChannel,
+			"guild_id":     msg.GuildID,
+			"user_id":      msg.Author.ID,
+			"username":     msg.Author.Username,
+			"reply_target": a.config.DefaultChannel,
+			"message_id":   msg.ID,
+			"sender":       msg.Author.Username,
+		}
+
+		audioURL, audioMIME := a.findAudioAttachment(msg.Attachments)
+		if audioURL != "" {
+			meta["message_type"] = "voice_note"
+			meta["audio_url"] = audioURL
+			meta["audio_mime"] = audioMIME
+			if strings.TrimSpace(msg.Content) != "" {
+				meta["caption"] = strings.TrimSpace(msg.Content)
+			}
+
+			threadID := strings.TrimSpace(msg.ParentID)
+			replyTarget := a.config.DefaultChannel
+			if threadID != "" {
+				replyTarget = threadID
+			}
+
+			sessionID, response, err := handle(ctx, "", audioURL, meta)
+			if err != nil {
+				return err
+			}
+			if err := a.sendMessage(ctx, replyTarget, threadID, response); err != nil {
+				return err
+			}
+			a.base.MarkActivity()
+			a.append("channel.discord.voice", sessionID, map[string]any{
+				"channel":      a.config.DefaultChannel,
+				"user":         msg.Author.Username,
+				"user_id":      msg.Author.ID,
+				"message_type": "voice_note",
+				"audio_url":    audioURL,
+				"audio_mime":   audioMIME,
+			})
+			continue
+		}
+
+		if strings.TrimSpace(msg.Content) == "" {
+			continue
+		}
+
+		threadID := strings.TrimSpace(msg.ParentID)
+		replyTarget := a.config.DefaultChannel
+		if threadID != "" {
+			replyTarget = threadID
+		}
+		sessionID, response, err := handle(ctx, "", msg.Content, meta)
+		if err != nil {
+			return err
+		}
+		if err := a.sendMessage(ctx, replyTarget, threadID, response); err != nil {
+			return err
+		}
+		a.base.MarkActivity()
+		a.append("channel.discord.message", sessionID, map[string]any{
+			"channel": a.config.DefaultChannel,
+			"user":    msg.Author.Username,
+			"user_id": msg.Author.ID,
+			"text":    msg.Content,
+		})
+	}
+	return nil
+}
+
+func (a *DiscordAdapter) sendMessage(ctx context.Context, target string, threadID string, text string) error {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		target = strings.TrimSpace(a.config.DefaultChannel)
+	}
+	bodyMap := map[string]any{"content": text}
+	if strings.TrimSpace(threadID) != "" && threadID != target {
+		bodyMap["message_reference"] = map[string]any{"message_id": threadID}
+	}
+	body, _ := json.Marshal(bodyMap)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/channels/%s/messages", a.apiBaseURL, target), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("discord send failed: %s", resp.Status)
+	}
+	return nil
+}
+
+func (a *DiscordAdapter) append(eventType string, sessionID string, payload map[string]any) {
+	if a.appendEvent != nil {
+		a.appendEvent(eventType, sessionID, payload)
+	}
+}
+
+func (a *DiscordAdapter) seen(id string) bool {
+	for key, ts := range a.processed {
+		if time.Since(ts) > 30*time.Minute {
+			delete(a.processed, key)
+		}
+	}
+	if _, ok := a.processed[id]; ok {
+		return true
+	}
+	a.processed[id] = time.Now().UTC()
+	return false
+}
+
+func (a *DiscordAdapter) sendStreamingMessage(ctx context.Context, target string, threadID string, streamFn func(onChunk func(chunk string)) error) error {
+	streamInterval := time.Duration(a.config.StreamInterval) * time.Millisecond
+	if streamInterval <= 0 {
+		streamInterval = 500 * time.Millisecond
+	}
+
+	initialMsgID, err := a.sendMessageWithResult(ctx, target, threadID, "\u200B")
+	if err != nil {
+		return err
+	}
+	if initialMsgID == "" {
+		return streamFn(func(chunk string) {})
+	}
+
+	var accumulated strings.Builder
+	var mu sync.Mutex
+	lastEdit := time.Now()
+
+	onChunk := func(chunk string) {
+		mu.Lock()
+		accumulated.WriteString(chunk)
+		shouldEdit := time.Since(lastEdit) >= streamInterval
+		if shouldEdit {
+			lastEdit = time.Now()
+		}
+		mu.Unlock()
+
+		if shouldEdit {
+			mu.Lock()
+			text := accumulated.String()
+			mu.Unlock()
+			a.editMessage(ctx, target, initialMsgID, text)
+		}
+	}
+
+	if err := streamFn(onChunk); err != nil {
+		mu.Lock()
+		final := accumulated.String()
+		mu.Unlock()
+		a.editMessage(ctx, target, initialMsgID, final+"\n\n[Error: "+err.Error()+"]")
+		return err
+	}
+
+	mu.Lock()
+	final := accumulated.String()
+	mu.Unlock()
+	a.editMessage(ctx, target, initialMsgID, final)
+	return nil
+}
+
+func (a *DiscordAdapter) sendMessageWithResult(ctx context.Context, target string, threadID string, text string) (string, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		target = strings.TrimSpace(a.config.DefaultChannel)
+	}
+	bodyMap := map[string]any{"content": text}
+	if strings.TrimSpace(threadID) != "" && threadID != target {
+		bodyMap["message_reference"] = map[string]any{"message_id": threadID}
+	}
+	body, _ := json.Marshal(bodyMap)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/channels/%s/messages", a.apiBaseURL, target), bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("discord send failed: %s", resp.Status)
+	}
+
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	return result.ID, nil
+}
+
+func (a *DiscordAdapter) editMessage(ctx context.Context, target string, messageID string, text string) error {
+	if messageID == "" {
+		return nil
+	}
+	target = strings.TrimSpace(target)
+	if target == "" {
+		target = strings.TrimSpace(a.config.DefaultChannel)
+	}
+	truncated := text
+	if len([]rune(truncated)) > 2000 {
+		truncated = string([]rune(truncated)[:1997]) + "..."
+	}
+	body := map[string]any{"content": truncated}
+	payload, _ := json.Marshal(body)
+	url := fmt.Sprintf("%s/channels/%s/messages/%s", a.apiBaseURL, target, messageID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func (a *DiscordAdapter) RunStream(ctx context.Context, handle StreamChunkHandler) error {
+	a.base.SetRunning(true)
+	defer a.base.SetRunning(false)
+	if a.config.UseGatewayWS {
+		if err := a.runGatewayWSStream(ctx, handle); err == nil {
+			return nil
+		} else {
+			a.append("channel.discord.gateway.error", "", map[string]any{"error": err.Error()})
+		}
+	}
+	interval := time.Duration(a.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := a.pollOnceStream(ctx, handle); err != nil {
+			a.base.SetError(err)
+			a.append("channel.discord.error", "", map[string]any{"error": err.Error()})
+		} else {
+			a.base.SetError(nil)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *DiscordAdapter) runGatewayWSStream(ctx context.Context, handle StreamChunkHandler) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://discord.com/api/gateway/bot", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var gateway struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&gateway); err != nil {
+		return err
+	}
+	if strings.TrimSpace(gateway.URL) == "" {
+		return fmt.Errorf("discord gateway URL missing")
+	}
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, gateway.URL+"?v=10&encoding=json", nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_ = conn.WriteJSON(map[string]any{"op": 2, "d": map[string]any{"token": a.config.BotToken, "intents": 4609, "properties": map[string]string{"$os": "windows", "$browser": "anyclaw", "$device": "anyclaw"}}})
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+		var packet struct {
+			Op int             `json:"op"`
+			T  string          `json:"t"`
+			D  json.RawMessage `json:"d"`
+		}
+		if err := conn.ReadJSON(&packet); err != nil {
+			return err
+		}
+		if packet.Op == 10 {
+			_ = conn.WriteJSON(map[string]any{"op": 1, "d": nil})
+			continue
+		}
+		if packet.T == "MESSAGE_CREATE" || packet.T == "THREAD_CREATE" {
+			_ = a.handleGatewayEventStream(ctx, packet.T, packet.D, handle)
+		}
+	}
+}
+
+func (a *DiscordAdapter) handleGatewayEventStream(ctx context.Context, eventType string, raw json.RawMessage, handle StreamChunkHandler) error {
+	if eventType == "MESSAGE_CREATE" {
+		var msg struct {
+			ID        string `json:"id"`
+			Content   string `json:"content"`
+			ChannelID string `json:"channel_id"`
+			GuildID   string `json:"guild_id"`
+			Author    struct {
+				ID       string `json:"id"`
+				Username string `json:"username"`
+				Bot      bool   `json:"bot"`
+			} `json:"author"`
+			MessageReference struct {
+				MessageID string `json:"message_id"`
+				ChannelID string `json:"channel_id"`
+			} `json:"message_reference"`
+		}
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			return err
+		}
+		if msg.Author.Bot || a.seen(msg.ID) {
+			return nil
+		}
+		if strings.TrimSpace(msg.Content) == "" {
+			return nil
+		}
+
+		meta := map[string]string{
+			"channel":      "discord",
+			"channel_id":   msg.ChannelID,
+			"guild_id":     msg.GuildID,
+			"user_id":      msg.Author.ID,
+			"username":     msg.Author.Username,
+			"reply_target": msg.ChannelID,
+			"message_id":   msg.ID,
+			"sender":       msg.Author.Username,
+		}
+
+		sessionID := ""
+		err := a.sendStreamingMessage(ctx, msg.ChannelID, "", func(onChunk func(chunk string)) error {
+			var err error
+			sessionID, err = handle(ctx, sessionID, msg.Content, meta, func(chunk string) error {
+				onChunk(chunk)
+				return nil
+			})
+			return err
+		})
+		if err != nil {
+			return err
+		}
+		a.base.MarkActivity()
+		return nil
+	}
+	return nil
+}
+
+func (a *DiscordAdapter) pollOnceStream(ctx context.Context, handle StreamChunkHandler) error {
+	url := fmt.Sprintf("%s/channels/%s/messages?limit=20", a.apiBaseURL, a.config.DefaultChannel)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("discord fetch failed: %s", resp.Status)
+	}
+
+	var messages []struct {
+		ID       string `json:"id"`
+		Content  string `json:"content"`
+		GuildID  string `json:"guild_id"`
+		ParentID string `json:"message_reference.message_id"`
+		Author   struct {
+			ID       string `json:"id"`
+			Username string `json:"username"`
+			Bot      bool   `json:"bot"`
+		} `json:"author"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&messages); err != nil {
+		return err
+	}
+
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.ID == "" || msg.ID == a.latestID || msg.Author.Bot || a.seen(msg.ID) {
+			continue
+		}
+		a.latestID = msg.ID
+
+		if strings.TrimSpace(msg.Content) == "" {
+			continue
+		}
+
+		meta := map[string]string{
+			"channel":      "discord",
+			"channel_id":   a.config.DefaultChannel,
+			"guild_id":     msg.GuildID,
+			"user_id":      msg.Author.ID,
+			"username":     msg.Author.Username,
+			"reply_target": a.config.DefaultChannel,
+			"message_id":   msg.ID,
+			"sender":       msg.Author.Username,
+		}
+
+		threadID := strings.TrimSpace(msg.ParentID)
+		replyTarget := a.config.DefaultChannel
+		if threadID != "" {
+			replyTarget = threadID
+		}
+		sessionID := ""
+
+		err := a.sendStreamingMessage(ctx, replyTarget, threadID, func(onChunk func(chunk string)) error {
+			var err error
+			sessionID, err = handle(ctx, sessionID, msg.Content, meta, func(chunk string) error {
+				onChunk(chunk)
+				return nil
+			})
+			return err
+		})
+		if err != nil {
+			return err
+		}
+		a.base.MarkActivity()
+		a.append("channel.discord.message", sessionID, map[string]any{
+			"channel":   a.config.DefaultChannel,
+			"user":      msg.Author.Username,
+			"user_id":   msg.Author.ID,
+			"text":      msg.Content,
+			"streaming": true,
+		})
+	}
+	return nil
+}

--- a/pkg/input/channels/signal.go
+++ b/pkg/input/channels/signal.go
@@ -1,0 +1,268 @@
+package channels
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+type SignalAdapter struct {
+	base        BaseAdapter
+	config      config.SignalChannelConfig
+	client      *http.Client
+	appendEvent func(eventType string, sessionID string, payload map[string]any)
+	latestTS    int64
+	processed   map[string]time.Time
+}
+
+func NewSignalAdapter(cfg config.SignalChannelConfig, appendEvent func(eventType string, sessionID string, payload map[string]any)) *SignalAdapter {
+	return &SignalAdapter{
+		base:        NewBaseAdapter("signal", cfg.Enabled && cfg.BaseURL != ""),
+		config:      cfg,
+		client:      &http.Client{Timeout: 20 * time.Second},
+		appendEvent: appendEvent,
+		processed:   make(map[string]time.Time),
+	}
+}
+
+func (a *SignalAdapter) Name() string { return "signal" }
+
+func (a *SignalAdapter) Enabled() bool {
+	return a.config.Enabled && strings.TrimSpace(a.config.BaseURL) != "" && strings.TrimSpace(a.config.Number) != ""
+}
+
+func (a *SignalAdapter) Status() Status {
+	status := a.base.Status()
+	status.Enabled = a.Enabled()
+	return status
+}
+
+func (a *SignalAdapter) Run(ctx context.Context, handle InboundHandler) error {
+	a.base.SetRunning(true)
+	defer a.base.SetRunning(false)
+	interval := time.Duration(a.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		if err := a.pollOnce(ctx, handle); err != nil {
+			a.base.SetError(err)
+			a.append("channel.signal.error", "", map[string]any{"error": err.Error()})
+		} else {
+			a.base.SetError(nil)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *SignalAdapter) pollOnce(ctx context.Context, handle InboundHandler) error {
+	baseURL := strings.TrimRight(strings.TrimSpace(a.config.BaseURL), "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1/receive/"+url.PathEscape(a.config.Number), nil)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(a.config.BearerToken) != "" {
+		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(a.config.BearerToken))
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("signal receive failed: %s", resp.Status)
+	}
+	var payload []struct {
+		Envelope struct {
+			Timestamp  int64  `json:"timestamp"`
+			Source     string `json:"source"`
+			SourceName string `json:"sourceName"`
+			GroupInfo  struct {
+				GroupID string `json:"groupId"`
+			} `json:"groupInfo"`
+			DataMessage struct {
+				Message     string `json:"message"`
+				Attachments []struct {
+					ContentType string `json:"contentType"`
+					Filename    string `json:"filename"`
+				} `json:"attachments"`
+			} `json:"dataMessage"`
+		} `json:"envelope"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return err
+	}
+	for _, item := range payload {
+		messageID := fmt.Sprintf("%s:%d", item.Envelope.Source, item.Envelope.Timestamp)
+		if item.Envelope.Timestamp <= a.latestTS || a.seen(messageID) {
+			continue
+		}
+		a.latestTS = item.Envelope.Timestamp
+
+		msg := strings.TrimSpace(item.Envelope.DataMessage.Message)
+		replyTarget := item.Envelope.Source
+		threadID := strings.TrimSpace(item.Envelope.GroupInfo.GroupID)
+		if threadID != "" {
+			replyTarget = threadID
+		}
+
+		meta := map[string]string{
+			"channel":      "signal",
+			"user_id":      item.Envelope.Source,
+			"username":     item.Envelope.SourceName,
+			"reply_target": replyTarget,
+			"thread_id":    threadID,
+			"message_id":   messageID,
+			"sender":       item.Envelope.SourceName,
+		}
+
+		audioURL, audioMIME := a.findAudioAttachment(item.Envelope.DataMessage.Attachments)
+		if audioURL != "" {
+			meta["message_type"] = "voice_note"
+			meta["audio_url"] = audioURL
+			meta["audio_mime"] = audioMIME
+			if msg != "" {
+				meta["caption"] = msg
+			}
+
+			sessionID, response, err := handle(ctx, "", audioURL, meta)
+			if err != nil {
+				return err
+			}
+			if err := a.sendMessage(ctx, replyTarget, response); err != nil {
+				return err
+			}
+			a.base.MarkActivity()
+			a.append("channel.signal.voice", sessionID, map[string]any{
+				"source":       item.Envelope.Source,
+				"source_name":  item.Envelope.SourceName,
+				"group_id":     threadID,
+				"message_type": "voice_note",
+				"audio_url":    audioURL,
+				"audio_mime":   audioMIME,
+			})
+			continue
+		}
+
+		if msg == "" {
+			continue
+		}
+
+		if len(item.Envelope.DataMessage.Attachments) > 0 {
+			meta["attachment_count"] = fmt.Sprintf("%d", len(item.Envelope.DataMessage.Attachments))
+		}
+		sessionID, response, err := handle(ctx, "", msg, meta)
+		if err != nil {
+			return err
+		}
+		if err := a.sendMessage(ctx, replyTarget, response); err != nil {
+			return err
+		}
+		a.base.MarkActivity()
+		a.append("channel.signal.message", sessionID, map[string]any{
+			"source":      item.Envelope.Source,
+			"source_name": item.Envelope.SourceName,
+			"group_id":    threadID,
+			"attachments": len(item.Envelope.DataMessage.Attachments),
+			"text":        msg,
+		})
+	}
+	return nil
+}
+
+func (a *SignalAdapter) sendMessage(ctx context.Context, recipient string, text string) error {
+	recipient = strings.TrimSpace(recipient)
+	if recipient == "" {
+		recipient = strings.TrimSpace(a.config.DefaultRecipient)
+	}
+	if recipient == "" {
+		return nil
+	}
+	body, _ := json.Marshal(map[string]any{
+		"message":    text,
+		"number":     a.config.Number,
+		"recipients": []string{recipient},
+	})
+	baseURL := strings.TrimRight(strings.TrimSpace(a.config.BaseURL), "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v2/send", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if strings.TrimSpace(a.config.BearerToken) != "" {
+		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(a.config.BearerToken))
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("signal send failed: %s", resp.Status)
+	}
+	return nil
+}
+
+func (a *SignalAdapter) append(eventType string, sessionID string, payload map[string]any) {
+	if a.appendEvent != nil {
+		a.appendEvent(eventType, sessionID, payload)
+	}
+}
+
+func (a *SignalAdapter) seen(id string) bool {
+	for key, ts := range a.processed {
+		if time.Since(ts) > 30*time.Minute {
+			delete(a.processed, key)
+		}
+	}
+	if _, ok := a.processed[id]; ok {
+		return true
+	}
+	a.processed[id] = time.Now().UTC()
+	return false
+}
+
+func (a *SignalAdapter) findAudioAttachment(attachments []struct {
+	ContentType string `json:"contentType"`
+	Filename    string `json:"filename"`
+}) (string, string) {
+	for _, att := range attachments {
+		mime := strings.ToLower(att.ContentType)
+		fn := strings.ToLower(att.Filename)
+		if strings.HasPrefix(mime, "audio/") {
+			return "", att.ContentType
+		}
+		if strings.HasSuffix(fn, ".ogg") || strings.HasSuffix(fn, ".mp3") || strings.HasSuffix(fn, ".wav") || strings.HasSuffix(fn, ".flac") || strings.HasSuffix(fn, ".m4a") || strings.HasSuffix(fn, ".webm") {
+			mimeType := "audio/unknown"
+			switch {
+			case strings.HasSuffix(fn, ".ogg"):
+				mimeType = "audio/ogg"
+			case strings.HasSuffix(fn, ".mp3"):
+				mimeType = "audio/mpeg"
+			case strings.HasSuffix(fn, ".wav"):
+				mimeType = "audio/wav"
+			case strings.HasSuffix(fn, ".flac"):
+				mimeType = "audio/flac"
+			case strings.HasSuffix(fn, ".m4a"):
+				mimeType = "audio/mp4"
+			case strings.HasSuffix(fn, ".webm"):
+				mimeType = "audio/webm"
+			}
+			return "", mimeType
+		}
+	}
+	return "", ""
+}

--- a/pkg/input/channels/signal.go
+++ b/pkg/input/channels/signal.go
@@ -127,6 +127,8 @@ func (a *SignalAdapter) pollOnce(ctx context.Context, handle InboundHandler) err
 			"thread_id":    threadID,
 			"message_id":   messageID,
 			"sender":       item.Envelope.SourceName,
+			"channel_type": signalChannelType(threadID),
+			"is_group":     boolString(threadID != ""),
 		}
 
 		audioURL, audioMIME, hasAudio := a.findAudioAttachment(item.Envelope.DataMessage.Attachments)
@@ -183,6 +185,13 @@ func (a *SignalAdapter) pollOnce(ctx context.Context, handle InboundHandler) err
 		})
 	}
 	return nil
+}
+
+func signalChannelType(threadID string) string {
+	if strings.TrimSpace(threadID) != "" {
+		return "group"
+	}
+	return "private"
 }
 
 func (a *SignalAdapter) sendMessage(ctx context.Context, recipient string, text string) error {

--- a/pkg/input/channels/signal.go
+++ b/pkg/input/channels/signal.go
@@ -129,11 +129,13 @@ func (a *SignalAdapter) pollOnce(ctx context.Context, handle InboundHandler) err
 			"sender":       item.Envelope.SourceName,
 		}
 
-		audioURL, audioMIME := a.findAudioAttachment(item.Envelope.DataMessage.Attachments)
-		if audioURL != "" {
+		audioURL, audioMIME, hasAudio := a.findAudioAttachment(item.Envelope.DataMessage.Attachments)
+		if hasAudio {
 			meta["message_type"] = "voice_note"
-			meta["audio_url"] = audioURL
 			meta["audio_mime"] = audioMIME
+			if audioURL != "" {
+				meta["audio_url"] = audioURL
+			}
 			if msg != "" {
 				meta["caption"] = msg
 			}
@@ -238,12 +240,12 @@ func (a *SignalAdapter) seen(id string) bool {
 func (a *SignalAdapter) findAudioAttachment(attachments []struct {
 	ContentType string `json:"contentType"`
 	Filename    string `json:"filename"`
-}) (string, string) {
+}) (string, string, bool) {
 	for _, att := range attachments {
 		mime := strings.ToLower(att.ContentType)
 		fn := strings.ToLower(att.Filename)
 		if strings.HasPrefix(mime, "audio/") {
-			return "", att.ContentType
+			return strings.TrimSpace(att.Filename), att.ContentType, true
 		}
 		if strings.HasSuffix(fn, ".ogg") || strings.HasSuffix(fn, ".mp3") || strings.HasSuffix(fn, ".wav") || strings.HasSuffix(fn, ".flac") || strings.HasSuffix(fn, ".m4a") || strings.HasSuffix(fn, ".webm") {
 			mimeType := "audio/unknown"
@@ -261,8 +263,8 @@ func (a *SignalAdapter) findAudioAttachment(attachments []struct {
 			case strings.HasSuffix(fn, ".webm"):
 				mimeType = "audio/webm"
 			}
-			return "", mimeType
+			return strings.TrimSpace(att.Filename), mimeType, true
 		}
 	}
-	return "", ""
+	return "", "", false
 }

--- a/pkg/input/channels/slack.go
+++ b/pkg/input/channels/slack.go
@@ -113,6 +113,7 @@ func (a *SlackAdapter) pollOnce(ctx context.Context, handle InboundHandler) erro
 			continue
 		}
 		a.latestTS = msg.Ts
+		channelType, isGroup := slackConversationMetadata(a.config.DefaultChannel)
 
 		meta := map[string]string{
 			"channel":      "slack",
@@ -122,6 +123,8 @@ func (a *SlackAdapter) pollOnce(ctx context.Context, handle InboundHandler) erro
 			"message_id":   msg.Ts,
 			"sender":       msg.User,
 			"thread_id":    msg.ThreadTS,
+			"channel_type": channelType,
+			"is_group":     boolString(isGroup),
 		}
 
 		audioURL, audioMIME := a.findAudioFile(msg.Files)
@@ -192,6 +195,20 @@ func (a *SlackAdapter) sendMessage(ctx context.Context, text string, threadTS st
 	if resp.StatusCode >= 300 {
 		return fmt.Errorf("slack send failed: %s", resp.Status)
 	}
+
+	var result struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+	if !result.OK {
+		if strings.TrimSpace(result.Error) == "" {
+			return fmt.Errorf("slack send failed: api returned ok=false")
+		}
+		return fmt.Errorf("slack send failed: %s", result.Error)
+	}
 	return nil
 }
 
@@ -215,8 +232,12 @@ func (a *SlackAdapter) findAudioFile(files []struct {
 	return "", ""
 }
 
-func (a *SlackAdapter) sendMessageWithResult(ctx context.Context, text string) (string, error) {
-	body, _ := json.Marshal(map[string]any{"channel": a.config.DefaultChannel, "text": text})
+func (a *SlackAdapter) sendMessageWithResult(ctx context.Context, text string, threadTS string) (string, error) {
+	bodyMap := map[string]any{"channel": a.config.DefaultChannel, "text": text}
+	if strings.TrimSpace(threadTS) != "" {
+		bodyMap["thread_ts"] = threadTS
+	}
+	body, _ := json.Marshal(bodyMap)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://slack.com/api/chat.postMessage", bytes.NewReader(body))
 	if err != nil {
 		return "", err
@@ -233,14 +254,18 @@ func (a *SlackAdapter) sendMessageWithResult(ctx context.Context, text string) (
 	}
 
 	var result struct {
-		OK bool   `json:"ok"`
-		Ts string `json:"ts"`
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+		Ts    string `json:"ts"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", err
 	}
-	if !result.OK || result.Ts == "" {
-		return "", nil
+	if !result.OK {
+		if strings.TrimSpace(result.Error) == "" {
+			return "", fmt.Errorf("slack send failed: api returned ok=false")
+		}
+		return "", fmt.Errorf("slack send failed: %s", result.Error)
 	}
 	return result.Ts, nil
 }
@@ -261,21 +286,36 @@ func (a *SlackAdapter) editMessage(ctx context.Context, ts string, text string) 
 		return nil
 	}
 	defer resp.Body.Close()
+	var result struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+	if !result.OK {
+		if strings.TrimSpace(result.Error) == "" {
+			return fmt.Errorf("slack update failed: api returned ok=false")
+		}
+		return fmt.Errorf("slack update failed: %s", result.Error)
+	}
 	return nil
 }
 
-func (a *SlackAdapter) sendStreamingMessage(ctx context.Context, streamFn func(onChunk func(chunk string)) error) error {
+func (a *SlackAdapter) sendStreamingMessage(ctx context.Context, threadTS string, streamFn func(onChunk func(chunk string)) error) error {
 	streamInterval := time.Duration(a.config.StreamInterval) * time.Millisecond
 	if streamInterval <= 0 {
 		streamInterval = 500 * time.Millisecond
 	}
 
-	initialTs, err := a.sendMessageWithResult(ctx, "\u200B")
+	initialTs, err := a.sendMessageWithResult(ctx, "\u200B", threadTS)
 	if err != nil {
 		return err
 	}
 	if initialTs == "" {
-		return streamFn(func(chunk string) {})
+		return streamWithMessageFallback(streamFn, func(final string) error {
+			return a.sendMessage(ctx, final, threadTS)
+		})
 	}
 
 	var accumulated strings.Builder
@@ -352,7 +392,8 @@ func (a *SlackAdapter) pollOnceStream(ctx context.Context, handle StreamChunkHan
 	defer resp.Body.Close()
 
 	var payload struct {
-		OK       bool `json:"ok"`
+		OK       bool   `json:"ok"`
+		Error    string `json:"error"`
 		Messages []struct {
 			Text     string `json:"text"`
 			Ts       string `json:"ts"`
@@ -363,6 +404,12 @@ func (a *SlackAdapter) pollOnceStream(ctx context.Context, handle StreamChunkHan
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		return err
+	}
+	if !payload.OK {
+		if strings.TrimSpace(payload.Error) == "" {
+			return fmt.Errorf("slack history failed: api returned ok=false")
+		}
+		return fmt.Errorf("slack history failed: %s", payload.Error)
 	}
 
 	for i := len(payload.Messages) - 1; i >= 0; i-- {
@@ -375,6 +422,7 @@ func (a *SlackAdapter) pollOnceStream(ctx context.Context, handle StreamChunkHan
 		if strings.TrimSpace(msg.Text) == "" {
 			continue
 		}
+		channelType, isGroup := slackConversationMetadata(a.config.DefaultChannel)
 
 		meta := map[string]string{
 			"channel":      "slack",
@@ -384,10 +432,12 @@ func (a *SlackAdapter) pollOnceStream(ctx context.Context, handle StreamChunkHan
 			"message_id":   msg.Ts,
 			"sender":       msg.User,
 			"thread_id":    msg.ThreadTS,
+			"channel_type": channelType,
+			"is_group":     boolString(isGroup),
 		}
 
 		sessionID := ""
-		err := a.sendStreamingMessage(ctx, func(onChunk func(chunk string)) error {
+		err := a.sendStreamingMessage(ctx, msg.ThreadTS, func(onChunk func(chunk string)) error {
 			var err error
 			sessionID, err = handle(ctx, sessionID, msg.Text, meta, func(chunk string) error {
 				onChunk(chunk)
@@ -407,4 +457,23 @@ func (a *SlackAdapter) pollOnceStream(ctx context.Context, handle StreamChunkHan
 		})
 	}
 	return nil
+}
+
+func slackConversationMetadata(channelID string) (string, bool) {
+	channelID = strings.ToUpper(strings.TrimSpace(channelID))
+	switch {
+	case strings.HasPrefix(channelID, "D"):
+		return "dm", false
+	case channelID != "":
+		return "group", true
+	default:
+		return "", false
+	}
+}
+
+func boolString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
 }

--- a/pkg/input/channels/slack.go
+++ b/pkg/input/channels/slack.go
@@ -1,0 +1,403 @@
+package channels
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+type SlackAdapter struct {
+	base        BaseAdapter
+	config      config.SlackChannelConfig
+	client      *http.Client
+	appendEvent func(eventType string, sessionID string, payload map[string]any)
+	latestTS    string
+}
+
+func NewSlackAdapter(cfg config.SlackChannelConfig, appendEvent func(eventType string, sessionID string, payload map[string]any)) *SlackAdapter {
+	return &SlackAdapter{
+		base:        NewBaseAdapter("slack", cfg.Enabled && cfg.BotToken != ""),
+		config:      cfg,
+		client:      &http.Client{Timeout: 20 * time.Second},
+		appendEvent: appendEvent,
+	}
+}
+
+func (a *SlackAdapter) Name() string {
+	return "slack"
+}
+
+func (a *SlackAdapter) Enabled() bool {
+	return a.config.Enabled && strings.TrimSpace(a.config.BotToken) != "" && strings.TrimSpace(a.config.DefaultChannel) != ""
+}
+
+func (a *SlackAdapter) Status() Status {
+	status := a.base.Status()
+	status.Enabled = a.Enabled()
+	return status
+}
+
+func (a *SlackAdapter) Run(ctx context.Context, handle InboundHandler) error {
+	a.base.SetRunning(true)
+	defer a.base.SetRunning(false)
+	interval := time.Duration(a.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := a.pollOnce(ctx, handle); err != nil {
+			a.base.SetError(err)
+			a.append("channel.slack.error", "", map[string]any{"error": err.Error()})
+		} else {
+			a.base.SetError(nil)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *SlackAdapter) pollOnce(ctx context.Context, handle InboundHandler) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://slack.com/api/conversations.history?channel="+a.config.DefaultChannel+"&limit=10", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.config.BotToken)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var payload struct {
+		OK       bool `json:"ok"`
+		Messages []struct {
+			Text     string `json:"text"`
+			Ts       string `json:"ts"`
+			ThreadTS string `json:"thread_ts"`
+			User     string `json:"user"`
+			BotID    string `json:"bot_id"`
+			Files    []struct {
+				Mimetype string `json:"mimetype"`
+				URL      string `json:"url_private"`
+				Title    string `json:"title"`
+			} `json:"files"`
+		} `json:"messages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return err
+	}
+
+	for i := len(payload.Messages) - 1; i >= 0; i-- {
+		msg := payload.Messages[i]
+		if msg.Ts == "" || msg.Ts == a.latestTS || msg.BotID != "" {
+			continue
+		}
+		a.latestTS = msg.Ts
+
+		meta := map[string]string{
+			"channel":      "slack",
+			"channel_id":   a.config.DefaultChannel,
+			"user_id":      msg.User,
+			"reply_target": a.config.DefaultChannel,
+			"message_id":   msg.Ts,
+			"sender":       msg.User,
+			"thread_id":    msg.ThreadTS,
+		}
+
+		audioURL, audioMIME := a.findAudioFile(msg.Files)
+		if audioURL != "" {
+			meta["message_type"] = "voice_note"
+			meta["audio_url"] = audioURL
+			meta["audio_mime"] = audioMIME
+			if strings.TrimSpace(msg.Text) != "" {
+				meta["caption"] = strings.TrimSpace(msg.Text)
+			}
+
+			sessionID, response, err := handle(ctx, "", audioURL, meta)
+			if err != nil {
+				return err
+			}
+			if err := a.sendMessage(ctx, response, msg.ThreadTS); err != nil {
+				return err
+			}
+			a.base.MarkActivity()
+			a.append("channel.slack.voice", sessionID, map[string]any{
+				"channel":      a.config.DefaultChannel,
+				"user":         msg.User,
+				"message_type": "voice_note",
+				"audio_url":    audioURL,
+				"audio_mime":   audioMIME,
+			})
+			continue
+		}
+
+		if strings.TrimSpace(msg.Text) == "" {
+			continue
+		}
+
+		sessionID, response, err := handle(ctx, "", msg.Text, meta)
+		if err != nil {
+			return err
+		}
+		if err := a.sendMessage(ctx, response, msg.ThreadTS); err != nil {
+			return err
+		}
+		a.base.MarkActivity()
+		a.append("channel.slack.message", sessionID, map[string]any{
+			"channel": a.config.DefaultChannel,
+			"user":    msg.User,
+			"text":    msg.Text,
+		})
+	}
+	return nil
+}
+
+func (a *SlackAdapter) sendMessage(ctx context.Context, text string, threadTS string) error {
+	bodyMap := map[string]any{"channel": a.config.DefaultChannel, "text": text}
+	if strings.TrimSpace(threadTS) != "" {
+		bodyMap["thread_ts"] = threadTS
+	}
+	body, _ := json.Marshal(bodyMap)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://slack.com/api/chat.postMessage", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("slack send failed: %s", resp.Status)
+	}
+	return nil
+}
+
+func (a *SlackAdapter) append(eventType string, sessionID string, payload map[string]any) {
+	if a.appendEvent != nil {
+		a.appendEvent(eventType, sessionID, payload)
+	}
+}
+
+func (a *SlackAdapter) findAudioFile(files []struct {
+	Mimetype string `json:"mimetype"`
+	URL      string `json:"url_private"`
+	Title    string `json:"title"`
+}) (string, string) {
+	for _, f := range files {
+		mime := strings.ToLower(f.Mimetype)
+		if strings.HasPrefix(mime, "audio/") {
+			return f.URL, f.Mimetype
+		}
+	}
+	return "", ""
+}
+
+func (a *SlackAdapter) sendMessageWithResult(ctx context.Context, text string) (string, error) {
+	body, _ := json.Marshal(map[string]any{"channel": a.config.DefaultChannel, "text": text})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://slack.com/api/chat.postMessage", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("slack send failed: %s", resp.Status)
+	}
+
+	var result struct {
+		OK bool   `json:"ok"`
+		Ts string `json:"ts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	if !result.OK || result.Ts == "" {
+		return "", nil
+	}
+	return result.Ts, nil
+}
+
+func (a *SlackAdapter) editMessage(ctx context.Context, ts string, text string) error {
+	if ts == "" {
+		return nil
+	}
+	body, _ := json.Marshal(map[string]any{"channel": a.config.DefaultChannel, "ts": ts, "text": text})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://slack.com/api/chat.update", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func (a *SlackAdapter) sendStreamingMessage(ctx context.Context, streamFn func(onChunk func(chunk string)) error) error {
+	streamInterval := time.Duration(a.config.StreamInterval) * time.Millisecond
+	if streamInterval <= 0 {
+		streamInterval = 500 * time.Millisecond
+	}
+
+	initialTs, err := a.sendMessageWithResult(ctx, "\u200B")
+	if err != nil {
+		return err
+	}
+	if initialTs == "" {
+		return streamFn(func(chunk string) {})
+	}
+
+	var accumulated strings.Builder
+	var mu sync.Mutex
+	lastEdit := time.Now()
+
+	onChunk := func(chunk string) {
+		mu.Lock()
+		accumulated.WriteString(chunk)
+		shouldEdit := time.Since(lastEdit) >= streamInterval
+		if shouldEdit {
+			lastEdit = time.Now()
+		}
+		mu.Unlock()
+
+		if shouldEdit {
+			mu.Lock()
+			text := accumulated.String()
+			mu.Unlock()
+			a.editMessage(ctx, initialTs, text)
+		}
+	}
+
+	if err := streamFn(onChunk); err != nil {
+		mu.Lock()
+		final := accumulated.String()
+		mu.Unlock()
+		a.editMessage(ctx, initialTs, final+"\n\n[Error: "+err.Error()+"]")
+		return err
+	}
+
+	mu.Lock()
+	final := accumulated.String()
+	mu.Unlock()
+	a.editMessage(ctx, initialTs, final)
+	return nil
+}
+
+func (a *SlackAdapter) RunStream(ctx context.Context, handle StreamChunkHandler) error {
+	a.base.SetRunning(true)
+	defer a.base.SetRunning(false)
+	interval := time.Duration(a.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := a.pollOnceStream(ctx, handle); err != nil {
+			a.base.SetError(err)
+			a.append("channel.slack.error", "", map[string]any{"error": err.Error()})
+		} else {
+			a.base.SetError(nil)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *SlackAdapter) pollOnceStream(ctx context.Context, handle StreamChunkHandler) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://slack.com/api/conversations.history?channel="+a.config.DefaultChannel+"&limit=10", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.config.BotToken)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var payload struct {
+		OK       bool `json:"ok"`
+		Messages []struct {
+			Text     string `json:"text"`
+			Ts       string `json:"ts"`
+			ThreadTS string `json:"thread_ts"`
+			User     string `json:"user"`
+			BotID    string `json:"bot_id"`
+		} `json:"messages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return err
+	}
+
+	for i := len(payload.Messages) - 1; i >= 0; i-- {
+		msg := payload.Messages[i]
+		if msg.Ts == "" || msg.Ts == a.latestTS || msg.BotID != "" {
+			continue
+		}
+		a.latestTS = msg.Ts
+
+		if strings.TrimSpace(msg.Text) == "" {
+			continue
+		}
+
+		meta := map[string]string{
+			"channel":      "slack",
+			"channel_id":   a.config.DefaultChannel,
+			"user_id":      msg.User,
+			"reply_target": a.config.DefaultChannel,
+			"message_id":   msg.Ts,
+			"sender":       msg.User,
+			"thread_id":    msg.ThreadTS,
+		}
+
+		sessionID := ""
+		err := a.sendStreamingMessage(ctx, func(onChunk func(chunk string)) error {
+			var err error
+			sessionID, err = handle(ctx, sessionID, msg.Text, meta, func(chunk string) error {
+				onChunk(chunk)
+				return nil
+			})
+			return err
+		})
+		if err != nil {
+			return err
+		}
+		a.base.MarkActivity()
+		a.append("channel.slack.message", sessionID, map[string]any{
+			"channel":   a.config.DefaultChannel,
+			"user":      msg.User,
+			"text":      msg.Text,
+			"streaming": true,
+		})
+	}
+	return nil
+}

--- a/pkg/input/channels/slack.go
+++ b/pkg/input/channels/slack.go
@@ -82,7 +82,8 @@ func (a *SlackAdapter) pollOnce(ctx context.Context, handle InboundHandler) erro
 	defer resp.Body.Close()
 
 	var payload struct {
-		OK       bool `json:"ok"`
+		OK       bool   `json:"ok"`
+		Error    string `json:"error"`
 		Messages []struct {
 			Text     string `json:"text"`
 			Ts       string `json:"ts"`
@@ -98,6 +99,12 @@ func (a *SlackAdapter) pollOnce(ctx context.Context, handle InboundHandler) erro
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		return err
+	}
+	if !payload.OK {
+		if strings.TrimSpace(payload.Error) == "" {
+			return fmt.Errorf("slack history failed: api returned ok=false")
+		}
+		return fmt.Errorf("slack history failed: %s", payload.Error)
 	}
 
 	for i := len(payload.Messages) - 1; i >= 0; i-- {

--- a/pkg/input/channels/telegram.go
+++ b/pkg/input/channels/telegram.go
@@ -38,7 +38,7 @@ func (a *TelegramAdapter) Name() string {
 }
 
 func (a *TelegramAdapter) Enabled() bool {
-	return a.config.Enabled && a.config.BotToken != "" && (strings.TrimSpace(a.config.ChatID) != "" || true)
+	return a.config.Enabled && strings.TrimSpace(a.config.BotToken) != ""
 }
 
 func (a *TelegramAdapter) Status() Status {
@@ -86,14 +86,16 @@ func (a *TelegramAdapter) pollOnce(ctx context.Context, runMessage InboundHandle
 	defer resp.Body.Close()
 
 	var payload struct {
-		OK     bool `json:"ok"`
-		Result []struct {
+		OK          bool   `json:"ok"`
+		Description string `json:"description"`
+		Result      []struct {
 			UpdateID int64 `json:"update_id"`
 			Message  struct {
 				Text    string `json:"text"`
 				Caption string `json:"caption"`
 				Chat    struct {
-					ID int64 `json:"id"`
+					ID   int64  `json:"id"`
+					Type string `json:"type"`
 				} `json:"chat"`
 				From struct {
 					Username string `json:"username"`
@@ -124,6 +126,12 @@ func (a *TelegramAdapter) pollOnce(ctx context.Context, runMessage InboundHandle
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		return err
 	}
+	if !payload.OK {
+		if strings.TrimSpace(payload.Description) == "" {
+			return fmt.Errorf("telegram getUpdates failed: api returned ok=false")
+		}
+		return fmt.Errorf("telegram getUpdates failed: %s", payload.Description)
+	}
 
 	for _, update := range payload.Result {
 		a.offset = update.UpdateID + 1
@@ -135,11 +143,17 @@ func (a *TelegramAdapter) pollOnce(ctx context.Context, runMessage InboundHandle
 		text := strings.TrimSpace(update.Message.Text)
 		caption := strings.TrimSpace(update.Message.Caption)
 		username := update.Message.From.Username
+		userID := strconv.FormatInt(update.Message.From.ID, 10)
 		messageID := strconv.FormatInt(update.UpdateID, 10)
+		channelType, isGroup := telegramConversationMetadata(update.Message.Chat.Type, update.Message.Chat.ID, update.Message.From.ID)
 
 		meta := map[string]string{
 			"channel":      "telegram",
 			"chat_id":      chatID,
+			"chat_type":    update.Message.Chat.Type,
+			"channel_type": channelType,
+			"is_group":     boolString(isGroup),
+			"user_id":      userID,
 			"username":     username,
 			"reply_target": chatID,
 			"message_id":   messageID,
@@ -240,8 +254,9 @@ func (a *TelegramAdapter) getFileURL(ctx context.Context, fileID string) (string
 	defer resp.Body.Close()
 
 	var result struct {
-		OK     bool `json:"ok"`
-		Result struct {
+		OK          bool   `json:"ok"`
+		Description string `json:"description"`
+		Result      struct {
 			FileID   string `json:"file_id"`
 			FileSize int    `json:"file_size"`
 			FilePath string `json:"file_path"`
@@ -251,6 +266,9 @@ func (a *TelegramAdapter) getFileURL(ctx context.Context, fileID string) (string
 		return "", err
 	}
 	if !result.OK || result.Result.FilePath == "" {
+		if strings.TrimSpace(result.Description) != "" {
+			return "", fmt.Errorf("telegram: %s", result.Description)
+		}
 		return "", fmt.Errorf("telegram: failed to get file URL for %s", fileID)
 	}
 
@@ -280,6 +298,20 @@ func (a *TelegramAdapter) sendMessage(ctx context.Context, chatID string, text s
 	if resp.StatusCode >= 300 {
 		return fmt.Errorf("telegram send failed: %s", resp.Status)
 	}
+
+	var result struct {
+		OK          bool   `json:"ok"`
+		Description string `json:"description"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+	if !result.OK {
+		if strings.TrimSpace(result.Description) == "" {
+			return fmt.Errorf("telegram send failed: api returned ok=false")
+		}
+		return fmt.Errorf("telegram send failed: %s", result.Description)
+	}
 	return nil
 }
 
@@ -294,7 +326,9 @@ func (a *TelegramAdapter) sendStreamingMessage(ctx context.Context, chatID strin
 		return err
 	}
 	if initialMsgID == "" {
-		return streamFn(func(chunk string) {})
+		return streamWithMessageFallback(streamFn, func(final string) error {
+			return a.sendMessage(ctx, chatID, final)
+		})
 	}
 
 	var accumulated strings.Builder
@@ -352,8 +386,9 @@ func (a *TelegramAdapter) sendMessageWithResult(ctx context.Context, chatID stri
 	}
 
 	var result struct {
-		OK     bool `json:"ok"`
-		Result struct {
+		OK          bool   `json:"ok"`
+		Description string `json:"description"`
+		Result      struct {
 			MessageID int `json:"message_id"`
 		} `json:"result"`
 	}
@@ -361,7 +396,10 @@ func (a *TelegramAdapter) sendMessageWithResult(ctx context.Context, chatID stri
 		return "", err
 	}
 	if !result.OK {
-		return "", nil
+		if strings.TrimSpace(result.Description) == "" {
+			return "", fmt.Errorf("telegram send failed: api returned ok=false")
+		}
+		return "", fmt.Errorf("telegram send failed: %s", result.Description)
 	}
 	return strconv.Itoa(result.Result.MessageID), nil
 }
@@ -388,6 +426,19 @@ func (a *TelegramAdapter) editMessage(ctx context.Context, chatID string, messag
 		return nil
 	}
 	defer resp.Body.Close()
+	var result struct {
+		OK          bool   `json:"ok"`
+		Description string `json:"description"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+	if !result.OK {
+		if strings.TrimSpace(result.Description) == "" {
+			return fmt.Errorf("telegram edit failed: api returned ok=false")
+		}
+		return fmt.Errorf("telegram edit failed: %s", result.Description)
+	}
 	return nil
 }
 
@@ -430,13 +481,15 @@ func (a *TelegramAdapter) pollOnceStream(ctx context.Context, handle StreamChunk
 	defer resp.Body.Close()
 
 	var payload struct {
-		OK     bool `json:"ok"`
-		Result []struct {
+		OK          bool   `json:"ok"`
+		Description string `json:"description"`
+		Result      []struct {
 			UpdateID int64 `json:"update_id"`
 			Message  struct {
 				Text string `json:"text"`
 				Chat struct {
-					ID int64 `json:"id"`
+					ID   int64  `json:"id"`
+					Type string `json:"type"`
 				} `json:"chat"`
 				From struct {
 					Username string `json:"username"`
@@ -447,6 +500,12 @@ func (a *TelegramAdapter) pollOnceStream(ctx context.Context, handle StreamChunk
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		return err
+	}
+	if !payload.OK {
+		if strings.TrimSpace(payload.Description) == "" {
+			return fmt.Errorf("telegram getUpdates failed: api returned ok=false")
+		}
+		return fmt.Errorf("telegram getUpdates failed: %s", payload.Description)
 	}
 
 	for _, update := range payload.Result {
@@ -462,11 +521,17 @@ func (a *TelegramAdapter) pollOnceStream(ctx context.Context, handle StreamChunk
 		}
 
 		username := update.Message.From.Username
+		userID := strconv.FormatInt(update.Message.From.ID, 10)
 		messageID := strconv.FormatInt(update.UpdateID, 10)
+		channelType, isGroup := telegramConversationMetadata(update.Message.Chat.Type, update.Message.Chat.ID, update.Message.From.ID)
 
 		meta := map[string]string{
 			"channel":      "telegram",
 			"chat_id":      chatID,
+			"chat_type":    update.Message.Chat.Type,
+			"channel_type": channelType,
+			"is_group":     boolString(isGroup),
+			"user_id":      userID,
 			"username":     username,
 			"reply_target": chatID,
 			"message_id":   messageID,
@@ -496,4 +561,21 @@ func (a *TelegramAdapter) pollOnceStream(ctx context.Context, handle StreamChunk
 		})
 	}
 	return nil
+}
+
+func telegramConversationMetadata(chatType string, chatID int64, userID int64) (string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(chatType))
+	switch normalized {
+	case "private":
+		return "private", false
+	case "group", "supergroup", "channel":
+		return normalized, true
+	}
+	if chatID < 0 {
+		return "group", true
+	}
+	if userID != 0 && chatID == userID {
+		return "private", false
+	}
+	return "", false
 }

--- a/pkg/input/channels/telegram.go
+++ b/pkg/input/channels/telegram.go
@@ -1,0 +1,499 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+type TelegramAdapter struct {
+	base        BaseAdapter
+	config      config.TelegramChannelConfig
+	baseURL     string
+	client      *http.Client
+	offset      int64
+	appendEvent func(eventType string, sessionID string, payload map[string]any)
+}
+
+func NewTelegramAdapter(cfg config.TelegramChannelConfig, appendEvent func(eventType string, sessionID string, payload map[string]any)) *TelegramAdapter {
+	return &TelegramAdapter{
+		base:        NewBaseAdapter("telegram", cfg.Enabled && cfg.BotToken != ""),
+		config:      cfg,
+		baseURL:     "https://api.telegram.org/bot" + cfg.BotToken,
+		client:      &http.Client{Timeout: 20 * time.Second},
+		appendEvent: appendEvent,
+	}
+}
+
+func (a *TelegramAdapter) Name() string {
+	return "telegram"
+}
+
+func (a *TelegramAdapter) Enabled() bool {
+	return a.config.Enabled && a.config.BotToken != "" && (strings.TrimSpace(a.config.ChatID) != "" || true)
+}
+
+func (a *TelegramAdapter) Status() Status {
+	status := a.base.Status()
+	status.Enabled = a.Enabled()
+	return status
+}
+
+func (a *TelegramAdapter) Run(ctx context.Context, runMessage InboundHandler) error {
+	a.base.SetRunning(true)
+	defer a.base.SetRunning(false)
+	interval := time.Duration(a.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := a.pollOnce(ctx, runMessage); err != nil {
+			a.base.SetError(err)
+			a.append("channel.telegram.error", "", map[string]any{"error": err.Error()})
+		} else {
+			a.base.SetError(nil)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *TelegramAdapter) pollOnce(ctx context.Context, runMessage InboundHandler) error {
+	u := fmt.Sprintf("%s/getUpdates?timeout=1&offset=%d", a.baseURL, a.offset)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var payload struct {
+		OK     bool `json:"ok"`
+		Result []struct {
+			UpdateID int64 `json:"update_id"`
+			Message  struct {
+				Text    string `json:"text"`
+				Caption string `json:"caption"`
+				Chat    struct {
+					ID int64 `json:"id"`
+				} `json:"chat"`
+				From struct {
+					Username string `json:"username"`
+					ID       int64  `json:"id"`
+				} `json:"from"`
+				Voice *struct {
+					FileID   string `json:"file_id"`
+					Duration int    `json:"duration"`
+					MimeType string `json:"mime_type"`
+					FileSize int    `json:"file_size"`
+				} `json:"voice"`
+				Audio *struct {
+					FileID   string `json:"file_id"`
+					Duration int    `json:"duration"`
+					MimeType string `json:"mime_type"`
+					FileSize int    `json:"file_size"`
+					FileName string `json:"file_name"`
+				} `json:"audio"`
+				Document *struct {
+					FileID   string `json:"file_id"`
+					MimeType string `json:"mime_type"`
+					FileSize int    `json:"file_size"`
+					FileName string `json:"file_name"`
+				} `json:"document"`
+			} `json:"message"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return err
+	}
+
+	for _, update := range payload.Result {
+		a.offset = update.UpdateID + 1
+		chatID := strconv.FormatInt(update.Message.Chat.ID, 10)
+		if strings.TrimSpace(a.config.ChatID) != "" && chatID != strings.TrimSpace(a.config.ChatID) {
+			continue
+		}
+
+		text := strings.TrimSpace(update.Message.Text)
+		caption := strings.TrimSpace(update.Message.Caption)
+		username := update.Message.From.Username
+		messageID := strconv.FormatInt(update.UpdateID, 10)
+
+		meta := map[string]string{
+			"channel":      "telegram",
+			"chat_id":      chatID,
+			"username":     username,
+			"reply_target": chatID,
+			"message_id":   messageID,
+			"sender":       username,
+		}
+
+		var messageType string
+		var audioURL string
+		var audioMIME string
+
+		if update.Message.Voice != nil {
+			messageType = "voice_note"
+			audioMIME = update.Message.Voice.MimeType
+			if audioMIME == "" {
+				audioMIME = "audio/ogg"
+			}
+			fileURL, err := a.getFileURL(ctx, update.Message.Voice.FileID)
+			if err != nil {
+				a.append("channel.telegram.error", "", map[string]any{"error": err.Error(), "type": "voice_download_failed"})
+				continue
+			}
+			audioURL = fileURL
+		} else if update.Message.Audio != nil {
+			messageType = "audio_file"
+			audioMIME = update.Message.Audio.MimeType
+			fileURL, err := a.getFileURL(ctx, update.Message.Audio.FileID)
+			if err != nil {
+				a.append("channel.telegram.error", "", map[string]any{"error": err.Error(), "type": "audio_download_failed"})
+				continue
+			}
+			audioURL = fileURL
+		} else if update.Message.Document != nil && strings.HasPrefix(update.Message.Document.MimeType, "audio/") {
+			messageType = "audio_file"
+			audioMIME = update.Message.Document.MimeType
+			fileURL, err := a.getFileURL(ctx, update.Message.Document.FileID)
+			if err != nil {
+				a.append("channel.telegram.error", "", map[string]any{"error": err.Error(), "type": "document_audio_download_failed"})
+				continue
+			}
+			audioURL = fileURL
+		}
+
+		if messageType != "" {
+			meta["message_type"] = messageType
+			meta["audio_url"] = audioURL
+			meta["audio_mime"] = audioMIME
+			if caption != "" {
+				meta["caption"] = caption
+			}
+
+			sessionID, response, err := runMessage(ctx, "", audioURL, meta)
+			if err != nil {
+				return err
+			}
+			if err := a.sendMessage(ctx, chatID, response); err != nil {
+				return err
+			}
+			a.base.MarkActivity()
+			a.append("channel.telegram.voice", sessionID, map[string]any{
+				"chat_id":      chatID,
+				"message_type": messageType,
+				"audio_url":    audioURL,
+				"audio_mime":   audioMIME,
+			})
+			continue
+		}
+
+		if text == "" {
+			continue
+		}
+
+		sessionID, response, err := runMessage(ctx, "", text, meta)
+		if err != nil {
+			return err
+		}
+		if err := a.sendMessage(ctx, chatID, response); err != nil {
+			return err
+		}
+		a.base.MarkActivity()
+		a.append("channel.telegram.message", sessionID, map[string]any{
+			"chat_id": chatID,
+			"text":    text,
+		})
+	}
+	return nil
+}
+
+func (a *TelegramAdapter) getFileURL(ctx context.Context, fileID string) (string, error) {
+	u := fmt.Sprintf("%s/getFile?file_id=%s", a.baseURL, url.QueryEscape(fileID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		OK     bool `json:"ok"`
+		Result struct {
+			FileID   string `json:"file_id"`
+			FileSize int    `json:"file_size"`
+			FilePath string `json:"file_path"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	if !result.OK || result.Result.FilePath == "" {
+		return "", fmt.Errorf("telegram: failed to get file URL for %s", fileID)
+	}
+
+	return fmt.Sprintf("https://api.telegram.org/file/bot%s/%s", a.config.BotToken, result.Result.FilePath), nil
+}
+
+func (a *TelegramAdapter) append(eventType string, sessionID string, payload map[string]any) {
+	if a.appendEvent != nil {
+		a.appendEvent(eventType, sessionID, payload)
+	}
+}
+
+func (a *TelegramAdapter) sendMessage(ctx context.Context, chatID string, text string) error {
+	values := url.Values{}
+	values.Set("chat_id", chatID)
+	values.Set("text", text)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+"/sendMessage", strings.NewReader(values.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("telegram send failed: %s", resp.Status)
+	}
+	return nil
+}
+
+func (a *TelegramAdapter) sendStreamingMessage(ctx context.Context, chatID string, streamFn func(onChunk func(chunk string)) error) error {
+	streamInterval := time.Duration(a.config.StreamInterval) * time.Millisecond
+	if streamInterval <= 0 {
+		streamInterval = 500 * time.Millisecond
+	}
+
+	initialMsgID, err := a.sendMessageWithResult(ctx, chatID, "\u200B")
+	if err != nil {
+		return err
+	}
+	if initialMsgID == "" {
+		return streamFn(func(chunk string) {})
+	}
+
+	var accumulated strings.Builder
+	var mu sync.Mutex
+	lastEdit := time.Now()
+
+	onChunk := func(chunk string) {
+		mu.Lock()
+		accumulated.WriteString(chunk)
+		shouldEdit := time.Since(lastEdit) >= streamInterval
+		if shouldEdit {
+			lastEdit = time.Now()
+		}
+		mu.Unlock()
+
+		if shouldEdit {
+			mu.Lock()
+			text := accumulated.String()
+			mu.Unlock()
+			a.editMessage(ctx, chatID, initialMsgID, text)
+		}
+	}
+
+	if err := streamFn(onChunk); err != nil {
+		mu.Lock()
+		final := accumulated.String()
+		mu.Unlock()
+		a.editMessage(ctx, chatID, initialMsgID, final+"\n\n[Error: "+err.Error()+"]")
+		return err
+	}
+
+	mu.Lock()
+	final := accumulated.String()
+	mu.Unlock()
+	a.editMessage(ctx, chatID, initialMsgID, final)
+	return nil
+}
+
+func (a *TelegramAdapter) sendMessageWithResult(ctx context.Context, chatID string, text string) (string, error) {
+	values := url.Values{}
+	values.Set("chat_id", chatID)
+	values.Set("text", text)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+"/sendMessage", strings.NewReader(values.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("telegram send failed: %s", resp.Status)
+	}
+
+	var result struct {
+		OK     bool `json:"ok"`
+		Result struct {
+			MessageID int `json:"message_id"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	if !result.OK {
+		return "", nil
+	}
+	return strconv.Itoa(result.Result.MessageID), nil
+}
+
+func (a *TelegramAdapter) editMessage(ctx context.Context, chatID string, messageID string, text string) error {
+	if messageID == "" {
+		return nil
+	}
+	values := url.Values{}
+	values.Set("chat_id", chatID)
+	values.Set("message_id", messageID)
+	truncated := text
+	if len([]rune(truncated)) > 4096 {
+		truncated = string([]rune(truncated)[:4093]) + "..."
+	}
+	values.Set("text", truncated)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+"/editMessageText", strings.NewReader(values.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func (a *TelegramAdapter) RunStream(ctx context.Context, handle StreamChunkHandler) error {
+	a.base.SetRunning(true)
+	defer a.base.SetRunning(false)
+	interval := time.Duration(a.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := a.pollOnceStream(ctx, handle); err != nil {
+			a.base.SetError(err)
+			a.append("channel.telegram.error", "", map[string]any{"error": err.Error()})
+		} else {
+			a.base.SetError(nil)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *TelegramAdapter) pollOnceStream(ctx context.Context, handle StreamChunkHandler) error {
+	u := fmt.Sprintf("%s/getUpdates?timeout=1&offset=%d", a.baseURL, a.offset)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var payload struct {
+		OK     bool `json:"ok"`
+		Result []struct {
+			UpdateID int64 `json:"update_id"`
+			Message  struct {
+				Text string `json:"text"`
+				Chat struct {
+					ID int64 `json:"id"`
+				} `json:"chat"`
+				From struct {
+					Username string `json:"username"`
+					ID       int64  `json:"id"`
+				} `json:"from"`
+			} `json:"message"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return err
+	}
+
+	for _, update := range payload.Result {
+		a.offset = update.UpdateID + 1
+		chatID := strconv.FormatInt(update.Message.Chat.ID, 10)
+		if strings.TrimSpace(a.config.ChatID) != "" && chatID != strings.TrimSpace(a.config.ChatID) {
+			continue
+		}
+
+		text := strings.TrimSpace(update.Message.Text)
+		if text == "" {
+			continue
+		}
+
+		username := update.Message.From.Username
+		messageID := strconv.FormatInt(update.UpdateID, 10)
+
+		meta := map[string]string{
+			"channel":      "telegram",
+			"chat_id":      chatID,
+			"username":     username,
+			"reply_target": chatID,
+			"message_id":   messageID,
+			"sender":       username,
+		}
+
+		sessionID := ""
+		var responseText string
+		err := a.sendStreamingMessage(ctx, chatID, func(onChunk func(chunk string)) error {
+			var err error
+			sessionID, err = handle(ctx, sessionID, text, meta, func(chunk string) error {
+				onChunk(chunk)
+				responseText += chunk
+				return nil
+			})
+			return err
+		})
+		if err != nil {
+			return err
+		}
+		_ = responseText
+		a.base.MarkActivity()
+		a.append("channel.telegram.message", sessionID, map[string]any{
+			"chat_id":   chatID,
+			"text":      text,
+			"streaming": true,
+		})
+	}
+	return nil
+}

--- a/pkg/input/channels/whatsapp.go
+++ b/pkg/input/channels/whatsapp.go
@@ -1,0 +1,162 @@
+package channels
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+type WhatsAppAdapter struct {
+	base        BaseAdapter
+	config      config.WhatsAppChannelConfig
+	client      *http.Client
+	appendEvent func(eventType string, sessionID string, payload map[string]any)
+	processed   map[string]time.Time
+	mu          sync.Mutex
+}
+
+func NewWhatsAppAdapter(cfg config.WhatsAppChannelConfig, appendEvent func(eventType string, sessionID string, payload map[string]any)) *WhatsAppAdapter {
+	return &WhatsAppAdapter{
+		base:        NewBaseAdapter("whatsapp", cfg.Enabled && cfg.AccessToken != "" && cfg.PhoneNumberID != ""),
+		config:      cfg,
+		client:      &http.Client{Timeout: 20 * time.Second},
+		appendEvent: appendEvent,
+		processed:   make(map[string]time.Time),
+	}
+}
+
+func (a *WhatsAppAdapter) Name() string { return "whatsapp" }
+
+func (a *WhatsAppAdapter) Enabled() bool {
+	return a.config.Enabled && strings.TrimSpace(a.config.AccessToken) != "" && strings.TrimSpace(a.config.PhoneNumberID) != ""
+}
+
+func (a *WhatsAppAdapter) Status() Status {
+	status := a.base.Status()
+	status.Enabled = a.Enabled()
+	return status
+}
+
+func (a *WhatsAppAdapter) Run(ctx context.Context, handle InboundHandler) error {
+	a.base.SetRunning(true)
+	defer a.base.SetRunning(false)
+	<-ctx.Done()
+	return nil
+}
+
+func (a *WhatsAppAdapter) HandleInbound(ctx context.Context, source string, text string, messageID string, profileName string, handle InboundHandler) (string, string, error) {
+	return a.HandleInboundWithMeta(ctx, source, text, messageID, profileName, nil, handle)
+}
+
+func (a *WhatsAppAdapter) HandleInboundWithMeta(ctx context.Context, source string, text string, messageID string, profileName string, meta map[string]string, handle InboundHandler) (string, string, error) {
+	if a.seen(messageID) {
+		return "", "", nil
+	}
+
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	meta["channel"] = "whatsapp"
+	meta["user_id"] = source
+	meta["username"] = profileName
+	meta["reply_target"] = source
+	meta["message_id"] = messageID
+	meta["sender"] = profileName
+
+	sessionID, response, err := handle(ctx, "", text, meta)
+	if err != nil {
+		return "", "", err
+	}
+	if err := a.sendMessage(ctx, source, response); err != nil {
+		return "", "", err
+	}
+	a.base.MarkActivity()
+	a.append("channel.whatsapp.message", sessionID, map[string]any{
+		"source": source,
+		"text":   text,
+	})
+	return sessionID, response, nil
+}
+
+func (a *WhatsAppAdapter) HandleStatus(sessionID string, status string, messageID string, recipient string) {
+	a.append("channel.whatsapp.status", sessionID, map[string]any{
+		"status":     status,
+		"message_id": messageID,
+		"recipient":  recipient,
+	})
+}
+
+func (a *WhatsAppAdapter) sendMessage(ctx context.Context, to string, text string) error {
+	to = strings.TrimSpace(to)
+	if to == "" {
+		to = strings.TrimSpace(a.config.DefaultRecipient)
+	}
+	if to == "" {
+		return nil
+	}
+	version := strings.TrimSpace(a.config.APIVersion)
+	if version == "" {
+		version = "v20.0"
+	}
+	url := fmt.Sprintf("https://graph.facebook.com/%s/%s/messages", version, a.config.PhoneNumberID)
+	body, _ := json.Marshal(map[string]any{
+		"messaging_product": "whatsapp",
+		"to":                to,
+		"type":              "text",
+		"text": map[string]any{
+			"body": text,
+		},
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.config.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("whatsapp send failed: %s", resp.Status)
+	}
+	var payload map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&payload)
+	if payload != nil {
+		a.append("channel.whatsapp.outbound", "", payload)
+	}
+	return nil
+}
+
+func (a *WhatsAppAdapter) append(eventType string, sessionID string, payload map[string]any) {
+	if a.appendEvent != nil {
+		a.appendEvent(eventType, sessionID, payload)
+	}
+}
+
+func (a *WhatsAppAdapter) seen(id string) bool {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for key, ts := range a.processed {
+		if time.Since(ts) > 30*time.Minute {
+			delete(a.processed, key)
+		}
+	}
+	if _, ok := a.processed[id]; ok {
+		return true
+	}
+	a.processed[id] = time.Now().UTC()
+	return false
+}

--- a/pkg/input/cli/consoleio/reader.go
+++ b/pkg/input/cli/consoleio/reader.go
@@ -1,0 +1,40 @@
+package consoleio
+
+import (
+	"bufio"
+	"io"
+	"os"
+)
+
+type Reader struct {
+	fallback *bufio.Reader
+	console  lineReader
+}
+
+type lineReader interface {
+	ReadString(delim byte) (string, error)
+}
+
+func NewReader(input io.Reader) *Reader {
+	reader := &Reader{}
+	if file, ok := input.(*os.File); ok {
+		reader.console = newConsoleLineReader(file)
+	}
+	if reader.console == nil {
+		reader.fallback = bufio.NewReader(input)
+	}
+	return reader
+}
+
+func (r *Reader) ReadString(delim byte) (string, error) {
+	if r == nil {
+		return "", io.EOF
+	}
+	if r.console != nil {
+		return r.console.ReadString(delim)
+	}
+	if r.fallback == nil {
+		return "", io.EOF
+	}
+	return r.fallback.ReadString(delim)
+}

--- a/pkg/input/cli/consoleio/reader_other.go
+++ b/pkg/input/cli/consoleio/reader_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package consoleio
+
+import "os"
+
+func newConsoleLineReader(*os.File) lineReader {
+	return nil
+}

--- a/pkg/input/cli/consoleio/reader_test.go
+++ b/pkg/input/cli/consoleio/reader_test.go
@@ -1,0 +1,31 @@
+package consoleio
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+func TestReaderFallsBackForPipes(t *testing.T) {
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer stdinReader.Close()
+
+	if _, err := io.WriteString(stdinWriter, "hello\n"); err != nil {
+		t.Fatalf("io.WriteString: %v", err)
+	}
+	if err := stdinWriter.Close(); err != nil {
+		t.Fatalf("stdinWriter.Close: %v", err)
+	}
+
+	reader := NewReader(stdinReader)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("ReadString: %v", err)
+	}
+	if line != "hello\n" {
+		t.Fatalf("expected %q, got %q", "hello\n", line)
+	}
+}

--- a/pkg/input/cli/consoleio/reader_windows.go
+++ b/pkg/input/cli/consoleio/reader_windows.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+package consoleio
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode/utf16"
+
+	"golang.org/x/sys/windows"
+)
+
+type windowsConsoleLineReader struct {
+	handle  windows.Handle
+	pending string
+}
+
+func newConsoleLineReader(file *os.File) lineReader {
+	if file == nil {
+		return nil
+	}
+	handle := windows.Handle(file.Fd())
+	var mode uint32
+	if err := windows.GetConsoleMode(handle, &mode); err != nil {
+		return nil
+	}
+	return &windowsConsoleLineReader{handle: handle}
+}
+
+func (r *windowsConsoleLineReader) ReadString(delim byte) (string, error) {
+	if delim != '\n' {
+		return "", fmt.Errorf("console reader only supports newline delimiter")
+	}
+
+	text := r.pending
+	r.pending = ""
+	for {
+		if idx := strings.IndexByte(text, delim); idx >= 0 {
+			r.pending = text[idx+1:]
+			return text[:idx+1], nil
+		}
+
+		chunk, err := r.readChunk()
+		if chunk != "" {
+			text += chunk
+		}
+		if err != nil {
+			if text != "" {
+				return text, err
+			}
+			return "", err
+		}
+	}
+}
+
+func (r *windowsConsoleLineReader) readChunk() (string, error) {
+	buf := make([]uint16, 256)
+	var read uint32
+	if err := windows.ReadConsole(r.handle, &buf[0], uint32(len(buf)), &read, nil); err != nil {
+		return "", err
+	}
+	if read == 0 {
+		return "", io.EOF
+	}
+	return string(utf16.Decode(buf[:read])), nil
+}

--- a/pkg/input/cli/setup/doctor.go
+++ b/pkg/input/cli/setup/doctor.go
@@ -1,0 +1,821 @@
+package setup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+	"github.com/1024XEngineer/anyclaw/pkg/capability/skills"
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/plugin"
+	inputlayer "github.com/1024XEngineer/anyclaw/pkg/input"
+	"github.com/1024XEngineer/anyclaw/pkg/workspace"
+)
+
+type Severity string
+
+const (
+	SeverityInfo    Severity = "info"
+	SeverityWarning Severity = "warning"
+	SeverityError   Severity = "error"
+)
+
+type CheckResult struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Severity    Severity `json:"severity"`
+	Message     string   `json:"message"`
+	Detail      string   `json:"detail,omitempty"`
+	Hint        string   `json:"hint,omitempty"`
+	Fixable     bool     `json:"fixable"`
+	FixAction   string   `json:"fix_action,omitempty"`
+	FixPriority int      `json:"fix_priority,omitempty"`
+}
+
+type Report struct {
+	ConfigPath string        `json:"config_path"`
+	StartedAt  time.Time     `json:"started_at"`
+	FinishedAt time.Time     `json:"finished_at"`
+	Checks     []CheckResult `json:"checks"`
+}
+
+type DoctorOptions struct {
+	CheckConnectivity bool
+	CreateMissingDirs bool
+	AutoFix           bool
+}
+
+func (r *Report) Add(check CheckResult) {
+	if r == nil {
+		return
+	}
+	r.Checks = append(r.Checks, check)
+}
+
+func (r *Report) ErrorCount() int {
+	return countSeverity(r, SeverityError)
+}
+
+func (r *Report) WarningCount() int {
+	return countSeverity(r, SeverityWarning)
+}
+
+func (r *Report) HasErrors() bool {
+	return r != nil && r.ErrorCount() > 0
+}
+
+type FixResult struct {
+	CheckID  string `json:"check_id"`
+	Fixed    bool   `json:"fixed"`
+	Action   string `json:"action"`
+	Error    string `json:"error,omitempty"`
+	NewValue string `json:"new_value,omitempty"`
+}
+
+func (r *Report) FixableCount() int {
+	count := 0
+	for _, check := range r.Checks {
+		if check.Fixable && (check.Severity == SeverityError || check.Severity == SeverityWarning) {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *Report) FixableChecks() []CheckResult {
+	var fixes []CheckResult
+	for _, check := range r.Checks {
+		if check.Fixable && (check.Severity == SeverityError || check.Severity == SeverityWarning) {
+			fixes = append(fixes, check)
+		}
+	}
+	return fixes
+}
+
+func (r *Report) FixAll(configPath string) ([]FixResult, error) {
+	fixes := make([]FixResult, 0)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	for _, check := range r.FixableChecks() {
+		result := FixResult{CheckID: check.ID}
+
+		switch check.ID {
+		case "security-dm-allow-all-no-ack":
+			cfg.Security.RiskAcknowledged = true
+			result.Action = "set security.risk_acknowledged=true"
+			result.NewValue = "true"
+			result.Fixed = true
+
+		case "security-dm-policy-permissive":
+			cfg.Channels.Security.DMPolicy = "allow-list"
+			result.Action = "set channels.security.dm_policy=allow-list"
+			result.NewValue = "allow-list"
+			result.Fixed = true
+
+		case "security-mention-gate-disabled":
+			cfg.Channels.Security.MentionGate = true
+			result.Action = "set channels.security.mention_gate=true"
+			result.NewValue = "true"
+			result.Fixed = true
+
+		case "security-group-policy-permissive":
+			cfg.Channels.Security.GroupPolicy = "mention-only"
+			result.Action = "set channels.security.group_policy=mention-only"
+			result.NewValue = "mention-only"
+			result.Fixed = true
+
+		case "security-no-default-deny":
+			cfg.Channels.Security.DefaultDenyDM = true
+			result.Action = "set channels.security.default_deny_dm=true"
+			result.NewValue = "true"
+			result.Fixed = true
+
+		case "security-risk-not-acknowledged":
+			cfg.Security.RiskAcknowledged = true
+			result.Action = "set security.risk_acknowledged=true"
+			result.NewValue = "true"
+			result.Fixed = true
+
+		default:
+			result.Action = check.FixAction
+			result.Error = "manual fix required"
+		}
+		fixes = append(fixes, result)
+	}
+
+	if err := cfg.Save(configPath); err != nil {
+		return fixes, fmt.Errorf("failed to save config: %w", err)
+	}
+
+	return fixes, nil
+}
+
+func RunDoctor(ctx context.Context, configPath string, opts DoctorOptions) (*Report, *config.Config, error) {
+	report := &Report{
+		ConfigPath: config.ResolveConfigPath(configPath),
+		StartedAt:  time.Now(),
+	}
+	defer func() {
+		report.FinishedAt = time.Now()
+	}()
+
+	cfg, loadErr := config.Load(configPath)
+	configExists := true
+	if _, err := os.Stat(configPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			configExists = false
+			report.Add(CheckResult{
+				ID:       "config-file",
+				Title:    "Config file",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("Config file not found: %s", report.ConfigPath),
+				Hint:     "Run `anyclaw onboard` to generate a ready-to-use config.",
+			})
+		} else {
+			report.Add(CheckResult{
+				ID:       "config-file",
+				Title:    "Config file",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("Unable to inspect config file: %v", err),
+			})
+		}
+	} else {
+		report.Add(CheckResult{
+			ID:       "config-file",
+			Title:    "Config file",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("Config file loaded from %s", report.ConfigPath),
+		})
+	}
+
+	if loadErr != nil {
+		report.Add(CheckResult{
+			ID:       "config-parse",
+			Title:    "Config parsing",
+			Severity: SeverityError,
+			Message:  loadErr.Error(),
+			Hint:     "Fix the JSON or rerun onboarding to regenerate a clean config.",
+		})
+		return report, nil, loadErr
+	}
+	if !configExists {
+		return report, cfg, fmt.Errorf("config file missing")
+	}
+
+	workDir := config.ResolvePath(configPath, cfg.Agent.WorkDir)
+	workingDir := config.ResolvePath(configPath, cfg.Agent.WorkingDir)
+	skillsDir := config.ResolvePath(configPath, cfg.Skills.Dir)
+	pluginsDir := config.ResolvePath(configPath, cfg.Plugins.Dir)
+	auditLog := config.ResolvePath(configPath, cfg.Security.AuditLog)
+
+	checkDirectory(report, "work-dir", "Work dir", workDir, opts.CreateMissingDirs)
+	checkDirectory(report, "workspace", "Workspace", workingDir, opts.CreateMissingDirs)
+	checkDirectory(report, "skills-dir", "Skills dir", skillsDir, opts.CreateMissingDirs)
+	checkDirectory(report, "plugins-dir", "Plugins dir", pluginsDir, opts.CreateMissingDirs)
+	checkFileParent(report, "audit-log", "Audit log", auditLog, opts.CreateMissingDirs)
+	checkWorkspaceBootstrap(report, workingDir)
+
+	checkProviderConfiguration(report, cfg)
+	if opts.CheckConnectivity {
+		checkProviderConnectivity(ctx, report, cfg)
+	}
+	checkSkills(report, cfg, skillsDir)
+	checkPlugins(report, cfg, pluginsDir)
+	checkGatewayPort(report, cfg)
+	checkDesktopDependencies(report, cfg)
+	checkSecurityPolicy(report, cfg)
+
+	if report.HasErrors() {
+		return report, cfg, fmt.Errorf("doctor found %d issue(s)", report.ErrorCount())
+	}
+	return report, cfg, nil
+}
+
+func countSeverity(report *Report, severity Severity) int {
+	if report == nil {
+		return 0
+	}
+	count := 0
+	for _, check := range report.Checks {
+		if check.Severity == severity {
+			count++
+		}
+	}
+	return count
+}
+
+func checkDirectory(report *Report, id string, title string, path string, create bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		report.Add(CheckResult{
+			ID:       id,
+			Title:    title,
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("%s is not configured.", title),
+		})
+		return
+	}
+	var err error
+	if create {
+		err = os.MkdirAll(path, 0o755)
+	} else {
+		_, err = os.Stat(path)
+	}
+	if err != nil {
+		report.Add(CheckResult{
+			ID:       id,
+			Title:    title,
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("%s is not ready: %v", title, err),
+		})
+		return
+	}
+	if probe := filepath.Join(path, ".anyclaw-write-check"); canWritePath(probe) {
+		report.Add(CheckResult{
+			ID:       id,
+			Title:    title,
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("%s is ready: %s", title, path),
+		})
+		return
+	}
+	report.Add(CheckResult{
+		ID:       id,
+		Title:    title,
+		Severity: SeverityError,
+		Message:  fmt.Sprintf("%s is not writable: %s", title, path),
+	})
+}
+
+func checkFileParent(report *Report, id string, title string, path string, create bool) {
+	if strings.TrimSpace(path) == "" {
+		report.Add(CheckResult{
+			ID:       id,
+			Title:    title,
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("%s is not configured.", title),
+		})
+		return
+	}
+	checkDirectory(report, id, title, filepath.Dir(path), create)
+}
+
+func checkWorkspaceBootstrap(report *Report, workingDir string) {
+	if strings.TrimSpace(workingDir) == "" {
+		return
+	}
+	files, err := workspace.LoadBootstrapFiles(workingDir, workspace.BootstrapOptions{})
+	if err != nil {
+		report.Add(CheckResult{
+			ID:       "workspace-bootstrap",
+			Title:    "Workspace bootstrap",
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("Unable to inspect workspace bootstrap files: %v", err),
+		})
+		return
+	}
+	missing := make([]string, 0)
+	for _, file := range files {
+		if file.Missing {
+			missing = append(missing, file.Name)
+		}
+	}
+	if len(missing) == 0 {
+		report.Add(CheckResult{
+			ID:       "workspace-bootstrap",
+			Title:    "Workspace bootstrap",
+			Severity: SeverityInfo,
+			Message:  "Workspace bootstrap files are present.",
+		})
+		return
+	}
+	report.Add(CheckResult{
+		ID:       "workspace-bootstrap",
+		Title:    "Workspace bootstrap",
+		Severity: SeverityWarning,
+		Message:  fmt.Sprintf("Workspace is missing bootstrap files: %s", strings.Join(missing, ", ")),
+		Hint:     "Running onboarding or starting the runtime will recreate the standard workspace files.",
+	})
+}
+
+func checkProviderConfiguration(report *Report, cfg *config.Config) {
+	target := resolvedProviderTarget(cfg)
+	if strings.TrimSpace(target.Provider) == "" {
+		report.Add(CheckResult{
+			ID:       "provider-config",
+			Title:    "Provider config",
+			Severity: SeverityError,
+			Message:  "No active provider is configured.",
+			Hint:     "Choose a provider during onboarding.",
+		})
+		return
+	}
+	if target.Provider == "compatible" && strings.TrimSpace(target.BaseURL) == "" {
+		report.Add(CheckResult{
+			ID:       "provider-base-url",
+			Title:    "Provider base URL",
+			Severity: SeverityError,
+			Message:  "OpenAI-compatible mode requires a base_url.",
+		})
+		return
+	}
+	if baseURL := strings.TrimSpace(target.BaseURL); baseURL != "" {
+		if _, err := url.ParseRequestURI(baseURL); err != nil {
+			report.Add(CheckResult{
+				ID:       "provider-base-url",
+				Title:    "Provider base URL",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("Invalid provider base URL: %s", baseURL),
+			})
+			return
+		}
+	}
+	if ProviderNeedsAPIKey(target.Provider) && strings.TrimSpace(target.APIKey) == "" {
+		report.Add(CheckResult{
+			ID:       "provider-api-key",
+			Title:    "Provider API key",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("%s requires an API key.", ProviderLabel(target.Provider)),
+			Hint:     ProviderHint(target.Provider),
+		})
+		return
+	}
+	report.Add(CheckResult{
+		ID:       "provider-config",
+		Title:    "Provider config",
+		Severity: SeverityInfo,
+		Message:  fmt.Sprintf("Active provider is %s / %s.", ProviderLabel(target.Provider), target.Model),
+	})
+}
+
+func checkProviderConnectivity(ctx context.Context, report *Report, cfg *config.Config) {
+	target := resolvedProviderTarget(cfg)
+	if strings.TrimSpace(target.Provider) == "" || strings.TrimSpace(target.Model) == "" {
+		return
+	}
+	if ProviderNeedsAPIKey(target.Provider) && strings.TrimSpace(target.APIKey) == "" {
+		return
+	}
+
+	testCtx, cancel := context.WithTimeout(ctx, 12*time.Second)
+	defer cancel()
+	client, err := llm.NewClient(llm.Config{
+		Provider:    target.Provider,
+		Model:       target.Model,
+		APIKey:      target.APIKey,
+		BaseURL:     target.BaseURL,
+		MaxTokens:   32,
+		Temperature: 0,
+	})
+	if err != nil {
+		report.Add(CheckResult{
+			ID:       "provider-connectivity",
+			Title:    "Model connectivity",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("Unable to initialize the provider client: %v", err),
+		})
+		return
+	}
+	_, err = client.Chat(testCtx, []llm.Message{{Role: "user", Content: "Reply with OK."}}, nil)
+	if err != nil {
+		report.Add(CheckResult{
+			ID:       "provider-connectivity",
+			Title:    "Model connectivity",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("Connectivity test failed for %s / %s.", ProviderLabel(target.Provider), target.Model),
+			Detail:   trimDoctorDetail(err.Error()),
+			Hint:     "Check the API key, model name, base URL, and outbound network access.",
+		})
+		return
+	}
+	report.Add(CheckResult{
+		ID:       "provider-connectivity",
+		Title:    "Model connectivity",
+		Severity: SeverityInfo,
+		Message:  fmt.Sprintf("Connectivity test passed for %s / %s.", ProviderLabel(target.Provider), target.Model),
+	})
+}
+
+func checkSkills(report *Report, cfg *config.Config, skillsDir string) {
+	manager := skills.NewSkillsManager(skillsDir)
+	if err := manager.Load(); err != nil {
+		report.Add(CheckResult{
+			ID:       "skills-load",
+			Title:    "Skills loading",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("Unable to load skills from %s: %v", skillsDir, err),
+		})
+		return
+	}
+	configured := configuredSkillNames(cfg)
+	if len(configured) == 0 {
+		report.Add(CheckResult{
+			ID:       "skills-load",
+			Title:    "Skills loading",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("%d skill(s) available.", len(manager.List())),
+		})
+		return
+	}
+	loaded := make(map[string]struct{}, len(manager.List()))
+	for _, skill := range manager.List() {
+		if skill == nil {
+			continue
+		}
+		loaded[strings.ToLower(strings.TrimSpace(skill.Name))] = struct{}{}
+	}
+	missing := make([]string, 0)
+	for _, name := range configured {
+		if _, ok := loaded[strings.ToLower(strings.TrimSpace(name))]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		report.Add(CheckResult{
+			ID:       "skills-load",
+			Title:    "Skills loading",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("Configured skills are present (%d loaded).", len(manager.List())),
+		})
+		return
+	}
+	report.Add(CheckResult{
+		ID:       "skills-missing",
+		Title:    "Configured skills",
+		Severity: SeverityError,
+		Message:  fmt.Sprintf("Missing configured skills: %s", strings.Join(missing, ", ")),
+		Hint:     "Install the missing skills or remove stale skill references from the agent profile.",
+	})
+}
+
+func checkPlugins(report *Report, cfg *config.Config, pluginsDir string) {
+	registry, err := plugin.NewRegistry(config.PluginsConfig{
+		Dir:                pluginsDir,
+		Enabled:            append([]string(nil), cfg.Plugins.Enabled...),
+		AllowExec:          cfg.Plugins.AllowExec,
+		ExecTimeoutSeconds: cfg.Plugins.ExecTimeoutSeconds,
+		TrustedSigners:     append([]string(nil), cfg.Plugins.TrustedSigners...),
+		RequireTrust:       cfg.Plugins.RequireTrust,
+	})
+	if err != nil {
+		report.Add(CheckResult{
+			ID:       "plugins-load",
+			Title:    "Plugin loading",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("Unable to load plugins from %s: %v", pluginsDir, err),
+		})
+		return
+	}
+	manifests := registry.List()
+	found := make(map[string]struct{}, len(manifests))
+	for _, manifest := range manifests {
+		found[strings.ToLower(strings.TrimSpace(manifest.Name))] = struct{}{}
+	}
+	missing := make([]string, 0)
+	for _, name := range cfg.Plugins.Enabled {
+		key := strings.ToLower(strings.TrimSpace(name))
+		if key == "" {
+			continue
+		}
+		if _, ok := found[key]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		report.Add(CheckResult{
+			ID:       "plugins-load",
+			Title:    "Plugin loading",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("%d plugin manifest(s) available.", len(manifests)),
+		})
+		return
+	}
+	report.Add(CheckResult{
+		ID:       "plugins-missing",
+		Title:    "Configured plugins",
+		Severity: SeverityWarning,
+		Message:  fmt.Sprintf("Configured plugins not found on disk: %s", strings.Join(missing, ", ")),
+		Hint:     "Install the missing plugins or remove them from plugins.enabled.",
+	})
+}
+
+func checkGatewayPort(report *Report, cfg *config.Config) {
+	address := gatewayListenAddress(cfg)
+	ln, err := net.Listen("tcp", address)
+	if err != nil {
+		report.Add(CheckResult{
+			ID:       "gateway-port",
+			Title:    "Gateway port",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("Gateway listen address is busy: %s", address),
+			Detail:   err.Error(),
+			Hint:     "Stop the conflicting process or change gateway.host / gateway.port.",
+		})
+		return
+	}
+	_ = ln.Close()
+	report.Add(CheckResult{
+		ID:       "gateway-port",
+		Title:    "Gateway port",
+		Severity: SeverityInfo,
+		Message:  fmt.Sprintf("Gateway listen address is free: %s", address),
+	})
+}
+
+func checkDesktopDependencies(report *Report, cfg *config.Config) {
+	if runtime.GOOS != "windows" {
+		if strings.EqualFold(strings.TrimSpace(cfg.Sandbox.ExecutionMode), "host-reviewed") {
+			report.Add(CheckResult{
+				ID:       "desktop-host",
+				Title:    "Desktop host mode",
+				Severity: SeverityWarning,
+				Message:  "Desktop automation tools currently require Windows host mode.",
+			})
+		}
+		return
+	}
+
+	if exe, err := findExecutable("pwsh", "powershell"); err == nil {
+		report.Add(CheckResult{
+			ID:       "desktop-powershell",
+			Title:    "PowerShell",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("Desktop host shell is available: %s", exe),
+		})
+	} else {
+		report.Add(CheckResult{
+			ID:       "desktop-powershell",
+			Title:    "PowerShell",
+			Severity: SeverityError,
+			Message:  "PowerShell is required for desktop automation.",
+		})
+	}
+
+	if err := runPowerShellProbe(`Add-Type -AssemblyName UIAutomationClient; "ok"`); err != nil {
+		report.Add(CheckResult{
+			ID:       "desktop-ui-automation",
+			Title:    "UI Automation",
+			Severity: SeverityWarning,
+			Message:  "Windows UI Automation assemblies are not ready.",
+			Detail:   trimDoctorDetail(err.Error()),
+		})
+	} else {
+		report.Add(CheckResult{
+			ID:       "desktop-ui-automation",
+			Title:    "UI Automation",
+			Severity: SeverityInfo,
+			Message:  "Windows UI Automation is available.",
+		})
+	}
+
+	if strings.EqualFold(strings.TrimSpace(cfg.Sandbox.ExecutionMode), "host-reviewed") {
+		if err := runPowerShellProbe(`[Environment]::UserInteractive`); err != nil {
+			report.Add(CheckResult{
+				ID:       "desktop-session",
+				Title:    "Desktop session",
+				Severity: SeverityWarning,
+				Message:  "Host-reviewed mode needs an interactive Windows desktop session.",
+				Detail:   trimDoctorDetail(err.Error()),
+			})
+		} else {
+			report.Add(CheckResult{
+				ID:       "desktop-session",
+				Title:    "Desktop session",
+				Severity: SeverityInfo,
+				Message:  "Interactive Windows desktop session is available.",
+			})
+		}
+	}
+
+	if exe, err := exec.LookPath("tesseract"); err == nil {
+		report.Add(CheckResult{
+			ID:       "ocr-engine",
+			Title:    "OCR engine",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("Tesseract OCR is available: %s", exe),
+		})
+	} else {
+		report.Add(CheckResult{
+			ID:       "ocr-engine",
+			Title:    "OCR engine",
+			Severity: SeverityWarning,
+			Message:  "Tesseract OCR is not installed or not in PATH.",
+			Hint:     "Install Tesseract if you plan to use desktop OCR or vision-driven app workflows.",
+		})
+	}
+}
+
+type providerTarget struct {
+	Provider string
+	Model    string
+	BaseURL  string
+	APIKey   string
+}
+
+func resolvedProviderTarget(cfg *config.Config) providerTarget {
+	if cfg == nil {
+		return providerTarget{}
+	}
+	if provider, ok := cfg.FindDefaultProviderProfile(); ok {
+		return providerTarget{
+			Provider: firstNonEmpty(provider.Provider, cfg.LLM.Provider),
+			Model:    firstNonEmpty(provider.DefaultModel, cfg.LLM.Model),
+			BaseURL:  firstNonEmpty(provider.BaseURL, cfg.LLM.BaseURL),
+			APIKey:   firstNonEmpty(provider.APIKey, cfg.LLM.APIKey),
+		}
+	}
+	return providerTarget{
+		Provider: strings.TrimSpace(cfg.LLM.Provider),
+		Model:    strings.TrimSpace(cfg.LLM.Model),
+		BaseURL:  strings.TrimSpace(cfg.LLM.BaseURL),
+		APIKey:   strings.TrimSpace(cfg.LLM.APIKey),
+	}
+}
+
+func configuredSkillNames(cfg *config.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	if profile, ok := cfg.ResolveMainAgentProfile(); ok {
+		return enabledSkillNames(profile.Skills)
+	}
+	return enabledSkillNames(cfg.Agent.Skills)
+}
+
+func enabledSkillNames(items []config.AgentSkillRef) []string {
+	names := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		if !item.Enabled {
+			continue
+		}
+		name := strings.TrimSpace(item.Name)
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		names = append(names, name)
+	}
+	return names
+}
+
+func gatewayListenAddress(cfg *config.Config) string {
+	host := strings.TrimSpace(cfg.Gateway.Host)
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	switch bind := strings.TrimSpace(strings.ToLower(cfg.Gateway.Bind)); bind {
+	case "all":
+		host = "0.0.0.0"
+	case "loopback", "":
+	default:
+		host = cfg.Gateway.Bind
+	}
+	port := cfg.Gateway.Port
+	if port <= 0 {
+		port = 18789
+	}
+	return net.JoinHostPort(host, fmt.Sprintf("%d", port))
+}
+
+func canWritePath(path string) bool {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return false
+	}
+	_ = file.Close()
+	_ = os.Remove(path)
+	return true
+}
+
+func findExecutable(names ...string) (string, error) {
+	for _, name := range names {
+		path, err := exec.LookPath(name)
+		if err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("not found")
+}
+
+func runPowerShellProbe(script string) error {
+	exe, err := findExecutable("pwsh", "powershell")
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(exe, "-NoProfile", "-Command", script)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func trimDoctorDetail(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) > 240 {
+		return value[:240] + "..."
+	}
+	return value
+}
+
+func checkSecurityPolicy(report *Report, cfg *config.Config) {
+	policy := inputlayer.ChannelPolicyFromConfig(cfg.Channels.Security)
+	audit := inputlayer.AuditChannelPolicy(policy)
+
+	if audit.Passed {
+		report.Add(CheckResult{
+			ID:       "security-policy",
+			Title:    "Security policy",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("Security policy score: %d/%d - All checks passed", audit.Score, audit.MaxScore),
+			Fixable:  false,
+		})
+		return
+	}
+
+	report.Add(CheckResult{
+		ID:       "security-policy",
+		Title:    "Security policy",
+		Severity: SeverityWarning,
+		Message:  fmt.Sprintf("Security policy score: %d/%d - %d issue(s) found", audit.Score, audit.MaxScore, len(audit.Issues)),
+	})
+
+	for _, issue := range audit.Issues {
+		fixPriority := 0
+		switch issue.Severity {
+		case "critical":
+			fixPriority = 3
+		case "warning":
+			fixPriority = 2
+		default:
+			fixPriority = 1
+		}
+		report.Add(CheckResult{
+			ID:          "security-" + issue.ID,
+			Title:       issue.Title,
+			Severity:    Severity(issue.Severity),
+			Message:     issue.Message,
+			Fixable:     issue.Fixable,
+			FixAction:   issue.FixAction,
+			FixPriority: fixPriority,
+		})
+	}
+}

--- a/pkg/input/cli/setup/onboard.go
+++ b/pkg/input/cli/setup/onboard.go
@@ -1,0 +1,331 @@
+package setup
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	"github.com/1024XEngineer/anyclaw/pkg/input/cli/consoleio"
+	"github.com/1024XEngineer/anyclaw/pkg/workspace"
+)
+
+type OnboardOptions struct {
+	Interactive       bool
+	CheckConnectivity bool
+	Stdin             io.Reader
+	Stdout            io.Writer
+}
+
+type OnboardResult struct {
+	Config  *config.Config
+	Report  *Report
+	Created bool
+}
+
+func RunOnboarding(ctx context.Context, configPath string, opts OnboardOptions) (*OnboardResult, error) {
+	if opts.Stdin == nil {
+		opts.Stdin = os.Stdin
+	}
+	if opts.Stdout == nil {
+		opts.Stdout = os.Stdout
+	}
+
+	created := false
+	if _, err := os.Stat(configPath); errorsIsNotExist(err) {
+		created = true
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil && !created {
+		return nil, err
+	}
+	if cfg == nil {
+		cfg = config.DefaultConfig()
+	}
+	applyOnboardingDefaults(cfg)
+
+	if opts.Interactive {
+		if err := runInteractiveOnboarding(cfg, opts.Stdin, opts.Stdout); err != nil {
+			return nil, err
+		}
+	} else {
+		EnsurePrimaryProviderProfile(cfg, cfg.LLM.Provider, cfg.LLM.Model, cfg.LLM.APIKey, cfg.LLM.BaseURL)
+	}
+
+	if err := prepareRuntimePaths(configPath, cfg); err != nil {
+		return nil, err
+	}
+	if err := cfg.Save(configPath); err != nil {
+		return nil, err
+	}
+
+	report, checkedCfg, doctorErr := RunDoctor(ctx, configPath, DoctorOptions{
+		CheckConnectivity: opts.CheckConnectivity,
+		CreateMissingDirs: true,
+	})
+	if checkedCfg != nil {
+		cfg = checkedCfg
+	}
+	if doctorErr != nil && report == nil {
+		return nil, doctorErr
+	}
+	return &OnboardResult{
+		Config:  cfg,
+		Report:  report,
+		Created: created,
+	}, doctorErr
+}
+
+func applyOnboardingDefaults(cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.LLM.Provider = firstNonEmpty(CanonicalProvider(cfg.LLM.Provider), "openai")
+	// Don't set model default here - it will be set after user chooses provider
+	cfg.Agent.Name = firstNonEmpty(cfg.Agent.Name, "AnyClaw")
+	cfg.Agent.WorkDir = firstNonEmpty(cfg.Agent.WorkDir, ".anyclaw")
+	cfg.Agent.WorkingDir = firstNonEmpty(cfg.Agent.WorkingDir, "workflows/default")
+	cfg.Agent.PermissionLevel = firstNonEmpty(cfg.Agent.PermissionLevel, "limited")
+	cfg.Skills.Dir = firstNonEmpty(cfg.Skills.Dir, "skills")
+	cfg.Plugins.Dir = firstNonEmpty(cfg.Plugins.Dir, "plugins")
+	cfg.Security.AuditLog = firstNonEmpty(cfg.Security.AuditLog, ".anyclaw/audit/audit.jsonl")
+	if cfg.Channels.Security.DMPolicy == "" {
+		cfg.Channels.Security.DMPolicy = "allow-list"
+	}
+	if cfg.Channels.Security.GroupPolicy == "" {
+		cfg.Channels.Security.GroupPolicy = "mention-only"
+	}
+	cfg.Channels.Security.MentionGate = true
+	cfg.Channels.Security.DefaultDenyDM = true
+	cfg.Channels.Security.PairingTTLHours = 72
+	cfg.Security.RateLimitRPM = firstNonEmptyInt(cfg.Security.RateLimitRPM, 120)
+}
+
+func firstNonEmptyInt(vals ...int) int {
+	for _, v := range vals {
+		if v > 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+func runInteractiveOnboarding(cfg *config.Config, input io.Reader, output io.Writer) error {
+	reader := consoleio.NewReader(input)
+	currentProvider := firstNonEmpty(cfg.LLM.Provider, "openai")
+	sameProvider := false
+
+	fmt.Fprintln(output, "")
+	fmt.Fprintln(output, "=== AnyClaw 设置向导 ===")
+	fmt.Fprintln(output, "")
+	fmt.Fprintln(output, "Step 1/8: 选择语言")
+	langPrompt := "语言 [zh-CN]"
+	langChoice, err := prompt(reader, output, langPrompt)
+	if err != nil {
+		return err
+	}
+	langChoice = strings.TrimSpace(langChoice)
+	if langChoice == "" {
+		langChoice = "zh-CN"
+	}
+	cfg.Agent.Lang = langChoice
+
+	fmt.Fprintln(output, "Step 2/8: 选择 LLM 提供商")
+	for idx, option := range ProviderOptions() {
+		fmt.Fprintf(output, "  %d. %s (%s)\n", idx+1, option.Label, option.ID)
+	}
+	providerChoice, err := prompt(reader, output, fmt.Sprintf("提供商 [%s]", currentProvider))
+	if err != nil {
+		return err
+	}
+	selectedProvider := ResolveProviderChoice(providerChoice, currentProvider)
+	if selectedProvider == "" {
+		selectedProvider = currentProvider
+	}
+	sameProvider = CanonicalProvider(currentProvider) == CanonicalProvider(selectedProvider)
+
+	availableModels := AvailableModelsForProvider(selectedProvider)
+	if len(availableModels) > 0 {
+		fmt.Fprintln(output, "  可用模型:")
+		for _, m := range availableModels {
+			fmt.Fprintf(output, "    - %s\n", m)
+		}
+	}
+
+	currentModel := firstNonEmpty(cfg.LLM.Model, DefaultModelForProvider(selectedProvider))
+	modelChoice, err := prompt(reader, output, fmt.Sprintf("模型 [%s]", currentModel))
+	if err != nil {
+		return err
+	}
+	selectedModel := firstNonEmpty(modelChoice, currentModel, DefaultModelForProvider(selectedProvider))
+
+	baseURL := strings.TrimSpace(cfg.LLM.BaseURL)
+	if !sameProvider {
+		baseURL = ""
+	}
+	if selectedProvider == "compatible" {
+		baseURLPrompt := firstNonEmpty(baseURL, "https://api.example.com/v1")
+		baseURL, err = prompt(reader, output, fmt.Sprintf("Base URL [%s]", baseURLPrompt))
+		if err != nil {
+			return err
+		}
+		baseURL = firstNonEmpty(baseURL, baseURLPrompt)
+	}
+
+	apiKey := strings.TrimSpace(cfg.LLM.APIKey)
+	if !sameProvider {
+		apiKey = ""
+	}
+	if ProviderNeedsAPIKey(selectedProvider) {
+		fmt.Fprintf(output, "%s\n", ProviderHint(selectedProvider))
+		apiKey, err = prompt(reader, output, "API key [回车保持当前]")
+		if err != nil {
+			return err
+		}
+		apiKey = firstNonEmpty(apiKey, cfg.LLM.APIKey)
+	} else {
+		apiKey = ""
+	}
+
+	workspacePrompt := firstNonEmpty(cfg.Agent.WorkingDir, "workflows/default")
+	workingDir, err := prompt(reader, output, fmt.Sprintf("工作区目录 [%s]", workspacePrompt))
+	if err != nil {
+		return err
+	}
+
+	namePrompt := firstNonEmpty(cfg.Agent.Name, "AnyClaw")
+	agentName, err := prompt(reader, output, fmt.Sprintf("Agent 名称 [%s]", namePrompt))
+	if err != nil {
+		return err
+	}
+
+	cfg.Agent.Name = firstNonEmpty(agentName, namePrompt)
+	cfg.Agent.WorkingDir = firstNonEmpty(workingDir, workspacePrompt)
+	cfg.LLM.Provider = selectedProvider
+	cfg.LLM.Model = selectedModel
+	cfg.LLM.APIKey = strings.TrimSpace(apiKey)
+	if selectedProvider == "compatible" {
+		cfg.LLM.BaseURL = strings.TrimSpace(baseURL)
+	} else {
+		cfg.LLM.BaseURL = DefaultBaseURLForProvider(selectedProvider)
+	}
+	if !ProviderNeedsAPIKey(selectedProvider) {
+		cfg.LLM.APIKey = ""
+	}
+	EnsurePrimaryProviderProfile(cfg, selectedProvider, selectedModel, cfg.LLM.APIKey, cfg.LLM.BaseURL)
+
+	fmt.Fprintln(output, "")
+	fmt.Fprintln(output, "Step 7/8: 工作偏好设置")
+	fmt.Fprintln(output, "  你希望我主要帮你做什么类型的工作？")
+	fmt.Fprintln(output, "  例如：编程、文档写作、日常任务、浏览器自动化等")
+	workFocus, err := prompt(reader, output, "工作方向 [通用]")
+	if err != nil {
+		return err
+	}
+	cfg.Agent.WorkFocus = firstNonEmpty(workFocus, "通用")
+
+	fmt.Fprintln(output, "  你希望我默认的行为方式是怎样的？")
+	fmt.Fprintln(output, "  例如：简洁快速 / 详细解释 / 主动建议")
+	behaviorStyle, err := prompt(reader, output, "行为风格 [简洁]")
+	if err != nil {
+		return err
+	}
+	cfg.Agent.BehaviorStyle = firstNonEmpty(behaviorStyle, "简洁")
+
+	fmt.Fprintln(output, "  有什么需要遵守的约束或偏好吗？")
+	fmt.Fprintln(output, "  例如：不要删除文件 / 只读模式 / 确认后执行")
+	constraints, err := prompt(reader, output, "约束偏好 [无]")
+	if err != nil {
+		return err
+	}
+	cfg.Agent.Constraints = strings.TrimSpace(constraints)
+
+	fmt.Fprintln(output, "")
+	fmt.Fprintln(output, "Step 8/8: 安全设置")
+	fmt.Fprintln(output, "  DM 策略: allow-list (仅允许的用户可以发私信)")
+	fmt.Fprintln(output, "  群组策略: mention-only (仅 @mention 时响应)")
+	fmt.Fprintln(output, "  提及门控: 启用")
+	fmt.Fprintln(output, "  默认拒绝私信: 启用")
+	secChoice, err := prompt(reader, output, "接受安全默认设置？[Y/n]")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(strings.ToLower(secChoice)) != "n" {
+		cfg.Channels.Security.DMPolicy = "allow-list"
+		cfg.Channels.Security.GroupPolicy = "mention-only"
+		cfg.Channels.Security.MentionGate = true
+		cfg.Channels.Security.DefaultDenyDM = true
+		cfg.Channels.Security.PairingTTLHours = 72
+		cfg.Security.RiskAcknowledged = true
+	}
+
+	fmt.Fprintln(output, "")
+	fmt.Fprintln(output, "风险提示")
+	fmt.Fprintln(output, "  AnyClaw 可以在你的系统上执行命令。")
+	fmt.Fprintln(output, "  确认后，你将对 agent 的行为负责。")
+	riskChoice, err := prompt(reader, output, "确认风险？[Y/n]")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(strings.ToLower(riskChoice)) != "n" {
+		cfg.Security.RiskAcknowledged = true
+	}
+
+	fmt.Fprintln(output, "")
+	fmt.Fprintln(output, "设置完成！")
+
+	return nil
+}
+
+func prepareRuntimePaths(configPath string, cfg *config.Config) error {
+	workDir := config.ResolvePath(configPath, cfg.Agent.WorkDir)
+	workingDir := config.ResolvePath(configPath, cfg.Agent.WorkingDir)
+	skillsDir := config.ResolvePath(configPath, cfg.Skills.Dir)
+	pluginsDir := config.ResolvePath(configPath, cfg.Plugins.Dir)
+
+	for _, path := range []string{workDir, workingDir, skillsDir, pluginsDir, filepath.Dir(config.ResolvePath(configPath, cfg.Security.AuditLog))} {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			return err
+		}
+	}
+	return workspace.EnsureBootstrap(workingDir, workspace.BootstrapOptions{
+		AgentName:        cfg.Agent.Name,
+		AgentDescription: cfg.Agent.Description,
+		UserProfile:      bootstrapUserProfile(cfg),
+		WorkspaceFocus:   strings.TrimSpace(cfg.Agent.WorkFocus),
+		AssistantStyle:   strings.TrimSpace(cfg.Agent.BehaviorStyle),
+		Constraints:      strings.TrimSpace(cfg.Agent.Constraints),
+	})
+}
+
+func bootstrapUserProfile(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+
+	parts := []string{}
+	if lang := strings.TrimSpace(cfg.Agent.Lang); lang != "" {
+		parts = append(parts, "Default language: "+lang)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func prompt(reader *consoleio.Reader, output io.Writer, label string) (string, error) {
+	fmt.Fprintf(output, "%s: ", label)
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	return strings.TrimSpace(line), nil
+}
+
+func errorsIsNotExist(err error) bool {
+	return err != nil && os.IsNotExist(err)
+}

--- a/pkg/input/cli/setup/providers.go
+++ b/pkg/input/cli/setup/providers.go
@@ -1,0 +1,190 @@
+package setup
+
+import (
+	"fmt"
+	"strings"
+
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+type ProviderOption struct {
+	ID              string
+	Label           string
+	DefaultModel    string
+	AvailableModels []string
+	Hint            string
+	RequiresAPIKey  bool
+}
+
+var providerOptions = []ProviderOption{
+	{ID: "openai", Label: "OpenAI", DefaultModel: "gpt-4o-mini", AvailableModels: []string{"gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-4", "gpt-3.5-turbo"}, Hint: "Use your OpenAI API key.", RequiresAPIKey: true},
+	{ID: "anthropic", Label: "Anthropic", DefaultModel: "claude-sonnet-4-7", AvailableModels: []string{"claude-opus-4-5", "claude-sonnet-4-7", "claude-haiku-3-5"}, Hint: "Use your Anthropic API key.", RequiresAPIKey: true},
+	{ID: "qwen", Label: "Qwen", DefaultModel: "qwen-plus", AvailableModels: []string{"qwen-plus", "qwen-turbo", "qwen-max", "qwen2.5-72b-instruct", "qwen2.5-14b-instruct", "qwq-32b-preview", "qwen-coder-plus"}, Hint: "Use your DashScope API key.", RequiresAPIKey: true},
+	{ID: "ollama", Label: "Ollama", DefaultModel: "llama3.2", AvailableModels: []string{"llama3.2", "llama3.1", "codellama", "mistral", "qwen2.5"}, Hint: "No API key needed. Make sure Ollama is running locally.", RequiresAPIKey: false},
+	{ID: "compatible", Label: "OpenAI-compatible", DefaultModel: "gpt-4o-mini", AvailableModels: nil, Hint: "Use your compatible endpoint URL and API key.", RequiresAPIKey: true},
+}
+
+func ProviderOptions() []ProviderOption {
+	items := make([]ProviderOption, len(providerOptions))
+	copy(items, providerOptions)
+	return items
+}
+
+func CanonicalProvider(provider string) string {
+	return llm.NormalizeProviderName(provider)
+}
+
+func DefaultModelForProvider(provider string) string {
+	provider = CanonicalProvider(provider)
+	for _, option := range providerOptions {
+		if option.ID == provider {
+			return option.DefaultModel
+		}
+	}
+	return "gpt-4o-mini"
+}
+
+func AvailableModelsForProvider(provider string) []string {
+	provider = CanonicalProvider(provider)
+	for _, option := range providerOptions {
+		if option.ID == provider {
+			return option.AvailableModels
+		}
+	}
+	return nil
+}
+
+func ProviderLabel(provider string) string {
+	provider = CanonicalProvider(provider)
+	for _, option := range providerOptions {
+		if option.ID == provider {
+			return option.Label
+		}
+	}
+	if provider == "" {
+		return "Unknown"
+	}
+	return strings.ToUpper(provider[:1]) + provider[1:]
+}
+
+func ProviderHint(provider string) string {
+	provider = CanonicalProvider(provider)
+	for _, option := range providerOptions {
+		if option.ID == provider {
+			return option.Hint
+		}
+	}
+	return "Provide the model, endpoint, and credentials for your provider."
+}
+
+func ProviderNeedsAPIKey(provider string) bool {
+	return llm.ProviderRequiresAPIKey(provider)
+}
+
+func DefaultBaseURLForProvider(provider string) string {
+	provider = CanonicalProvider(provider)
+	switch provider {
+	case "openai":
+		return "https://api.openai.com/v1"
+	case "anthropic":
+		return "https://api.anthropic.com/v1"
+	case "ollama":
+		return "http://localhost:11434/v1"
+	case "qwen":
+		return "https://dashscope.aliyuncs.com/compatible-mode/v1"
+	default:
+		return ""
+	}
+}
+
+func ResolveProviderChoice(input string, fallback string) string {
+	input = strings.TrimSpace(strings.ToLower(input))
+	if input == "" {
+		return CanonicalProvider(fallback)
+	}
+	for idx, option := range providerOptions {
+		if input == option.ID {
+			return option.ID
+		}
+		if input == fmt.Sprintf("%d", idx+1) {
+			return option.ID
+		}
+	}
+	switch input {
+	case "alibaba", "dashscope", "tongyi":
+		return "qwen"
+	case "claude":
+		return "anthropic"
+	case "local":
+		return "ollama"
+	default:
+		return CanonicalProvider(input)
+	}
+}
+
+func EnsurePrimaryProviderProfile(cfg *config.Config, provider string, model string, apiKey string, baseURL string) string {
+	if cfg == nil {
+		return ""
+	}
+	provider = CanonicalProvider(provider)
+	if strings.TrimSpace(model) == "" {
+		model = DefaultModelForProvider(provider)
+	}
+
+	profileID := "primary-" + provider
+	profileName := "Primary " + ProviderLabel(provider)
+	profileType := provider
+	if provider == "compatible" {
+		profileType = "openai-compatible"
+	}
+
+	profile := config.ProviderProfile{
+		ID:           profileID,
+		Name:         profileName,
+		Type:         profileType,
+		Provider:     provider,
+		BaseURL:      strings.TrimSpace(baseURL),
+		APIKey:       strings.TrimSpace(apiKey),
+		DefaultModel: strings.TrimSpace(model),
+		Enabled:      config.BoolPtr(true),
+	}
+	if existing, ok := cfg.FindProviderProfile(profileID); ok {
+		if profile.BaseURL == "" {
+			profile.BaseURL = existing.BaseURL
+		}
+		if profile.APIKey == "" {
+			profile.APIKey = existing.APIKey
+		}
+		if profile.DefaultModel == "" {
+			profile.DefaultModel = existing.DefaultModel
+		}
+		if profile.Type == "" {
+			profile.Type = existing.Type
+		}
+		if len(profile.Capabilities) == 0 {
+			profile.Capabilities = append([]string(nil), existing.Capabilities...)
+		}
+	}
+
+	_ = cfg.UpsertProviderProfile(profile)
+	_ = cfg.SetDefaultProviderProfile(profileID)
+	cfg.LLM.Provider = provider
+	cfg.LLM.Model = firstNonEmpty(strings.TrimSpace(model), cfg.LLM.Model, DefaultModelForProvider(provider))
+	if strings.TrimSpace(baseURL) != "" || provider == "compatible" {
+		cfg.LLM.BaseURL = strings.TrimSpace(baseURL)
+	}
+	if strings.TrimSpace(apiKey) != "" || !ProviderNeedsAPIKey(provider) {
+		cfg.LLM.APIKey = strings.TrimSpace(apiKey)
+	}
+	return profileID
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/pkg/input/cli/ui/markdown.go
+++ b/pkg/input/cli/ui/markdown.go
@@ -1,0 +1,348 @@
+package ui
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	mdHeading1Style = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7C3AED"))
+	mdHeading2Style = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#06B6D4"))
+	mdHeading3Style = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#10B981"))
+	mdInlineCode    = lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Background(lipgloss.Color("#1F2937")).Padding(0, 1)
+	mdCodeBlock     = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("#334155")).
+			Padding(0, 1).
+			Margin(1, 0)
+	mdQuoteStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).BorderLeft(true).BorderForeground(lipgloss.Color("#475569")).PaddingLeft(1)
+	mdStrikeStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("244")).Strikethrough(true)
+	mdLinkTextStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#60A5FA")).Underline(true)
+	mdLinkURLStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
+	mdTaskDoneStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#10B981")).Bold(true)
+	mdTaskPendingStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#94A3B8")).Bold(true)
+	mdTableBorderStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
+	mdTableHeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#06B6D4"))
+
+	mdFenceRE        = regexp.MustCompile("^```\\s*([A-Za-z0-9_+.-]*)\\s*$")
+	mdHeadingRE      = regexp.MustCompile(`^(#{1,6})\s+(.*)$`)
+	mdTaskRE         = regexp.MustCompile(`^(\s*)[-*+]\s+\[([ xX])\]\s+(.*)$`)
+	mdBulletRE       = regexp.MustCompile(`^(\s*)[-*+]\s+(.*)$`)
+	mdNumberRE       = regexp.MustCompile(`^(\s*)(\d+)\.\s+(.*)$`)
+	mdQuoteRE        = regexp.MustCompile(`^\s*>\s?(.*)$`)
+	mdStrongRE       = regexp.MustCompile(`\*\*(.+?)\*\*`)
+	mdEmRE           = regexp.MustCompile(`\*(.+?)\*`)
+	mdStrikeRE       = regexp.MustCompile(`~~(.+?)~~`)
+	mdLinkRE         = regexp.MustCompile(`\[([^\]]+)\]\(([^)\s]+)\)`)
+	mdHRRE           = regexp.MustCompile(`^\s*(?:-{3,}|\*{3,}|_{3,})\s*$`)
+	mdTableSepCellRE = regexp.MustCompile(`^:?-{3,}:?$`)
+)
+
+// RenderMarkdown renders a lightweight markdown view suitable for terminal chat output.
+func RenderMarkdown(input string) string {
+	if strings.TrimSpace(input) == "" {
+		return ""
+	}
+
+	lines := strings.Split(strings.ReplaceAll(input, "\r\n", "\n"), "\n")
+	out := make([]string, 0, len(lines))
+
+	var codeLines []string
+	codeLang := ""
+	inCodeBlock := false
+
+	flushCodeBlock := func() {
+		header := ""
+		if codeLang != "" {
+			header = Dim.Sprint(strings.ToUpper(codeLang)) + "\n"
+		}
+		block := header + strings.Join(codeLines, "\n")
+		out = append(out, mdCodeBlock.Render(block))
+		codeLines = nil
+		codeLang = ""
+	}
+
+	for i := 0; i < len(lines); i++ {
+		rawLine := lines[i]
+		line := strings.TrimRight(rawLine, " \t")
+		if matches := mdFenceRE.FindStringSubmatch(strings.TrimSpace(line)); matches != nil {
+			if inCodeBlock {
+				flushCodeBlock()
+				inCodeBlock = false
+			} else {
+				inCodeBlock = true
+				codeLang = matches[1]
+			}
+			continue
+		}
+
+		if inCodeBlock {
+			codeLines = append(codeLines, line)
+			continue
+		}
+
+		if block, next, ok := renderMarkdownTableBlock(lines, i); ok {
+			out = append(out, block)
+			i = next - 1
+			continue
+		}
+
+		if strings.TrimSpace(line) == "" {
+			out = append(out, "")
+			continue
+		}
+
+		if mdHRRE.MatchString(line) {
+			out = append(out, Dim.Sprint(strings.Repeat("-", 56)))
+			continue
+		}
+
+		if matches := mdHeadingRE.FindStringSubmatch(line); matches != nil {
+			content := renderInlineMarkdown(matches[2])
+			switch len(matches[1]) {
+			case 1:
+				out = append(out, mdHeading1Style.Render(content))
+			case 2:
+				out = append(out, mdHeading2Style.Render(content))
+			default:
+				out = append(out, mdHeading3Style.Render(content))
+			}
+			continue
+		}
+
+		if matches := mdQuoteRE.FindStringSubmatch(line); matches != nil {
+			out = append(out, mdQuoteStyle.Render(renderInlineMarkdown(matches[1])))
+			continue
+		}
+
+		if matches := mdTaskRE.FindStringSubmatch(line); matches != nil {
+			markerStyle := mdTaskPendingStyle
+			marker := "[ ]"
+			if strings.EqualFold(matches[2], "x") {
+				markerStyle = mdTaskDoneStyle
+				marker = "[x]"
+			}
+			out = append(out, matches[1]+markerStyle.Render(marker)+" "+renderInlineMarkdown(matches[3]))
+			continue
+		}
+
+		if matches := mdBulletRE.FindStringSubmatch(line); matches != nil {
+			out = append(out, matches[1]+Cyan.Sprint("* ")+renderInlineMarkdown(matches[2]))
+			continue
+		}
+
+		if matches := mdNumberRE.FindStringSubmatch(line); matches != nil {
+			out = append(out, matches[1]+Yellow.Sprint(matches[2]+". ")+renderInlineMarkdown(matches[3]))
+			continue
+		}
+
+		out = append(out, renderInlineMarkdown(line))
+	}
+
+	if inCodeBlock {
+		flushCodeBlock()
+	}
+
+	return strings.Join(out, "\n")
+}
+
+func renderInlineMarkdown(input string) string {
+	if input == "" {
+		return ""
+	}
+
+	parts := strings.Split(input, "`")
+	for i := range parts {
+		if i%2 == 1 {
+			parts[i] = mdInlineCode.Render(parts[i])
+			continue
+		}
+		parts[i] = renderInlineText(parts[i])
+	}
+
+	return strings.Join(parts, "")
+}
+
+func renderInlineText(input string) string {
+	if input == "" {
+		return ""
+	}
+
+	input = mdLinkRE.ReplaceAllStringFunc(input, func(match string) string {
+		groups := mdLinkRE.FindStringSubmatch(match)
+		if len(groups) < 3 {
+			return match
+		}
+		label := renderInlineTextNoLinks(groups[1])
+		return mdLinkTextStyle.Render(label) + mdLinkURLStyle.Render(" ("+groups[2]+")")
+	})
+	return renderInlineTextNoLinks(input)
+}
+
+func renderInlineTextNoLinks(input string) string {
+	input = mdStrongRE.ReplaceAllStringFunc(input, func(match string) string {
+		groups := mdStrongRE.FindStringSubmatch(match)
+		if len(groups) < 2 {
+			return match
+		}
+		return Bold.Sprint(groups[1])
+	})
+	input = mdEmRE.ReplaceAllStringFunc(input, func(match string) string {
+		groups := mdEmRE.FindStringSubmatch(match)
+		if len(groups) < 2 {
+			return match
+		}
+		return Cyan.Sprint(groups[1])
+	})
+	input = mdStrikeRE.ReplaceAllStringFunc(input, func(match string) string {
+		groups := mdStrikeRE.FindStringSubmatch(match)
+		if len(groups) < 2 {
+			return match
+		}
+		return mdStrikeStyle.Render(groups[1])
+	})
+	return input
+}
+
+func renderMarkdownTableBlock(lines []string, start int) (string, int, bool) {
+	if start+1 >= len(lines) {
+		return "", start, false
+	}
+
+	headerLine := strings.TrimRight(lines[start], " \t")
+	separatorLine := strings.TrimRight(lines[start+1], " \t")
+	if !strings.Contains(headerLine, "|") || !strings.Contains(separatorLine, "|") {
+		return "", start, false
+	}
+
+	headerCells := splitMarkdownTableLine(headerLine)
+	if len(headerCells) == 0 || !isMarkdownTableSeparator(separatorLine, len(headerCells)) {
+		return "", start, false
+	}
+
+	rows := [][]string{headerCells}
+	next := start + 2
+	for next < len(lines) {
+		line := strings.TrimRight(lines[next], " \t")
+		if strings.TrimSpace(line) == "" || !strings.Contains(line, "|") {
+			break
+		}
+		rows = append(rows, normalizeTableCells(splitMarkdownTableLine(line), len(headerCells)))
+		next++
+	}
+
+	return renderMarkdownTable(rows), next, true
+}
+
+func splitMarkdownTableLine(line string) []string {
+	trimmed := strings.TrimSpace(line)
+	if !strings.Contains(trimmed, "|") {
+		return nil
+	}
+
+	trimmed = strings.TrimPrefix(trimmed, "|")
+	trimmed = strings.TrimSuffix(trimmed, "|")
+	parts := strings.Split(trimmed, "|")
+	cells := make([]string, 0, len(parts))
+	for _, part := range parts {
+		cells = append(cells, strings.TrimSpace(part))
+	}
+	return cells
+}
+
+func isMarkdownTableSeparator(line string, columns int) bool {
+	cells := splitMarkdownTableLine(line)
+	if len(cells) == 0 {
+		return false
+	}
+	if columns > 0 && len(cells) != columns {
+		return false
+	}
+	for _, cell := range cells {
+		if !mdTableSepCellRE.MatchString(strings.TrimSpace(cell)) {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeTableCells(cells []string, columns int) []string {
+	if columns <= 0 {
+		return cells
+	}
+	normalized := make([]string, columns)
+	copy(normalized, cells)
+	return normalized
+}
+
+func renderMarkdownTable(rows [][]string) string {
+	if len(rows) == 0 {
+		return ""
+	}
+
+	columnCount := 0
+	for _, row := range rows {
+		if len(row) > columnCount {
+			columnCount = len(row)
+		}
+	}
+	if columnCount == 0 {
+		return ""
+	}
+
+	renderedRows := make([][]string, len(rows))
+	widths := make([]int, columnCount)
+	for i, row := range rows {
+		normalized := normalizeTableCells(row, columnCount)
+		renderedRows[i] = make([]string, columnCount)
+		for j, cell := range normalized {
+			rendered := renderInlineMarkdown(cell)
+			renderedRows[i][j] = rendered
+			if width := lipgloss.Width(rendered); width > widths[j] {
+				widths[j] = width
+			}
+		}
+	}
+
+	for i := range widths {
+		if widths[i] < 3 {
+			widths[i] = 3
+		}
+	}
+
+	out := []string{
+		buildMarkdownTableRow(renderedRows[0], widths, true),
+		buildMarkdownTableSeparator(widths),
+	}
+	for _, row := range renderedRows[1:] {
+		out = append(out, buildMarkdownTableRow(row, widths, false))
+	}
+	return strings.Join(out, "\n")
+}
+
+func buildMarkdownTableRow(cells []string, widths []int, header bool) string {
+	parts := make([]string, 0, len(widths)*2+1)
+	parts = append(parts, mdTableBorderStyle.Render("|"))
+	for i, width := range widths {
+		cell := ""
+		if i < len(cells) {
+			cell = cells[i]
+		}
+		if header {
+			cell = mdTableHeaderStyle.Render(cell)
+		}
+		padded := lipgloss.NewStyle().Width(width).Render(cell)
+		parts = append(parts, " "+padded+" ", mdTableBorderStyle.Render("|"))
+	}
+	return strings.Join(parts, "")
+}
+
+func buildMarkdownTableSeparator(widths []int) string {
+	parts := []string{mdTableBorderStyle.Render("|")}
+	for _, width := range widths {
+		parts = append(parts, mdTableBorderStyle.Render(strings.Repeat("-", width+2)), mdTableBorderStyle.Render("|"))
+	}
+	return strings.Join(parts, "")
+}

--- a/pkg/input/cli/ui/markdown_test.go
+++ b/pkg/input/cli/ui/markdown_test.go
@@ -1,0 +1,62 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderMarkdownFormatsHeadingsAndLists(t *testing.T) {
+	rendered := RenderMarkdown("# Title\n- item one\n1. item two")
+
+	if strings.Contains(rendered, "# Title") {
+		t.Fatal("expected heading marker to be removed")
+	}
+	if strings.Contains(rendered, "- item one") {
+		t.Fatal("expected bullet marker to be rendered")
+	}
+	if !strings.Contains(rendered, "Title") {
+		t.Fatal("expected heading content to be present")
+	}
+	if !strings.Contains(rendered, "item one") || !strings.Contains(rendered, "item two") {
+		t.Fatal("expected list content to be present")
+	}
+}
+
+func TestRenderMarkdownFormatsCodeBlocksAndInlineCode(t *testing.T) {
+	rendered := RenderMarkdown("Use `fmt.Println` here.\n```go\nfmt.Println(\"hi\")\n```")
+
+	if strings.Contains(rendered, "```") {
+		t.Fatal("expected fence markers to be removed")
+	}
+	if !strings.Contains(rendered, "fmt.Println") {
+		t.Fatal("expected code content to be present")
+	}
+	if !strings.Contains(rendered, "GO") {
+		t.Fatal("expected code block language label to be rendered")
+	}
+}
+
+func TestRenderMarkdownFormatsTaskListsAndLinks(t *testing.T) {
+	rendered := RenderMarkdown("- [x] done\n- [ ] pending\nRead [Guide](https://example.com/docs)")
+
+	if strings.Contains(rendered, "- [x]") || strings.Contains(rendered, "- [ ]") {
+		t.Fatal("expected task list markers to be reformatted")
+	}
+	if !strings.Contains(rendered, "[x] done") || !strings.Contains(rendered, "[ ] pending") {
+		t.Fatal("expected task states to be present")
+	}
+	if !strings.Contains(rendered, "Guide") || !strings.Contains(rendered, "https://example.com/docs") {
+		t.Fatal("expected markdown link label and URL to be present")
+	}
+}
+
+func TestRenderMarkdownFormatsTables(t *testing.T) {
+	rendered := RenderMarkdown("| Name | Status |\n| --- | --- |\n| Build | Ready |\n| Ship | Waiting |")
+
+	if strings.Contains(rendered, "| --- | --- |") {
+		t.Fatal("expected markdown separator row to be reformatted")
+	}
+	if !strings.Contains(rendered, "Name") || !strings.Contains(rendered, "Build") || !strings.Contains(rendered, "Waiting") {
+		t.Fatal("expected table content to be present")
+	}
+}

--- a/pkg/input/cli/ui/ui.go
+++ b/pkg/input/cli/ui/ui.go
@@ -1,0 +1,269 @@
+// Package ui provides terminal UI styling utilities using lipgloss.
+package ui
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/input/cli/consoleio"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	term "github.com/charmbracelet/x/term"
+)
+
+// Style wraps lipgloss.Style with Sprint method for compatibility.
+type Style struct {
+	style lipgloss.Style
+}
+
+func (s Style) Sprint(a ...interface{}) string {
+	return s.style.Render(fmt.Sprint(a...))
+}
+
+func (s Style) Sprintf(format string, a ...interface{}) string {
+	return s.style.Render(fmt.Sprintf(format, a...))
+}
+
+// Compatibility aliases (used as ui.Bold, ui.Dim, etc.)
+var (
+	Bold    = Style{style: lipgloss.NewStyle().Bold(true)}
+	Dim     = Style{style: lipgloss.NewStyle().Foreground(lipgloss.Color("242"))}
+	Green   = Style{style: lipgloss.NewStyle().Foreground(lipgloss.Color("#10B981"))}
+	Cyan    = Style{style: lipgloss.NewStyle().Foreground(lipgloss.Color("#06B6D4"))}
+	Red     = Style{style: lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444"))}
+	Yellow  = Style{style: lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B"))}
+	Reset   = Style{style: lipgloss.NewStyle()}
+	Success = Style{style: lipgloss.NewStyle().Foreground(lipgloss.Color("#10B981"))}
+	Error   = Style{style: lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444"))}
+	Info    = Style{style: lipgloss.NewStyle().Foreground(lipgloss.Color("#3B82F6"))}
+	Warning = Style{style: lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B"))}
+
+	bannerCardStyle    = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("#155E75")).Padding(0, 1)
+	bannerTitleStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#E0F2FE"))
+	bannerLeadStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#67E8F9"))
+	bannerMetaStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#CBD5E1"))
+	bannerHintStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#94A3B8"))
+	bannerVersionStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#0F172A")).Background(lipgloss.Color("#FDE68A")).Padding(0, 1)
+	panelStyle         = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("#334155")).Padding(0, 1)
+	panelTitleStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#E2E8F0"))
+	sectionTitle       = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#67E8F9"))
+	keyStyle           = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#94A3B8")).Width(9)
+	valueStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("#E2E8F0"))
+	promptLabelStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#E2E8F0"))
+	promptArrowStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#67E8F9"))
+	chatRoleStyle      = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#67E8F9"))
+	chatBodyStyle      = lipgloss.NewStyle().BorderLeft(true).BorderForeground(lipgloss.Color("#155E75")).PaddingLeft(1).MarginLeft(1).Foreground(lipgloss.Color("#E2E8F0"))
+)
+
+const (
+	defaultTerminalWidth = 100
+	minRenderableWidth   = 36
+	maxBannerWidth       = 112
+	maxPanelWidth        = 88
+	maxChatWidth         = 100
+)
+
+func terminalWidth() int {
+	if raw := strings.TrimSpace(os.Getenv("COLUMNS")); raw != "" {
+		if width, err := strconv.Atoi(raw); err == nil && width > 0 {
+			return width
+		}
+	}
+
+	if width, _, err := term.GetSize(os.Stdout.Fd()); err == nil && width > 0 {
+		return width
+	}
+
+	return defaultTerminalWidth
+}
+
+func boundedWidth(maxWidth int) int {
+	width := terminalWidth()
+	if maxWidth > 0 && width > maxWidth {
+		width = maxWidth
+	}
+	if width < minRenderableWidth {
+		width = minRenderableWidth
+	}
+	return width
+}
+
+func fixedWidthRender(style lipgloss.Style, maxWidth int, content string) string {
+	width := boundedWidth(maxWidth) - style.GetHorizontalFrameSize()
+	if width < 8 {
+		width = 8
+	}
+	return style.Width(width).Render(content)
+}
+
+func wrappedRender(style lipgloss.Style, maxWidth int, content string) string {
+	width := boundedWidth(maxWidth) - style.GetHorizontalFrameSize()
+	if width < 8 {
+		width = 8
+	}
+	return style.MaxWidth(width).Render(content)
+}
+
+func trimRenderedLines(content string) string {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatTips(tips []string) string {
+	filtered := make([]string, 0, len(tips))
+	for _, tip := range tips {
+		tip = strings.TrimSpace(tip)
+		if tip == "" {
+			continue
+		}
+		filtered = append(filtered, tip)
+	}
+	return strings.Join(filtered, " | ")
+}
+
+func bannerView(version string) string {
+	title := bannerTitleStyle.Render("AnyClaw")
+	if version != "" {
+		title = lipgloss.JoinHorizontal(lipgloss.Center, title, "  ", bannerVersionStyle.Render("v"+version))
+	}
+
+	content := []string{
+		lipgloss.JoinHorizontal(lipgloss.Center, title, "  ", bannerLeadStyle.Render("gateway-first AI agent")),
+		bannerMetaStyle.Render("chat, tools, files, automation | Chinese assistant | file-first workspace"),
+		bannerHintStyle.Render("/help commands | /markdown on|off | /quit exit"),
+	}
+
+	return fixedWidthRender(bannerCardStyle, maxBannerWidth, strings.Join(content, "\n"))
+}
+
+func Banner(version string) {
+	fmt.Printf("\n%s\n\n", bannerView(version))
+}
+
+type SpinnerModel struct {
+	spinner  spinner.Model
+	message  string
+	quitting bool
+}
+
+func NewSpinner(msg string) *SpinnerModel {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("#7C3AED"))
+	return &SpinnerModel{spinner: s, message: msg}
+}
+
+func (m *SpinnerModel) Init() tea.Cmd {
+	return m.spinner.Tick
+}
+
+func (m *SpinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "esc", "ctrl+c":
+			m.quitting = true
+			return m, tea.Quit
+		}
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m *SpinnerModel) View() string {
+	if m.quitting {
+		return ""
+	}
+	return m.spinner.View() + " " + m.message
+}
+
+func RunSpinner(msg string, fn func() error) error {
+	s := NewSpinner(msg)
+	p := tea.NewProgram(s, tea.WithOutput(os.Stderr))
+	go func() {
+		err := fn()
+		s.quitting = true
+		p.Quit()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "\n%s %v\n", Error.Sprint("Error:"), err)
+		}
+	}()
+	_, _ = p.Run()
+	return nil
+}
+
+func Prompt(label string) string {
+	fmt.Printf("%s > ", label)
+	reader := consoleio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	return strings.TrimSpace(line)
+}
+
+func PromptWithDefault(label, defaultVal string) string {
+	fmt.Printf("%s (%s) > ", label, defaultVal)
+	reader := consoleio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	val := strings.TrimSpace(line)
+	if val == "" {
+		return defaultVal
+	}
+	return val
+}
+
+func Confirm(label string) bool {
+	fmt.Printf("%s (y/N) > ", label)
+	reader := consoleio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	val := strings.TrimSpace(strings.ToLower(line))
+	return val == "y" || val == "yes"
+}
+
+func KeyValue(label, value string) string {
+	return lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		keyStyle.Render(strings.ToLower(strings.TrimSpace(label))),
+		valueStyle.Render(strings.TrimSpace(value)),
+	)
+}
+
+func InteractivePanel(title string, lines []string, tips []string) string {
+	content := []string{panelTitleStyle.Render(title)}
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		content = append(content, line)
+	}
+	if len(tips) > 0 {
+		content = append(content, "", bannerHintStyle.Render(formatTips(tips)))
+	}
+	return fixedWidthRender(panelStyle, maxPanelWidth, strings.Join(content, "\n"))
+}
+
+func SectionTitle(text string) string {
+	return sectionTitle.Render(text)
+}
+
+func PromptPrefix(label string) string {
+	return promptLabelStyle.Render(strings.ToLower(strings.TrimSpace(label))) + " " + promptArrowStyle.Render(">")
+}
+
+func ChatHeader(label string) string {
+	if strings.TrimSpace(label) == "" {
+		label = "assistant"
+	}
+	return chatRoleStyle.Render(label)
+}
+
+func ChatBody(content string) string {
+	return trimRenderedLines(fixedWidthRender(chatBodyStyle, maxChatWidth, content))
+}

--- a/pkg/input/cli/ui/ui.go
+++ b/pkg/input/cli/ui/ui.go
@@ -189,6 +189,7 @@ func (m *SpinnerModel) View() string {
 func RunSpinner(msg string, fn func() error) error {
 	s := NewSpinner(msg)
 	p := tea.NewProgram(s, tea.WithOutput(os.Stderr))
+	errCh := make(chan error, 1)
 	go func() {
 		err := fn()
 		s.quitting = true
@@ -196,9 +197,14 @@ func RunSpinner(msg string, fn func() error) error {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "\n%s %v\n", Error.Sprint("Error:"), err)
 		}
+		errCh <- err
 	}()
-	_, _ = p.Run()
-	return nil
+	_, runErr := p.Run()
+	fnErr := <-errCh
+	if runErr != nil {
+		return runErr
+	}
+	return fnErr
 }
 
 func Prompt(label string) string {

--- a/pkg/input/cli/ui/ui_test.go
+++ b/pkg/input/cli/ui/ui_test.go
@@ -1,0 +1,43 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestBannerViewRespectsTerminalWidth(t *testing.T) {
+	t.Setenv("COLUMNS", "64")
+
+	rendered := bannerView("2026.3.13")
+	if width := maxLineWidth(rendered); width > 64 {
+		t.Fatalf("expected banner width <= 64, got %d\n%s", width, rendered)
+	}
+	if !strings.Contains(rendered, "AnyClaw") {
+		t.Fatalf("expected banner to include title, got %q", rendered)
+	}
+}
+
+func TestChatBodyWrapsWithinTerminalWidth(t *testing.T) {
+	t.Setenv("COLUMNS", "44")
+
+	rendered := ChatBody("这是一段很长很长很长很长的中文内容，用来验证聊天内容会在窄终端里自动换行。")
+	if width := maxLineWidth(rendered); width > 44 {
+		t.Fatalf("expected chat body width <= 44, got %d\n%s", width, rendered)
+	}
+	if !strings.Contains(rendered, "\n") {
+		t.Fatalf("expected wrapped chat body to span multiple lines, got %q", rendered)
+	}
+}
+
+func maxLineWidth(text string) int {
+	lines := strings.Split(text, "\n")
+	maxWidth := 0
+	for _, line := range lines {
+		if width := lipgloss.Width(line); width > maxWidth {
+			maxWidth = width
+		}
+	}
+	return maxWidth
+}

--- a/pkg/input/cli/ui/ui_test.go
+++ b/pkg/input/cli/ui/ui_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -40,4 +41,15 @@ func maxLineWidth(text string) int {
 		}
 	}
 	return maxWidth
+}
+
+func TestRunSpinnerReturnsFunctionError(t *testing.T) {
+	expectedErr := errors.New("boom")
+
+	err := RunSpinner("testing", func() error {
+		return expectedErr
+	})
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected %v, got %v", expectedErr, err)
+	}
 }

--- a/pkg/input/contracts.go
+++ b/pkg/input/contracts.go
@@ -1,0 +1,105 @@
+package input
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type InboundHandler func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error)
+
+type StreamChunkHandler func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error)
+
+type StreamAdapter interface {
+	Adapter
+	RunStream(ctx context.Context, handle StreamChunkHandler) error
+}
+
+type Status struct {
+	Name         string    `json:"name"`
+	Enabled      bool      `json:"enabled"`
+	Running      bool      `json:"running"`
+	Healthy      bool      `json:"healthy"`
+	LastError    string    `json:"last_error,omitempty"`
+	LastActivity time.Time `json:"last_activity,omitempty"`
+}
+
+type Adapter interface {
+	Name() string
+	Enabled() bool
+	Run(ctx context.Context, handle InboundHandler) error
+	Status() Status
+}
+
+type BaseAdapter struct {
+	mu     sync.RWMutex
+	status Status
+}
+
+func NewBaseAdapter(name string, enabled bool) BaseAdapter {
+	return BaseAdapter{status: Status{Name: name, Enabled: enabled}}
+}
+
+func (b *BaseAdapter) Status() Status {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.status
+}
+
+func (b *BaseAdapter) SetRunning(running bool) {
+	b.mu.Lock()
+	b.status.Running = running
+	b.mu.Unlock()
+}
+
+func (b *BaseAdapter) SetError(err error) {
+	b.mu.Lock()
+	if err != nil {
+		b.status.LastError = err.Error()
+		b.status.Healthy = false
+	} else {
+		b.status.LastError = ""
+		b.status.Healthy = true
+	}
+	b.mu.Unlock()
+}
+
+func (b *BaseAdapter) MarkActivity() {
+	b.mu.Lock()
+	b.status.LastActivity = time.Now().UTC()
+	b.status.Healthy = true
+	b.mu.Unlock()
+}
+
+type Manager struct {
+	adapters []Adapter
+}
+
+func NewManager(adapters ...Adapter) *Manager {
+	filtered := make([]Adapter, 0, len(adapters))
+	for _, adapter := range adapters {
+		if adapter != nil {
+			filtered = append(filtered, adapter)
+		}
+	}
+	return &Manager{adapters: filtered}
+}
+
+func (m *Manager) Run(ctx context.Context, handle InboundHandler) {
+	for _, adapter := range m.adapters {
+		if !adapter.Enabled() {
+			continue
+		}
+		go func(adapter Adapter) {
+			_ = adapter.Run(ctx, handle)
+		}(adapter)
+	}
+}
+
+func (m *Manager) Statuses() []Status {
+	statuses := make([]Status, 0, len(m.adapters))
+	for _, adapter := range m.adapters {
+		statuses = append(statuses, adapter.Status())
+	}
+	return statuses
+}

--- a/pkg/input/middleware.go
+++ b/pkg/input/middleware.go
@@ -133,9 +133,17 @@ func (cc *ChannelCommands) Wrap(handler InboundHandler) InboundHandler {
 
 func (cc *ChannelCommands) WrapStream(handler StreamChunkHandler) StreamChunkHandler {
 	return func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
-		_, handled, err := cc.Handle(ctx, message, meta)
+		result, handled, err := cc.Handle(ctx, message, meta)
 		if handled {
-			return sessionID, err
+			if err != nil {
+				return sessionID, err
+			}
+			if strings.TrimSpace(result) != "" {
+				if chunkErr := onChunk(result); chunkErr != nil {
+					return sessionID, chunkErr
+				}
+			}
+			return sessionID, nil
 		}
 		return handler(ctx, sessionID, message, meta, onChunk)
 	}
@@ -234,6 +242,7 @@ func (mg *MentionGate) Wrap(handler InboundHandler) InboundHandler {
 			cleanMessage = message
 		}
 		meta["bot_user_id"] = botUserID
+		meta["bot_mention_ids"] = strings.Join(mentionIDs, ",")
 		return handler(ctx, sessionID, cleanMessage, meta)
 	}
 }
@@ -267,6 +276,7 @@ func (mg *MentionGate) WrapStream(handler StreamChunkHandler) StreamChunkHandler
 			cleanMessage = message
 		}
 		meta["bot_user_id"] = botUserID
+		meta["bot_mention_ids"] = strings.Join(mentionIDs, ",")
 		return handler(ctx, sessionID, cleanMessage, meta, onChunk)
 	}
 }

--- a/pkg/input/middleware.go
+++ b/pkg/input/middleware.go
@@ -1,0 +1,834 @@
+package input
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+type ChannelCommands struct {
+	mu       sync.RWMutex
+	botName  string
+	handlers map[string]CommandHandler
+}
+
+type CommandHandler func(ctx context.Context, args string, meta map[string]string) (string, error)
+
+func NewChannelCommands(botName string) *ChannelCommands {
+	cc := &ChannelCommands{
+		botName:  botName,
+		handlers: make(map[string]CommandHandler),
+	}
+	cc.Register("help", cc.handleHelp)
+	cc.Register("status", cc.handleStatus)
+	cc.Register("ping", cc.handlePing)
+	cc.Register("sessions", cc.handleSessions)
+	return cc
+}
+
+func (cc *ChannelCommands) Register(name string, handler CommandHandler) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	cc.handlers[strings.ToLower(name)] = handler
+}
+
+func (cc *ChannelCommands) Handle(ctx context.Context, text string, meta map[string]string) (string, bool, error) {
+	cmd, args := cc.parseCommand(text)
+	if cmd == "" {
+		return "", false, nil
+	}
+
+	cc.mu.RLock()
+	handler, ok := cc.handlers[strings.ToLower(cmd)]
+	cc.mu.RUnlock()
+
+	if !ok {
+		return fmt.Sprintf("Unknown command: /%s. Use /help for available commands.", cmd), true, nil
+	}
+
+	result, err := handler(ctx, args, meta)
+	return result, true, err
+}
+
+func (cc *ChannelCommands) parseCommand(text string) (string, string) {
+	text = strings.TrimSpace(text)
+
+	if strings.HasPrefix(text, "/") {
+		parts := strings.SplitN(text[1:], " ", 2)
+		cmd := parts[0]
+		args := ""
+		if len(parts) > 1 {
+			args = strings.TrimSpace(parts[1])
+		}
+		return cmd, args
+	}
+
+	botMentionPattern := fmt.Sprintf(`(?i)^@?%s\s*[/!](\w+)(.*)`, regexp.QuoteMeta(cc.botName))
+	re := regexp.MustCompile(botMentionPattern)
+	if matches := re.FindStringSubmatch(text); len(matches) >= 2 {
+		cmd := matches[1]
+		args := ""
+		if len(matches) > 2 {
+			args = strings.TrimSpace(matches[2])
+		}
+		return cmd, args
+	}
+
+	return "", ""
+}
+
+func (cc *ChannelCommands) handleHelp(ctx context.Context, args string, meta map[string]string) (string, error) {
+	cc.mu.RLock()
+	names := make([]string, 0, len(cc.handlers))
+	for name := range cc.handlers {
+		names = append(names, name)
+	}
+	cc.mu.RUnlock()
+
+	helpText := "Available commands:\n"
+	for _, name := range names {
+		helpText += fmt.Sprintf("  /%s\n", name)
+	}
+	return helpText, nil
+}
+
+func (cc *ChannelCommands) handleStatus(ctx context.Context, args string, meta map[string]string) (string, error) {
+	channel := meta["channel"]
+	userID := meta["user_id"]
+	username := meta["username"]
+	if username == "" {
+		username = meta["sender"]
+	}
+
+	status := fmt.Sprintf("AnyClaw Channel Status\n")
+	status += fmt.Sprintf("Channel: %s\n", channel)
+	if userID != "" {
+		status += fmt.Sprintf("User: %s (%s)\n", username, userID)
+	}
+	status += fmt.Sprintf("Time: %s\n", time.Now().UTC().Format("2006-01-02 15:04:05 UTC"))
+	status += "Status: Online"
+	return status, nil
+}
+
+func (cc *ChannelCommands) handlePing(ctx context.Context, args string, meta map[string]string) (string, error) {
+	return fmt.Sprintf("Pong! Latency: %dms", time.Now().UnixMilli()%1000), nil
+}
+
+func (cc *ChannelCommands) handleSessions(ctx context.Context, args string, meta map[string]string) (string, error) {
+	return "Session management is available via the web UI.", nil
+}
+
+func (cc *ChannelCommands) Wrap(handler InboundHandler) InboundHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		result, handled, err := cc.Handle(ctx, message, meta)
+		if handled {
+			return sessionID, result, err
+		}
+		return handler(ctx, sessionID, message, meta)
+	}
+}
+
+func (cc *ChannelCommands) WrapStream(handler StreamChunkHandler) StreamChunkHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+		_, handled, err := cc.Handle(ctx, message, meta)
+		if handled {
+			return sessionID, err
+		}
+		return handler(ctx, sessionID, message, meta, onChunk)
+	}
+}
+
+type MentionGate struct {
+	mu            sync.RWMutex
+	enabled       bool
+	botUserID     string
+	botMentionIDs []string
+}
+
+func NewMentionGate(enabled bool, botUserID string, additionalMentions []string) *MentionGate {
+	return &MentionGate{
+		enabled:       enabled,
+		botUserID:     botUserID,
+		botMentionIDs: append([]string{botUserID}, additionalMentions...),
+	}
+}
+
+func (mg *MentionGate) ShouldProcess(text string, meta map[string]string) bool {
+	mg.mu.RLock()
+	enabled := mg.enabled
+	mentionIDs := mg.botMentionIDs
+	mg.mu.RUnlock()
+
+	if !enabled {
+		return true
+	}
+
+	if isMentioned(text, mentionIDs) {
+		return true
+	}
+
+	channelType := meta["channel_type"]
+	isGroup := meta["is_group"] == "true"
+	isGuild := meta["guild_id"] != ""
+
+	if channelType == "dm" || channelType == "private" {
+		return true
+	}
+
+	if !isGroup && !isGuild {
+		return true
+	}
+
+	return false
+}
+
+func (mg *MentionGate) StripMention(text string) string {
+	mg.mu.RLock()
+	mentionIDs := mg.botMentionIDs
+	mg.mu.RUnlock()
+
+	return stripMentions(text, mentionIDs)
+}
+
+func (mg *MentionGate) SetEnabled(enabled bool) {
+	mg.mu.Lock()
+	mg.enabled = enabled
+	mg.mu.Unlock()
+}
+
+func (mg *MentionGate) IsEnabled() bool {
+	mg.mu.RLock()
+	defer mg.mu.RUnlock()
+	return mg.enabled
+}
+
+func (mg *MentionGate) Wrap(handler InboundHandler) InboundHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		mg.mu.RLock()
+		enabled := mg.enabled
+		botUserID := mg.botUserID
+		mentionIDs := mg.botMentionIDs
+		mg.mu.RUnlock()
+
+		if !enabled {
+			return handler(ctx, sessionID, message, meta)
+		}
+
+		channelType := meta["channel_type"]
+		isGroup := meta["is_group"] == "true"
+		isGuild := meta["guild_id"] != ""
+
+		if channelType == "dm" || channelType == "private" || (!isGroup && !isGuild) {
+			return handler(ctx, sessionID, message, meta)
+		}
+
+		if !isMentioned(message, mentionIDs) {
+			return sessionID, "", nil
+		}
+
+		cleanMessage := stripMentions(message, mentionIDs)
+		if cleanMessage == "" {
+			cleanMessage = message
+		}
+		meta["bot_user_id"] = botUserID
+		return handler(ctx, sessionID, cleanMessage, meta)
+	}
+}
+
+func (mg *MentionGate) WrapStream(handler StreamChunkHandler) StreamChunkHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+		mg.mu.RLock()
+		enabled := mg.enabled
+		botUserID := mg.botUserID
+		mentionIDs := mg.botMentionIDs
+		mg.mu.RUnlock()
+
+		if !enabled {
+			return handler(ctx, sessionID, message, meta, onChunk)
+		}
+
+		channelType := meta["channel_type"]
+		isGroup := meta["is_group"] == "true"
+		isGuild := meta["guild_id"] != ""
+
+		if channelType == "dm" || channelType == "private" || (!isGroup && !isGuild) {
+			return handler(ctx, sessionID, message, meta, onChunk)
+		}
+
+		if !isMentioned(message, mentionIDs) {
+			return sessionID, nil
+		}
+
+		cleanMessage := stripMentions(message, mentionIDs)
+		if cleanMessage == "" {
+			cleanMessage = message
+		}
+		meta["bot_user_id"] = botUserID
+		return handler(ctx, sessionID, cleanMessage, meta, onChunk)
+	}
+}
+
+func isMentioned(text string, mentionIDs []string) bool {
+	for _, id := range mentionIDs {
+		if id == "" {
+			continue
+		}
+		discordMention := fmt.Sprintf("<@%s>", id)
+		discordNickMention := fmt.Sprintf("<@!%s>", id)
+		slackMention := fmt.Sprintf("<@%s>", id)
+
+		if strings.Contains(text, discordMention) ||
+			strings.Contains(text, discordNickMention) ||
+			strings.Contains(text, slackMention) {
+			return true
+		}
+
+		if strings.HasPrefix(strings.TrimSpace(text), "@"+id) {
+			return true
+		}
+	}
+	return false
+}
+
+func stripMentions(text string, mentionIDs []string) string {
+	for _, id := range mentionIDs {
+		if id == "" {
+			continue
+		}
+		discordMention := fmt.Sprintf("<@%s> ", id)
+		discordNickMention := fmt.Sprintf("<@!%s> ", id)
+		slackMention := fmt.Sprintf("<@%s> ", id)
+
+		text = strings.ReplaceAll(text, discordMention, "")
+		text = strings.ReplaceAll(text, discordNickMention, "")
+		text = strings.ReplaceAll(text, slackMention, "")
+
+		discordMentionNoSpace := fmt.Sprintf("<@%s>", id)
+		discordNickMentionNoSpace := fmt.Sprintf("<@!%s>", id)
+		slackMentionNoSpace := fmt.Sprintf("<@%s>", id)
+
+		text = strings.ReplaceAll(text, discordMentionNoSpace, "")
+		text = strings.ReplaceAll(text, discordNickMentionNoSpace, "")
+		text = strings.ReplaceAll(text, slackMentionNoSpace, "")
+	}
+	return strings.TrimSpace(text)
+}
+
+type GroupSecurity struct {
+	mu              sync.RWMutex
+	allowedGroups   map[string]map[string]bool
+	deniedUsers     map[string]bool
+	allowedUsers    map[string]bool
+	requireApproval bool
+}
+
+func NewGroupSecurity() *GroupSecurity {
+	return &GroupSecurity{
+		allowedGroups: make(map[string]map[string]bool),
+		deniedUsers:   make(map[string]bool),
+		allowedUsers:  make(map[string]bool),
+	}
+}
+
+func (gs *GroupSecurity) AllowGroup(groupID string) {
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+	if gs.allowedGroups[groupID] == nil {
+		gs.allowedGroups[groupID] = make(map[string]bool)
+	}
+	gs.allowedGroups[groupID]["allowed"] = true
+}
+
+func (gs *GroupSecurity) DenyGroup(groupID string) {
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+	delete(gs.allowedGroups, groupID)
+}
+
+func (gs *GroupSecurity) AllowUser(userID string) {
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+	gs.allowedUsers[userID] = true
+	delete(gs.deniedUsers, userID)
+}
+
+func (gs *GroupSecurity) DenyUser(userID string) {
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+	gs.deniedUsers[userID] = true
+	delete(gs.allowedUsers, userID)
+}
+
+func (gs *GroupSecurity) ShouldProcess(userID string, groupID string) bool {
+	gs.mu.RLock()
+	defer gs.mu.RUnlock()
+
+	if gs.deniedUsers[userID] {
+		return false
+	}
+
+	if gs.allowedUsers[userID] {
+		return true
+	}
+
+	if groupID != "" {
+		if gs.allowedGroups[groupID] == nil {
+			return !gs.requireApproval
+		}
+		return gs.allowedGroups[groupID]["allowed"]
+	}
+
+	return true
+}
+
+func (gs *GroupSecurity) SetRequireApproval(require bool) {
+	gs.mu.Lock()
+	gs.requireApproval = require
+	gs.mu.Unlock()
+}
+
+func (gs *GroupSecurity) Wrap(handler InboundHandler) InboundHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		userID := meta["user_id"]
+		groupID := meta["guild_id"]
+		if groupID == "" {
+			groupID = meta["chat_id"]
+		}
+
+		if !gs.ShouldProcess(userID, groupID) {
+			return sessionID, "", fmt.Errorf("user %s not authorized in group %s", userID, groupID)
+		}
+		return handler(ctx, sessionID, message, meta)
+	}
+}
+
+func (gs *GroupSecurity) WrapStream(handler StreamChunkHandler) StreamChunkHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+		userID := meta["user_id"]
+		groupID := meta["guild_id"]
+		if groupID == "" {
+			groupID = meta["chat_id"]
+		}
+
+		if !gs.ShouldProcess(userID, groupID) {
+			return sessionID, fmt.Errorf("user %s not authorized in group %s", userID, groupID)
+		}
+		return handler(ctx, sessionID, message, meta, onChunk)
+	}
+}
+
+type ChannelPairing struct {
+	mu       sync.RWMutex
+	pairings map[string]PairingInfo
+	enabled  bool
+}
+
+type PairingInfo struct {
+	UserID      string    `json:"user_id"`
+	DeviceID    string    `json:"device_id"`
+	Channel     string    `json:"channel"`
+	PairedAt    time.Time `json:"paired_at"`
+	ExpiresAt   time.Time `json:"expires_at"`
+	LastSeen    time.Time `json:"last_seen"`
+	DisplayName string    `json:"display_name"`
+}
+
+func NewChannelPairing() *ChannelPairing {
+	return &ChannelPairing{
+		pairings: make(map[string]PairingInfo),
+	}
+}
+
+func (cp *ChannelPairing) Pair(userID, deviceID, channel, displayName string, ttl time.Duration) PairingInfo {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	key := cp.pairingKey(userID, deviceID, channel)
+	now := time.Now().UTC()
+	info := PairingInfo{
+		UserID:      userID,
+		DeviceID:    deviceID,
+		Channel:     channel,
+		PairedAt:    now,
+		ExpiresAt:   now.Add(ttl),
+		LastSeen:    now,
+		DisplayName: displayName,
+	}
+	cp.pairings[key] = info
+	return info
+}
+
+func (cp *ChannelPairing) Unpair(userID, deviceID, channel string) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	key := cp.pairingKey(userID, deviceID, channel)
+	delete(cp.pairings, key)
+}
+
+func (cp *ChannelPairing) IsPaired(userID, deviceID, channel string) bool {
+	cp.mu.RLock()
+	defer cp.mu.RUnlock()
+	key := cp.pairingKey(userID, deviceID, channel)
+	info, ok := cp.pairings[key]
+	if !ok {
+		return false
+	}
+	return time.Now().UTC().Before(info.ExpiresAt)
+}
+
+func (cp *ChannelPairing) UpdateLastSeen(userID, deviceID, channel string) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	key := cp.pairingKey(userID, deviceID, channel)
+	if info, ok := cp.pairings[key]; ok {
+		info.LastSeen = time.Now().UTC()
+		cp.pairings[key] = info
+	}
+}
+
+func (cp *ChannelPairing) ListPaired() []PairingInfo {
+	cp.mu.RLock()
+	defer cp.mu.RUnlock()
+	now := time.Now().UTC()
+	result := make([]PairingInfo, 0, len(cp.pairings))
+	for _, info := range cp.pairings {
+		if now.Before(info.ExpiresAt) {
+			result = append(result, info)
+		}
+	}
+	return result
+}
+
+func (cp *ChannelPairing) CleanupExpired() {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	now := time.Now().UTC()
+	for key, info := range cp.pairings {
+		if now.After(info.ExpiresAt) {
+			delete(cp.pairings, key)
+		}
+	}
+}
+
+func (cp *ChannelPairing) pairingKey(userID, deviceID, channel string) string {
+	return fmt.Sprintf("%s:%s:%s", channel, userID, deviceID)
+}
+
+func (cp *ChannelPairing) SetEnabled(enabled bool) {
+	cp.mu.Lock()
+	cp.enabled = enabled
+	cp.mu.Unlock()
+}
+
+func (cp *ChannelPairing) IsEnabled() bool {
+	cp.mu.RLock()
+	defer cp.mu.RUnlock()
+	return cp.enabled
+}
+
+func (cp *ChannelPairing) Wrap(handler InboundHandler) InboundHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		cp.mu.RLock()
+		enabled := cp.enabled
+		cp.mu.RUnlock()
+
+		if !enabled {
+			return handler(ctx, sessionID, message, meta)
+		}
+
+		userID := meta["user_id"]
+		deviceID := meta["device_id"]
+		channel := meta["channel"]
+
+		if !cp.IsPaired(userID, deviceID, channel) {
+			return sessionID, "Device not paired. Please pair your device first.", nil
+		}
+
+		cp.UpdateLastSeen(userID, deviceID, channel)
+		return handler(ctx, sessionID, message, meta)
+	}
+}
+
+func (cp *ChannelPairing) WrapStream(handler StreamChunkHandler) StreamChunkHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+		cp.mu.RLock()
+		enabled := cp.enabled
+		cp.mu.RUnlock()
+
+		if !enabled {
+			return handler(ctx, sessionID, message, meta, onChunk)
+		}
+
+		userID := meta["user_id"]
+		deviceID := meta["device_id"]
+		channel := meta["channel"]
+
+		if !cp.IsPaired(userID, deviceID, channel) {
+			return sessionID, fmt.Errorf("device not paired")
+		}
+
+		cp.UpdateLastSeen(userID, deviceID, channel)
+		return handler(ctx, sessionID, message, meta, onChunk)
+	}
+}
+
+type PresenceManager struct {
+	mu        sync.RWMutex
+	presences map[string]PresenceInfo
+	onUpdate  func(channel, userID string, presence PresenceInfo)
+}
+
+type PresenceInfo struct {
+	Status     string    `json:"status"`
+	Activity   string    `json:"activity,omitempty"`
+	Since      time.Time `json:"since"`
+	LastUpdate time.Time `json:"last_update"`
+}
+
+func NewPresenceManager(onUpdate func(channel, userID string, presence PresenceInfo)) *PresenceManager {
+	return &PresenceManager{
+		presences: make(map[string]PresenceInfo),
+		onUpdate:  onUpdate,
+	}
+}
+
+func (pm *PresenceManager) SetPresence(channel, userID string, status string, activity string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	key := fmt.Sprintf("%s:%s", channel, userID)
+	now := time.Now().UTC()
+	info := PresenceInfo{
+		Status:     status,
+		Activity:   activity,
+		Since:      now,
+		LastUpdate: now,
+	}
+
+	if existing, ok := pm.presences[key]; ok {
+		info.Since = existing.Since
+		if existing.Status == status {
+			info.Since = existing.Since
+		}
+	}
+
+	pm.presences[key] = info
+
+	if pm.onUpdate != nil {
+		pm.onUpdate(channel, userID, info)
+	}
+}
+
+func (pm *PresenceManager) GetPresence(channel, userID string) (PresenceInfo, bool) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	key := fmt.Sprintf("%s:%s", channel, userID)
+	info, ok := pm.presences[key]
+	return info, ok
+}
+
+func (pm *PresenceManager) SetTyping(channel, userID string, typing bool) {
+	if typing {
+		pm.SetPresence(channel, userID, "typing", "")
+	} else {
+		pm.SetPresence(channel, userID, "online", "")
+	}
+}
+
+func (pm *PresenceManager) SetOffline(channel, userID string) {
+	pm.SetPresence(channel, userID, "offline", "")
+}
+
+func (pm *PresenceManager) ListActive() map[string]PresenceInfo {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	result := make(map[string]PresenceInfo)
+	for k, v := range pm.presences {
+		if v.Status != "offline" {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+func (pm *PresenceManager) CleanupStale(timeout time.Duration) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	now := time.Now().UTC()
+	for key, info := range pm.presences {
+		if now.Sub(info.LastUpdate) > timeout && info.Status != "offline" {
+			info.Status = "offline"
+			info.LastUpdate = now
+			pm.presences[key] = info
+		}
+	}
+}
+
+func (pm *PresenceManager) Wrap(handler InboundHandler) InboundHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		channel := meta["channel"]
+		userID := meta["user_id"]
+		if channel != "" && userID != "" {
+			pm.SetTyping(channel, userID, true)
+		}
+
+		respSessionID, response, err := handler(ctx, sessionID, message, meta)
+
+		if channel != "" && userID != "" {
+			pm.SetTyping(channel, userID, false)
+		}
+		return respSessionID, response, err
+	}
+}
+
+func (pm *PresenceManager) WrapStream(handler StreamChunkHandler) StreamChunkHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+		channel := meta["channel"]
+		userID := meta["user_id"]
+		if channel != "" && userID != "" {
+			pm.SetTyping(channel, userID, true)
+		}
+
+		respSessionID, err := handler(ctx, sessionID, message, meta, onChunk)
+
+		if channel != "" && userID != "" {
+			pm.SetTyping(channel, userID, false)
+		}
+		return respSessionID, err
+	}
+}
+
+type ContactDirectory struct {
+	mu       sync.RWMutex
+	contacts map[string]ContactInfo
+}
+
+type ContactInfo struct {
+	UserID      string            `json:"user_id"`
+	Channel     string            `json:"channel"`
+	DisplayName string            `json:"display_name"`
+	Username    string            `json:"username"`
+	FirstName   string            `json:"first_name"`
+	LastName    string            `json:"last_name"`
+	IsBot       bool              `json:"is_bot"`
+	AddedAt     time.Time         `json:"added_at"`
+	LastSeen    time.Time         `json:"last_seen"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+func NewContactDirectory() *ContactDirectory {
+	return &ContactDirectory{
+		contacts: make(map[string]ContactInfo),
+	}
+}
+
+func (cd *ContactDirectory) AddOrUpdate(contact ContactInfo) {
+	cd.mu.Lock()
+	defer cd.mu.Unlock()
+
+	key := fmt.Sprintf("%s:%s", contact.Channel, contact.UserID)
+	now := time.Now().UTC()
+
+	if existing, ok := cd.contacts[key]; ok {
+		contact.AddedAt = existing.AddedAt
+		contact.LastSeen = now
+		if contact.DisplayName == "" {
+			contact.DisplayName = existing.DisplayName
+		}
+		if contact.Username == "" {
+			contact.Username = existing.Username
+		}
+	} else {
+		contact.AddedAt = now
+		contact.LastSeen = now
+	}
+
+	cd.contacts[key] = contact
+}
+
+func (cd *ContactDirectory) Get(channel, userID string) (ContactInfo, bool) {
+	cd.mu.RLock()
+	defer cd.mu.RUnlock()
+	key := fmt.Sprintf("%s:%s", channel, userID)
+	contact, ok := cd.contacts[key]
+	return contact, ok
+}
+
+func (cd *ContactDirectory) Remove(channel, userID string) {
+	cd.mu.Lock()
+	defer cd.mu.Unlock()
+	key := fmt.Sprintf("%s:%s", channel, userID)
+	delete(cd.contacts, key)
+}
+
+func (cd *ContactDirectory) List(channel string) []ContactInfo {
+	cd.mu.RLock()
+	defer cd.mu.RUnlock()
+
+	result := make([]ContactInfo, 0, len(cd.contacts))
+	for _, contact := range cd.contacts {
+		if channel == "" || contact.Channel == channel {
+			result = append(result, contact)
+		}
+	}
+	return result
+}
+
+func (cd *ContactDirectory) Search(query string) []ContactInfo {
+	cd.mu.RLock()
+	defer cd.mu.RUnlock()
+
+	query = strings.ToLower(query)
+	result := make([]ContactInfo, 0, len(cd.contacts))
+	for _, contact := range cd.contacts {
+		if strings.Contains(strings.ToLower(contact.DisplayName), query) ||
+			strings.Contains(strings.ToLower(contact.Username), query) ||
+			strings.Contains(strings.ToLower(contact.UserID), query) {
+			result = append(result, contact)
+		}
+	}
+	return result
+}
+
+func (cd *ContactDirectory) Count() int {
+	cd.mu.RLock()
+	defer cd.mu.RUnlock()
+	return len(cd.contacts)
+}
+
+func (cd *ContactDirectory) Wrap(handler InboundHandler) InboundHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		userID := meta["user_id"]
+		channel := meta["channel"]
+		if userID != "" && channel != "" {
+			cd.AddOrUpdate(ContactInfo{
+				UserID:      userID,
+				Channel:     channel,
+				DisplayName: meta["username"],
+				Username:    meta["username"],
+				Metadata:    meta,
+			})
+		}
+		return handler(ctx, sessionID, message, meta)
+	}
+}
+
+func (cd *ContactDirectory) WrapStream(handler StreamChunkHandler) StreamChunkHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+		userID := meta["user_id"]
+		channel := meta["channel"]
+		if userID != "" && channel != "" {
+			cd.AddOrUpdate(ContactInfo{
+				UserID:      userID,
+				Channel:     channel,
+				DisplayName: meta["username"],
+				Username:    meta["username"],
+				Metadata:    meta,
+			})
+		}
+		return handler(ctx, sessionID, message, meta, onChunk)
+	}
+}

--- a/pkg/input/middleware_test.go
+++ b/pkg/input/middleware_test.go
@@ -1,0 +1,33 @@
+package input
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestChannelCommandsWrapStreamEmitsCommandOutput(t *testing.T) {
+	cc := NewChannelCommands("AnyClaw")
+	wrapped := cc.WrapStream(func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+		t.Fatal("stream handler should not be called for built-in commands")
+		return "", nil
+	})
+
+	var chunks []string
+	sessionID, err := wrapped(context.Background(), "session-1", "/help", map[string]string{"channel": "slack"}, func(chunk string) error {
+		chunks = append(chunks, chunk)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("wrap stream returned error: %v", err)
+	}
+	if sessionID != "session-1" {
+		t.Fatalf("expected session to be preserved, got %q", sessionID)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected one streamed command response, got %d", len(chunks))
+	}
+	if !strings.Contains(chunks[0], "Available commands:") {
+		t.Fatalf("expected streamed help output, got %q", chunks[0])
+	}
+}

--- a/pkg/input/plugin_adapter.go
+++ b/pkg/input/plugin_adapter.go
@@ -1,0 +1,116 @@
+package input
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/plugin"
+)
+
+type pluginChannelAdapter struct {
+	base        BaseAdapter
+	runner      plugin.ChannelRunner
+	appendEvent func(eventType string, sessionID string, payload map[string]any)
+}
+
+// NewPluginChannelAdapter adapts a plugin-backed channel runner into the input layer contract.
+func NewPluginChannelAdapter(runner plugin.ChannelRunner, appendEvent func(eventType string, sessionID string, payload map[string]any)) Adapter {
+	return &pluginChannelAdapter{
+		base:        NewBaseAdapter(runner.Manifest.Name, true),
+		runner:      runner,
+		appendEvent: appendEvent,
+	}
+}
+
+func (a *pluginChannelAdapter) Name() string  { return a.runner.Manifest.Name }
+func (a *pluginChannelAdapter) Enabled() bool { return true }
+
+func (a *pluginChannelAdapter) Status() Status {
+	status := a.base.Status()
+	status.Enabled = true
+	return status
+}
+
+func (a *pluginChannelAdapter) Run(ctx context.Context, handle InboundHandler) error {
+	a.base.SetRunning(true)
+	defer a.base.SetRunning(false)
+
+	ticker := time.NewTicker(a.runner.Timeout)
+	defer ticker.Stop()
+
+	for {
+		if err := a.pollOnce(ctx, handle); err != nil {
+			a.base.SetError(err)
+			a.append("channel.plugin.error", "", map[string]any{"plugin": a.runner.Manifest.Name, "error": err.Error()})
+		} else {
+			a.base.SetError(nil)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *pluginChannelAdapter) pollOnce(ctx context.Context, handle InboundHandler) error {
+	ctx, cancel := context.WithTimeout(ctx, a.runner.Timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, a.runner.Entrypoint)
+	pluginDir := filepath.Dir(a.runner.Entrypoint)
+	cmd.Dir = pluginDir
+	cmd.Env = append(os.Environ(),
+		"ANYCLAW_PLUGIN_MODE=channel-poll",
+		"ANYCLAW_PLUGIN_DIR="+pluginDir,
+		"ANYCLAW_PLUGIN_TIMEOUT_SECONDS="+fmt.Sprintf("%d", int(a.runner.Timeout/time.Second)),
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("channel plugin timed out after %s", a.runner.Timeout)
+		}
+		return fmt.Errorf("channel plugin failed: %w: %s", err, string(output))
+	}
+
+	var messages []struct {
+		Source  string `json:"source"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(output, &messages); err != nil {
+		return err
+	}
+
+	for _, item := range messages {
+		sessionID, _, err := handle(ctx, "", item.Message, map[string]string{
+			"channel":      a.runner.Manifest.Channel.Name,
+			"source":       item.Source,
+			"reply_target": item.Source,
+		})
+		if err != nil {
+			return err
+		}
+		a.base.MarkActivity()
+		a.append("channel.plugin.message", sessionID, map[string]any{
+			"plugin":  a.runner.Manifest.Name,
+			"channel": a.runner.Manifest.Channel.Name,
+			"source":  item.Source,
+			"message": item.Message,
+		})
+	}
+
+	return nil
+}
+
+func (a *pluginChannelAdapter) append(eventType string, sessionID string, payload map[string]any) {
+	if a.appendEvent != nil {
+		a.appendEvent(eventType, sessionID, payload)
+	}
+}

--- a/pkg/input/plugin_contracts.go
+++ b/pkg/input/plugin_contracts.go
@@ -1,0 +1,354 @@
+package input
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	gatewayevents "github.com/1024XEngineer/anyclaw/pkg/gateway/events"
+)
+
+type ChannelID string
+
+type ChannelStatus string
+
+const (
+	ChannelStatusConnected    ChannelStatus = "connected"
+	ChannelStatusDisconnected ChannelStatus = "disconnected"
+	ChannelStatusConnecting   ChannelStatus = "connecting"
+	ChannelStatusError        ChannelStatus = "error"
+)
+
+type Message struct {
+	ID        string                 `json:"id"`
+	ChannelID ChannelID              `json:"channel_id"`
+	SenderID  string                 `json:"sender_id"`
+	Content   string                 `json:"content"`
+	Type      MessageType            `json:"type"`
+	Metadata  map[string]interface{} `json:"metadata,omitempty"`
+	Timestamp time.Time              `json:"timestamp"`
+}
+
+type MessageType string
+
+const (
+	MessageTypeText     MessageType = "text"
+	MessageTypeImage    MessageType = "image"
+	MessageTypeFile     MessageType = "file"
+	MessageTypeCommand  MessageType = "command"
+	MessageTypeResponse MessageType = "response"
+)
+
+type ChannelPlugin interface {
+	ID() ChannelID
+	Name() string
+	Description() string
+	Connect(ctx context.Context) error
+	Disconnect(ctx context.Context) error
+	SendMessage(ctx context.Context, message *Message) error
+	GetStatus() ChannelStatus
+	GetCapabilities() ChannelCapabilities
+	SetMessageHandler(handler MessageHandler)
+	HealthCheck(ctx context.Context) error
+}
+
+type ChannelCapabilities struct {
+	SupportsText     bool
+	SupportsImages   bool
+	SupportsFiles    bool
+	SupportsCommands bool
+	SupportsRichText bool
+	SupportsMarkdown bool
+	MaxMessageSize   int
+}
+
+type MessageHandler func(ctx context.Context, message *Message) error
+
+type ChannelManager struct {
+	mu           sync.RWMutex
+	plugins      map[ChannelID]ChannelPlugin
+	handlers     map[ChannelID]MessageHandler
+	eventBus     *gatewayevents.EventBus
+	healthTicker *time.Ticker
+	stopHealth   chan struct{}
+}
+
+func NewChannelManager(eventBus *gatewayevents.EventBus) *ChannelManager {
+	return &ChannelManager{
+		plugins:    make(map[ChannelID]ChannelPlugin),
+		handlers:   make(map[ChannelID]MessageHandler),
+		eventBus:   eventBus,
+		stopHealth: make(chan struct{}),
+	}
+}
+
+func (m *ChannelManager) RegisterPlugin(plugin ChannelPlugin) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	id := plugin.ID()
+	if _, exists := m.plugins[id]; exists {
+		return fmt.Errorf("channel plugin %s already registered", id)
+	}
+
+	m.plugins[id] = plugin
+	plugin.SetMessageHandler(func(ctx context.Context, message *Message) error {
+		return m.handleMessage(ctx, id, message)
+	})
+
+	if m.eventBus != nil {
+		m.eventBus.PublishAsync(context.Background(), gatewayevents.Event{
+			Type:   gatewayevents.EventChannelConnect,
+			Source: "channel_manager",
+			Data: map[string]interface{}{
+				"channel_id":   string(id),
+				"channel_name": plugin.Name(),
+			},
+			Timestamp: time.Now().Unix(),
+		})
+	}
+
+	return nil
+}
+
+func (m *ChannelManager) UnregisterPlugin(id ChannelID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	plugin, exists := m.plugins[id]
+	if !exists {
+		return fmt.Errorf("channel plugin %s not found", id)
+	}
+
+	if err := plugin.Disconnect(context.Background()); err != nil {
+		return fmt.Errorf("failed to disconnect channel %s: %w", id, err)
+	}
+
+	delete(m.plugins, id)
+	delete(m.handlers, id)
+	return nil
+}
+
+func (m *ChannelManager) GetPlugin(id ChannelID) (ChannelPlugin, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	plugin, exists := m.plugins[id]
+	if !exists {
+		return nil, fmt.Errorf("channel plugin %s not found", id)
+	}
+
+	return plugin, nil
+}
+
+func (m *ChannelManager) GetAllPlugins() []ChannelPlugin {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	plugins := make([]ChannelPlugin, 0, len(m.plugins))
+	for _, plugin := range m.plugins {
+		plugins = append(plugins, plugin)
+	}
+
+	return plugins
+}
+
+func (m *ChannelManager) ConnectAll(ctx context.Context) error {
+	m.mu.RLock()
+	plugins := make([]ChannelPlugin, 0, len(m.plugins))
+	for _, plugin := range m.plugins {
+		plugins = append(plugins, plugin)
+	}
+	m.mu.RUnlock()
+
+	var errors []error
+	for _, plugin := range plugins {
+		if err := plugin.Connect(ctx); err != nil {
+			errors = append(errors, fmt.Errorf("failed to connect channel %s: %w", plugin.ID(), err))
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("failed to connect some channels: %v", errors)
+	}
+
+	return nil
+}
+
+func (m *ChannelManager) DisconnectAll(ctx context.Context) error {
+	m.mu.RLock()
+	plugins := make([]ChannelPlugin, 0, len(m.plugins))
+	for _, plugin := range m.plugins {
+		plugins = append(plugins, plugin)
+	}
+	m.mu.RUnlock()
+
+	var errors []error
+	for _, plugin := range plugins {
+		if err := plugin.Disconnect(ctx); err != nil {
+			errors = append(errors, fmt.Errorf("failed to disconnect channel %s: %w", plugin.ID(), err))
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("failed to disconnect some channels: %v", errors)
+	}
+
+	return nil
+}
+
+func (m *ChannelManager) SendMessage(ctx context.Context, channelID ChannelID, message *Message) error {
+	m.mu.RLock()
+	plugin, exists := m.plugins[channelID]
+	m.mu.RUnlock()
+
+	if !exists {
+		return fmt.Errorf("channel plugin %s not found", channelID)
+	}
+
+	if plugin.GetStatus() != ChannelStatusConnected {
+		return fmt.Errorf("channel %s is not connected", channelID)
+	}
+
+	if err := plugin.SendMessage(ctx, message); err != nil {
+		if m.eventBus != nil {
+			m.eventBus.PublishAsync(ctx, gatewayevents.Event{
+				Type:   gatewayevents.EventChannelError,
+				Source: "channel_manager",
+				Data: map[string]interface{}{
+					"channel_id": string(channelID),
+					"error":      err.Error(),
+				},
+				Timestamp: time.Now().Unix(),
+			})
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *ChannelManager) BroadcastMessage(ctx context.Context, message *Message) error {
+	m.mu.RLock()
+	plugins := make([]ChannelPlugin, 0, len(m.plugins))
+	for _, plugin := range m.plugins {
+		if plugin.GetStatus() == ChannelStatusConnected {
+			plugins = append(plugins, plugin)
+		}
+	}
+	m.mu.RUnlock()
+
+	var errors []error
+	for _, plugin := range plugins {
+		msg := *message
+		msg.ChannelID = plugin.ID()
+		if err := plugin.SendMessage(ctx, &msg); err != nil {
+			errors = append(errors, fmt.Errorf("failed to send to channel %s: %w", plugin.ID(), err))
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("failed to broadcast to some channels: %v", errors)
+	}
+
+	return nil
+}
+
+func (m *ChannelManager) SetChannelHandler(channelID ChannelID, handler MessageHandler) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.handlers[channelID] = handler
+}
+
+func (m *ChannelManager) handleMessage(ctx context.Context, channelID ChannelID, message *Message) error {
+	m.mu.RLock()
+	handler, exists := m.handlers[channelID]
+	m.mu.RUnlock()
+
+	if !exists {
+		return m.defaultHandler(ctx, message)
+	}
+
+	return handler(ctx, message)
+}
+
+func (m *ChannelManager) defaultHandler(ctx context.Context, message *Message) error {
+	if m.eventBus != nil {
+		m.eventBus.PublishAsync(ctx, gatewayevents.Event{
+			Type:   gatewayevents.EventChannelMessage,
+			Source: "channel_manager",
+			Data: map[string]interface{}{
+				"channel_id": string(message.ChannelID),
+				"sender_id":  message.SenderID,
+				"content":    message.Content,
+				"type":       string(message.Type),
+			},
+			Timestamp: time.Now().Unix(),
+		})
+	}
+
+	return nil
+}
+
+func (m *ChannelManager) StartHealthCheck(interval time.Duration) {
+	m.mu.Lock()
+	m.healthTicker = time.NewTicker(interval)
+	m.mu.Unlock()
+
+	go func() {
+		for {
+			select {
+			case <-m.healthTicker.C:
+				m.checkHealth()
+			case <-m.stopHealth:
+				return
+			}
+		}
+	}()
+}
+
+func (m *ChannelManager) StopHealthCheck() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.healthTicker != nil {
+		m.healthTicker.Stop()
+		close(m.stopHealth)
+	}
+}
+
+func (m *ChannelManager) checkHealth() {
+	m.mu.RLock()
+	plugins := make([]ChannelPlugin, 0, len(m.plugins))
+	for _, plugin := range m.plugins {
+		plugins = append(plugins, plugin)
+	}
+	m.mu.RUnlock()
+
+	for _, plugin := range plugins {
+		if err := plugin.HealthCheck(context.Background()); err != nil && m.eventBus != nil {
+			m.eventBus.PublishAsync(context.Background(), gatewayevents.Event{
+				Type:   gatewayevents.EventChannelError,
+				Source: "channel_manager",
+				Data: map[string]interface{}{
+					"channel_id": string(plugin.ID()),
+					"error":      err.Error(),
+				},
+				Timestamp: time.Now().Unix(),
+			})
+		}
+	}
+}
+
+func (m *ChannelManager) GetStatus() map[ChannelID]ChannelStatus {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	status := make(map[ChannelID]ChannelStatus)
+	for id, plugin := range m.plugins {
+		status[id] = plugin.GetStatus()
+	}
+
+	return status
+}

--- a/pkg/input/security.go
+++ b/pkg/input/security.go
@@ -1,0 +1,467 @@
+package input
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+type DMPolicy string
+
+const (
+	DMPolicyAllowAll  DMPolicy = "allow-all"
+	DMPolicyAllowList DMPolicy = "allow-list"
+	DMPolicyPairing   DMPolicy = "pairing"
+	DMPolicyDenyAll   DMPolicy = "deny-all"
+)
+
+type GroupPolicy string
+
+const (
+	GroupPolicyAllowAll  GroupPolicy = "allow-all"
+	GroupPolicyAllowList GroupPolicy = "allow-list"
+	GroupPolicyMention   GroupPolicy = "mention-only"
+	GroupPolicyDenyAll   GroupPolicy = "deny-all"
+)
+
+type ChannelPolicy struct {
+	mu               sync.RWMutex
+	dmPolicy         DMPolicy
+	groupPolicy      GroupPolicy
+	allowFrom        map[string]bool
+	pairingEnabled   bool
+	pairingTTL       time.Duration
+	mentionGate      bool
+	riskAcknowledged bool
+	defaultDenyDM    bool
+}
+
+func DefaultChannelPolicy() *ChannelPolicy {
+	return &ChannelPolicy{
+		dmPolicy:         DMPolicyAllowList,
+		groupPolicy:      GroupPolicyMention,
+		allowFrom:        make(map[string]bool),
+		pairingEnabled:   false,
+		pairingTTL:       72 * time.Hour,
+		mentionGate:      true,
+		riskAcknowledged: false,
+		defaultDenyDM:    true,
+	}
+}
+
+func ChannelPolicyFromConfig(cfg config.ChannelSecurityConfig) *ChannelPolicy {
+	policy := DefaultChannelPolicy()
+
+	dm := DMPolicy(strings.TrimSpace(cfg.DMPolicy))
+	switch dm {
+	case DMPolicyAllowAll, DMPolicyAllowList, DMPolicyPairing, DMPolicyDenyAll:
+		policy.dmPolicy = dm
+	default:
+		if cfg.DMPolicy != "" {
+			policy.dmPolicy = DMPolicy(cfg.DMPolicy)
+		}
+	}
+
+	gp := GroupPolicy(strings.TrimSpace(cfg.GroupPolicy))
+	switch gp {
+	case GroupPolicyAllowAll, GroupPolicyAllowList, GroupPolicyMention, GroupPolicyDenyAll:
+		policy.groupPolicy = gp
+	default:
+		if cfg.GroupPolicy != "" {
+			policy.groupPolicy = GroupPolicy(cfg.GroupPolicy)
+		}
+	}
+
+	policy.allowFrom = make(map[string]bool)
+	for _, id := range cfg.AllowFrom {
+		if id = strings.TrimSpace(id); id != "" {
+			policy.allowFrom[id] = true
+		}
+	}
+
+	if cfg.PairingEnabled {
+		policy.pairingEnabled = true
+	}
+	if cfg.PairingTTLHours > 0 {
+		policy.pairingTTL = time.Duration(cfg.PairingTTLHours) * time.Hour
+	}
+	if cfg.MentionGate {
+		policy.mentionGate = true
+	}
+	policy.riskAcknowledged = cfg.RiskAcknowledged
+	if cfg.DefaultDenyDM {
+		policy.defaultDenyDM = true
+	}
+
+	return policy
+}
+
+func (p *ChannelPolicy) Validate() []string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	var issues []string
+
+	switch p.dmPolicy {
+	case DMPolicyAllowAll, DMPolicyAllowList, DMPolicyPairing, DMPolicyDenyAll:
+	default:
+		issues = append(issues, fmt.Sprintf("invalid dm_policy: %q", p.dmPolicy))
+	}
+
+	switch p.groupPolicy {
+	case GroupPolicyAllowAll, GroupPolicyAllowList, GroupPolicyMention, GroupPolicyDenyAll:
+	default:
+		issues = append(issues, fmt.Sprintf("invalid group_policy: %q", p.groupPolicy))
+	}
+
+	if p.dmPolicy == DMPolicyAllowList && len(p.allowFrom) == 0 {
+		issues = append(issues, "dm_policy is allow-list but allow_from is empty")
+	}
+
+	if p.dmPolicy == DMPolicyAllowAll && !p.riskAcknowledged {
+		issues = append(issues, "dm_policy is allow-all without risk acknowledgement")
+	}
+
+	if p.pairingTTL <= 0 {
+		issues = append(issues, "pairing_ttl must be positive")
+	}
+
+	return issues
+}
+
+func (p *ChannelPolicy) AllowDM(userID string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	switch p.dmPolicy {
+	case DMPolicyDenyAll:
+		return false
+	case DMPolicyAllowAll:
+		return true
+	case DMPolicyAllowList:
+		return p.allowFrom[userID]
+	case DMPolicyPairing:
+		return true
+	default:
+		if p.defaultDenyDM {
+			return false
+		}
+		return true
+	}
+}
+
+func (p *ChannelPolicy) AllowGroup(userID, groupID string, mentioned bool) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	switch p.groupPolicy {
+	case GroupPolicyDenyAll:
+		return false
+	case GroupPolicyAllowAll:
+		return true
+	case GroupPolicyAllowList:
+		return p.allowFrom[userID]
+	case GroupPolicyMention:
+		return mentioned
+	default:
+		return mentioned
+	}
+}
+
+func (p *ChannelPolicy) IsUserAllowed(userID string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if len(p.allowFrom) == 0 {
+		return true
+	}
+	return p.allowFrom[userID]
+}
+
+func (p *ChannelPolicy) AddAllowedUser(userID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	userID = strings.TrimSpace(userID)
+	if userID != "" {
+		p.allowFrom[userID] = true
+	}
+}
+
+func (p *ChannelPolicy) RemoveAllowedUser(userID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.allowFrom, strings.TrimSpace(userID))
+}
+
+func (p *ChannelPolicy) AllowedUsers() []string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	result := make([]string, 0, len(p.allowFrom))
+	for id := range p.allowFrom {
+		result = append(result, id)
+	}
+	return result
+}
+
+func (p *ChannelPolicy) DMPolicy() DMPolicy {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.dmPolicy
+}
+
+func (p *ChannelPolicy) SetDMPolicy(policy DMPolicy) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.dmPolicy = policy
+}
+
+func (p *ChannelPolicy) GroupPolicy() GroupPolicy {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.groupPolicy
+}
+
+func (p *ChannelPolicy) SetGroupPolicy(policy GroupPolicy) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.groupPolicy = policy
+}
+
+func (p *ChannelPolicy) MentionGateEnabled() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.mentionGate
+}
+
+func (p *ChannelPolicy) SetMentionGate(enabled bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.mentionGate = enabled
+}
+
+func (p *ChannelPolicy) PairingEnabled() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.pairingEnabled
+}
+
+func (p *ChannelPolicy) SetPairingEnabled(enabled bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.pairingEnabled = enabled
+}
+
+func (p *ChannelPolicy) PairingTTL() time.Duration {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.pairingTTL
+}
+
+func (p *ChannelPolicy) SetPairingTTL(ttl time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.pairingTTL = ttl
+}
+
+func (p *ChannelPolicy) RiskAcknowledged() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.riskAcknowledged
+}
+
+func (p *ChannelPolicy) AcknowledgeRisk() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.riskAcknowledged = true
+}
+
+func (p *ChannelPolicy) DefaultDenyDM() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.defaultDenyDM
+}
+
+func (p *ChannelPolicy) Wrap(handler InboundHandler) InboundHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		userID := meta["user_id"]
+		channelType := meta["channel_type"]
+		isGroup := meta["is_group"] == "true"
+		isGuild := meta["guild_id"] != ""
+		mentioned := isMentioned(message, []string{meta["bot_user_id"]})
+
+		if isGroup || isGuild {
+			if !p.AllowGroup(userID, meta["guild_id"], mentioned) {
+				return sessionID, "", fmt.Errorf("user %s blocked by group policy", userID)
+			}
+		} else if channelType == "dm" || channelType == "private" {
+			if !p.AllowDM(userID) {
+				return sessionID, "", fmt.Errorf("user %s blocked by DM policy", userID)
+			}
+		}
+
+		if len(p.allowFrom) > 0 && !p.IsUserAllowed(userID) {
+			return sessionID, "", fmt.Errorf("user %s not in allow_from list", userID)
+		}
+
+		return handler(ctx, sessionID, message, meta)
+	}
+}
+
+func (p *ChannelPolicy) WrapStream(handler StreamChunkHandler) StreamChunkHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+		userID := meta["user_id"]
+		channelType := meta["channel_type"]
+		isGroup := meta["is_group"] == "true"
+		isGuild := meta["guild_id"] != ""
+		mentioned := isMentioned(message, []string{meta["bot_user_id"]})
+
+		if isGroup || isGuild {
+			if !p.AllowGroup(userID, meta["guild_id"], mentioned) {
+				return sessionID, fmt.Errorf("user %s blocked by group policy", userID)
+			}
+		} else if channelType == "dm" || channelType == "private" {
+			if !p.AllowDM(userID) {
+				return sessionID, fmt.Errorf("user %s blocked by DM policy", userID)
+			}
+		}
+
+		if len(p.allowFrom) > 0 && !p.IsUserAllowed(userID) {
+			return sessionID, fmt.Errorf("user %s not in allow_from list", userID)
+		}
+
+		return handler(ctx, sessionID, message, meta, onChunk)
+	}
+}
+
+type SecurityAuditResult struct {
+	Issues   []SecurityAuditIssue `json:"issues"`
+	Passed   bool                 `json:"passed"`
+	Score    int                  `json:"score"`
+	MaxScore int                  `json:"max_score"`
+}
+
+type SecurityAuditIssue struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	Severity  string `json:"severity"`
+	Message   string `json:"message"`
+	Fixable   bool   `json:"fixable"`
+	FixAction string `json:"fix_action,omitempty"`
+}
+
+func AuditChannelPolicy(policy *ChannelPolicy) SecurityAuditResult {
+	var issues []SecurityAuditIssue
+	score := 0
+	maxScore := 7
+
+	policy.mu.RLock()
+	dmPolicy := policy.dmPolicy
+	groupPolicy := policy.groupPolicy
+	allowFromCount := len(policy.allowFrom)
+	mentionGate := policy.mentionGate
+	riskAck := policy.riskAcknowledged
+	defaultDeny := policy.defaultDenyDM
+	policy.mu.RUnlock()
+	_ = allowFromCount
+
+	if dmPolicy != DMPolicyAllowAll || riskAck {
+		score++
+	} else {
+		issues = append(issues, SecurityAuditIssue{
+			ID:        "dm-allow-all-no-ack",
+			Title:     "DM allow-all without risk acknowledgement",
+			Severity:  "critical",
+			Message:   "DM policy is allow-all but risk has not been acknowledged",
+			Fixable:   true,
+			FixAction: "set channels.security.risk_acknowledged=true or change dm_policy to allow-list",
+		})
+	}
+
+	if dmPolicy == DMPolicyDenyAll || dmPolicy == DMPolicyAllowList || dmPolicy == DMPolicyPairing {
+		score++
+	} else {
+		issues = append(issues, SecurityAuditIssue{
+			ID:        "dm-policy-permissive",
+			Title:     "DM policy is permissive",
+			Severity:  "warning",
+			Message:   fmt.Sprintf("DM policy is %q, consider allow-list or pairing", dmPolicy),
+			Fixable:   true,
+			FixAction: "set channels.security.dm_policy=allow-list",
+		})
+	}
+
+	if mentionGate {
+		score++
+	} else {
+		issues = append(issues, SecurityAuditIssue{
+			ID:        "mention-gate-disabled",
+			Title:     "Mention gate disabled",
+			Severity:  "warning",
+			Message:   "Group messages without @mention will be processed",
+			Fixable:   true,
+			FixAction: "set channels.security.mention_gate=true",
+		})
+	}
+
+	if groupPolicy == GroupPolicyMention || groupPolicy == GroupPolicyAllowList || groupPolicy == GroupPolicyDenyAll {
+		score++
+	} else {
+		issues = append(issues, SecurityAuditIssue{
+			ID:        "group-policy-permissive",
+			Title:     "Group policy is permissive",
+			Severity:  "warning",
+			Message:   fmt.Sprintf("Group policy is %q, consider mention-only", groupPolicy),
+			Fixable:   true,
+			FixAction: "set channels.security.group_policy=mention-only",
+		})
+	}
+
+	if defaultDeny || dmPolicy != DMPolicyAllowAll {
+		score++
+	} else {
+		issues = append(issues, SecurityAuditIssue{
+			ID:        "no-default-deny",
+			Title:     "No default-deny for DM",
+			Severity:  "warning",
+			Message:   "DM default-deny is not enabled",
+			Fixable:   true,
+			FixAction: "set channels.security.default_deny_dm=true",
+		})
+	}
+
+	if riskAck {
+		score++
+	} else {
+		issues = append(issues, SecurityAuditIssue{
+			ID:        "risk-not-acknowledged",
+			Title:     "Risk not acknowledged",
+			Severity:  "info",
+			Message:   "No explicit risk acknowledgement on file",
+			Fixable:   true,
+			FixAction: "set security.risk_acknowledged=true",
+		})
+	}
+
+	if allowFromCount > 0 || dmPolicy == DMPolicyDenyAll {
+		score++
+	} else {
+		issues = append(issues, SecurityAuditIssue{
+			ID:        "no-allowlist",
+			Title:     "No user allowlist configured",
+			Severity:  "info",
+			Message:   fmt.Sprintf("No users in allow_from list (%d entries)", allowFromCount),
+			Fixable:   true,
+			FixAction: "add user IDs to channels.security.allow_from",
+		})
+	}
+
+	return SecurityAuditResult{
+		Issues:   issues,
+		Passed:   len(issues) == 0,
+		Score:    score,
+		MaxScore: maxScore,
+	}
+}

--- a/pkg/input/security.go
+++ b/pkg/input/security.go
@@ -287,23 +287,17 @@ func (p *ChannelPolicy) DefaultDenyDM() bool {
 func (p *ChannelPolicy) Wrap(handler InboundHandler) InboundHandler {
 	return func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
 		userID := meta["user_id"]
-		channelType := meta["channel_type"]
-		isGroup := meta["is_group"] == "true"
-		isGuild := meta["guild_id"] != ""
-		mentioned := isMentioned(message, []string{meta["bot_user_id"]})
+		channelType, isGroup, groupID := inferChannelPolicyContext(meta)
+		mentioned := isMentioned(message, mentionIDsForPolicy(meta))
 
-		if isGroup || isGuild {
-			if !p.AllowGroup(userID, meta["guild_id"], mentioned) {
+		if isGroup {
+			if !p.AllowGroup(userID, groupID, mentioned) {
 				return sessionID, "", fmt.Errorf("user %s blocked by group policy", userID)
 			}
-		} else if channelType == "dm" || channelType == "private" {
+		} else if isDirectChannelPolicyType(channelType) {
 			if !p.AllowDM(userID) {
 				return sessionID, "", fmt.Errorf("user %s blocked by DM policy", userID)
 			}
-		}
-
-		if len(p.allowFrom) > 0 && !p.IsUserAllowed(userID) {
-			return sessionID, "", fmt.Errorf("user %s not in allow_from list", userID)
 		}
 
 		return handler(ctx, sessionID, message, meta)
@@ -313,27 +307,130 @@ func (p *ChannelPolicy) Wrap(handler InboundHandler) InboundHandler {
 func (p *ChannelPolicy) WrapStream(handler StreamChunkHandler) StreamChunkHandler {
 	return func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
 		userID := meta["user_id"]
-		channelType := meta["channel_type"]
-		isGroup := meta["is_group"] == "true"
-		isGuild := meta["guild_id"] != ""
-		mentioned := isMentioned(message, []string{meta["bot_user_id"]})
+		channelType, isGroup, groupID := inferChannelPolicyContext(meta)
+		mentioned := isMentioned(message, mentionIDsForPolicy(meta))
 
-		if isGroup || isGuild {
-			if !p.AllowGroup(userID, meta["guild_id"], mentioned) {
+		if isGroup {
+			if !p.AllowGroup(userID, groupID, mentioned) {
 				return sessionID, fmt.Errorf("user %s blocked by group policy", userID)
 			}
-		} else if channelType == "dm" || channelType == "private" {
+		} else if isDirectChannelPolicyType(channelType) {
 			if !p.AllowDM(userID) {
 				return sessionID, fmt.Errorf("user %s blocked by DM policy", userID)
 			}
 		}
 
-		if len(p.allowFrom) > 0 && !p.IsUserAllowed(userID) {
-			return sessionID, fmt.Errorf("user %s not in allow_from list", userID)
-		}
-
 		return handler(ctx, sessionID, message, meta, onChunk)
 	}
+}
+
+func inferChannelPolicyContext(meta map[string]string) (string, bool, string) {
+	channelType := strings.ToLower(strings.TrimSpace(meta["channel_type"]))
+	isGroup := strings.EqualFold(strings.TrimSpace(meta["is_group"]), "true")
+	groupID := strings.TrimSpace(meta["guild_id"])
+	if groupID == "" {
+		groupID = strings.TrimSpace(meta["thread_id"])
+	}
+
+	switch strings.ToLower(strings.TrimSpace(meta["channel"])) {
+	case "discord":
+		if channelType == "" {
+			if strings.TrimSpace(meta["guild_id"]) != "" {
+				channelType = "guild"
+				isGroup = true
+			} else {
+				channelType = "private"
+			}
+		}
+	case "slack":
+		if channelType == "" {
+			channelID := strings.ToUpper(strings.TrimSpace(meta["channel_id"]))
+			if strings.HasPrefix(channelID, "D") {
+				channelType = "dm"
+			} else if channelID != "" {
+				channelType = "group"
+				isGroup = true
+				if groupID == "" {
+					groupID = channelID
+				}
+			}
+		}
+	case "telegram":
+		chatID := strings.TrimSpace(meta["chat_id"])
+		if channelType == "" {
+			chatType := strings.ToLower(strings.TrimSpace(meta["chat_type"]))
+			switch chatType {
+			case "private":
+				channelType = "private"
+			case "group", "supergroup", "channel":
+				channelType = chatType
+				isGroup = true
+			default:
+				switch {
+				case strings.HasPrefix(chatID, "-"):
+					channelType = "group"
+					isGroup = true
+				case chatID != "" && chatID == strings.TrimSpace(meta["user_id"]):
+					channelType = "private"
+				}
+			}
+		}
+		if groupID == "" && isGroup {
+			groupID = chatID
+		}
+	case "signal":
+		if channelType == "" {
+			if strings.TrimSpace(meta["thread_id"]) != "" {
+				channelType = "group"
+				isGroup = true
+			} else {
+				channelType = "private"
+			}
+		}
+	}
+
+	if !isGroup {
+		switch channelType {
+		case "group", "supergroup", "guild", "channel":
+			isGroup = true
+		}
+	}
+
+	if groupID == "" && isGroup {
+		if id := strings.TrimSpace(meta["chat_id"]); id != "" {
+			groupID = id
+		} else if id := strings.TrimSpace(meta["channel_id"]); id != "" {
+			groupID = id
+		}
+	}
+
+	if channelType == "" && !isGroup {
+		channelType = "private"
+	}
+
+	return channelType, isGroup, groupID
+}
+
+func isDirectChannelPolicyType(channelType string) bool {
+	switch channelType {
+	case "dm", "private", "direct", "im":
+		return true
+	default:
+		return false
+	}
+}
+
+func mentionIDsForPolicy(meta map[string]string) []string {
+	result := make([]string, 0, 4)
+	if id := strings.TrimSpace(meta["bot_user_id"]); id != "" {
+		result = append(result, id)
+	}
+	for _, rawID := range strings.Split(strings.TrimSpace(meta["bot_mention_ids"]), ",") {
+		if id := strings.TrimSpace(rawID); id != "" {
+			result = append(result, id)
+		}
+	}
+	return result
 }
 
 type SecurityAuditResult struct {

--- a/pkg/input/security_test.go
+++ b/pkg/input/security_test.go
@@ -1,0 +1,56 @@
+package input
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestChannelPolicyWrapAllowsGroupMessagesWhenOnlyDMAllowListIsConfigured(t *testing.T) {
+	policy := DefaultChannelPolicy()
+	policy.SetDMPolicy(DMPolicyAllowList)
+	policy.SetGroupPolicy(GroupPolicyAllowAll)
+	policy.AddAllowedUser("dm-user")
+
+	called := false
+	wrapped := policy.Wrap(func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		called = true
+		return sessionID, "ok", nil
+	})
+
+	_, _, err := wrapped(context.Background(), "session-1", "hello", map[string]string{
+		"channel":    "discord",
+		"guild_id":   "guild-1",
+		"channel_id": "channel-1",
+		"user_id":    "group-user",
+	})
+	if err != nil {
+		t.Fatalf("expected group message to pass, got %v", err)
+	}
+	if !called {
+		t.Fatal("expected wrapped handler to be called")
+	}
+}
+
+func TestChannelPolicyWrapAppliesDMPolicyToTelegramPrivateChatFallback(t *testing.T) {
+	policy := DefaultChannelPolicy()
+	policy.SetDMPolicy(DMPolicyAllowList)
+	policy.AddAllowedUser("allowed-user")
+
+	wrapped := policy.Wrap(func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		t.Fatal("handler should not be called for blocked DM")
+		return "", "", nil
+	})
+
+	_, _, err := wrapped(context.Background(), "session-1", "hello", map[string]string{
+		"channel": "telegram",
+		"chat_id": "42",
+		"user_id": "42",
+	})
+	if err == nil {
+		t.Fatal("expected DM policy to block unlisted user")
+	}
+	if !strings.Contains(err.Error(), "blocked by DM policy") {
+		t.Fatalf("expected DM policy error, got %v", err)
+	}
+}


### PR DESCRIPTION
## 变更概述
本次 PR 聚焦输入层后端能力补齐，主要包括：

- 补齐输入层核心契约与插件接口
- 增加输入安全策略与中间件能力
- 增加渠道接入能力，覆盖 Discord、Slack、Telegram、Signal、WhatsApp
- 增加 CLI 输入、初始化检测和终端 UI 辅助能力
- 补充输入层相关测试文件

## 主要改动
### 输入层核心
- 新增输入层基础契约定义
- 新增渠道插件契约定义
- 新增插件适配桥接能力

### 安全与策略
- 新增输入安全策略
- 新增输入中间件处理逻辑

### 渠道接入
- 新增 Discord 渠道接入
- 新增 Slack 渠道接入
- 新增 Telegram 渠道接入
- 新增 Signal 渠道接入
- 新增 WhatsApp 渠道接入

### CLI 输入能力
- 新增控制台输入读取能力
- 新增初始化检测与引导能力
- 新增终端 UI 展示与 Markdown 渲染能力

### 测试
- 补充输入层相关测试文件

## 影响范围
主要涉及以下目录：

- `pkg/input/contracts.go`
- `pkg/input/plugin_contracts.go`
- `pkg/input/security.go`
- `pkg/input/middleware.go`
- `pkg/input/plugin_adapter.go`
- `pkg/input/channels/*`
- `pkg/input/cli/*`
- `pkg/input/advanced_test.go`

## 测试情况
已尝试执行以下测试：

```bash
go test ./pkg/input/...
