### PR TITLE
feat(adapters): add extension adapter framework

### DIFF
--- a/pkg/extensions/adapters/builtins.go
+++ b/pkg/extensions/adapters/builtins.go
@@ -1,0 +1,28 @@
+package extension
+
+func builtinExtensionManifests() []Manifest {
+	return []Manifest{
+		{ID: "email", Name: "Email", Version: "1.0.0", Description: "Inbound and outbound email automation hooks", Kind: "channel", Builtin: true, Channels: []string{"email"}},
+		{ID: "sms", Name: "SMS", Version: "1.0.0", Description: "SMS notifications and reply workflows", Kind: "channel", Builtin: true, Channels: []string{"sms"}},
+		{ID: "webhook", Name: "Webhook", Version: "1.0.0", Description: "Generic webhook ingestion and dispatch", Kind: "hook", Builtin: true},
+		{ID: "rss", Name: "RSS Watcher", Version: "1.0.0", Description: "RSS feed ingestion and summarization", Kind: "hook", Builtin: true},
+		{ID: "github-webhook", Name: "GitHub Webhook", Version: "1.0.0", Description: "GitHub issue and PR event adapter", Kind: "hook", Builtin: true, Skills: []string{"github", "github-issues"}},
+		{ID: "gitlab", Name: "GitLab", Version: "1.0.0", Description: "GitLab notifications and merge event routing", Kind: "channel", Builtin: true, Channels: []string{"gitlab"}},
+		{ID: "jira", Name: "Jira", Version: "1.0.0", Description: "Jira issue stream and workflow hooks", Kind: "tool", Builtin: true},
+		{ID: "confluence", Name: "Confluence", Version: "1.0.0", Description: "Confluence page sync and note surfaces", Kind: "tool", Builtin: true},
+		{ID: "notion", Name: "Notion", Version: "1.0.0", Description: "Notion knowledge capture and publishing", Kind: "tool", Builtin: true},
+		{ID: "linear", Name: "Linear", Version: "1.0.0", Description: "Linear issue routing and sprint actions", Kind: "tool", Builtin: true},
+		{ID: "reddit", Name: "Reddit", Version: "1.0.0", Description: "Reddit thread ingestion and moderation hooks", Kind: "channel", Builtin: true, Channels: []string{"reddit"}},
+		{ID: "x", Name: "X", Version: "1.0.0", Description: "X posting and mention handling surface", Kind: "channel", Builtin: true, Channels: []string{"x"}},
+		{ID: "mastodon", Name: "Mastodon", Version: "1.0.0", Description: "Mastodon timeline and social publishing support", Kind: "channel", Builtin: true, Channels: []string{"mastodon"}},
+		{ID: "linkedin", Name: "LinkedIn", Version: "1.0.0", Description: "LinkedIn publishing and outreach automation", Kind: "channel", Builtin: true, Channels: []string{"linkedin"}},
+		{ID: "youtube", Name: "YouTube", Version: "1.0.0", Description: "YouTube publishing and comment triage", Kind: "channel", Builtin: true, Channels: []string{"youtube"}},
+		{ID: "outlook", Name: "Outlook", Version: "1.0.0", Description: "Outlook calendar and mailbox integration", Kind: "channel", Builtin: true, Channels: []string{"outlook"}},
+		{ID: "zoom", Name: "Zoom", Version: "1.0.0", Description: "Zoom meeting event hooks and summaries", Kind: "hook", Builtin: true},
+		{ID: "webex", Name: "Webex", Version: "1.0.0", Description: "Webex meetings and chat event adapter", Kind: "channel", Builtin: true, Channels: []string{"webex"}},
+		{ID: "basecamp", Name: "Basecamp", Version: "1.0.0", Description: "Basecamp project update integration", Kind: "tool", Builtin: true},
+		{ID: "asana", Name: "Asana", Version: "1.0.0", Description: "Asana project and task synchronization", Kind: "tool", Builtin: true},
+		{ID: "clickup", Name: "ClickUp", Version: "1.0.0", Description: "ClickUp task and workflow hooks", Kind: "tool", Builtin: true},
+		{ID: "webhook-relay", Name: "Webhook Relay", Version: "1.0.0", Description: "Shared webhook relay and routing helper", Kind: "hook", Builtin: true},
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/adguardhome/adguardhome.go
+++ b/pkg/extensions/adapters/cli/adapters/adguardhome/adguardhome.go
@@ -1,0 +1,136 @@
+package adguardhome
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+type Client struct {
+	baseURL  string
+	username string
+	password string
+	client   *http.Client
+}
+
+type Config struct {
+	BaseURL  string
+	Username string
+	Password string
+}
+
+func New(cfg Config) *Client {
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = os.Getenv("ADGUARD_URL")
+		if baseURL == "" {
+			baseURL = "http://localhost:3000"
+		}
+	}
+	return &Client{
+		baseURL:  baseURL,
+		username: cfg.Username,
+		password: cfg.Password,
+		client:   &http.Client{},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "status":
+		return c.status(ctx)
+	case "dns":
+		return c.dns(subArgs)
+	case "filters":
+		return c.filters(ctx)
+	case "stats":
+		return c.stats(ctx)
+	case "help":
+		return c.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (c *Client) status(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/status", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) dns(args []string) (string, error) {
+	if len(args) == 0 {
+		return "Available: enable, disable, config", nil
+	}
+
+	action := args[0]
+	switch action {
+	case "enable":
+		return "DNS enabled", nil
+	case "disable":
+		return "DNS disabled", nil
+	default:
+		return "", fmt.Errorf("unknown dns action: %s", action)
+	}
+}
+
+func (c *Client) filters(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/filters", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) stats(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/stats", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) help() (string, error) {
+	return `AdGuardHome CLI adapter (REST API)
+Commands:
+  status    - Get status
+  dns       - DNS control
+  filters   - List filters
+  stats     - Get statistics
+  help      - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/anygen/anygen.go
+++ b/pkg/extensions/adapters/cli/adapters/anygen/anygen.go
@@ -1,0 +1,152 @@
+package anygen
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+type Client struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+type Config struct {
+	APIKey string
+}
+
+func New(cfg Config) *Client {
+	apiKey := cfg.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ANYGEN_API_KEY")
+	}
+	return &Client{
+		apiKey:     apiKey,
+		baseURL:    "https://api.anygen.com/v1",
+		httpClient: &http.Client{Timeout: 5 * time.Minute},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "docs":
+		return c.docs(ctx, subArgs)
+	case "slides":
+		return c.slides(ctx, subArgs)
+	case "website":
+		return c.website(ctx, subArgs)
+	case "help":
+		return c.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (c *Client) docs(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("docs requires <topic> <output.md>")
+	}
+	topic := args[0]
+	output := args[1]
+
+	body := map[string]string{"topic": topic, "type": "docs"}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/generate", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	os.WriteFile(output, b, 0644)
+
+	return fmt.Sprintf("Generated docs: %s", output), nil
+}
+
+func (c *Client) slides(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("slides requires <topic> <output.pptx>")
+	}
+	topic := args[0]
+	output := args[1]
+
+	body := map[string]string{"topic": topic, "type": "slides"}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/generate", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	os.WriteFile(output, b, 0644)
+
+	return fmt.Sprintf("Generated slides: %s", output), nil
+}
+
+func (c *Client) website(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("website requires <topic> <output-dir>")
+	}
+	topic := args[0]
+	outputDir := args[1]
+
+	body := map[string]string{"topic": topic, "type": "website"}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/generate", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	os.MkdirAll(outputDir, 0755)
+	os.WriteFile(outputDir+"/index.html", b, 0644)
+
+	return fmt.Sprintf("Generated website: %s", outputDir), nil
+}
+
+func (c *Client) help() (string, error) {
+	return `AnyGen CLI adapter
+Commands:
+  docs <topic> <output.md>      - Generate docs
+  slides <topic> <output.pptx>   - Generate slides
+  website <topic> <output-dir>  - Generate website
+  help                          - Show this help
+Note: Requires ANYGEN_API_KEY`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/audacity/audacity.go
+++ b/pkg/extensions/adapters/cli/adapters/audacity/audacity.go
@@ -1,0 +1,96 @@
+package audacity
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Client struct {
+	soxPath string
+}
+
+type Config struct {
+	SoxPath string
+}
+
+func NewClient(cfg Config) *Client {
+	soxPath := cfg.SoxPath
+	if soxPath == "" {
+		soxPath = "sox"
+	}
+
+	return &Client{
+		soxPath: soxPath,
+	}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.info(ctx)
+	}
+
+	switch args[0] {
+	case "info", "version":
+		return c.info(ctx)
+	case "convert":
+		return c.convert(ctx, args[1:])
+	case "trim":
+		return c.trim(ctx, args[1:])
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) info(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"--version"})
+}
+
+func (c *Client) convert(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("usage: audacity convert <input> <output>")
+	}
+
+	input := args[0]
+	output := args[1]
+	format := strings.TrimPrefix(strings.ToLower(filepath.Ext(output)), ".")
+	if format == "" {
+		return "", fmt.Errorf("output file must include an extension")
+	}
+
+	_, err := c.run(ctx, []string{input, "-t", format, output})
+	if err != nil {
+		return "", fmt.Errorf("conversion failed: %w", err)
+	}
+
+	return fmt.Sprintf("Converted %s to %s", input, output), nil
+}
+
+func (c *Client) trim(ctx context.Context, args []string) (string, error) {
+	if len(args) < 3 {
+		return "", fmt.Errorf("usage: audacity trim <input> <output> <duration>")
+	}
+
+	input := args[0]
+	output := args[1]
+	duration := args[2]
+
+	_, err := c.run(ctx, []string{input, output, "trim", "0", duration})
+	if err != nil {
+		return "", fmt.Errorf("trim failed: %w", err)
+	}
+
+	return fmt.Sprintf("Trimmed %s to %s seconds", output, duration), nil
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.soxPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}

--- a/pkg/extensions/adapters/cli/adapters/aws/aws.go
+++ b/pkg/extensions/adapters/cli/adapters/aws/aws.go
@@ -1,0 +1,206 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	awsPath string
+	region  string
+	profile string
+}
+
+type Config struct {
+	AWSPath string
+	Region  string
+	Profile string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.AWSPath
+	if path == "" {
+		path = "aws"
+	}
+	return &Client{
+		awsPath: path,
+		region:  cfg.Region,
+		profile: cfg.Profile,
+	}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"sts", "get-caller-identity"})
+	}
+
+	service := args[0]
+	switch service {
+	case "s3":
+		return c.s3(ctx, args[1:])
+	case "ec2":
+		return c.ec2(ctx, args[1:])
+	case "lambda":
+		return c.lambda(ctx, args[1:])
+	case "rds":
+		return c.rds(ctx, args[1:])
+	case "iam":
+		return c.iam(ctx, args[1:])
+	case "ecs":
+		return c.ecs(ctx, args[1:])
+	case "eks":
+		return c.eks(ctx, args[1:])
+	case "dynamodb":
+		return c.dynamodb(ctx, args[1:])
+	case "logs":
+		return c.logs(ctx, args[1:])
+	case "cloudwatch":
+		return c.cloudwatch(ctx, args[1:])
+	case "ssm":
+		return c.ssm(ctx, args[1:])
+	case "configure":
+		return c.configure(ctx, args[1:])
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) s3(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"s3", "ls"})
+	}
+
+	subcmd := args[0]
+	switch subcmd {
+	case "ls", "list":
+		return c.run(ctx, []string{"s3", "ls", "s3://"})
+	case "mb":
+		return c.run(ctx, append([]string{"s3", "mb"}, args[1:]...))
+	case "rb":
+		return c.run(ctx, append([]string{"s3", "rb"}, args[1:]...))
+	case "cp":
+		return c.run(ctx, append([]string{"s3", "cp"}, args[1:]...))
+	case "sync":
+		return c.run(ctx, append([]string{"s3", "sync"}, args[1:]...))
+	case "rm":
+		return c.run(ctx, append([]string{"s3", "rm"}, args[1:]...))
+	default:
+		return c.run(ctx, append([]string{"s3", subcmd}, args[1:]...))
+	}
+}
+
+func (c *Client) ec2(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"ec2", "describe-instances"})
+	}
+
+	return c.run(ctx, append([]string{"ec2"}, args...))
+}
+
+func (c *Client) lambda(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"lambda", "list-functions"})
+	}
+
+	return c.run(ctx, append([]string{"lambda"}, args...))
+}
+
+func (c *Client) rds(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"rds", "describe-db-instances"})
+	}
+
+	return c.run(ctx, append([]string{"rds"}, args...))
+}
+
+func (c *Client) iam(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"iam", "list-users"})
+	}
+
+	return c.run(ctx, append([]string{"iam"}, args...))
+}
+
+func (c *Client) ecs(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"ecs", "list-clusters"})
+	}
+
+	return c.run(ctx, append([]string{"ecs"}, args...))
+}
+
+func (c *Client) eks(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"eks", "list-clusters"})
+	}
+
+	return c.run(ctx, append([]string{"eks"}, args...))
+}
+
+func (c *Client) dynamodb(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"dynamodb", "list-tables"})
+	}
+
+	return c.run(ctx, append([]string{"dynamodb"}, args...))
+}
+
+func (c *Client) logs(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"logs", "describe-log-groups"})
+	}
+
+	return c.run(ctx, append([]string{"logs"}, args...))
+}
+
+func (c *Client) cloudwatch(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"cloudwatch", "list-metrics"})
+	}
+
+	return c.run(ctx, append([]string{"cloudwatch"}, args...))
+}
+
+func (c *Client) ssm(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"ssm", "list-commands"})
+	}
+
+	return c.run(ctx, append([]string{"ssm"}, args...))
+}
+
+func (c *Client) configure(ctx context.Context, args []string) (string, error) {
+	configArgs := []string{"configure"}
+	configArgs = append(configArgs, args...)
+
+	if c.region != "" {
+		fmt.Println("Region:", c.region)
+	}
+	if c.profile != "" {
+		fmt.Println("Profile:", c.profile)
+	}
+
+	return c.run(ctx, configArgs)
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.awsPath, args...)
+	if c.region != "" {
+		cmd.Env = append(cmd.Env, "AWS_DEFAULT_REGION="+c.region)
+	}
+	if c.profile != "" {
+		cmd.Env = append(cmd.Env, "AWS_PROFILE="+c.profile)
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.awsPath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/blender/blender.go
+++ b/pkg/extensions/adapters/cli/adapters/blender/blender.go
@@ -1,0 +1,239 @@
+package blender
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Client struct {
+	blenderPath string
+	workspace   string
+}
+
+type Config struct {
+	BlenderPath string
+	Workspace   string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.BlenderPath
+	if path == "" {
+		path = "blender"
+	}
+	workspace := cfg.Workspace
+	if workspace == "" {
+		workspace = "."
+	}
+
+	return &Client{
+		blenderPath: path,
+		workspace:   workspace,
+	}
+}
+
+type Scene struct {
+	Name        string       `json:"name"`
+	Objects     []Object     `json:"objects"`
+	Collections []Collection `json:"collections"`
+}
+
+type Object struct {
+	Name     string    `json:"name"`
+	Type     string    `json:"type"`
+	Location []float64 `json:"location"`
+	Rotation []float64 `json:"rotation"`
+	Scale    []float64 `json:"scale"`
+}
+
+type Collection struct {
+	Name     string   `json:"name"`
+	Children []string `json:"children,omitempty"`
+}
+
+type RenderResult struct {
+	OutputPath string `json:"output_path"`
+	Width      int    `json:"width"`
+	Height     int    `json:"height"`
+	Engine     string `json:"engine"`
+	Duration   string `json:"duration"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.listScenes(ctx)
+	}
+
+	cmd := args[0]
+	switch cmd {
+	case "list", "ls":
+		return c.listScenes(ctx)
+	case "scene", "new":
+		return c.createScene(ctx, args[1:])
+	case "object", "add":
+		return c.addObject(ctx, args[1:])
+	case "render", "export":
+		return c.render(ctx, args[1:])
+	case "info":
+		return c.info(ctx)
+	default:
+		return c.runPython(ctx, strings.Join(args, " "))
+	}
+}
+
+func (c *Client) listScenes(ctx context.Context) (string, error) {
+	script := `
+import bpy
+for scene in bpy.data.scenes:
+    print(scene.name)
+`
+	return c.runScript(ctx, script)
+}
+
+func (c *Client) createScene(ctx context.Context, args []string) (string, error) {
+	name := "NewScene"
+	if len(args) > 0 {
+		name = args[0]
+	}
+
+	script := fmt.Sprintf(`
+import bpy
+scene = bpy.data.scenes.new(name="%s")
+bpy.context.window.scene = scene
+print("Created scene:", "%s")
+`, name, name)
+
+	out, err := c.runScript(ctx, script)
+	if err != nil {
+		return "", err
+	}
+	return out + "\nScene created: " + name, nil
+}
+
+func (c *Client) addObject(ctx context.Context, args []string) (string, error) {
+	objType := "cube"
+	objName := "Object"
+	if len(args) > 0 {
+		objType = args[0]
+	}
+	if len(args) > 1 {
+		objName = args[1]
+	}
+
+	script := fmt.Sprintf(`
+import bpy
+obj_type = "%s"
+name = "%s"
+if obj_type == "cube":
+    bpy.ops.mesh.primitive_cube_add(size=2, location=(0, 0, 0))
+    obj = bpy.context.active_object
+elif obj_type == "sphere":
+    bpy.ops.mesh.primitive_uv_sphere_add(radius=1, location=(0, 0, 0))
+    obj = bpy.context.active_object
+elif obj_type == "plane":
+    bpy.ops.mesh.primitive_plane_add(size=2, location=(0, 0, 0))
+    obj = bpy.context.active_object
+elif obj_type == "cylinder":
+    bpy.ops.mesh.primitive_cylinder_add(radius=1, depth=2, location=(0, 0, 0))
+    obj = bpy.context.active_object
+elif obj_type == "cone":
+    bpy.ops.mesh.primitive_cone_add(radius1=1, depth=2, location=(0, 0, 0))
+    obj = bpy.context.active_object
+else:
+    bpy.ops.mesh.primitive_cube_add(size=2, location=(0, 0, 0))
+    obj = bpy.context.active_object
+
+obj.name = name
+print("Added object:", name, "type:", obj_type)
+`, objType, objName)
+
+	return c.runScript(ctx, script)
+}
+
+func (c *Client) render(ctx context.Context, args []string) (string, error) {
+	outputPath := "render.png"
+	format := "PNG"
+	if len(args) > 0 {
+		outputPath = args[0]
+	}
+	if len(args) > 1 {
+		format = args[1]
+	}
+
+	absPath, _ := filepath.Abs(outputPath)
+
+	script := fmt.Sprintf(`
+import bpy
+scene = bpy.context.scene
+scene.render.filepath = "%s"
+scene.render.image_settings.file_format = "%s"
+bpy.ops.render.render(write=True)
+print("Rendered to:", "%s")
+`, outputPath, format, absPath)
+
+	_, err := c.runScript(ctx, script)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Rendered: %s", absPath), nil
+}
+
+func (c *Client) info(ctx context.Context) (string, error) {
+	script := `
+import bpy
+scene = bpy.context.scene
+print("Scene:", scene.name)
+print("Objects:", len(bpy.data.objects))
+print("Collections:", len(bpy.data.collections))
+for obj in bpy.data.objects[:5]:
+    print(" -", obj.name, "type:", obj.type)
+`
+	return c.runScript(ctx, script)
+}
+
+func (c *Client) runPython(ctx context.Context, code string) (string, error) {
+	script := code
+	return c.runScript(ctx, script)
+}
+
+func (c *Client) runScript(ctx context.Context, script string) (string, error) {
+	tmpfile, err := os.CreateTemp("", "blender_*.py")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.WriteString(script); err != nil {
+		return "", err
+	}
+	tmpfile.Close()
+
+	cmd := exec.CommandContext(ctx, c.blenderPath, "--background", "--python", tmpfile.Name())
+	cmd.Dir = c.workspace
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return string(output), err
+	}
+
+	lines := strings.Split(string(output), "\n")
+	var result []string
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "Read prefs:") &&
+			!strings.HasPrefix(line, "found bundled Python:") &&
+			!strings.HasPrefix(line, "Warning:") {
+			result = append(result, line)
+		}
+	}
+
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.blenderPath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/comfyui/comfyui.go
+++ b/pkg/extensions/adapters/cli/adapters/comfyui/comfyui.go
@@ -1,0 +1,169 @@
+package comfyui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+type Config struct {
+	BaseURL string
+}
+
+func NewClient(cfg Config) *Client {
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "http://localhost:8188"
+	}
+
+	return &Client{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Minute,
+		},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.history(ctx)
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "queue":
+		return c.queue(ctx)
+	case "history":
+		return c.history(ctx)
+	case "prompt":
+		return c.prompt(ctx, subArgs)
+	case "interrupt":
+		return c.interrupt(ctx)
+	case "check":
+		return c.check(ctx, subArgs)
+	case "seed":
+		return c.seed(ctx, subArgs)
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (c *Client) queue(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/queue", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) history(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/history", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) prompt(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("prompt JSON required")
+	}
+
+	workflow := args[0]
+
+	reqBody := map[string]any{"prompt": workflow}
+	body, _ := json.Marshal(reqBody)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/prompt", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) interrupt(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/interrupt", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	return "Interrupted", nil
+}
+
+func (c *Client) check(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("prompt_id required")
+	}
+	promptID := args[0]
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/history/"+promptID, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) seed(ctx context.Context, args []string) (string, error) {
+	return fmt.Sprintf("Use 'prompt' with seed parameter in workflow JSON"), nil
+}
+
+func (c *Client) IsRunning(ctx context.Context) bool {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/system_stats", nil)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode < 300
+}

