### PR TITLE
ci: add Go test workflow with matrix and coverage upload

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,39 @@
+name: Test
+on:
+  push:
+    branches:
+      - "**"
+      - "!dependabot/**"
+      - "!xgopilot/**"
+  pull_request:
+    branches: [ "**" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - 1.24.x
+          - 1.25.x
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{matrix.go}}
+      - name: Download Go modules
+        run: go mod download
+      - name: Test Go code
+        run: go test -v -race -covermode atomic -coverprofile coverage.out ./...
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+          disable_search: true
+          files: coverage.out


### PR DESCRIPTION
Add a new GitHub Actions workflow to run Go tests on pushes and pull requests, with branch exclusions for dependabot and xgopilot branches.

The workflow tests against Go 1.24.x and 1.25.x, runs race-enabled tests with coverage output, and uploads coverage reports to Codecov. This establishes consistent CI validation across supported Go versions and improves test visibility.ci: add Go test workflow with matrix and coverage upload