--- a/pkg/extensions/adapters/cli/adapters/curl/curl.go
+++ b/pkg/extensions/adapters/cli/adapters/curl/curl.go
@@ -1,0 +1,167 @@
+package curl
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	curlPath string
+	timeout  time.Duration
+}
+
+type Config struct {
+	CurlPath string
+	Timeout  time.Duration
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.CurlPath
+	if path == "" {
+		path = "curl"
+	}
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	return &Client{
+		curlPath: path,
+		timeout:  timeout,
+	}
+}
+
+type Response struct {
+	Status     string            `json:"status"`
+	StatusCode int               `json:"status_code"`
+	Headers    map[string]string `json:"headers"`
+	Body       string            `json:"body"`
+	Time       int64             `json:"time_ms"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "Usage: curl <url> [options]", nil
+	}
+
+	url := args[0]
+	isJSON := false
+
+	for _, arg := range args {
+		if arg == "-H" {
+			isJSON = true
+		}
+	}
+
+	if isJSON || strings.HasPrefix(url, "http") {
+		return c.request(ctx, args)
+	}
+
+	return c.run(ctx, args)
+}
+
+func (c *Client) request(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("URL required")
+	}
+
+	url := args[0]
+	method := "GET"
+	headers := make(map[string]string)
+	data := ""
+
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "-X":
+			if i+1 < len(args) {
+				method = args[i+1]
+				i++
+			}
+		case "-H":
+			if i+1 < len(args) {
+				header := args[i+1]
+				if idx := strings.Index(header, ":"); idx > 0 {
+					key := strings.TrimSpace(header[:idx])
+					val := strings.TrimSpace(header[idx+1:])
+					headers[key] = val
+				}
+				i++
+			}
+		case "-d", "--data":
+			if i+1 < len(args) {
+				data = args[i+1]
+				if method == "GET" {
+					method = "POST"
+				}
+				i++
+			}
+		case "-o", "--output":
+			if i+1 < len(args) {
+				i++
+			}
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, strings.NewReader(data))
+	if err != nil {
+		return "", err
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	if data != "" && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+
+	client := &http.Client{Timeout: c.timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	result := fmt.Sprintf("HTTP %d %s\n\n%s", resp.StatusCode, resp.Status, string(body))
+	return result, nil
+}
+
+func (c *Client) get(ctx context.Context, url string) (string, error) {
+	return c.request(ctx, []string{url})
+}
+
+func (c *Client) post(ctx context.Context, url, data string) (string, error) {
+	return c.request(ctx, []string{url, "-X", "POST", "-d", data})
+}
+
+func (c *Client) put(ctx context.Context, url, data string) (string, error) {
+	return c.request(ctx, []string{url, "-X", "PUT", "-d", data})
+}
+
+func (c *Client) delete(ctx context.Context, url string) (string, error) {
+	return c.request(ctx, []string{url, "-X", "DELETE"})
+}
+
+func (c *Client) head(ctx context.Context, url string) (string, error) {
+	return c.request(ctx, []string{url, "-I"})
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.curlPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.curlPath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/docker/docker.go
+++ b/pkg/extensions/adapters/cli/adapters/docker/docker.go
@@ -1,0 +1,306 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	dockerPath string
+}
+
+type Config struct {
+	DockerPath string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.DockerPath
+	if path == "" {
+		path = "docker"
+	}
+	return &Client{dockerPath: path}
+}
+
+type Container struct {
+	ID     string `json:"id"`
+	Image  string `json:"image"`
+	Status string `json:"status"`
+	Ports  string `json:"ports"`
+	Names  string `json:"names"`
+}
+
+type Image struct {
+	Repository string `json:"repository"`
+	Tag        string `json:"tag"`
+	Size       string `json:"size"`
+	ID         string `json:"id"`
+}
+
+type Volume struct {
+	Name   string `json:"name"`
+	Driver string `json:"driver"`
+	Mount  string `json:"mountpoint"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.ps(ctx)
+	}
+
+	cmd := args[0]
+	switch cmd {
+	case "ps", "list":
+		return c.ps(ctx)
+	case "images", "list-images":
+		return c.images(ctx)
+	case "run", "start":
+		return c.run(ctx, args[1:])
+	case "stop", "kill":
+		return c.stop(ctx, args[1:])
+	case "rm", "remove":
+		return c.rm(ctx, args[1:])
+	case "logs":
+		return c.logs(ctx, args[1:])
+	case "exec":
+		return c.exec(ctx, args[1:])
+	case "pull":
+		return c.pull(ctx, args[1:])
+	case "volumes", "vol":
+		return c.volumes(ctx)
+	case "info", "system":
+		return c.info(ctx)
+	case "search":
+		return c.search(ctx, args[1:])
+	default:
+		return c.runDocker(ctx, args)
+	}
+}
+
+func (c *Client) ps(ctx context.Context) (string, error) {
+	out, err := c.runDocker(ctx, []string{"ps", "--format", "{{json .}}"})
+	if err != nil {
+		return "", err
+	}
+
+	var containers []Container
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		var ctr Container
+		json.Unmarshal([]byte(line), &ctr)
+		containers = append(containers, ctr)
+	}
+
+	if len(containers) == 0 {
+		return "No running containers", nil
+	}
+
+	var result []string
+	result = append(result, "CONTAINERS:")
+	for _, ctr := range containers {
+		result = append(result, fmt.Sprintf("  %s  %s  %s  %s", ctr.Names, ctr.ID[:12], ctr.Image, ctr.Status))
+	}
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) images(ctx context.Context) (string, error) {
+	out, err := c.runDocker(ctx, []string{"images", "--format", "{{json .}}"})
+	if err != nil {
+		return "", err
+	}
+
+	var images []Image
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		var img Image
+		json.Unmarshal([]byte(line), &img)
+		images = append(images, img)
+	}
+
+	if len(images) == 0 {
+		return "No images", nil
+	}
+
+	var result []string
+	result = append(result, "IMAGES:")
+	for _, img := range images {
+		result = append(result, fmt.Sprintf("  %s:%s  %s", img.Repository, img.Tag, img.Size))
+	}
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	containerName := ""
+	image := ""
+	cmdArgs := []string{}
+
+	for i, arg := range args {
+		if arg == "-d" || arg == "-it" || arg == "--detach" {
+			continue
+		}
+		if arg == "--name" && i+1 < len(args) {
+			containerName = args[i+1]
+			continue
+		}
+		if !strings.HasPrefix(arg, "-") && image == "" {
+			image = arg
+			continue
+		}
+		cmdArgs = append(cmdArgs, arg)
+	}
+
+	if image == "" {
+		return "", fmt.Errorf("image required")
+	}
+
+	dockerArgs := []string{"run", "-d"}
+	if containerName != "" {
+		dockerArgs = append(dockerArgs, "--name", containerName)
+	}
+	dockerArgs = append(dockerArgs, image)
+	dockerArgs = append(dockerArgs, cmdArgs...)
+
+	_, err := c.runDocker(ctx, dockerArgs)
+	if err != nil {
+		return "", err
+	}
+
+	if containerName != "" {
+		return fmt.Sprintf("Container %s started", containerName), nil
+	}
+	return fmt.Sprintf("Container started from image %s", image), nil
+}
+
+func (c *Client) stop(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("container name or ID required")
+	}
+
+	_, err := c.runDocker(ctx, []string{"stop", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Container %s stopped", args[0]), nil
+}
+
+func (c *Client) rm(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("container name or ID required")
+	}
+
+	_, err := c.runDocker(ctx, []string{"rm", "-f", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Container %s removed", args[0]), nil
+}
+
+func (c *Client) logs(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("container name or ID required")
+	}
+
+	dockerArgs := []string{"logs"}
+	if len(args) > 1 && args[1] == "--follow" {
+		dockerArgs = append(dockerArgs, "-f")
+		args = args[1:]
+	}
+	dockerArgs = append(dockerArgs, args[0])
+
+	if len(args) > 1 {
+		dockerArgs = append(dockerArgs, args[1:]...)
+	}
+
+	return c.runDocker(ctx, dockerArgs)
+}
+
+func (c *Client) exec(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("usage: docker exec <container> <command>")
+	}
+
+	container := args[0]
+	cmd := strings.Join(args[1:], " ")
+
+	return c.runDocker(ctx, []string{"exec", container, "sh", "-c", cmd})
+}
+
+func (c *Client) pull(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("image name required")
+	}
+
+	_, err := c.runDocker(ctx, []string{"pull", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Image %s pulled", args[0]), nil
+}
+
+func (c *Client) volumes(ctx context.Context) (string, error) {
+	out, err := c.runDocker(ctx, []string{"volume", "ls", "--format", "{{json .}}"})
+	if err != nil {
+		return "", err
+	}
+
+	var volumes []Volume
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		var vol Volume
+		json.Unmarshal([]byte(line), &vol)
+		volumes = append(volumes, vol)
+	}
+
+	if len(volumes) == 0 {
+		return "No volumes", nil
+	}
+
+	var result []string
+	result = append(result, "VOLUMES:")
+	for _, vol := range volumes {
+		result = append(result, fmt.Sprintf("  %s", vol.Name))
+	}
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) info(ctx context.Context) (string, error) {
+	return c.runDocker(ctx, []string{"info", "--format", "{{.ServerVersion}}"})
+}
+
+func (c *Client) search(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("search term required")
+	}
+
+	out, err := c.runDocker(ctx, []string{"search", "--limit", "10", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return out, nil
+}
+
+func (c *Client) runDocker(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.dockerPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.dockerPath, "version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/drawio/drawio.go
+++ b/pkg/extensions/adapters/cli/adapters/drawio/drawio.go
@@ -1,0 +1,79 @@
+package drawio
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Adapter struct {
+	drawioPath string
+}
+
+type Config struct {
+	DrawioPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.DrawioPath
+	if path == "" {
+		path = "drawio"
+	}
+	return &Adapter{drawioPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "drawio"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "export":
+		return a.export(subArgs)
+	case "convert":
+		return a.convert(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) export(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("export requires <input.drawio> <output.pdf/png/svg>")
+	}
+	input := args[0]
+	output := args[1]
+
+	ext := strings.ToLower(filepath.Ext(output))
+	format := strings.TrimPrefix(ext, ".")
+
+	cmd := exec.Command(a.drawioPath, "--export", "--output", output, "--format", format, input)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("export failed: %w", err)
+	}
+
+	return fmt.Sprintf("Exported to %s", output), nil
+}
+
+func (a *Adapter) convert(args []string) (string, error) {
+	return a.export(args)
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Draw.io CLI adapter
+Commands:
+  export <input.drawio> <output.pdf/png/svg> - Export diagram
+  convert <input> <output>                   - Convert (alias)
+  help                                       - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/ffmpeg/ffmpeg.go
+++ b/pkg/extensions/adapters/cli/adapters/ffmpeg/ffmpeg.go
@@ -1,0 +1,173 @@
+package ffmpeg
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Client struct {
+	ffmpegPath  string
+	ffprobePath string
+}
+
+type Config struct {
+	FFmpegPath  string
+	FFProbePath string
+}
+
+func NewClient(cfg Config) *Client {
+	ffmpeg := cfg.FFmpegPath
+	if ffmpeg == "" {
+		ffmpeg = "ffmpeg"
+	}
+	ffprobe := cfg.FFProbePath
+	if ffprobe == "" {
+		ffprobe = "ffprobe"
+	}
+	return &Client{
+		ffmpegPath:  ffmpeg,
+		ffprobePath: ffprobe,
+	}
+}
+
+type Stream struct {
+	Index   int    `json:"index"`
+	Type    string `json:"codec_type"`
+	Codec   string `json:"codec_name"`
+	Width   int    `json:"width"`
+	Height  int    `json:"height"`
+	FPS     string `json:"r_frame_rate"`
+	Bitrate string `json:"bit_rate"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.probeMedia(ctx)
+	}
+
+	switch args[0] {
+	case "info", "probe":
+		return c.probeMediaArgs(ctx, args[1:])
+	case "convert", "transcode":
+		return c.convertMedia(ctx, args[1:])
+	case "thumbnail", "screenshot":
+		return c.thumbnailMedia(ctx, args[1:])
+	case "version":
+		return c.run(ctx, []string{"-version"})
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) probeMedia(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"-version"})
+}
+
+func (c *Client) probeMediaArgs(ctx context.Context, args []string) (string, error) {
+	input := "input.mp4"
+	if len(args) > 0 {
+		input = args[0]
+	}
+
+	output, err := c.runFFProbe(ctx, []string{"-v", "quiet", "-print_format", "json", "-show_format", "-show_streams", input})
+	if err != nil {
+		return "", err
+	}
+
+	var result []string
+	result = append(result, fmt.Sprintf("File: %s", input))
+	result = append(result, output[:min(500, len(output))])
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) convertMedia(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("usage: ffmpeg convert <input> <output>")
+	}
+
+	input := args[0]
+	output := args[1]
+
+	_, err := c.run(ctx, []string{"-i", input, "-y", output})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Converted: %s -> %s", input, output), nil
+}
+
+func (c *Client) thumbnailMedia(ctx context.Context, args []string) (string, error) {
+	input := "input.mp4"
+	output := "thumb.jpg"
+	time := "00:00:01"
+
+	for i, arg := range args {
+		if arg == "-i" && i+1 < len(args) {
+			input = args[i+1]
+		}
+		if arg == "-o" && i+1 < len(args) {
+			output = args[i+1]
+		}
+		if arg == "-t" && i+1 < len(args) {
+			time = args[i+1]
+		}
+	}
+
+	_, err := c.run(ctx, []string{"-i", input, "-ss", time, "-vframes", "1", "-y", output})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Thumbnail: %s at %s", output, time), nil
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.ffmpegPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) runFFProbe(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.ffprobePath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.ffmpegPath, "-version")
+	return cmd.Run() == nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func getExt(filename string) string {
+	ext := filepath.Ext(filename)
+	return strings.ToLower(ext)
+}
+
+func audioCodec(ext string) string {
+	switch ext {
+	case ".mp3":
+		return "libmp3lame"
+	case ".wav":
+		return "pcm_s16le"
+	case ".aac", ".m4a":
+		return "aac"
+	default:
+		return "copy"
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/freecad/freecad.go
+++ b/pkg/extensions/adapters/cli/adapters/freecad/freecad.go
@@ -1,0 +1,109 @@
+package freecad
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type Adapter struct {
+	freecadPath string
+}
+
+type Config struct {
+	FreecadPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.FreecadPath
+	if path == "" {
+		path = "FreeCAD"
+	}
+	return &Adapter{freecadPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "freecad"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "info":
+		return a.info()
+	case "open":
+		return a.open(subArgs)
+	case "macro":
+		return a.macro(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) info() (string, error) {
+	cmd := exec.Command(a.freecadPath, "--version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("freecad not found: %w", err)
+	}
+	return string(output), nil
+}
+
+func (a *Adapter) open(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("open requires <file.fcstd1> [file.fcstd2...]")
+	}
+
+	for _, f := range args {
+		if _, err := os.Stat(f); os.IsNotExist(err) {
+			return "", fmt.Errorf("file not found: %s", f)
+		}
+	}
+
+	cmd := exec.Command(a.freecadPath, "--background", args[0])
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Opened %d files", len(args)), nil
+}
+
+func (a *Adapter) macro(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("macro requires <file.fcstd> <macro.py>")
+	}
+	model := args[0]
+	script := args[1]
+
+	if _, err := os.Stat(script); os.IsNotExist(err) {
+		return "", fmt.Errorf("script not found: %s", script)
+	}
+
+	cmd := exec.Command(a.freecadPath, "--background", "--python-script", script, model)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("macro failed: %s", string(output))
+	}
+
+	return "Macro executed", nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `FreeCAD CLI adapter (258 commands: Part, Sketcher, PartDesign, Assembly, Mesh, TechDraw, Draft, FEM, CAM)
+Commands:
+  info                   - Show FreeCAD version
+  open <file.fcstd...>  - Open model file(s)
+  macro <file> <script> - Run Python script on model
+  help                   - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/gimp/gimp.go
+++ b/pkg/extensions/adapters/cli/adapters/gimp/gimp.go
@@ -1,0 +1,110 @@
+package gimp
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	gimpPath string
+}
+
+type Config struct {
+	GimpPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.GimpPath
+	if path == "" {
+		path = "gimp"
+	}
+	return &Adapter{gimpPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "gimp"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "convert":
+		return a.convert(subArgs)
+	case "resize":
+		return a.resize(subArgs)
+	case "crop":
+		return a.crop(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) convert(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("convert requires <input> <output>")
+	}
+	input := args[0]
+	output := args[1]
+
+	script := fmt.Sprintf("(gimp-file-load RUN-NONINTERACTIVE \"%s\" \"%s\") (gimp-file-save RUN-NONINTERACTIVE (car (gimp-image-get-active-layer 1)) (car (gimp-image-get-active-drawable 1)) \"%s\" \"%s\") (gimp-quit 1)", input, input, output, output)
+
+	cmd := exec.Command(a.gimpPath, "-i", "-b", script)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("conversion failed: %w", err)
+	}
+
+	return fmt.Sprintf("Converted to %s", output), nil
+}
+
+func (a *Adapter) resize(args []string) (string, error) {
+	if len(args) < 3 {
+		return "", fmt.Errorf("resize requires <input> <width> <height>")
+	}
+	input := args[0]
+	width := args[1]
+	height := args[2]
+
+	script := fmt.Sprintf("(gimp-file-load RUN-NONINTERACTIVE \"%s\" \"%s\") (gimp-image-scale 1 %s %s) (gimp-file-save RUN-NONINTERACTIVE (car (gimp-image-get-active-layer 1)) (car (gimp-image-get-active-drawable 1)) \"%s\" \"%s\") (gimp-quit 1)", input, input, width, height, input, input)
+
+	cmd := exec.Command(a.gimpPath, "-i", "-b", script)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("resize failed: %w", err)
+	}
+
+	return fmt.Sprintf("Resized to %sx%s", width, height), nil
+}
+
+func (a *Adapter) crop(args []string) (string, error) {
+	if len(args) < 5 {
+		return "", fmt.Errorf("crop requires <input> <x> <y> <width> <height>")
+	}
+	input := args[0]
+	x, y, w, h := args[1], args[2], args[3], args[4]
+
+	script := fmt.Sprintf("(gimp-file-load RUN-NONINTERACTIVE \"%s\" \"%s\") (gimp-image-crop 1 %s %s %s %s) (gimp-file-save RUN-NONINTERACTIVE (car (gimp-image-get-active-layer 1)) (car (gimp-image-get-active-drawable 1)) \"%s\" \"%s\") (gimp-quit 1)", input, input, w, h, x, y, input, input)
+
+	cmd := exec.Command(a.gimpPath, "-i", "-b", script)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("crop failed: %w", err)
+	}
+
+	return "Cropped successfully", nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `GIMP CLI adapter (batch mode)
+Commands:
+  convert <input> <output>           - Convert format
+  resize <input> <width> <height>   - Resize image
+  crop <input> <x> <y> <w> <h>      - Crop image
+  help                               - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/git/git.go
+++ b/pkg/extensions/adapters/cli/adapters/git/git.go
@@ -1,0 +1,441 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	gitPath string
+	repoDir string
+}
+
+type Config struct {
+	GitPath string
+	RepoDir string
+}
+
+func NewClient(cfg Config) *Client {
+	gitPath := cfg.GitPath
+	if gitPath == "" {
+		gitPath = "git"
+	}
+	repoDir := cfg.RepoDir
+	if repoDir == "" {
+		repoDir = "."
+	}
+	return &Client{
+		gitPath: gitPath,
+		repoDir: repoDir,
+	}
+}
+
+type Status struct {
+	Branch    string   `json:"branch"`
+	Staged    []string `json:"staged"`
+	Modified  []string `json:"modified"`
+	Untracked []string `json:"untracked"`
+	Conflict  []string `json:"conflict"`
+}
+
+type Commit struct {
+	Hash    string `json:"hash"`
+	Author  string `json:"author"`
+	Date    string `json:"date"`
+	Message string `json:"message"`
+}
+
+type Branch struct {
+	Name   string `json:"name"`
+	Remote bool   `json:"remote"`
+	Head   bool   `json:"head"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.status(ctx)
+	}
+
+	switch args[0] {
+	case "status", "st":
+		return c.status(ctx)
+	case "log":
+		return c.log(ctx, args[1:])
+	case "branch", "br":
+		return c.branch(ctx, args[1:])
+	case "commit", "ci":
+		return c.commit(ctx, args[1:])
+	case "add":
+		return c.add(ctx, args[1:])
+	case "push":
+		return c.push(ctx, args[1:])
+	case "pull":
+		return c.pull(ctx, args[1:])
+	case "clone":
+		return c.clone(ctx, args[1:])
+	case "checkout", "co":
+		return c.checkout(ctx, args[1:])
+	case "diff":
+		return c.diff(ctx, args[1:])
+	case "merge":
+		return c.merge(ctx, args[1:])
+	case "rebase":
+		return c.rebase(ctx, args[1:])
+	case "stash":
+		return c.stash(ctx, args[1:])
+	case "remote", "remote -v":
+		return c.remote(ctx)
+	case "fetch":
+		return c.fetch(ctx, args[1:])
+	case "init":
+		return c.init(ctx, args[1:])
+	case "tag":
+		return c.tag(ctx, args[1:])
+	case "show":
+		return c.show(ctx, args[1:])
+	case "reset":
+		return c.reset(ctx, args[1:])
+	case "clean":
+		return c.clean(ctx, args[1:])
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) status(ctx context.Context) (string, error) {
+	output, err := c.run(ctx, []string{"status", "--porcelain"})
+	if err != nil {
+		return "", err
+	}
+
+	status := &Status{}
+	lines := strings.Split(output, "\n")
+
+	for _, line := range lines {
+		if len(line) < 2 {
+			continue
+		}
+		file := strings.TrimSpace(line[3:])
+		switch line[:2] {
+		case "M ":
+			status.Modified = append(status.Modified, file)
+		case "A ":
+			status.Staged = append(status.Staged, file)
+		case "D ":
+			status.Modified = append(status.Modified, file)
+		case "??":
+			status.Untracked = append(status.Untracked, file)
+		case "UU":
+			status.Conflict = append(status.Conflict, file)
+		}
+	}
+
+	branch, _ := c.run(ctx, []string{"branch", "--show-current"})
+	status.Branch = strings.TrimSpace(branch)
+
+	var result []string
+	result = append(result, fmt.Sprintf("On branch: %s", status.Branch))
+	if len(status.Staged) > 0 {
+		result = append(result, "Staged:")
+		for _, f := range status.Staged {
+			result = append(result, fmt.Sprintf("  %s", f))
+		}
+	}
+	if len(status.Modified) > 0 {
+		result = append(result, "Modified:")
+		for _, f := range status.Modified {
+			result = append(result, fmt.Sprintf("  %s", f))
+		}
+	}
+	if len(status.Untracked) > 0 {
+		result = append(result, "Untracked:")
+		for _, f := range status.Untracked {
+			result = append(result, fmt.Sprintf("  %s", f))
+		}
+	}
+
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) log(ctx context.Context, args []string) (string, error) {
+	limit := "10"
+	for i, arg := range args {
+		if arg == "-n" && i+1 < len(args) {
+			limit = args[i+1]
+		}
+	}
+
+	output, err := c.run(ctx, []string{"log", "--oneline", "-n", limit})
+	return output, err
+}
+
+func (c *Client) branch(ctx context.Context, args []string) (string, error) {
+	output, err := c.run(ctx, []string{"branch", "-a"})
+	if err != nil {
+		return "", err
+	}
+
+	var result []string
+	lines := strings.Split(output, "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "* ") {
+			result = append(result, fmt.Sprintf("* %s (current)", strings.TrimPrefix(line, "* ")))
+		} else {
+			result = append(result, "  "+line)
+		}
+	}
+
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) commit(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("commit message required")
+	}
+
+	msg := strings.Join(args, " ")
+	_, err := c.run(ctx, []string{"commit", "-m", msg})
+	if err != nil {
+		return "", err
+	}
+
+	return "Committed: " + msg, nil
+}
+
+func (c *Client) add(ctx context.Context, args []string) (string, error) {
+	files := []string{"."}
+	if len(args) > 0 {
+		files = args
+	}
+
+	_, err := c.run(ctx, append([]string{"add"}, files...))
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Added %d files", len(files)), nil
+}
+
+func (c *Client) push(ctx context.Context, args []string) (string, error) {
+	pushArgs := []string{"push"}
+	pushArgs = append(pushArgs, args...)
+
+	_, err := c.run(ctx, pushArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Pushed successfully", nil
+}
+
+func (c *Client) pull(ctx context.Context, args []string) (string, error) {
+	pullArgs := []string{"pull"}
+	pullArgs = append(pullArgs, args...)
+
+	_, err := c.run(ctx, pullArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Pulled successfully", nil
+}
+
+func (c *Client) clone(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("repository URL required")
+	}
+
+	_, err := c.run(ctx, []string{"clone", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Cloned: %s", args[0]), nil
+}
+
+func (c *Client) checkout(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("branch name required")
+	}
+
+	_, err := c.run(ctx, []string{"checkout", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Switched to: %s", args[0]), nil
+}
+
+func (c *Client) diff(ctx context.Context, args []string) (string, error) {
+	diffArgs := []string{"diff"}
+	diffArgs = append(diffArgs, args...)
+
+	return c.run(ctx, diffArgs)
+}
+
+func (c *Client) merge(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("branch name required")
+	}
+
+	_, err := c.run(ctx, []string{"merge", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Merged: %s", args[0]), nil
+}
+
+func (c *Client) rebase(ctx context.Context, args []string) (string, error) {
+	branch := "main"
+	if len(args) > 0 {
+		branch = args[0]
+	}
+
+	_, err := c.run(ctx, []string{"rebase", branch})
+	if err != nil {
+		return "", err
+	}
+
+	return "Rebased successfully", nil
+}
+
+func (c *Client) stash(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		output, _ := c.run(ctx, []string{"stash", "list"})
+		return output, nil
+	}
+
+	switch args[0] {
+	case "push", "save":
+		msg := "WIP"
+		if len(args) > 1 {
+			msg = args[1]
+		}
+		_, err := c.run(ctx, []string{"stash", "push", "-m", msg})
+		if err != nil {
+			return "", err
+		}
+		return "Stashed", nil
+	case "pop":
+		_, err := c.run(ctx, []string{"stash", "pop"})
+		return "Stash applied", err
+	case "list":
+		return c.run(ctx, []string{"stash", "list"})
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) remote(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"remote", "-v"})
+}
+
+func (c *Client) fetch(ctx context.Context, args []string) (string, error) {
+	fetchArgs := []string{"fetch"}
+	fetchArgs = append(fetchArgs, args...)
+
+	_, err := c.run(ctx, fetchArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Fetched successfully", nil
+}
+
+func (c *Client) init(ctx context.Context, args []string) (string, error) {
+	dir := "."
+	if len(args) > 0 {
+		dir = args[0]
+	}
+
+	_, err := c.run(ctx, []string{"init", dir})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Initialized: %s", dir), nil
+}
+
+func (c *Client) tag(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"tag", "-l"})
+	}
+
+	name := args[0]
+	msg := ""
+	if len(args) > 1 {
+		msg = args[1]
+	}
+
+	if msg != "" {
+		_, err := c.run(ctx, []string{"tag", "-a", name, "-m", msg})
+		return fmt.Sprintf("Tag created: %s", name), err
+	}
+
+	_, err := c.run(ctx, []string{"tag", name})
+	return fmt.Sprintf("Tag created: %s", name), err
+}
+
+func (c *Client) show(ctx context.Context, args []string) (string, error) {
+	rev := "HEAD"
+	if len(args) > 0 {
+		rev = args[0]
+	}
+
+	return c.run(ctx, []string{"show", rev})
+}
+
+func (c *Client) reset(ctx context.Context, args []string) (string, error) {
+	mode := "--soft"
+	if len(args) > 0 && strings.HasPrefix(args[0], "--") {
+		mode = args[0]
+		args = args[1:]
+	}
+
+	commit := "HEAD~1"
+	if len(args) > 0 {
+		commit = args[0]
+	}
+
+	_, err := c.run(ctx, []string{"reset", mode, commit})
+	if err != nil {
+		return "", err
+	}
+
+	return "Reset successful", nil
+}
+
+func (c *Client) clean(ctx context.Context, args []string) (string, error) {
+	cleanArgs := []string{"clean", "-fd"}
+	cleanArgs = append(cleanArgs, args...)
+
+	_, err := c.run(ctx, cleanArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Cleaned untracked files", nil
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.gitPath, args...)
+	cmd.Dir = c.repoDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.gitPath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/inkscape/inkscape.go
+++ b/pkg/extensions/adapters/cli/adapters/inkscape/inkscape.go
@@ -1,0 +1,74 @@
+package inkscape
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	inkscapePath string
+}
+
+type Config struct {
+	InkscapePath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.InkscapePath
+	if path == "" {
+		path = "inkscape"
+	}
+	return &Adapter{inkscapePath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "inkscape"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "export":
+		return a.export(subArgs)
+	case "convert":
+		return a.convert(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) export(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("export requires <input.svg> <output.png/pdf/eps>")
+	}
+	input := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.inkscapePath, "--export-filename", output, input)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("export failed: %w", err)
+	}
+
+	return fmt.Sprintf("Exported to %s", output), nil
+}
+
+func (a *Adapter) convert(args []string) (string, error) {
+	return a.export(args)
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Inkscape CLI adapter
+Commands:
+  export <input.svg> <output.png/pdf/eps> - Export to format
+  convert <input> <output>               - Convert (alias)
+  help                                    - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/kdenlive/kdenlive.go
+++ b/pkg/extensions/adapters/cli/adapters/kdenlive/kdenlive.go
@@ -1,0 +1,79 @@
+package kdenlive
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	meltPath string
+}
+
+type Config struct {
+	MeltPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.MeltPath
+	if path == "" {
+		path = "melt"
+	}
+	return &Adapter{meltPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "kdenlive"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "render":
+		return a.render(subArgs)
+	case "info":
+		return a.info(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) render(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("render requires <profile> <output>")
+	}
+	profile := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.meltPath, profile, "-", "out", output)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("render failed: %w", err)
+	}
+
+	return fmt.Sprintf("Rendered to %s", output), nil
+}
+
+func (a *Adapter) info(args []string) (string, error) {
+	cmd := exec.Command(a.meltPath, "-query", "profiles")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Kdenlive CLI adapter (via melt)
+Commands:
+  render <profile> <output> - Render video
+  info                      - List profiles
+  help                      - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/krita/krita.go
+++ b/pkg/extensions/adapters/cli/adapters/krita/krita.go
@@ -1,0 +1,67 @@
+package krita
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	kritaPath string
+}
+
+type Config struct {
+	KritaPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.KritaPath
+	if path == "" {
+		path = "krita"
+	}
+	return &Adapter{kritaPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "krita"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "export":
+		return a.export(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) export(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("export requires <input.kra> <output.png>")
+	}
+	input := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.kritaPath, "--export", "--export-filename", output, input)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("export failed: %w", err)
+	}
+
+	return fmt.Sprintf("Exported to %s", output), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Krita CLI adapter
+Commands:
+  export <input.kra> <output.png> - Export to format
+  help                           - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/kubectl/kubectl.go
+++ b/pkg/extensions/adapters/cli/adapters/kubectl/kubectl.go
@@ -1,0 +1,338 @@
+package kubectl
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	kubectlPath string
+	namespace   string
+	kubeconfig  string
+}
+
+type Config struct {
+	KubectlPath string
+	Namespace   string
+	Kubeconfig  string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.KubectlPath
+	if path == "" {
+		path = "kubectl"
+	}
+	ns := cfg.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+	return &Client{
+		kubectlPath: path,
+		namespace:   ns,
+		kubeconfig:  cfg.Kubeconfig,
+	}
+}
+
+type Resource struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	Type      string `json:"type"`
+	Status    string `json:"status,omitempty"`
+	Age       string `json:"age"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.getPods(ctx)
+	}
+
+	switch args[0] {
+	case "get", "g":
+		return c.get(ctx, args[1:])
+	case "describe", "desc":
+		return c.describe(ctx, args[1:])
+	case "apply", "a":
+		return c.apply(ctx, args[1:])
+	case "delete", "d":
+		return c.delete(ctx, args[1:])
+	case "create":
+		return c.create(ctx, args[1:])
+	case "logs", "log":
+		return c.logs(ctx, args[1:])
+	case "exec":
+		return c.exec(ctx, args[1:])
+	case "port-forward", "pf":
+		return c.portForward(ctx, args[1:])
+	case "scale":
+		return c.scale(ctx, args[1:])
+	case "rollout":
+		return c.rollout(ctx, args[1:])
+	case "top":
+		return c.top(ctx, args[1:])
+	case "cluster-info":
+		return c.clusterInfo(ctx)
+	case "config":
+		return c.config(ctx, args[1:])
+	case "api-resources":
+		return c.apiResources(ctx)
+	case "version":
+		return c.version(ctx)
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) get(ctx context.Context, args []string) (string, error) {
+	resourceType := "pods"
+	if len(args) > 0 {
+		if !isKnownResource(args[0]) {
+			resourceType = args[0]
+			args = args[1:]
+		}
+	}
+
+	getArgs := []string{"get", resourceType}
+	if c.namespace != "" {
+		getArgs = append(getArgs, "-n", c.namespace)
+	}
+	getArgs = append(getArgs, "-o", "wide")
+	getArgs = append(getArgs, args...)
+
+	return c.run(ctx, getArgs)
+}
+
+func (c *Client) getPods(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"get", "pods", "-n", c.namespace, "-o", "wide"})
+}
+
+func (c *Client) describe(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("resource type and name required")
+	}
+
+	resourceType := args[0]
+	name := ""
+	if len(args) > 1 {
+		name = args[1]
+	}
+
+	descArgs := []string{"describe", resourceType}
+	if name != "" {
+		descArgs = append(descArgs, name)
+	}
+	if c.namespace != "" {
+		descArgs = append(descArgs, "-n", c.namespace)
+	}
+
+	return c.run(ctx, descArgs)
+}
+
+func (c *Client) apply(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("file or directory required")
+	}
+
+	applyArgs := []string{"apply", "-f"}
+	applyArgs = append(applyArgs, args...)
+
+	_, err := c.run(ctx, applyArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Applied successfully", nil
+}
+
+func (c *Client) delete(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("resource required")
+	}
+
+	deleteArgs := []string{"delete"}
+	if isKnownResource(args[0]) {
+		resourceType := args[0]
+		name := ""
+		if len(args) > 1 {
+			name = args[1]
+		}
+		deleteArgs = append(deleteArgs, resourceType)
+		if name != "" {
+			deleteArgs = append(deleteArgs, name)
+		}
+	} else {
+		deleteArgs = append(deleteArgs, "-f", args[0])
+	}
+
+	deleteArgs = append(deleteArgs, "--cascade=foreground")
+
+	_, err := c.run(ctx, deleteArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Deleted successfully", nil
+}
+
+func (c *Client) create(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("file required")
+	}
+
+	createArgs := []string{"create", "-f"}
+	createArgs = append(createArgs, args...)
+
+	_, err := c.run(ctx, createArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Created successfully", nil
+}
+
+func (c *Client) logs(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("pod name required")
+	}
+
+	logArgs := []string{"logs"}
+	if c.namespace != "" {
+		logArgs = append(logArgs, "-n", c.namespace)
+	}
+	logArgs = append(logArgs, args...)
+
+	return c.run(ctx, logArgs)
+}
+
+func (c *Client) exec(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("pod name and command required")
+	}
+
+	pod := args[0]
+	cmd := args[1:]
+
+	execArgs := []string{"exec", "-n", c.namespace, pod, "--"}
+	execArgs = append(execArgs, cmd...)
+
+	return c.run(ctx, execArgs)
+}
+
+func (c *Client) portForward(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("pod and ports required")
+	}
+
+	pod := args[0]
+	ports := args[1]
+
+	return fmt.Sprintf("Port forward: kubectl port-forward %s %s -n %s", pod, ports, c.namespace), nil
+}
+
+func (c *Client) scale(ctx context.Context, args []string) (string, error) {
+	if len(args) < 3 {
+		return "", fmt.Errorf("resource type, name and replica count required")
+	}
+
+	resourceType := args[0]
+	name := args[1]
+	replicas := args[2]
+
+	scaleArgs := []string{"scale", resourceType, name, "--replicas=" + replicas}
+	if c.namespace != "" {
+		scaleArgs = append(scaleArgs, "-n", c.namespace)
+	}
+
+	_, err := c.run(ctx, scaleArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Scaled %s/%s to %s replicas", resourceType, name, replicas), nil
+}
+
+func (c *Client) rollout(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("resource type and name required")
+	}
+
+	subcmd := args[0]
+	resource := args[1]
+
+	rolloutArgs := []string{"rollout", subcmd, resource}
+	if c.namespace != "" {
+		rolloutArgs = append(rolloutArgs, "-n", c.namespace)
+	}
+	if len(args) > 2 {
+		rolloutArgs = append(rolloutArgs, args[2:]...)
+	}
+
+	return c.run(ctx, rolloutArgs)
+}
+
+func (c *Client) top(ctx context.Context, args []string) (string, error) {
+	topArgs := []string{"top"}
+	if c.namespace != "" {
+		topArgs = append(topArgs, "-n", c.namespace)
+	}
+	topArgs = append(topArgs, args...)
+
+	return c.run(ctx, topArgs)
+}
+
+func (c *Client) clusterInfo(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"cluster-info"})
+}
+
+func (c *Client) config(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"config", "current-context"})
+	}
+
+	configArgs := []string{"config"}
+	configArgs = append(configArgs, args...)
+
+	return c.run(ctx, configArgs)
+}
+
+func (c *Client) apiResources(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"api-resources", "-o", "wide"})
+}
+
+func (c *Client) version(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"version", "--client"})
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.kubectlPath, args...)
+	if c.kubeconfig != "" {
+		cmd.Env = append(cmd.Env, "KUBECONFIG="+c.kubeconfig)
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.kubectlPath, "version", "--client")
+	return cmd.Run() == nil
+}
+
+func isKnownResource(s string) bool {
+	resources := []string{
+		"pods", "po", "services", "svc", "deployments", "deploy",
+		"replicasets", "rs", "statefulsets", "sts", "daemonsets", "ds",
+		"configmaps", "cm", "secrets", "ingress", "ing", "persistentvolumeclaims", "pvc",
+		"namespaces", "ns", "nodes", "no", "persistentvolumes", "pv",
+		"jobs", "cronjobs", "cj", "poddisruptionbudgets", "pdb",
+	}
+	for _, r := range resources {
+		if s == r {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/extensions/adapters/cli/adapters/libreoffice/libreoffice.go
+++ b/pkg/extensions/adapters/cli/adapters/libreoffice/libreoffice.go
@@ -1,0 +1,142 @@
+package libreoffice
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Client struct {
+	sofficePath string
+}
+
+type Config struct {
+	SofficePath string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.SofficePath
+	if path == "" {
+		path = "soffice"
+	}
+	return &Client{sofficePath: path}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "LibreOffice available. Use: convert, pdf, view", nil
+	}
+
+	switch args[0] {
+	case "convert":
+		return c.convert(ctx, args[1:])
+	case "pdf":
+		return c.toPDF(ctx, args[1:])
+	case "view":
+		return c.view(ctx, args[1:])
+	case "headless":
+		return c.headless(ctx, args[1:])
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) convert(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("usage: libreoffice convert <input> <output>")
+	}
+
+	input := args[0]
+	output := args[1]
+
+	inputAbs, _ := filepath.Abs(input)
+	outputAbs, _ := filepath.Abs(output)
+
+	_, err := c.run(ctx, []string{
+		"--headless",
+		"--convert-to",
+		filepath.Ext(output)[1:],
+		"--outdir",
+		filepath.Dir(outputAbs),
+		inputAbs,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Converted: %s -> %s", input, output), nil
+}
+
+func (c *Client) toPDF(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("usage: libreoffice pdf <input> [output]")
+	}
+
+	input := args[0]
+	var output string
+	if len(args) > 1 {
+		output = args[1]
+	} else {
+		ext := filepath.Ext(input)
+		output = strings.TrimSuffix(input, ext) + ".pdf"
+	}
+
+	inputAbs, _ := filepath.Abs(input)
+	outputAbs, _ := filepath.Abs(output)
+
+	_, err := c.run(ctx, []string{
+		"--headless",
+		"--convert-to",
+		"pdf",
+		"--outdir",
+		filepath.Dir(outputAbs),
+		inputAbs,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("PDF created: %s", output), nil
+}
+
+func (c *Client) view(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("usage: libreoffice view <file>")
+	}
+
+	input := args[0]
+	inputAbs, _ := filepath.Abs(input)
+
+	_, err := c.run(ctx, []string{
+		"--view",
+		inputAbs,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Opened: %s", input), nil
+}
+
+func (c *Client) headless(ctx context.Context, args []string) (string, error) {
+	headlessArgs := []string{"--headless"}
+	headlessArgs = append(headlessArgs, args...)
+
+	return c.run(ctx, headlessArgs)
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.sofficePath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.sofficePath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/mermaid/mermaid.go
+++ b/pkg/extensions/adapters/cli/adapters/mermaid/mermaid.go
@@ -1,0 +1,110 @@
+package mermaid
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Adapter struct{}
+
+func New() *Adapter {
+	return &Adapter{}
+}
+
+func (a *Adapter) Name() string {
+	return "mermaid"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "render":
+		return a.render(subArgs)
+	case "serve":
+		return a.serve(subArgs)
+	case "validate":
+		return a.validate(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) render(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("render requires <input.mmd> <output.png/pdf/svg>")
+	}
+	input := args[0]
+	output := args[1]
+
+	ext := strings.ToLower(filepath.Ext(output))
+	format := strings.TrimPrefix(ext, ".")
+
+	outputDir := filepath.Dir(output)
+	if outputDir == "." {
+		outputDir = "./dist"
+		os.MkdirAll(outputDir, 0755)
+	}
+
+	cmd := exec.Command("npx", "-y", "@mermaid-js/mermaid-cli", "-i", input, "-o", outputDir, "-t", format)
+	cmd.Dir = filepath.Dir(input)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("render failed: %s", string(out))
+	}
+
+	return fmt.Sprintf("Rendered to %s", output), nil
+}
+
+func (a *Adapter) serve(args []string) (string, error) {
+	port := "8080"
+	if len(args) > 0 {
+		port = args[0]
+	}
+
+	cmd := exec.Command("npx", "-y", "mermaid", "-p", port)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Mermaid server started on port %s", port), nil
+}
+
+func (a *Adapter) validate(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("validate requires <input.mmd>")
+	}
+	input := args[0]
+
+	cmd := exec.Command("npx", "-y", "@mermaid-js/mermaid-cli", "-i", input, "-o", "/dev/null")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("validation failed: %s", string(output))
+	}
+
+	return "Valid Mermaid diagram", nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Mermaid CLI adapter
+Commands:
+  render <input.mmd> <output>  - Render diagram to file
+  serve [port]                - Start local server
+  validate <input.mmd>        - Validate diagram syntax
+  help                        - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/mubu/mubu.go
+++ b/pkg/extensions/adapters/cli/adapters/mubu/mubu.go
@@ -1,0 +1,107 @@
+package mubu
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Adapter struct {
+	dataDir string
+}
+
+type Config struct {
+	DataDir string
+}
+
+func New(cfg Config) *Adapter {
+	dir := cfg.DataDir
+	if dir == "" {
+		home, _ := os.UserHomeDir()
+		dir = filepath.Join(home, "Library", "Application Support", "Mubu")
+	}
+	return &Adapter{dataDir: dir}
+}
+
+func (a *Adapter) Name() string {
+	return "mubu"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.list()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "list":
+		return a.list()
+	case "documents":
+		return a.documents()
+	case "search":
+		return a.search(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) list() (string, error) {
+	entries, err := os.ReadDir(a.dataDir)
+	if err != nil {
+		return "", fmt.Errorf("cannot read mubu data: %w", err)
+	}
+
+	var result []string
+	for _, e := range entries {
+		if e.IsDir() {
+			result = append(result, e.Name())
+		}
+	}
+	if len(result) == 0 {
+		return "No documents found", nil
+	}
+	return strings.Join(result, "\n"), nil
+}
+
+func (a *Adapter) documents() (string, error) {
+	return a.list()
+}
+
+func (a *Adapter) search(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("search requires <query>")
+	}
+	query := strings.Join(args, " ")
+
+	entries, err := os.ReadDir(a.dataDir)
+	if err != nil {
+		return "", err
+	}
+
+	var result []string
+	for _, e := range entries {
+		if e.IsDir() && strings.Contains(strings.ToLower(e.Name()), strings.ToLower(query)) {
+			result = append(result, e.Name())
+		}
+	}
+
+	if len(result) == 0 {
+		return fmt.Sprintf("No documents matching '%s'", query), nil
+	}
+	return strings.Join(result, "\n"), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Mubu CLI adapter (knowledge management)
+Commands:
+  list                    - List documents
+  documents               - List documents (alias)
+  search <query>          - Search documents
+  help                    - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/musescore/musescore.go
+++ b/pkg/extensions/adapters/cli/adapters/musescore/musescore.go
@@ -1,0 +1,112 @@
+package musescore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Adapter struct {
+	mscorePath string
+}
+
+type Config struct {
+	MscorePath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.MscorePath
+	if path == "" {
+		path = "mscore"
+	}
+	return &Adapter{mscorePath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "musescore"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "convert":
+		return a.convert(subArgs)
+	case "export":
+		return a.export(subArgs)
+	case "info":
+		return a.info(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) convert(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("convert requires <input.mscz> <output.pdf/mp3/midi>")
+	}
+	input := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.mscorePath, "-o", output, input)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("conversion failed: %w", err)
+	}
+
+	return fmt.Sprintf("Converted %s to %s", input, output), nil
+}
+
+func (a *Adapter) export(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("export requires <input.mscz> <format>")
+	}
+	input := args[0]
+	format := args[1]
+
+	ext := "." + format
+	output := strings.TrimSuffix(filepath.Base(input), filepath.Ext(input)) + ext
+
+	cmd := exec.Command(a.mscorePath, "-o", output, input)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("export failed: %w", err)
+	}
+
+	return fmt.Sprintf("Exported to %s", output), nil
+}
+
+func (a *Adapter) info(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("info requires <input.mscz>")
+	}
+	input := args[0]
+
+	cmd := exec.Command(a.mscorePath, "-i", input)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("info failed: %w", err)
+	}
+
+	return string(output), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `MuseScore CLI adapter
+Commands:
+  convert <input.mscz> <output.pdf/mp3/midi>  - Convert score
+  export <input.mscz> <format>               - Export to format
+  info <input.mscz>                           - Show score info
+  help                                        - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/node/node.go
+++ b/pkg/extensions/adapters/cli/adapters/node/node.go
@@ -1,0 +1,124 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	nodePath string
+	npmPath  string
+}
+
+type Config struct {
+	NodePath string
+	NPMPath  string
+}
+
+func NewClient(cfg Config) *Client {
+	nodePath := cfg.NodePath
+	if nodePath == "" {
+		nodePath = "node"
+	}
+	npmPath := cfg.NPMPath
+	if npmPath == "" {
+		npmPath = "npm"
+	}
+	return &Client{
+		nodePath: nodePath,
+		npmPath:  npmPath,
+	}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.version(ctx)
+	}
+
+	switch args[0] {
+	case "run", "r":
+		return c.runScript(ctx, args[1:])
+	case "exec", "e":
+		return c.exec(ctx, args[1:])
+	case "version", "v":
+		return c.version(ctx)
+	case "npm":
+		return c.npm(ctx, args[1:])
+	case "npx":
+		return c.npx(ctx, args[1:])
+	case "info":
+		return c.info(ctx)
+	case "REPL":
+		return c.repl(ctx)
+	default:
+		if strings.HasSuffix(args[0], ".js") {
+			return c.runFile(ctx, args)
+		}
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) version(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"--version"})
+}
+
+func (c *Client) info(ctx context.Context) (string, error) {
+	nodeVersion, _ := c.run(ctx, []string{"--version"})
+	npmVersion, _ := c.run(c.ctxWithNPM(ctx), []string{"--version"})
+	return fmt.Sprintf("Node: %s\nNPM: %s", strings.TrimSpace(nodeVersion), strings.TrimSpace(npmVersion)), nil
+}
+
+func (c *Client) ctxWithNPM(ctx context.Context) context.Context {
+	return ctx
+}
+
+func (c *Client) runScript(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(c.ctxWithNPM(ctx), []string{c.npmPath, "run"})
+	}
+
+	return c.run(c.ctxWithNPM(ctx), append([]string{c.npmPath, "run"}, args...))
+}
+
+func (c *Client) exec(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("code required")
+	}
+
+	code := strings.Join(args, " ")
+	return c.run(ctx, []string{"-e", code})
+}
+
+func (c *Client) npm(ctx context.Context, args []string) (string, error) {
+	npmArgs := []string{c.npmPath}
+	npmArgs = append(npmArgs, args...)
+	return c.run(ctx, npmArgs)
+}
+
+func (c *Client) npx(ctx context.Context, args []string) (string, error) {
+	return c.run(ctx, append([]string{"npx"}, args...))
+}
+
+func (c *Client) runFile(ctx context.Context, args []string) (string, error) {
+	return c.run(ctx, args)
+}
+
+func (c *Client) repl(ctx context.Context) (string, error) {
+	return "Entering Node.js REPL. Type .exit to exit.", nil
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.nodePath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.nodePath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/notebooklm/notebooklm.go
+++ b/pkg/extensions/adapters/cli/adapters/notebooklm/notebooklm.go
@@ -1,0 +1,204 @@
+package notebooklm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+type Client struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+type Config struct {
+	APIKey string
+}
+
+func New(cfg Config) *Client {
+	apiKey := cfg.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("NOTEBOOKLM_API_KEY")
+	}
+	return &Client{
+		apiKey:     apiKey,
+		baseURL:    "https://notebooklm.google.com/api/v1",
+		httpClient: &http.Client{Timeout: 5 * time.Minute},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "notebook":
+		return c.notebook(ctx, subArgs)
+	case "source":
+		return c.source(ctx, subArgs)
+	case "chat":
+		return c.chat(ctx, subArgs)
+	case "download":
+		return c.download(ctx, subArgs)
+	case "help":
+		return c.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (c *Client) notebook(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "Available: list, create, delete", nil
+	}
+
+	action := args[0]
+	switch action {
+	case "list":
+		return c.listNotebooks(ctx)
+	case "create":
+		if len(args) < 2 {
+			return "", fmt.Errorf("create requires <name>")
+		}
+		return c.createNotebook(ctx, args[1])
+	default:
+		return "", fmt.Errorf("unknown notebook action: %s", action)
+	}
+}
+
+func (c *Client) listNotebooks(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/notebooks", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) createNotebook(ctx context.Context, name string) (string, error) {
+	body := map[string]string{"name": name}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/notebooks", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) source(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("source add <notebook_id> <url/file>")
+	}
+	notebookID := args[0]
+	source := args[1]
+
+	body := map[string]string{"source": source}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/notebooks/"+notebookID+"/sources", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) chat(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("chat <notebook_id> <message>")
+	}
+	notebookID := args[0]
+	message := args[1]
+
+	body := map[string]string{"message": message}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/notebooks/"+notebookID+"/chat", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) download(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("download <notebook_id> <output.zip>")
+	}
+	notebookID := args[0]
+	output := args[1]
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/notebooks/"+notebookID+"/export", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	os.WriteFile(output, b, 0644)
+
+	return fmt.Sprintf("Downloaded to %s", output), nil
+}
+
+func (c *Client) help() (string, error) {
+	return `NotebookLM CLI adapter
+Commands:
+  notebook list                           - List notebooks
+  notebook create <name>                 - Create notebook
+  source add <notebook_id> <url>        - Add source
+  chat <notebook_id> <message>          - Send chat
+  download <notebook_id> <output.zip>   - Export
+  help                                    - Show this help
+Note: Requires NOTEBOOKLM_API_KEY`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/novita/novita.go
+++ b/pkg/extensions/adapters/cli/adapters/novita/novita.go
@@ -1,0 +1,153 @@
+package novita
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+type Config struct {
+	APIKey string
+}
+
+func New(cfg Config) *Client {
+	apiKey := cfg.APIKey
+	if apiKey == "" {
+		apiKey = "novita"
+	}
+	return &Client{
+		apiKey:     apiKey,
+		baseURL:    "https://api.novita.ai/v1",
+		httpClient: &http.Client{Timeout: 5 * time.Minute},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "chat":
+		return c.chat(ctx, subArgs)
+	case "models":
+		return c.models(ctx)
+	case "help":
+		return c.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+type ChatRequest struct {
+	Model       string    `json:"model"`
+	Messages    []Message `json:"messages"`
+	Stream      bool      `json:"stream,omitempty"`
+	MaxTokens   int       `json:"max_tokens,omitempty"`
+	Temperature float64   `json:"temperature,omitempty"`
+}
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ChatResponse struct {
+	ID      string   `json:"id"`
+	Choices []Choice `json:"choices"`
+	Usage   Usage    `json:"usage"`
+}
+
+type Choice struct {
+	Message Message `json:"message"`
+	Index   int     `json:"index"`
+}
+
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+func (c *Client) chat(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("chat requires <model> <prompt>")
+	}
+	model := args[0]
+	prompt := strings.Join(args[1:], " ")
+
+	body := ChatRequest{
+		Model: model,
+		Messages: []Message{
+			{Role: "user", Content: prompt},
+		},
+		MaxTokens: 1024,
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+
+	var result ChatResponse
+	if err := json.Unmarshal(b, &result); err != nil {
+		return string(b), err
+	}
+
+	if len(result.Choices) > 0 {
+		return result.Choices[0].Message.Content, nil
+	}
+	return "", fmt.Errorf("no response")
+}
+
+func (c *Client) models(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/models", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) help() (string, error) {
+	return `Novita AI CLI adapter (OpenAI-compatible API)
+Models: deepseek, glm, minimax, qwen, and more
+Commands:
+  chat <model> <prompt>  - Send chat request
+  models                  - List available models
+  help                    - Show this help
+Note: Requires NOVITA_API_KEY`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/npm/npm.go
+++ b/pkg/extensions/adapters/cli/adapters/npm/npm.go
@@ -1,0 +1,259 @@
+package npm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	npmPath    string
+	workingDir string
+}
+
+type Config struct {
+	NPMPath    string
+	WorkingDir string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.NPMPath
+	if path == "" {
+		path = "npm"
+	}
+	dir := cfg.WorkingDir
+	if dir == "" {
+		dir = "."
+	}
+	return &Client{
+		npmPath:    path,
+		workingDir: dir,
+	}
+}
+
+type PackageInfo struct {
+	Name         string            `json:"name"`
+	Version      string            `json:"version"`
+	Description  string            `json:"description"`
+	Dependencies map[string]string `json:"dependencies"`
+}
+
+type PackageList struct {
+	Dependencies map[string]PackageInfo `json:"dependencies"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.list(ctx)
+	}
+
+	switch args[0] {
+	case "install", "i":
+		return c.install(ctx, args[1:])
+	case "uninstall", "remove", "rm":
+		return c.uninstall(ctx, args[1:])
+	case "update", "up":
+		return c.update(ctx, args[1:])
+	case "list", "ls":
+		return c.listArgs(ctx, args[1:])
+	case "outdated":
+		return c.outdated(ctx)
+	case "init":
+		return c.init(ctx, args[1:])
+	case "run":
+		return c.runScript(ctx, args[1:])
+	case "start":
+		return c.runScript(ctx, []string{"start"})
+	case "test":
+		return c.runScript(ctx, []string{"test"})
+	case "publish":
+		return c.publish(ctx, args[1:])
+	case "info":
+		return c.info(ctx, args[1:])
+	case "search":
+		return c.search(ctx, args[1:])
+	case "version":
+		return c.version(ctx, args[1:])
+	case "view":
+		return c.view(ctx, args[1:])
+	case "doc", "docs":
+		return c.docs(ctx, args[1:])
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) install(ctx context.Context, args []string) (string, error) {
+	installArgs := []string{"install"}
+	installArgs = append(installArgs, args...)
+
+	_, err := c.run(ctx, installArgs)
+	if err != nil {
+		return "", err
+	}
+
+	if len(args) == 0 {
+		return "Installed all dependencies from package.json", nil
+	}
+	return fmt.Sprintf("Installed: %s", strings.Join(args, " ")), nil
+}
+
+func (c *Client) uninstall(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("package name required")
+	}
+
+	_, err := c.run(ctx, []string{"uninstall", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Uninstalled: %s", args[0]), nil
+}
+
+func (c *Client) update(ctx context.Context, args []string) (string, error) {
+	updateArgs := []string{"update"}
+	if len(args) > 0 {
+		updateArgs = append(updateArgs, args...)
+	}
+
+	_, err := c.run(ctx, updateArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Updated packages", nil
+}
+
+func (c *Client) list(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"list", "--depth=0"})
+}
+
+func (c *Client) listArgs(ctx context.Context, args []string) (string, error) {
+	listArgs := []string{"list"}
+	listArgs = append(listArgs, args...)
+
+	return c.run(ctx, listArgs)
+}
+
+func (c *Client) outdated(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"outdated"})
+}
+
+func (c *Client) init(ctx context.Context, args []string) (string, error) {
+	initArgs := []string{"init"}
+	if len(args) > 0 {
+		initArgs = append(initArgs, "-y")
+	}
+
+	_, err := c.run(ctx, initArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Initialized package.json", nil
+}
+
+func (c *Client) runScript(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"run"})
+	}
+
+	scriptArgs := []string{"run"}
+	scriptArgs = append(scriptArgs, args...)
+
+	return c.run(ctx, scriptArgs)
+}
+
+func (c *Client) publish(ctx context.Context, args []string) (string, error) {
+	publishArgs := []string{"publish"}
+	publishArgs = append(publishArgs, args...)
+
+	_, err := c.run(ctx, publishArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Published to npm", nil
+}
+
+func (c *Client) info(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("package name required")
+	}
+
+	return c.run(ctx, []string{"info", args[0]})
+}
+
+func (c *Client) search(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("search term required")
+	}
+
+	searchArgs := []string{"search", "--long"}
+	searchArgs = append(searchArgs, args...)
+
+	return c.run(ctx, searchArgs)
+}
+
+func (c *Client) version(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"--version"})
+	}
+
+	_, err := c.run(ctx, []string{"version", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Version updated to %s", args[0]), nil
+}
+
+func (c *Client) view(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("package name required")
+	}
+
+	viewArgs := []string{"view"}
+	viewArgs = append(viewArgs, args...)
+
+	return c.run(ctx, viewArgs)
+}
+
+func (c *Client) docs(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("package name required")
+	}
+
+	return fmt.Sprintf("https://www.npmjs.com/package/%s", args[0]), nil
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.npmPath, args...)
+	cmd.Dir = c.workingDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.npmPath, "--version")
+	return cmd.Run() == nil
+}
+
+func ParseDependencies(output string) (map[string]string, error) {
+	var pkgList PackageList
+	if err := json.Unmarshal([]byte(output), &pkgList); err != nil {
+		return nil, err
+	}
+
+	deps := make(map[string]string)
+	for name, info := range pkgList.Dependencies {
+		deps[name] = info.Version
+	}
+	return deps, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/obsstudio/obsstudio.go
+++ b/pkg/extensions/adapters/cli/adapters/obsstudio/obsstudio.go
@@ -1,0 +1,110 @@
+package obsstudio
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	obsPath string
+}
+
+type Config struct {
+	ObsPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.ObsPath
+	if path == "" {
+		path = "obs"
+	}
+	return &Adapter{obsPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "obs-studio"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "start":
+		return a.start(subArgs)
+	case "stop":
+		return a.stop()
+	case "scene":
+		return a.scene(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) start(args []string) (string, error) {
+	mode := "recording"
+	if len(args) > 0 {
+		mode = args[0]
+	}
+
+	cmd := exec.Command(a.obsPath, "--start"+mode)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Started %s", mode), nil
+}
+
+func (a *Adapter) stop() (string, error) {
+	cmd := exec.Command(a.obsPath, "--stop")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	return "Stopped", nil
+}
+
+func (a *Adapter) scene(args []string) (string, error) {
+	if len(args) == 0 {
+		return "Available: list, switch <name>", nil
+	}
+
+	action := args[0]
+	switch action {
+	case "list":
+		cmd := exec.Command(a.obsPath, "--scene-list")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return "", err
+		}
+		return string(output), nil
+	case "switch":
+		if len(args) < 2 {
+			return "", fmt.Errorf("switch requires <scene_name>")
+		}
+		cmd := exec.Command(a.obsPath, "--scene-switch", args[1])
+		if err := cmd.Run(); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Switched to %s", args[1]), nil
+	default:
+		return "", fmt.Errorf("unknown scene action: %s", action)
+	}
+}
+
+func (a *Adapter) help() (string, error) {
+	return `OBS Studio CLI adapter
+Commands:
+  start [recording/streaming] - Start recording/streaming
+  stop                         - Stop
+  scene list                   - List scenes
+  scene switch <name>          - Switch scene
+  help                         - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/ollama/ollama.go
+++ b/pkg/extensions/adapters/cli/adapters/ollama/ollama.go
@@ -1,0 +1,247 @@
+package ollama
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+	Model      string
+}
+
+type Config struct {
+	BaseURL string
+	Model   string
+}
+
+func NewClient(cfg Config) *Client {
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "http://localhost:11434"
+	}
+	if cfg.Model == "" {
+		cfg.Model = "llama2"
+	}
+
+	return &Client{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 5 * time.Minute,
+		},
+		Model: cfg.Model,
+	}
+}
+
+type GenerateRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+	Stream bool   `json:"stream,omitempty"`
+}
+
+type GenerateResponse struct {
+	Model     string `json:"model"`
+	Response  string `json:"response"`
+	Done      bool   `json:"done"`
+	Context   any    `json:"context,omitempty"`
+	TotalDur  int64  `json:"total_duration,omitempty"`
+	LoadDur   int64  `json:"load_duration,omitempty"`
+	PromptDur int64  `json:"prompt_eval_duration,omitempty"`
+	EvalDur   int64  `json:"eval_duration,omitempty"`
+}
+
+func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
+	reqBody := GenerateRequest{
+		Model:  c.Model,
+		Prompt: prompt,
+		Stream: false,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/generate", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("ollama error: %s", string(b))
+	}
+
+	var result GenerateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	return result.Response, nil
+}
+
+type ChatRequest struct {
+	Model    string    `json:"model"`
+	Messages []Message `json:"messages"`
+	Stream   bool      `json:"stream,omitempty"`
+}
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ChatResponse struct {
+	Model    string  `json:"model"`
+	Message  Message `json:"message"`
+	Done     bool    `json:"done"`
+	TotalDur int64   `json:"total_duration,omitempty"`
+	EvalDur  int64   `json:"eval_duration,omitempty"`
+}
+
+func (c *Client) Chat(ctx context.Context, messages []Message) (string, error) {
+	reqBody := ChatRequest{
+		Model:    c.Model,
+		Messages: messages,
+		Stream:   false,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/chat", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("ollama error: %s", string(b))
+	}
+
+	var result ChatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	return result.Message.Content, nil
+}
+
+type Model struct {
+	Name       string `json:"name"`
+	Size       int64  `json:"size"`
+	ModifiedAt string `json:"modified_at"`
+	Digest     string `json:"digest"`
+}
+
+type ListResponse struct {
+	Models []Model `json:"models"`
+}
+
+func (c *Client) ListModels(ctx context.Context) ([]Model, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/tags", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("ollama error: %s", string(b))
+	}
+
+	var result ListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	return result.Models, nil
+}
+
+func (c *Client) Show(ctx context.Context, modelName string) (string, error) {
+	reqBody := map[string]string{"name": modelName}
+	body, _ := json.Marshal(reqBody)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/show", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) Pull(ctx context.Context, modelName string, onProgress func(string)) error {
+	reqBody := map[string]any{"name": modelName, "stream": true}
+	body, _ := json.Marshal(reqBody)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/pull", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	decoder := json.NewDecoder(resp.Body)
+	for {
+		var msg map[string]any
+		if err := decoder.Decode(&msg); err != nil {
+			break
+		}
+		if status, ok := msg["status"].(string); ok && onProgress != nil {
+			onProgress(status)
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) IsRunning(ctx context.Context) bool {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/tags", nil)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode < 300
+}

--- a/pkg/extensions/adapters/cli/adapters/python/python.go
+++ b/pkg/extensions/adapters/cli/adapters/python/python.go
@@ -1,0 +1,125 @@
+package python
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	pythonPath string
+	venvPath   string
+}
+
+type Config struct {
+	PythonPath string
+	VenvPath   string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.PythonPath
+	if path == "" {
+		path = "python"
+	}
+	return &Client{
+		pythonPath: path,
+		venvPath:   cfg.VenvPath,
+	}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.version(ctx)
+	}
+
+	switch args[0] {
+	case "run":
+		return c.runScript(ctx, args[1:])
+	case "install":
+		return c.pipInstall(ctx, args[1:])
+	case "pip":
+		return c.pip(ctx, args[1:])
+	case "version", "V":
+		return c.version(ctx)
+	case "info":
+		return c.info(ctx)
+	case "list":
+		return c.listPackages(ctx)
+	case "env":
+		return c.venv(ctx)
+	case "script":
+		return c.runScriptFile(ctx, args[1:])
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) version(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"--version"})
+}
+
+func (c *Client) info(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"-c", "import sys; print(sys.executable); print(sys.version)"})
+}
+
+func (c *Client) runScript(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("code required")
+	}
+
+	code := strings.Join(args, " ")
+	return c.run(ctx, []string{"-c", code})
+}
+
+func (c *Client) runScriptFile(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("script path required")
+	}
+
+	return c.run(ctx, args)
+}
+
+func (c *Client) pipInstall(ctx context.Context, args []string) (string, error) {
+	pipArgs := []string{"-m", "pip", "install"}
+	pipArgs = append(pipArgs, args...)
+
+	_, err := c.run(ctx, pipArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Installed: %s", strings.Join(args, " ")), nil
+}
+
+func (c *Client) pip(ctx context.Context, args []string) (string, error) {
+	pipArgs := []string{"-m", "pip"}
+	pipArgs = append(pipArgs, args...)
+
+	return c.run(ctx, pipArgs)
+}
+
+func (c *Client) listPackages(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"-m", "pip", "list"})
+}
+
+func (c *Client) venv(ctx context.Context) (string, error) {
+	if c.venvPath == "" {
+		return c.run(ctx, []string{"-m", "venv"})
+	}
+	return c.run(ctx, []string{"-m", "venv", c.venvPath})
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.pythonPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.pythonPath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/renderdoc/renderdoc.go
+++ b/pkg/extensions/adapters/cli/adapters/renderdoc/renderdoc.go
@@ -1,0 +1,84 @@
+package renderdoc
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	renderdocPath string
+}
+
+type Config struct {
+	RenderdocPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.RenderdocPath
+	if path == "" {
+		path = "renderdoc"
+	}
+	return &Adapter{renderdocPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "renderdoc"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "capture":
+		return a.capture(subArgs)
+	case "info":
+		return a.info(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) capture(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("capture requires <executable> <output.rdc>")
+	}
+	exe := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.renderdocPath, "--capture", "--exe", exe, "--output", output)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("capture failed: %w", err)
+	}
+
+	return fmt.Sprintf("Captured to %s", output), nil
+}
+
+func (a *Adapter) info(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("info requires <capture.rdc>")
+	}
+	input := args[0]
+
+	cmd := exec.Command(a.renderdocPath, "--info", input)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `RenderDoc CLI adapter (GPU frame capture)
+Commands:
+  capture <exe> <output.rdc> - Capture frames
+  info <capture.rdc>         - Show capture info
+  help                       - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/rms/rms.go
+++ b/pkg/extensions/adapters/cli/adapters/rms/rms.go
@@ -1,0 +1,137 @@
+package rms
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+type Client struct {
+	apiToken string
+	baseURL  string
+	client   *http.Client
+}
+
+type Config struct {
+	APIToken string
+}
+
+func New(cfg Config) *Client {
+	token := cfg.APIToken
+	if token == "" {
+		token = os.Getenv("RMS_API_TOKEN")
+	}
+	return &Client{
+		apiToken: token,
+		baseURL:  "https://rms.teltonika-networks.com/api/v1",
+		client:   &http.Client{},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "devices":
+		return c.devices(ctx)
+	case "info":
+		return c.info(subArgs)
+	case "status":
+		return c.status(subArgs)
+	case "help":
+		return c.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+type Device struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	IP       string `json:"ip"`
+	Model    string `json:"model"`
+	Firmware string `json:"firmware"`
+}
+
+func (c *Client) devices(ctx context.Context) (string, error) {
+	if c.apiToken == "" {
+		return "", fmt.Errorf("RMS_API_TOKEN not configured")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/devices", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Token "+c.apiToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) info(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("info requires <device_id>")
+	}
+	deviceID := args[0]
+
+	req, err := http.NewRequest(http.MethodGet, c.baseURL+"/devices/"+deviceID, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Token "+c.apiToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) status(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("status requires <device_id>")
+	}
+	deviceID := args[0]
+
+	req, err := http.NewRequest(http.MethodGet, c.baseURL+"/devices/"+deviceID+"/status", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Token "+c.apiToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) help() (string, error) {
+	return `Teltonika RMS CLI adapter
+Commands:
+  devices                - List all devices
+  info <device_id>       - Get device info
+  status <device_id>    - Get device status
+  help                  - Show this help
+Note: Requires RMS_API_TOKEN`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/shotcut/shotcut.go
+++ b/pkg/extensions/adapters/cli/adapters/shotcut/shotcut.go
@@ -1,0 +1,91 @@
+package shotcut
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	meltPath   string
+	ffmpegPath string
+}
+
+type Config struct {
+	MeltPath   string
+	FfmpegPath string
+}
+
+func New(cfg Config) *Adapter {
+	meltPath := cfg.MeltPath
+	if meltPath == "" {
+		meltPath = "melt"
+	}
+	ffmpegPath := cfg.FfmpegPath
+	if ffmpegPath == "" {
+		ffmpegPath = "ffmpeg"
+	}
+	return &Adapter{meltPath: meltPath, ffmpegPath: ffmpegPath}
+}
+
+func (a *Adapter) Name() string {
+	return "shotcut"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "render":
+		return a.render(subArgs)
+	case "convert":
+		return a.convert(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) render(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("render requires <input> <output>")
+	}
+	input := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.meltPath, input, "-", "out", output)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("render failed: %w", err)
+	}
+
+	return fmt.Sprintf("Rendered to %s", output), nil
+}
+
+func (a *Adapter) convert(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("convert requires <input> <output>")
+	}
+	input := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.ffmpegPath, "-i", input, "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "aac", "-b:a", "128k", output)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("convert failed: %w", err)
+	}
+
+	return fmt.Sprintf("Converted to %s", output), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Shotcut CLI adapter (via melt/ffmpeg)
+Commands:
+  render <input> <output> - Render video (melt)
+  convert <input> <output> - Convert format (ffmpeg)
+  help                    - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/sketch/sketch.go
+++ b/pkg/extensions/adapters/cli/adapters/sketch/sketch.go
@@ -1,0 +1,85 @@
+package sketch
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	nodePath string
+}
+
+type Config struct {
+	NodePath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.NodePath
+	if path == "" {
+		path = "node"
+	}
+	return &Adapter{nodePath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "sketch"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "create":
+		return a.create(subArgs)
+	case "export":
+		return a.export(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) create(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("create requires <output.sketch> <json-spec>")
+	}
+	output := args[0]
+	spec := args[1]
+
+	cmd := exec.Command(a.nodePath, "sketch-cli", "create", "-o", output, spec)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("create failed: %w", err)
+	}
+
+	return fmt.Sprintf("Created %s", output), nil
+}
+
+func (a *Adapter) export(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("export requires <input.sketch> <output.pdf/png>")
+	}
+	input := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.nodePath, "sketch-cli", "export", "-o", output, input)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("export failed: %w", err)
+	}
+
+	return fmt.Sprintf("Exported to %s", output), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Sketch CLI adapter (via sketch-constructor)
+Commands:
+  create <output.sketch> <spec.json> - Create sketch file
+  export <input.sketch> <output>      - Export to format
+  help                               - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/sqlite/sqlite.go
+++ b/pkg/extensions/adapters/cli/adapters/sqlite/sqlite.go
@@ -1,0 +1,75 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	sqlitePath string
+}
+
+type Config struct {
+	SQLitePath string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.SQLitePath
+	if path == "" {
+		path = "sqlite3"
+	}
+	return &Client{sqlitePath: path}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "Usage: sqlite <db> <sql>", nil
+	}
+
+	dbPath := args[0]
+	sqlQuery := strings.Join(args[1:], " ")
+
+	query := strings.TrimSpace(sqlQuery)
+	if strings.HasPrefix(strings.ToLower(query), "select") ||
+		strings.HasPrefix(strings.ToLower(query), "pragma") {
+		return c.query(ctx, dbPath, query)
+	}
+
+	return c.execute(ctx, dbPath, query)
+}
+
+func (c *Client) query(ctx context.Context, dbPath, query string) (string, error) {
+	return c.run(ctx, []string{"-header", "-column", dbPath, query})
+}
+
+func (c *Client) execute(ctx context.Context, dbPath, query string) (string, error) {
+	return c.run(ctx, []string{dbPath, query})
+}
+
+func (c *Client) tables(ctx context.Context, dbPath string) (string, error) {
+	return c.run(ctx, []string{dbPath, ".tables"})
+}
+
+func (c *Client) schema(ctx context.Context, dbPath, table string) (string, error) {
+	return c.run(ctx, []string{dbPath, fmt.Sprintf(".schema %s", table)})
+}
+
+func (c *Client) dump(ctx context.Context, dbPath string) (string, error) {
+	return c.run(ctx, []string{dbPath, ".dump"})
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.sqlitePath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.sqlitePath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/zip/zip.go
+++ b/pkg/extensions/adapters/cli/adapters/zip/zip.go
@@ -1,0 +1,241 @@
+package zip
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Client struct{}
+
+type Config struct{}
+
+func NewClient(cfg Config) *Client {
+	return &Client{}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "Usage: zip <command> [args]\nCommands: create, extract, list, add", nil
+	}
+
+	switch args[0] {
+	case "create", "c":
+		return c.create(ctx, args[1:])
+	case "extract", "unzip", "x":
+		return c.extract(ctx, args[1:])
+	case "list", "l":
+		return c.list(ctx, args[1:])
+	case "add", "a":
+		return c.add(ctx, args[1:])
+	default:
+		return "", fmt.Errorf("unknown command: %s", args[0])
+	}
+}
+
+func (c *Client) create(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("usage: zip create <archive> <files...>")
+	}
+
+	archive := args[0]
+	files := args[1:]
+
+	output, err := os.Create(archive)
+	if err != nil {
+		return "", err
+	}
+	defer output.Close()
+
+	writer := zip.NewWriter(output)
+	defer writer.Close()
+
+	for _, file := range files {
+		if err := c.addFile(writer, file); err != nil {
+			return "", err
+		}
+	}
+
+	return fmt.Sprintf("Created: %s with %d files", archive, len(files)), nil
+}
+
+func (c *Client) addFile(writer *zip.Writer, path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	header, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+
+	header.Name = filepath.Base(path)
+
+	entry, err := writer.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(entry, file)
+	return err
+}
+
+func (c *Client) extract(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("usage: zip extract <archive> [destination]")
+	}
+
+	archive := args[0]
+	dest := "."
+	if len(args) > 1 {
+		dest = args[1]
+	}
+
+	reader, err := zip.OpenReader(archive)
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return "", err
+	}
+
+	count := 0
+	for _, file := range reader.File {
+		path := filepath.Join(dest, file.Name)
+
+		if file.FileInfo().IsDir() {
+			os.MkdirAll(path, 0755)
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return "", err
+		}
+
+		out, err := os.Create(path)
+		if err != nil {
+			return "", err
+		}
+
+		rc, err := file.Open()
+		if err != nil {
+			out.Close()
+			return "", err
+		}
+
+		io.Copy(out, rc)
+		rc.Close()
+		out.Close()
+		count++
+	}
+
+	return fmt.Sprintf("Extracted %d files to %s", count, dest), nil
+}
+
+func (c *Client) list(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("usage: zip list <archive>")
+	}
+
+	archive := args[0]
+
+	reader, err := zip.OpenReader(archive)
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	var result []string
+	result = append(result, fmt.Sprintf("Archive: %s", archive))
+	result = append(result, fmt.Sprintf("Files: %d\n", len(reader.File)))
+
+	for _, file := range reader.File {
+		info := file.FileInfo()
+		size := info.Size()
+		if size == 0 {
+			result = append(result, fmt.Sprintf("  %s/", file.Name))
+		} else {
+			result = append(result, fmt.Sprintf("  %s (%d bytes)", file.Name, size))
+		}
+	}
+
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) add(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("usage: zip add <archive> <files...>")
+	}
+
+	archive := args[0]
+	files := args[1:]
+
+	tempFile := archive + ".tmp"
+	temp, err := os.Create(tempFile)
+	if err != nil {
+		return "", err
+	}
+
+	original, err := os.Open(archive)
+	if err == nil {
+		zipReader, _ := zip.OpenReader(archive)
+		if zipReader != nil {
+			writer := zip.NewWriter(temp)
+
+			for _, file := range zipReader.File {
+				rc, _ := file.Open()
+				if rc != nil {
+					header, _ := zip.FileInfoHeader(file.FileInfo())
+					header.Name = file.Name
+					entry, _ := writer.CreateHeader(header)
+					io.Copy(entry, rc)
+					rc.Close()
+				}
+			}
+
+			for _, file := range files {
+				c.addFile(writer, file)
+			}
+
+			writer.Close()
+			original.Close()
+			zipReader.Close()
+		}
+	}
+	temp.Close()
+
+	os.Rename(tempFile, archive)
+
+	return fmt.Sprintf("Added %d files to %s", len(files), archive), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	return true
+}
+
+func ListZIP(archive string) ([]string, error) {
+	reader, err := zip.OpenReader(archive)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	files := make([]string, len(reader.File))
+	for i, file := range reader.File {
+		files[i] = file.Name
+	}
+	return files, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/zoom/zoom.go
+++ b/pkg/extensions/adapters/cli/adapters/zoom/zoom.go
@@ -1,0 +1,172 @@
+package zoom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type Client struct {
+	apiKey    string
+	apiSecret string
+	baseURL   string
+	token     string
+	client    *http.Client
+}
+
+type Config struct {
+	APIKey    string
+	APISecret string
+	AccountID string
+	Token     string
+}
+
+func New(cfg Config) *Client {
+	token := cfg.Token
+	if token == "" {
+		token = os.Getenv("ZOOM_TOKEN")
+	}
+	return &Client{
+		apiKey:    cfg.APIKey,
+		apiSecret: cfg.APISecret,
+		baseURL:   "https://api.zoom.us/v2",
+		token:     token,
+		client:    &http.Client{},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "meetings":
+		return c.meetings(subArgs)
+	case "list":
+		return c.list(subArgs)
+	case "create":
+		if len(subArgs) < 1 {
+			return "", fmt.Errorf("create requires <topic>")
+		}
+		return c.createMeeting(subArgs[0], subArgs[1:])
+	case "join":
+		return c.join(subArgs)
+	case "help":
+		return c.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+type Meeting struct {
+	ID        int64  `json:"id"`
+	Topic     string `json:"topic"`
+	StartTime string `json:"start_time"`
+	Duration  int    `json:"duration"`
+	JoinURL   string `json:"join_url"`
+}
+
+func (c *Client) meetings(args []string) (string, error) {
+	if len(args) == 0 {
+		return c.listMeetings()
+	}
+
+	action := args[0]
+	switch action {
+	case "list":
+		return c.listMeetings()
+	case "create":
+		if len(args) < 2 {
+			return "", fmt.Errorf("create requires <topic> [duration]")
+		}
+		return c.createMeeting(args[1], args[2:])
+	default:
+		return "", fmt.Errorf("unknown meeting action: %s", action)
+	}
+}
+
+func (c *Client) listMeetings() (string, error) {
+	if c.token == "" {
+		return "", fmt.Errorf("ZOOM_TOKEN not configured")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, c.baseURL+"/users/me/meetings", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) createMeeting(topic string, args []string) (string, error) {
+	if c.token == "" {
+		return "", fmt.Errorf("ZOOM_TOKEN not configured")
+	}
+
+	duration := 60
+	if len(args) > 0 {
+		fmt.Sscanf(args[0], "%d", &duration)
+	}
+
+	body := map[string]any{
+		"topic":    topic,
+		"type":     2,
+		"duration": duration,
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/users/me/meetings", strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) list(args []string) (string, error) {
+	return c.listMeetings()
+}
+
+func (c *Client) join(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("join requires <meeting_id>")
+	}
+	meetingID := args[0]
+	return fmt.Sprintf("Join at: https://zoom.us/j/%s", meetingID), nil
+}
+
+func (c *Client) help() (string, error) {
+	return `Zoom CLI adapter (REST API)
+Commands:
+  meetings list              - List upcoming meetings
+  meetings create <topic>    - Create instant meeting
+  list                       - List meetings (alias)
+  join <meeting_id>          - Get join URL
+  help                       - Show this help
+Note: Requires ZOOM_TOKEN environment variable`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/zotero/zotero.go
+++ b/pkg/extensions/adapters/cli/adapters/zotero/zotero.go
@@ -1,0 +1,349 @@
+package zotero
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	httpClient  *http.Client
+	apiKey      string
+	userID      string
+	baseURL     string
+	libraryPath string
+}
+
+type Config struct {
+	APIKey      string
+	UserID      string
+	LibraryPath string
+}
+
+func NewClient(cfg Config) *Client {
+	baseURL := "https://api.zotero.org"
+	if cfg.UserID == "" {
+		cfg.UserID = os.Getenv("ZOTERO_USER_ID")
+	}
+	if cfg.APIKey == "" {
+		cfg.APIKey = os.Getenv("ZOTERO_API_KEY")
+	}
+	if cfg.LibraryPath == "" {
+		cfg.LibraryPath = os.Getenv("ZOTERO_LIBRARY_PATH")
+	}
+
+	return &Client{
+		httpClient:  &http.Client{Timeout: 30 * time.Second},
+		apiKey:      cfg.APIKey,
+		userID:      cfg.UserID,
+		baseURL:     baseURL,
+		libraryPath: cfg.LibraryPath,
+	}
+}
+
+type Item struct {
+	Key          string         `json:"key"`
+	Version      int            `json:"version"`
+	Library      map[string]any `json:"library"`
+	Parent       string         `json:"parent,omitempty"`
+	ItemType     string         `json:"itemType"`
+	Title        string         `json:"title"`
+	Creators     []Creator      `json:"creators,omitempty"`
+	Tags         []Tag          `json:"tags,omitempty"`
+	Collections  []string       `json:"collections,omitempty"`
+	Date         string         `json:"date,omitempty"`
+	URL          string         `json:"url,omitempty"`
+	AbstractNote string         `json:"abstractNote,omitempty"`
+	Extra        string         `json:"extra,omitempty"`
+	Metadata     map[string]any `json:"metadata,omitempty"`
+}
+
+type Creator struct {
+	CreatorType string `json:"creatorType"`
+	FirstName   string `json:"firstName"`
+	LastName    string `json:"lastName"`
+	Name        string `json:"name,omitempty"`
+}
+
+type Tag struct {
+	Tag  string `json:"tag"`
+	Type int    `json:"type"`
+}
+
+type Collection struct {
+	Key      string   `json:"key"`
+	Name     string   `json:"name"`
+	Parent   string   `json:"parent,omitempty"`
+	Children []string `json:"children,omitempty"`
+}
+
+type SearchResult struct {
+	Items   []Item `json:"items"`
+	Total   int    `json:"total"`
+	Library string `json:"library"`
+}
+
+func (c *Client) ListItems(ctx context.Context, collectionKey string, limit int) ([]Item, error) {
+	url := fmt.Sprintf("%s/users/%s/items", c.baseURL, c.userID)
+	if collectionKey != "" {
+		url = fmt.Sprintf("%s/users/%s/collections/%s/items", c.baseURL, c.userID, collectionKey)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Zotero-API-Key", c.apiKey)
+	req.Header.Set("Zotero-API-Version", "3")
+	if limit > 0 {
+		req.Header.Set("Limit", strconv.Itoa(limit))
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("zotero error: %s", string(b))
+	}
+
+	var items []Item
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return nil, err
+	}
+
+	return items, nil
+}
+
+func (c *Client) GetItem(ctx context.Context, itemKey string) (*Item, error) {
+	url := fmt.Sprintf("%s/users/%s/items/%s", c.baseURL, c.userID, itemKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Zotero-API-Key", c.apiKey)
+	req.Header.Set("Zotero-API-Version", "3")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("zotero error: %s", string(b))
+	}
+
+	var items []Item
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return nil, err
+	}
+
+	if len(items) == 0 {
+		return nil, fmt.Errorf("item not found")
+	}
+
+	return &items[0], nil
+}
+
+func (c *Client) Search(ctx context.Context, query string, itemType string, limit int) ([]Item, error) {
+	url := fmt.Sprintf("%s/users/%s/items", c.baseURL, c.userID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	q := req.URL.Query()
+	q.Add("q", query)
+	if itemType != "" {
+		q.Add("itemType", itemType)
+	}
+	if limit > 0 {
+		q.Add("limit", strconv.Itoa(limit))
+	}
+	req.URL.RawQuery = q.Encode()
+
+	req.Header.Set("Zotero-API-Key", c.apiKey)
+	req.Header.Set("Zotero-API-Version", "3")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("zotero error: %s", string(b))
+	}
+
+	var items []Item
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return nil, err
+	}
+
+	return items, nil
+}
+
+func (c *Client) ListCollections(ctx context.Context) ([]Collection, error) {
+	url := fmt.Sprintf("%s/users/%s/collections", c.baseURL, c.userID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Zotero-API-Key", c.apiKey)
+	req.Header.Set("Zotero-API-Version", "3")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("zotero error: %s", string(b))
+	}
+
+	var collections []Collection
+	if err := json.NewDecoder(resp.Body).Decode(&collections); err != nil {
+		return nil, err
+	}
+
+	return collections, nil
+}
+
+func (c *Client) CreateCollection(ctx context.Context, name string, parentKey string) (*Collection, error) {
+	url := fmt.Sprintf("%s/users/%s/collections", c.baseURL, c.userID)
+
+	body, _ := json.Marshal(map[string]any{
+		"name":   name,
+		"parent": parentKey,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(body)))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Zotero-API-Key", c.apiKey)
+	req.Header.Set("Zotero-API-Version", "3")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("zotero error: %s", string(b))
+	}
+
+	var collection Collection
+	if err := json.NewDecoder(resp.Body).Decode(&collection); err != nil {
+		return nil, err
+	}
+
+	return &collection, nil
+}
+
+func (c *Client) AttachFile(ctx context.Context, itemKey string, filePath string) error {
+	if c.libraryPath == "" {
+		return fmt.Errorf("library path not configured")
+	}
+
+	if _, err := os.Stat(filePath); err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/users/%s/items/%s/attachments", c.baseURL, c.userID, itemKey)
+
+	filename := filepath.Base(filePath)
+	body, _ := json.Marshal(map[string]any{
+		"filename": filename,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Zotero-API-Key", c.apiKey)
+	req.Header.Set("Zotero-API-Version", "3")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("zotero error: %s", string(b))
+	}
+
+	return nil
+}
+
+func (c *Client) Export(itemKey string, format string) (string, error) {
+	url := fmt.Sprintf("%s/users/%s/items/%s?format=%s", c.baseURL, c.userID, itemKey, format)
+
+	cmd := exec.Command("curl", "-s", "-H", "Zotero-API-Key: "+c.apiKey, url)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
+}
+
+func (c *Client) IsConfigured() bool {
+	return c.apiKey != "" && c.userID != ""
+}
+
+func FormatItem(item *Item) string {
+	var parts []string
+
+	if item.Title != "" {
+		parts = append(parts, item.Title)
+	}
+
+	for _, c := range item.Creators {
+		if c.Name != "" {
+			parts = append(parts, c.Name)
+		} else {
+			parts = append(parts, c.LastName+", "+c.FirstName)
+		}
+	}
+
+	if item.Date != "" {
+		parts = append(parts, "("+item.Date+")")
+	}
+
+	if item.URL != "" {
+		parts = append(parts, item.URL)
+	}
+
+	return strings.Join(parts, " - ")
+}

--- a/pkg/extensions/adapters/cli/cliadapter.go
+++ b/pkg/extensions/adapters/cli/cliadapter.go
@@ -1,0 +1,333 @@
+package cliadapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/aws"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/blender"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/curl"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/docker"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/ffmpeg"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/git"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/kubectl"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/libreoffice"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/node"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/npm"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/ollama"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/python"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/sqlite"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/zip"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/zotero"
+	ce "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/exec"
+	cr "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/registry"
+)
+
+var defaultRegistry *cr.Registry
+var defaultExecutor *ce.Executor
+
+func Init(root string) error {
+	reg, err := cr.NewRegistry(root)
+	if err != nil {
+		return err
+	}
+
+	defaultRegistry = reg
+	defaultExecutor = ce.NewExecutor(reg)
+
+	registerBuiltInHandlers()
+
+	return nil
+}
+
+func InitFromEnv() error {
+	roots := []string{
+		os.Getenv("ANYCLAW_CLIADAPTER_ROOT"),
+		"CLI-Anything-0.2.0",
+		"../CLI-Anything-0.2.0",
+		"../../CLI-Anything-0.2.0",
+	}
+
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+
+		absRoot, err := filepath.Abs(root)
+		if err != nil {
+			continue
+		}
+
+		if _, err := os.Stat(filepath.Join(absRoot, "registry.json")); err == nil {
+			return Init(absRoot)
+		}
+	}
+
+	return nil
+}
+
+func GetRegistry() *cr.Registry {
+	return defaultRegistry
+}
+
+func GetExecutor() *ce.Executor {
+	return defaultExecutor
+}
+
+type SearchResult struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Category    string `json:"category"`
+	Description string `json:"description"`
+	Installed   bool   `json:"installed"`
+}
+
+func Search(query, category string, limit int) ([]SearchResult, error) {
+	if defaultExecutor == nil {
+		return nil, nil
+	}
+
+	entries := defaultExecutor.Search(query, category, limit)
+	results := make([]SearchResult, 0, len(entries))
+
+	for _, e := range entries {
+		results = append(results, SearchResult{
+			Name:        e.Name,
+			DisplayName: e.DisplayName,
+			Category:    e.Category,
+			Description: e.Description,
+			Installed:   e.Installed,
+		})
+
+		if limit > 0 && len(results) >= limit {
+			break
+		}
+	}
+
+	return results, nil
+}
+
+func Exec(ctx context.Context, name string, args []string) (string, error) {
+	if defaultExecutor == nil {
+		return "", nil
+	}
+
+	result := defaultExecutor.Exec(ctx, name, args)
+	if result.Error != "" {
+		return result.Output, errors.New(result.Error)
+	}
+	return result.Output, nil
+}
+
+func ListCategories() map[string]int {
+	if defaultExecutor == nil {
+		return nil
+	}
+	return defaultExecutor.Categories()
+}
+
+func registerBuiltInHandlers() {
+	if defaultExecutor == nil {
+		return
+	}
+
+	defaultExecutor.RegisterHandler("echo", func(ctx context.Context, args []string) (string, error) {
+		return strings.Join(args, " "), nil
+	})
+
+	defaultExecutor.RegisterHandler("date", func(ctx context.Context, args []string) (string, error) {
+		return "2026-04-03", nil
+	})
+
+	defaultExecutor.RegisterHandler("pwd", func(ctx context.Context, args []string) (string, error) {
+		dir, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return dir, nil
+	})
+
+	defaultExecutor.RegisterHandler("ollama", func(ctx context.Context, args []string) (string, error) {
+		client := ollama.NewClient(ollama.Config{
+			BaseURL: "http://localhost:11434",
+			Model:   "llama2",
+		})
+
+		if len(args) == 0 {
+			models, err := client.ListModels(ctx)
+			if err != nil {
+				return "", err
+			}
+			var out []string
+			for _, m := range models {
+				out = append(out, m.Name)
+			}
+			return strings.Join(out, "\n"), nil
+		}
+
+		switch args[0] {
+		case "list":
+			models, err := client.ListModels(ctx)
+			if err != nil {
+				return "", err
+			}
+			var out []string
+			for _, m := range models {
+				out = append(out, m.Name)
+			}
+			return strings.Join(out, "\n"), nil
+		case "run":
+			if len(args) < 2 {
+				return "", fmt.Errorf("usage: ollama run <model> <prompt>")
+			}
+			client.Model = args[1]
+			prompt := strings.Join(args[2:], " ")
+			return client.Generate(ctx, prompt)
+		default:
+			return client.Generate(ctx, strings.Join(args, " "))
+		}
+	})
+
+	defaultExecutor.RegisterHandler("zotero", func(ctx context.Context, args []string) (string, error) {
+		client := zotero.NewClient(zotero.Config{
+			LibraryPath: os.Getenv("ZOTERO_LIBRARY_PATH"),
+		})
+
+		if !client.IsConfigured() {
+			return "", fmt.Errorf("Zotero not configured: set ZOTERO_API_KEY and ZOTERO_USER_ID")
+		}
+
+		if len(args) == 0 {
+			items, err := client.ListItems(ctx, "", 10)
+			if err != nil {
+				return "", err
+			}
+			var out []string
+			for _, item := range items {
+				out = append(out, zotero.FormatItem(&item))
+			}
+			return strings.Join(out, "\n"), nil
+		}
+
+		switch args[0] {
+		case "list":
+			items, err := client.ListItems(ctx, "", 20)
+			if err != nil {
+				return "", err
+			}
+			var out []string
+			for _, item := range items {
+				out = append(out, zotero.FormatItem(&item))
+			}
+			return strings.Join(out, "\n"), nil
+		case "search":
+			if len(args) < 2 {
+				return "", fmt.Errorf("usage: zotero search <query>")
+			}
+			items, err := client.Search(ctx, args[1], "", 10)
+			if err != nil {
+				return "", err
+			}
+			var out []string
+			for _, item := range items {
+				out = append(out, zotero.FormatItem(&item))
+			}
+			return strings.Join(out, "\n"), nil
+		default:
+			return "", fmt.Errorf("unknown command: %s", args[0])
+		}
+	})
+
+	defaultExecutor.RegisterHandler("blender", func(ctx context.Context, args []string) (string, error) {
+		client := blender.NewClient(blender.Config{})
+		return client.Run(ctx, args)
+	})
+
+	defaultExecutor.RegisterHandler("docker", func(ctx context.Context, args []string) (string, error) {
+		client := docker.NewClient(docker.Config{})
+		return client.Run(ctx, args)
+	})
+
+	defaultExecutor.RegisterHandler("ffmpeg", func(ctx context.Context, args []string) (string, error) {
+		client := ffmpeg.NewClient(ffmpeg.Config{})
+		return client.Run(ctx, args)
+	})
+
+	defaultExecutor.RegisterHandler("git", func(ctx context.Context, args []string) (string, error) {
+		client := git.NewClient(git.Config{})
+		return client.Run(ctx, args)
+	})
+
+	defaultExecutor.RegisterHandler("libreoffice", func(ctx context.Context, args []string) (string, error) {
+		client := libreoffice.NewClient(libreoffice.Config{})
+		return client.Run(ctx, args)
+	})
+
+	defaultExecutor.RegisterHandler("npm", func(ctx context.Context, args []string) (string, error) {
+		client := npm.NewClient(npm.Config{})
+		return client.Run(ctx, args)
+	})
+
+	defaultExecutor.RegisterHandler("curl", func(ctx context.Context, args []string) (string, error) {
+		client := curl.NewClient(curl.Config{})
+		return client.Run(ctx, args)
+	})
+
+	defaultExecutor.RegisterHandler("zip", func(ctx context.Context, args []string) (string, error) {
+		client := zip.NewClient(zip.Config{})
+		return client.Run(ctx, args)
+	})
+
+	defaultExecutor.RegisterHandler("kubectl", func(ctx context.Context, args []string) (string, error) {
+		client := kubectl.NewClient(kubectl.Config{})
+		return client.Run(ctx, args)
+	})
+
+	defaultExecutor.RegisterHandler("aws", func(ctx context.Context, args []string) (string, error) {
+		client := aws.NewClient(aws.Config{})
+		return client.Run(ctx, args)
+	})
+
+	defaultExecutor.RegisterHandler("sqlite", func(ctx context.Context, args []string) (string, error) {
+		client := sqlite.NewClient(sqlite.Config{})
+		return client.Run(ctx, args)
+	})
+
+	defaultExecutor.RegisterHandler("python", func(ctx context.Context, args []string) (string, error) {
+		client := python.NewClient(python.Config{})
+		return client.Run(ctx, args)
+	})
+
+	defaultExecutor.RegisterHandler("node", func(ctx context.Context, args []string) (string, error) {
+		client := node.NewClient(node.Config{})
+		return client.Run(ctx, args)
+	})
+}
+
+func DiscoverRoot(start string) (string, bool) {
+	candidates := []string{
+		start,
+		filepath.Join(start, "CLI-Anything-0.2.0"),
+		filepath.Join(start, "CLI-Anything"),
+		"..",
+		"../..",
+		"../../..",
+	}
+
+	for _, candidate := range candidates {
+		abs, err := filepath.Abs(candidate)
+		if err != nil {
+			continue
+		}
+
+		if _, err := os.Stat(filepath.Join(abs, "registry.json")); err == nil {
+			return abs, true
+		}
+	}
+
+	return "", false
+}

--- a/pkg/extensions/adapters/cli/exec/exec.go
+++ b/pkg/extensions/adapters/cli/exec/exec.go
@@ -1,0 +1,156 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	cr "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/registry"
+)
+
+type Executor struct {
+	mu       sync.RWMutex
+	reg      *cr.Registry
+	handlers map[string]CommandHandler
+}
+
+type CommandHandler func(ctx context.Context, args []string) (string, error)
+
+type ExecResult struct {
+	Name      string   `json:"name"`
+	Args      []string `json:"args"`
+	Output    string   `json:"output"`
+	Error     string   `json:"error,omitempty"`
+	ExitCode  int      `json:"exit_code"`
+	Installed bool     `json:"installed"`
+}
+
+func NewExecutor(reg *cr.Registry) *Executor {
+	return &Executor{
+		reg:      reg,
+		handlers: make(map[string]CommandHandler),
+	}
+}
+
+func (e *Executor) RegisterHandler(name string, handler CommandHandler) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.handlers[name] = handler
+}
+
+func (e *Executor) Exec(ctx context.Context, name string, args []string) *ExecResult {
+	result := &ExecResult{
+		Name: name,
+		Args: args,
+	}
+
+	entry, ok := e.reg.Find(name)
+	if !ok {
+		result.Error = fmt.Sprintf("CLI not found: %s", name)
+		return result
+	}
+
+	e.mu.RLock()
+	if handler, exists := e.handlers[name]; exists {
+		e.mu.RUnlock()
+		output, err := handler(ctx, args)
+		result.Output = output
+		if err != nil {
+			result.Error = err.Error()
+			result.ExitCode = 1
+		} else {
+			result.ExitCode = 0
+		}
+		result.Installed = true
+		return result
+	}
+	e.mu.RUnlock()
+
+	if entry.Installed && entry.ExecutablePath != "" {
+		return e.execBinary(ctx, entry.ExecutablePath, args, result)
+	}
+
+	result.Error = fmt.Sprintf("CLI not installed: %s (install with: %s)", name, entry.InstallCmd)
+	result.Installed = false
+	return result
+}
+
+func (e *Executor) execBinary(ctx context.Context, path string, args []string, result *ExecResult) *ExecResult {
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	output, err := cmd.CombinedOutput()
+	result.Output = string(output)
+	result.Installed = true
+
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			result.ExitCode = exitErr.ExitCode()
+		} else {
+			result.ExitCode = 1
+		}
+		result.Error = err.Error()
+	} else {
+		result.ExitCode = 0
+	}
+
+	return result
+}
+
+func (e *Executor) AutoInstall(ctx context.Context, name string) *ExecResult {
+	result := &ExecResult{Name: name}
+
+	entry, ok := e.reg.Get(name)
+	if !ok {
+		result.Error = "CLI not found in registry"
+		return result
+	}
+
+	if entry.InstallCmd == "" {
+		result.Error = "No install command available"
+		return result
+	}
+
+	parts := strings.Fields(entry.InstallCmd)
+	if len(parts) < 2 {
+		result.Error = "Invalid install command"
+		return result
+	}
+
+	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		result.Error = fmt.Sprintf("Install failed: %v", err)
+		result.ExitCode = 1
+		return result
+	}
+
+	result.Output = "Installation completed"
+	result.ExitCode = 0
+	result.Installed = true
+	e.reg.MarkInstalled(name, entry.EntryPoint)
+
+	return result
+}
+
+func (e *Executor) List() []*cr.EntryStatus {
+	return e.reg.List()
+}
+
+func (e *Executor) Search(query, category string, limit int) []*cr.EntryStatus {
+	return e.reg.Search(query, category, limit)
+}
+
+func (e *Executor) Categories() map[string]int {
+	return e.reg.Categories()
+}
+
+func (e *Executor) JSON() (string, error) {
+	return e.reg.JSON()
+}

--- a/pkg/extensions/adapters/cli/registry/registry.go
+++ b/pkg/extensions/adapters/cli/registry/registry.go
@@ -1,0 +1,243 @@
+package cliadapter
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type Entry struct {
+	Name           string `json:"name"`
+	DisplayName    string `json:"display_name"`
+	Version        string `json:"version"`
+	Description    string `json:"description"`
+	Requires       string `json:"requires"`
+	Homepage       string `json:"homepage"`
+	InstallCmd     string `json:"install_cmd"`
+	EntryPoint     string `json:"entry_point"`
+	SkillMD        string `json:"skill_md"`
+	Category       string `json:"category"`
+	Contributor    string `json:"contributor"`
+	ContributorURL string `json:"contributor_url"`
+}
+
+type EntryStatus struct {
+	Entry
+	Installed      bool   `json:"installed"`
+	ExecutablePath string `json:"executable_path,omitempty"`
+}
+
+type Registry struct {
+	mu         sync.RWMutex
+	root       string
+	entries    map[string]*EntryStatus
+	categories map[string]int
+}
+
+func NewRegistry(root string) (*Registry, error) {
+	r := &Registry{
+		root:       root,
+		entries:    make(map[string]*EntryStatus),
+		categories: make(map[string]int),
+	}
+
+	if err := r.load(); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (r *Registry) load() error {
+	data, err := os.ReadFile(filepath.Join(r.root, "registry.json"))
+	if err != nil {
+		return err
+	}
+
+	var file struct {
+		Meta struct {
+			Repo        string `json:"repo"`
+			Description string `json:"description"`
+			Updated     string `json:"updated"`
+		} `json:"meta"`
+		CLIs []Entry `json:"clis"`
+	}
+
+	if err := json.Unmarshal(data, &file); err != nil {
+		return err
+	}
+
+	for _, e := range file.CLIs {
+		entry := e
+		r.entries[e.Name] = &EntryStatus{
+			Entry:     entry,
+			Installed: false,
+		}
+		r.categories[e.Category]++
+	}
+
+	return nil
+}
+
+func (r *Registry) Get(name string) (*EntryStatus, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, ok := r.entries[name]
+	return entry, ok
+}
+
+func (r *Registry) List() []*EntryStatus {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]*EntryStatus, 0, len(r.entries))
+	for _, e := range r.entries {
+		result = append(result, e)
+	}
+	return result
+}
+
+func (r *Registry) Search(query string, category string, limit int) []*EntryStatus {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var results []*EntryStatus
+	query = strings.ToLower(query)
+	category = strings.ToLower(category)
+
+	for _, e := range r.entries {
+		if category != "" && strings.ToLower(e.Category) != category {
+			continue
+		}
+
+		if query == "" {
+			results = append(results, e)
+			continue
+		}
+
+		if strings.Contains(strings.ToLower(e.Name), query) ||
+			strings.Contains(strings.ToLower(e.DisplayName), query) ||
+			strings.Contains(strings.ToLower(e.Description), query) {
+			results = append(results, e)
+		}
+
+		if limit > 0 && len(results) >= limit {
+			break
+		}
+	}
+
+	return results
+}
+
+func (r *Registry) Categories() map[string]int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make(map[string]int)
+	for k, v := range r.categories {
+		result[k] = v
+	}
+	return result
+}
+
+func (r *Registry) Root() string {
+	return r.root
+}
+
+func (r *Registry) EntriesCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.entries)
+}
+
+type builtinAdapter struct {
+	Name        string
+	Description string
+	Category    string
+	Handler     func(args []string) (string, error)
+}
+
+var builtinAdapters = map[string]*builtinAdapter{}
+
+func RegisterBuiltinAdapter(name, desc, category string, handler func(args []string) (string, error)) {
+	builtinAdapters[name] = &builtinAdapter{
+		Name:        name,
+		Description: desc,
+		Category:    category,
+		Handler:     handler,
+	}
+}
+
+func GetBuiltinAdapter(name string) (*builtinAdapter, bool) {
+	a, ok := builtinAdapters[name]
+	return a, ok
+}
+
+func ListBuiltinAdapters() []*builtinAdapter {
+	result := make([]*builtinAdapter, 0, len(builtinAdapters))
+	for _, a := range builtinAdapters {
+		result = append(result, a)
+	}
+	return result
+}
+
+func (r *Registry) Find(name string) (*EntryStatus, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	name = strings.ToLower(name)
+
+	if entry, ok := r.entries[name]; ok {
+		return entry, true
+	}
+
+	for _, e := range r.entries {
+		if strings.ToLower(e.EntryPoint) == name ||
+			strings.ToLower(e.DisplayName) == name {
+			return e, true
+		}
+	}
+
+	if adapter, ok := builtinAdapters[name]; ok {
+		return &EntryStatus{
+			Entry: Entry{
+				Name:        adapter.Name,
+				DisplayName: adapter.Name,
+				Description: adapter.Description,
+				Category:    adapter.Category,
+			},
+			Installed: true,
+		}, true
+	}
+
+	return nil, false
+}
+
+func (r *Registry) MarkInstalled(name string, path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if e, ok := r.entries[name]; ok {
+		e.Installed = true
+		e.ExecutablePath = path
+	}
+}
+
+func (r *Registry) JSON() (string, error) {
+	data := map[string]any{
+		"root":          r.root,
+		"entries_count": r.EntriesCount(),
+		"categories":    r.Categories(),
+		"entries":       r.List(),
+		"builtin_count": len(builtinAdapters),
+	}
+
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}

--- a/pkg/extensions/adapters/extension.go
+++ b/pkg/extensions/adapters/extension.go
@@ -1,0 +1,198 @@
+// Package extension provides the extension loading and management system.
+// Extensions are self-contained modules that add channels, tools, providers,
+// and other capabilities to AnyClaw, similar to OpenClaw's extensions/ architecture.
+package extension
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Manifest defines the extension metadata (anyclaw.extension.json).
+type Manifest struct {
+	ID           string         `json:"id"`
+	Name         string         `json:"name"`
+	Version      string         `json:"version"`
+	Description  string         `json:"description"`
+	Kind         string         `json:"kind"` // "channel", "tool", "provider", "memory", "hook"
+	Builtin      bool           `json:"builtin,omitempty"`
+	Channels     []string       `json:"channels,omitempty"`      // Channel IDs this extension provides
+	Providers    []string       `json:"providers,omitempty"`     // LLM provider IDs
+	Skills       []string       `json:"skills,omitempty"`        // Skill IDs bundled
+	Entrypoint   string         `json:"entrypoint"`              // Main executable/script
+	Permissions  []string       `json:"permissions,omitempty"`   // Required permissions
+	ConfigSchema map[string]any `json:"config_schema,omitempty"` // JSON Schema for config
+}
+
+// Extension represents a loaded extension with runtime state.
+type Extension struct {
+	Manifest Manifest
+	Path     string
+	Enabled  bool
+	Config   map[string]any
+}
+
+// Registry manages all loaded extensions.
+type Registry struct {
+	mu            sync.RWMutex
+	extensions    map[string]*Extension
+	extensionsDir string
+}
+
+// NewRegistry creates a new extension registry.
+func NewRegistry(extensionsDir string) *Registry {
+	return &Registry{
+		extensions:    make(map[string]*Extension),
+		extensionsDir: extensionsDir,
+	}
+}
+
+// Discover scans the extensions directory for available extensions.
+func (r *Registry) Discover() ([]Manifest, error) {
+	manifests := append([]Manifest(nil), builtinExtensionManifests()...)
+
+	entries, err := os.ReadDir(r.extensionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return manifests, nil
+		}
+		return nil, fmt.Errorf("failed to read extensions dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		manifestPath := filepath.Join(r.extensionsDir, entry.Name(), "anyclaw.extension.json")
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read manifest %s: %w", manifestPath, err)
+		}
+
+		var m Manifest
+		if err := json.Unmarshal(data, &m); err != nil {
+			return nil, fmt.Errorf("invalid manifest %s: %w", manifestPath, err)
+		}
+
+		manifests = append(manifests, m)
+	}
+
+	return manifests, nil
+}
+
+// Register adds an extension to the registry.
+func (r *Registry) Register(ext *Extension) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.extensions[ext.Manifest.ID] = ext
+}
+
+// Get returns an extension by ID.
+func (r *Registry) Get(id string) (*Extension, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ext, ok := r.extensions[id]
+	return ext, ok
+}
+
+// List returns all registered extensions.
+func (r *Registry) List() []*Extension {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]*Extension, 0, len(r.extensions))
+	for _, ext := range r.extensions {
+		result = append(result, ext)
+	}
+	return result
+}
+
+// ListByKind returns extensions filtered by kind.
+func (r *Registry) ListByKind(kind string) []*Extension {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var result []*Extension
+	for _, ext := range r.extensions {
+		if ext.Manifest.Kind == kind && ext.Enabled {
+			result = append(result, ext)
+		}
+	}
+	return result
+}
+
+// Enable marks an extension as enabled.
+func (r *Registry) Enable(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ext, ok := r.extensions[id]
+	if !ok {
+		return fmt.Errorf("extension %q not found", id)
+	}
+	ext.Enabled = true
+	return nil
+}
+
+// Disable marks an extension as disabled.
+func (r *Registry) Disable(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ext, ok := r.extensions[id]
+	if !ok {
+		return fmt.Errorf("extension %q not found", id)
+	}
+	ext.Enabled = false
+	return nil
+}
+
+// LoadExtension loads a single extension from its directory.
+func LoadExtension(dir string) (*Extension, error) {
+	manifestPath := filepath.Join(dir, "anyclaw.extension.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read manifest: %w", err)
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("invalid manifest: %w", err)
+	}
+
+	return &Extension{
+		Manifest: m,
+		Path:     dir,
+		Enabled:  true,
+	}, nil
+}
+
+// LoadAll discovers and loads all extensions from the registry's directory.
+func (r *Registry) LoadAll() error {
+	manifests, err := r.Discover()
+	if err != nil {
+		return err
+	}
+
+	for _, m := range manifests {
+		if m.Builtin {
+			r.Register(&Extension{
+				Manifest: m,
+				Path:     "builtin://extensions/" + m.ID,
+				Enabled:  true,
+			})
+			continue
+		}
+		extPath := filepath.Join(r.extensionsDir, m.ID)
+		ext, err := LoadExtension(extPath)
+		if err != nil {
+			return fmt.Errorf("failed to load extension %s: %w", m.ID, err)
+		}
+		r.Register(ext)
+	}
+
+	return nil
+}

--- a/pkg/extensions/adapters/extension_test.go
+++ b/pkg/extensions/adapters/extension_test.go
@@ -1,0 +1,37 @@
+package extension
+
+import "testing"
+
+func TestBuiltinExtensionCatalogHasRecommendedCount(t *testing.T) {
+	if got := len(builtinExtensionManifests()); got != 22 {
+		t.Fatalf("expected 22 builtin extensions, got %d", got)
+	}
+}
+
+func TestDiscoverIncludesBuiltinExtensionsWithoutDirectory(t *testing.T) {
+	registry := NewRegistry("missing-dir")
+	items, err := registry.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(items) != 22 {
+		t.Fatalf("expected 22 builtin extensions from discover, got %d", len(items))
+	}
+}
+
+func TestLoadAllRegistersBuiltinExtensionsWithoutDirectory(t *testing.T) {
+	registry := NewRegistry("missing-dir")
+	if err := registry.LoadAll(); err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if got := len(registry.List()); got != 22 {
+		t.Fatalf("expected 22 loaded builtin extensions, got %d", got)
+	}
+	ext, ok := registry.Get("zoom")
+	if !ok {
+		t.Fatal("expected zoom builtin extension")
+	}
+	if !ext.Manifest.Builtin {
+		t.Fatal("expected builtin flag on zoom manifest")
+	}
+}

--- a/pkg/extensions/adapters/webhook/handler.go
+++ b/pkg/extensions/adapters/webhook/handler.go
@@ -1,0 +1,200 @@
+package webhook
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Handler manages incoming webhooks from external services.
+type Handler struct {
+	mu      sync.RWMutex
+	hooks   map[string]*Webhook
+	history []Event
+	maxHist int
+}
+
+type Webhook struct {
+	ID           string            `json:"id"`
+	Name         string            `json:"name"`
+	Path         string            `json:"path"`
+	Secret       string            `json:"secret,omitempty"`
+	Agent        string            `json:"agent,omitempty"`
+	Template     string            `json:"template,omitempty"`
+	Headers      map[string]string `json:"headers,omitempty"`
+	Enabled      bool              `json:"enabled"`
+	CreatedAt    time.Time         `json:"created_at"`
+	LastTrigger  *time.Time        `json:"last_trigger,omitempty"`
+	TriggerCount int               `json:"trigger_count"`
+}
+
+type Event struct {
+	ID        string            `json:"id"`
+	WebhookID string            `json:"webhook_id"`
+	Timestamp time.Time         `json:"timestamp"`
+	Headers   map[string]string `json:"headers,omitempty"`
+	Body      string            `json:"body,omitempty"`
+	Response  string            `json:"response,omitempty"`
+	Status    string            `json:"status"`
+	Error     string            `json:"error,omitempty"`
+	Duration  time.Duration     `json:"duration"`
+}
+
+func NewHandler() *Handler {
+	return &Handler{
+		hooks:   make(map[string]*Webhook),
+		maxHist: 100,
+	}
+}
+
+func (h *Handler) Register(webhook *Webhook) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if webhook.ID == "" {
+		webhook.ID = fmt.Sprintf("wh-%d", time.Now().UnixNano())
+	}
+	if webhook.Path == "" {
+		webhook.Path = fmt.Sprintf("/webhooks/%s", webhook.ID)
+	}
+	webhook.CreatedAt = time.Now()
+	webhook.Enabled = true
+
+	h.hooks[webhook.ID] = webhook
+	return nil
+}
+
+func (h *Handler) Unregister(id string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.hooks[id]; !ok {
+		return fmt.Errorf("webhook not found: %s", id)
+	}
+	delete(h.hooks, id)
+	return nil
+}
+
+func (h *Handler) Get(id string) (*Webhook, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	hook, ok := h.hooks[id]
+	return hook, ok
+}
+
+func (h *Handler) List() []*Webhook {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	list := make([]*Webhook, 0, len(h.hooks))
+	for _, hook := range h.hooks {
+		list = append(list, hook)
+	}
+	return list
+}
+
+func (h *Handler) GetHistory(limit int) []Event {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if limit <= 0 || limit > len(h.history) {
+		limit = len(h.history)
+	}
+	return h.history[len(h.history)-limit:]
+}
+
+func (h *Handler) HandleRequest(ctx context.Context, r *http.Request, processFn func(context.Context, *Webhook, []byte) (string, error)) (int, []byte) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	path := r.URL.Path
+
+	var matched *Webhook
+	for _, hook := range h.hooks {
+		if hook.Enabled && strings.HasPrefix(path, hook.Path) {
+			matched = hook
+			break
+		}
+	}
+
+	if matched == nil {
+		return http.StatusNotFound, []byte(`{"error":"webhook not found"}`)
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return http.StatusBadRequest, []byte(fmt.Sprintf(`{"error":"%s"}`, err.Error()))
+	}
+
+	if matched.Secret != "" {
+		signature := r.Header.Get("X-Hub-Signature-256")
+		if signature == "" {
+			signature = r.Header.Get("X-Signature-256")
+		}
+		if !verifySignature(matched.Secret, body, signature) {
+			return http.StatusUnauthorized, []byte(`{"error":"invalid signature"}`)
+		}
+	}
+
+	event := Event{
+		ID:        fmt.Sprintf("evt-%d", time.Now().UnixNano()),
+		WebhookID: matched.ID,
+		Timestamp: time.Now(),
+		Body:      string(body),
+		Status:    "processing",
+		Headers:   map[string]string{},
+	}
+	for key, values := range r.Header {
+		if len(values) > 0 {
+			event.Headers[key] = values[0]
+		}
+	}
+
+	start := time.Now()
+	response, err := processFn(ctx, matched, body)
+	event.Duration = time.Since(start)
+
+	if err != nil {
+		event.Status = "failed"
+		event.Error = err.Error()
+	} else {
+		event.Status = "success"
+		event.Response = response
+	}
+
+	now := time.Now()
+	matched.LastTrigger = &now
+	matched.TriggerCount++
+
+	h.history = append(h.history, event)
+	if len(h.history) > h.maxHist {
+		h.history = h.history[len(h.history)-h.maxHist:]
+	}
+
+	if err != nil {
+		return http.StatusInternalServerError, []byte(fmt.Sprintf(`{"error":"%s"}`, err.Error()))
+	}
+
+	return http.StatusOK, []byte(response)
+}
+
+func verifySignature(secret string, body []byte, signature string) bool {
+	if signature == "" {
+		return false
+	}
+
+	signature = strings.TrimPrefix(signature, "sha256=")
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+
+	return hmac.Equal([]byte(signature), []byte(expected))
+}


### PR DESCRIPTION
## 变更说明

本 PR 仅引入 `pkg/extensions/adapters/` 目录，主要包含扩展适配器框架与一批 CLI / webhook 相关适配实现，例如：

- extension registry / manifest 相关能力
- CLI adapter 体系
- webhook handler
- aws / docker / git / kubectl / npm / node / python / sqlite / zip / zotero 等 CLI 适配实现

## 本次范围

本 PR 只包含：

- `pkg/extensions/adapters/`

不包含其他目录：

- `pkg/extensions/mcp/`
- `pkg/extensions/plugin/`
- `extensions/`
- `skills/`
- `pkg/capability/`

## 拆分方式

按负责目录逐个拆分提交。
这一条先单独提交 `pkg/extensions/adapters/`，避免和 `pkg/extensions/mcp/` 或 `pkg/extensions/plugin/` 混在一起，便于评审和后续合并。

## 验证情况

已执行：

```bash
go test ./pkg/extensions/adapters/...
```

测试结果通过。