### PR TITLE
feats(agents):add capability agents module

### DIFF
--- a/pkg/capability/agents/agent.go
+++ b/pkg/capability/agents/agent.go
@@ -1,0 +1,1209 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/1024XEngineer/anyclaw/pkg/capability/agents/prompt"
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+	"github.com/1024XEngineer/anyclaw/pkg/capability/skills"
+	"github.com/1024XEngineer/anyclaw/pkg/capability/tools"
+	"github.com/1024XEngineer/anyclaw/pkg/clawbridge"
+	"github.com/1024XEngineer/anyclaw/pkg/clihub"
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/plugin"
+	ctxpkg "github.com/1024XEngineer/anyclaw/pkg/runtime/context/store"
+	"github.com/1024XEngineer/anyclaw/pkg/state/memory"
+	"github.com/1024XEngineer/anyclaw/pkg/workspace"
+)
+
+type LLMCaller interface {
+	Chat(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition) (*llm.Response, error)
+	StreamChat(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition, onChunk func(string)) error
+	Name() string
+}
+
+type Agent struct {
+	config             Config
+	llm                LLMCaller
+	memory             memory.MemoryBackend
+	skills             *skills.SkillsManager
+	tools              *tools.Registry
+	workDir            string
+	workingDir         string
+	history            []prompt.Message
+	maxToolCalls       int
+	observer           Observer
+	observerMu         sync.RWMutex
+	lastToolActivities []ToolActivity
+	intentPreprocessor *IntentPreprocessor
+	preferenceLearner  *PreferenceLearner
+	contextRuntime     *contextRuntime
+}
+
+type Config struct {
+	Name        string
+	Description string
+	Personality string
+	IsSubAgent  bool
+	LLM         LLMCaller
+	Memory      memory.MemoryBackend
+	Skills      *skills.SkillsManager
+	Tools       *tools.Registry
+	WorkDir     string
+	WorkingDir  string
+	CLIHubRoot  string
+
+	MaxContextTokens       int
+	ContextSafetyMargin    int
+	BootstrapWatchInterval time.Duration
+	ContextEngine          ctxpkg.ContextEngine
+}
+
+var (
+	codeBlockRegex = regexp.MustCompile("(?s)```(?:json)?[\\s]*(.+?)[\\s]*```")
+	writeFileRegex = regexp.MustCompile("write_file\\s+path\\s*=\\s*\"([^\"]+)\"\\s+content\\s*=\\s*\"([\\s\\S]*?)\"")
+	readFileRegex  = regexp.MustCompile("read_file\\s+path\\s*=\\s*\"([^\"]+)\"")
+	listDirRegex   = regexp.MustCompile("list_directory\\s+path\\s*=\\s*\"([^\"]+)\"")
+	searchRegex    = regexp.MustCompile("search_files\\s+path\\s*=\\s*\"([^\"]+)\"\\s+pattern\\s*=\\s*\"([^\"]+)\"")
+	runCmdRegex    = regexp.MustCompile("run_command\\s+command\\s*=\\s*\"([^\"]+)\"")
+)
+
+const (
+	promptMemoryMaxChars      = 4000
+	promptMemoryMaxEntries    = 8
+	promptMemoryEntryMaxChars = 600
+)
+
+func New(cfg Config) *Agent {
+	agent := &Agent{
+		config:       cfg,
+		llm:          cfg.LLM,
+		memory:       cfg.Memory,
+		skills:       cfg.Skills,
+		tools:        cfg.Tools,
+		workDir:      cfg.WorkDir,
+		workingDir:   cfg.WorkingDir,
+		history:      []prompt.Message{},
+		maxToolCalls: 10,
+	}
+	agent.contextRuntime = newContextRuntime(cfg)
+
+	if cfg.CLIHubRoot != "" {
+		agent.intentPreprocessor, _ = NewIntentPreprocessor(cfg.CLIHubRoot, nil)
+	}
+
+	if cfg.WorkingDir != "" {
+		agent.preferenceLearner = NewPreferenceLearner(cfg.WorkingDir)
+	}
+
+	return agent
+}
+
+func (a *Agent) EnableIntentPreprocessing(root string, execFunc func([]string, string) (string, error)) error {
+	ip, err := NewIntentPreprocessor(root, execFunc)
+	if err != nil {
+		return err
+	}
+	a.intentPreprocessor = ip
+	return nil
+}
+
+func (a *Agent) Run(ctx context.Context, userInput string) (string, error) {
+	a.resetToolActivities()
+	exec, err := a.acquireContextExecution(ctx, userInput)
+	if err != nil {
+		return "", err
+	}
+	defer a.releaseContextExecution(exec)
+
+	if bootstrapResult, handled, err := a.handleBootstrapRitual(ctx, userInput); handled {
+		return bootstrapResult, err
+	}
+	if execResult, handled, err := a.tryAutoRouteCLIHubIntent(ctx, userInput); handled {
+		return execResult, err
+	}
+	selectedTools := a.selectToolInfos(userInput)
+	a.appendHistoryMessage(ctx, "user", userInput)
+	systemPrompt, err := a.prepareSystemPrompt(ctx, selectedTools)
+	if err != nil {
+		return "", err
+	}
+	messages := a.buildMessages(systemPrompt)
+	toolDefs := buildToolDefinitionsFromInfos(selectedTools)
+
+	a.heartbeatContextExecution(exec)
+	response, err := a.chatWithTools(ctx, messages, toolDefs)
+	if err != nil {
+		return "", err
+	}
+
+	a.appendHistoryMessage(ctx, "assistant", response)
+
+	a.memory.Add(memory.MemoryEntry{Type: "conversation", Role: "user", Content: userInput})
+	a.memory.Add(memory.MemoryEntry{Type: "conversation", Role: "assistant", Content: response})
+
+	if a.preferenceLearner != nil {
+		if prefResponse, learned := a.preferenceLearner.Learn(userInput, response); learned {
+			response = prefResponse + "\n\n" + response
+		}
+	}
+
+	return response, nil
+}
+
+func (a *Agent) RunStream(ctx context.Context, userInput string, onChunk func(string)) error {
+	a.resetToolActivities()
+	exec, err := a.acquireContextExecution(ctx, userInput)
+	if err != nil {
+		return err
+	}
+	defer a.releaseContextExecution(exec)
+
+	if bootstrapResult, handled, err := a.handleBootstrapRitual(ctx, userInput); handled {
+		if err != nil {
+			return err
+		}
+		if onChunk != nil {
+			onChunk(bootstrapResult)
+		}
+		return nil
+	}
+	if execResult, handled, err := a.tryAutoRouteCLIHubIntent(ctx, userInput); handled {
+		if err != nil {
+			return err
+		}
+		if onChunk != nil {
+			onChunk(execResult)
+		}
+		return nil
+	}
+
+	selectedTools := a.selectToolInfos(userInput)
+	a.appendHistoryMessage(ctx, "user", userInput)
+	systemPrompt, err := a.prepareSystemPrompt(ctx, selectedTools)
+	if err != nil {
+		return err
+	}
+	messages := a.buildMessages(systemPrompt)
+	toolDefs := buildToolDefinitionsFromInfos(selectedTools)
+
+	a.heartbeatContextExecution(exec)
+	err = a.llm.StreamChat(ctx, messages, toolDefs, func(chunk string) {
+		onChunk(chunk)
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *Agent) handleBootstrapRitual(ctx context.Context, userInput string) (string, bool, error) {
+	if strings.TrimSpace(a.workingDir) == "" {
+		return "", false, nil
+	}
+	result, err := workspace.AdvanceBootstrapRitual(a.workingDir, userInput, workspace.BootstrapRitualOptions{
+		AgentName:        a.config.Name,
+		AgentDescription: a.config.Description,
+	})
+	if err != nil {
+		return "", true, err
+	}
+	if result == nil || !result.Active {
+		return "", false, nil
+	}
+	a.appendHistoryMessage(ctx, "user", userInput)
+	a.appendHistoryMessage(ctx, "assistant", result.Response)
+	a.recordConversation(userInput, result.Response)
+	return result.Response, true, nil
+}
+
+func (a *Agent) chatWithTools(ctx context.Context, messages []llm.Message, toolDefs []llm.ToolDefinition) (string, error) {
+	for toolCalls := 0; ; toolCalls++ {
+		resp, err := a.llm.Chat(ctx, messages, toolDefs)
+		if err != nil {
+			return "", fmt.Errorf("LLM error: %w", err)
+		}
+
+		if len(resp.ToolCalls) == 0 {
+			if result, handled, err := a.executeProtocolResponse(ctx, resp); handled {
+				if err != nil {
+					return "", err
+				}
+				if toolCalls >= a.maxToolCalls {
+					return result + "\n\n[Max tool calls reached]", nil
+				}
+				messages = append(messages, llm.Message{Role: "assistant", Content: resp.Content})
+				messages = append(messages, llm.Message{Role: "user", Content: a.protocolContinuationPrompt(result)})
+				continue
+			}
+		}
+
+		calls := a.extractToolCalls(resp)
+		if len(calls) == 0 {
+			return resp.Content, nil
+		}
+
+		if toolCalls >= a.maxToolCalls {
+			return resp.Content + "\n\n[Max tool calls reached]", nil
+		}
+
+		toolMessages := make([]llm.Message, 0, len(calls)+1)
+		results := make([]string, 0, len(calls))
+		assistantCallMsg := llm.Message{Role: "assistant", Content: resp.Content, ToolCalls: make([]llm.ToolCall, 0, len(calls))}
+		approvalHook := toolApprovalHookFromContext(ctx)
+		for _, tc := range calls {
+			currentToolCall := llm.ToolCall{ID: tc.ID, Type: "function", Function: llm.FunctionCall{Name: tc.Name, Arguments: mustJSON(tc.Args)}}
+			if approvalHook != nil {
+				if err := approvalHook(ctx, tc); err != nil {
+					return "", &ApprovalPauseError{
+						State: ApprovalResumeState{
+							Messages:         cloneLLMMessages(messages),
+							AssistantMessage: llm.Message{Role: "assistant", Content: resp.Content, ToolCalls: append(append([]llm.ToolCall(nil), assistantCallMsg.ToolCalls...), currentToolCall)},
+							ToolMessages:     cloneLLMMessages(toolMessages),
+							Results:          append([]string(nil), results...),
+							PendingTool:      cloneToolCall(tc),
+						},
+						Cause: err,
+					}
+				}
+			}
+			assistantCallMsg.ToolCalls = append(assistantCallMsg.ToolCalls, currentToolCall)
+			if result, err := a.executeTool(ctx, tc); err != nil {
+				results = append(results, fmt.Sprintf("[%s] Error: %v", tc.Name, err))
+				a.recordToolActivity(ToolActivity{ToolName: tc.Name, Args: tc.Args, Error: err.Error()})
+				toolMessages = append(toolMessages, llm.Message{Role: "tool", ToolCallID: tc.ID, Name: tc.Name, Content: fmt.Sprintf("error: %v", err)})
+			} else {
+				results = append(results, fmt.Sprintf("[%s] %s", tc.Name, result))
+				a.recordToolActivity(ToolActivity{ToolName: tc.Name, Args: tc.Args, Result: result})
+				toolMessages = append(toolMessages, llm.Message{Role: "tool", ToolCallID: tc.ID, Name: tc.Name, Content: result})
+			}
+		}
+
+		messages = append(messages, assistantCallMsg)
+		messages = append(messages, toolMessages...)
+		messages = append(messages, llm.Message{Role: "user", Content: a.toolContinuationPrompt(results)})
+	}
+}
+
+type ToolCall struct {
+	ID   string         `json:"id,omitempty"`
+	Name string         `json:"name"`
+	Args map[string]any `json:"args,omitempty"`
+}
+
+func (a *Agent) parseToolCalls(content string) []ToolCall {
+	var calls []ToolCall
+
+	for _, match := range codeBlockRegex.FindAllStringSubmatch(content, -1) {
+		jsonStr := strings.TrimSpace(match[1])
+		if strings.HasPrefix(jsonStr, "{") {
+			var tc struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+				Tool      string         `json:"tool"`
+				Args      map[string]any `json:"args"`
+			}
+			if err := json.Unmarshal([]byte(jsonStr), &tc); err == nil {
+				name, args := tc.Name, tc.Arguments
+				if name == "" {
+					name, args = tc.Tool, tc.Args
+				}
+				if name != "" {
+					calls = append(calls, ToolCall{Name: name, Args: args})
+				}
+			}
+		}
+	}
+
+	if len(calls) > 0 {
+		return calls
+	}
+
+	for _, match := range writeFileRegex.FindAllStringSubmatch(content, -1) {
+		calls = append(calls, ToolCall{
+			Name: "write_file",
+			Args: map[string]any{"path": match[1], "content": match[2]},
+		})
+	}
+
+	for _, match := range readFileRegex.FindAllStringSubmatch(content, -1) {
+		calls = append(calls, ToolCall{
+			Name: "read_file",
+			Args: map[string]any{"path": match[1]},
+		})
+	}
+
+	for _, match := range listDirRegex.FindAllStringSubmatch(content, -1) {
+		calls = append(calls, ToolCall{
+			Name: "list_directory",
+			Args: map[string]any{"path": match[1]},
+		})
+	}
+
+	for _, match := range searchRegex.FindAllStringSubmatch(content, -1) {
+		calls = append(calls, ToolCall{
+			Name: "search_files",
+			Args: map[string]any{"path": match[1], "pattern": match[2]},
+		})
+	}
+
+	for _, match := range runCmdRegex.FindAllStringSubmatch(content, -1) {
+		calls = append(calls, ToolCall{
+			Name: "run_command",
+			Args: map[string]any{"command": match[1]},
+		})
+	}
+
+	return calls
+}
+
+func (a *Agent) extractToolCalls(resp *llm.Response) []ToolCall {
+	if resp == nil {
+		return nil
+	}
+	if len(resp.ToolCalls) > 0 {
+		calls := make([]ToolCall, 0, len(resp.ToolCalls))
+		for i, tc := range resp.ToolCalls {
+			args := map[string]any{}
+			if strings.TrimSpace(tc.Function.Arguments) != "" {
+				_ = json.Unmarshal([]byte(tc.Function.Arguments), &args)
+			}
+			id := strings.TrimSpace(tc.ID)
+			if id == "" {
+				id = fmt.Sprintf("toolcall_%d_%d", time.Now().UnixNano(), i)
+			}
+			calls = append(calls, ToolCall{ID: id, Name: tc.Function.Name, Args: args})
+		}
+		return calls
+	}
+	return a.parseToolCalls(resp.Content)
+}
+
+func (a *Agent) executeTool(ctx context.Context, tc ToolCall) (string, error) {
+	if _, ok := a.tools.Get(tc.Name); !ok {
+		return "", fmt.Errorf("tool not found: %s", tc.Name)
+	}
+
+	if strings.HasPrefix(tc.Name, "browser_") {
+		if _, ok := tc.Args["session_id"]; !ok || strings.TrimSpace(fmt.Sprintf("%v", tc.Args["session_id"])) == "" {
+			tc.Args["session_id"] = a.defaultBrowserSessionID()
+		}
+		ctx = tools.WithBrowserSession(ctx, fmt.Sprintf("%v", tc.Args["session_id"]))
+	}
+
+	result, err := a.tools.Call(a.toolCallContext(ctx), tc.Name, tc.Args)
+	if err != nil {
+		return "", fmt.Errorf("tool execution failed: %w", err)
+	}
+
+	return result, nil
+}
+
+func (a *Agent) executeProtocolResponse(ctx context.Context, resp *llm.Response) (string, bool, error) {
+	if resp == nil || a.tools == nil {
+		return "", false, nil
+	}
+	for _, payload := range extractProtocolPayloads(resp.Content) {
+		result, handled, err := plugin.ExecuteProtocolOutput(ctx, a.tools, plugin.ProtocolExecutionMeta{
+			ToolName: "agent_desktop_plan",
+			App:      strings.TrimSpace(a.config.Name),
+			Action:   "user_request",
+			Input: map[string]any{
+				"request": a.latestUserInput(),
+			},
+		}, payload)
+		if handled {
+			return result, true, err
+		}
+	}
+	return "", false, nil
+}
+
+func (a *Agent) defaultBrowserSessionID() string {
+	for i := len(a.history) - 1; i >= 0; i-- {
+		msg := a.history[i]
+		if strings.TrimSpace(msg.Role) == "user" && strings.TrimSpace(msg.Content) != "" {
+			return fmt.Sprintf("agent-%s", sanitizeBrowserSessionID(msg.Content))
+		}
+	}
+	return "agent-default"
+}
+
+func (a *Agent) latestUserInput() string {
+	for i := len(a.history) - 1; i >= 0; i-- {
+		if strings.TrimSpace(a.history[i].Role) == "user" && strings.TrimSpace(a.history[i].Content) != "" {
+			return strings.TrimSpace(a.history[i].Content)
+		}
+	}
+	return ""
+}
+
+func (a *Agent) protocolContinuationPrompt(result string) string {
+	lines := []string{
+		"Desktop plan execution result:",
+		strings.TrimSpace(result),
+		"",
+		"Treat this as observable evidence about the current world state.",
+		"Decide whether the user's requested outcome is now complete.",
+		"If more work is still genuinely required, continue with the next best action or emit another desktop plan only for the remaining work.",
+		"Before claiming completion, verify the requested outcome with the most reliable available checks.",
+		"When you finish, provide a concise user-facing update that states what was done, what was verified, and anything still blocked or unverified.",
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (a *Agent) toolContinuationPrompt(results []string) string {
+	lines := []string{
+		"Tool results above are evidence about the current world state, not proof that the task is fully complete.",
+	}
+	if len(results) > 0 {
+		lines = append(lines, "Latest evidence:")
+		for _, item := range limitStrings(results, 8) {
+			lines = append(lines, "- "+item)
+		}
+	}
+	lines = append(lines,
+		"Use the observed state to decide the next step.",
+		"If the requested outcome is not there yet, keep working or switch strategy instead of guessing.",
+		"Before claiming completion, verify the outcome with the strongest available checks such as files, command output, browser state, UI inspection, OCR, screenshots, or app/window state.",
+		"If part of the task is done but not yet verified, continue or say exactly what remains unconfirmed.",
+	)
+	return strings.Join(lines, "\n")
+}
+
+func (a *Agent) buildSystemPrompt() (string, error) {
+	var toolList []tools.ToolInfo
+	if a.tools != nil {
+		toolList = a.visibleToolInfos()
+	}
+	return a.buildSystemPromptForToolInfos(toolList)
+}
+
+func (a *Agent) buildSystemPromptForToolInfos(toolList []tools.ToolInfo) (string, error) {
+	memoryContent := a.buildPromptMemory()
+
+	workspaceFiles := []prompt.WorkspaceFile{}
+	if strings.TrimSpace(a.workingDir) != "" {
+		files, err := a.loadBootstrapFiles()
+		if err == nil {
+			workspaceFiles = make([]prompt.WorkspaceFile, 0, len(files))
+			for _, file := range files {
+				workspaceFiles = append(workspaceFiles, prompt.WorkspaceFile{
+					Name:    file.Name,
+					Content: file.Content,
+				})
+			}
+			if workspace.HasInjectedMemoryFile(files) && strings.Contains(strings.TrimSpace(memoryContent), "(No entries)") {
+				memoryContent = ""
+			}
+		}
+	}
+
+	toolInfos := make([]prompt.ToolInfo, len(toolList))
+	for i, t := range toolList {
+		toolInfos[i] = prompt.ToolInfo{
+			Name:        t.Name,
+			Description: t.Description,
+			InputSchema: t.InputSchema,
+		}
+	}
+
+	var skillPrompts []string
+	if a.skills != nil {
+		skillPrompts = a.skills.GetSystemPrompts()
+	}
+
+	var cliHubInfo *prompt.CLIHubInfo
+	if hubRoot := strings.TrimSpace(firstNonEmpty(a.workingDir, a.workDir)); hubRoot != "" {
+		if catalog, err := clihub.LoadAuto(hubRoot); err == nil {
+			summary := clihub.SummaryFor(catalog, 6)
+			skills := clihub.LoadSkillsForCatalog(catalog)
+			var skillCommands []string
+			for name, skill := range skills {
+				for _, cmd := range skill.Commands {
+					skillCommands = append(skillCommands, fmt.Sprintf("%s_%s", name, cmd.Name))
+				}
+			}
+			cliHubInfo = &prompt.CLIHubInfo{
+				Root:           summary.Root,
+				EntriesCount:   summary.EntriesCount,
+				RunnableCount:  summary.RunnableCount,
+				InstalledCount: summary.InstalledCount,
+				Categories:     categoryNames(summary.Categories, 6),
+				Runnable:       cliHubEntryNames(summary.Runnable, 8),
+				Installed:      cliHubEntryNames(summary.Installed, 6),
+				SkillCommands:  skillCommands,
+			}
+			if reg, err := clihub.LoadCapabilityRegistry(summary.Root); err == nil {
+				cliHubInfo.CapabilitiesCount = reg.Count()
+				cliHubInfo.IntentExamples = cliHubCapabilityExamples(reg.All(), 6)
+			}
+		}
+	}
+
+	var bridgeInfo *prompt.ClawBridgeInfo
+	if bridgeRoot := strings.TrimSpace(firstNonEmpty(a.workingDir, a.workDir)); bridgeRoot != "" {
+		if bridgeSummary, err := clawbridge.LoadAuto(bridgeRoot); err == nil {
+			bridgeInfo = &prompt.ClawBridgeInfo{
+				Root:            bridgeSummary.Root,
+				CommandsCount:   bridgeSummary.CommandsCount,
+				ToolsCount:      bridgeSummary.ToolsCount,
+				SubsystemsCount: len(bridgeSummary.Subsystems),
+				CommandFamilies: familyNames(bridgeSummary.CommandFamily, 6),
+				ToolFamilies:    familyNames(bridgeSummary.ToolFamily, 6),
+				Subsystems:      subsystemNames(bridgeSummary.Subsystems, 5),
+			}
+		}
+	}
+
+	description := strings.TrimSpace(strings.Join(compactStrings(a.config.Description, a.config.Personality), "\n\n"))
+	data := prompt.PromptData{
+		Name:           a.config.Name,
+		Description:    description,
+		WorkingDir:     a.workingDir,
+		Memory:         memoryContent,
+		SkillPrompts:   skillPrompts,
+		Tools:          toolInfos,
+		CLIHub:         cliHubInfo,
+		ClawBridge:     bridgeInfo,
+		WorkspaceFiles: workspaceFiles,
+		History:        a.history,
+	}
+
+	return prompt.BuildSystemPrompt(a.config.Name, description, data)
+}
+
+func (a *Agent) buildPromptMemory() string {
+	if a.memory == nil {
+		return ""
+	}
+
+	entries, err := a.memory.List()
+	if err != nil || len(entries) == 0 {
+		return ""
+	}
+
+	selected := selectPromptMemoryEntries(entries)
+	if len(selected) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("# Memory\n\n")
+
+	added := 0
+	for _, entry := range selected {
+		if added >= promptMemoryMaxEntries {
+			break
+		}
+		content := strings.TrimSpace(entry.Content)
+		if content == "" {
+			continue
+		}
+		content = truncatePromptMemoryString(content, promptMemoryEntryMaxChars)
+		block := fmt.Sprintf("## [%s] %s\n\n%s\n\n", entry.Type, entry.Timestamp.Format("2006-01-02 15:04"), content)
+		if sb.Len()+len(block) > promptMemoryMaxChars {
+			break
+		}
+		sb.WriteString(block)
+		added++
+	}
+
+	if added == 0 {
+		return ""
+	}
+
+	if len(entries) > added {
+		notice := "_Prompt memory limited. Use memory_search or memory_get when older context is needed._"
+		if sb.Len()+len(notice)+2 <= promptMemoryMaxChars {
+			sb.WriteString(notice)
+		}
+	}
+
+	return strings.TrimSpace(sb.String())
+}
+
+func selectPromptMemoryEntries(entries []memory.MemoryEntry) []memory.MemoryEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	selected := make([]memory.MemoryEntry, 0, promptMemoryMaxEntries)
+	for _, entry := range entries {
+		if entry.Type == memory.TypeConversation {
+			continue
+		}
+		selected = append(selected, entry)
+		if len(selected) >= promptMemoryMaxEntries {
+			break
+		}
+	}
+	return selected
+}
+
+func truncatePromptMemoryString(input string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	runes := []rune(strings.TrimSpace(input))
+	if len(runes) <= limit {
+		return string(runes)
+	}
+	return strings.TrimSpace(string(runes[:limit])) + "..."
+}
+
+func (a *Agent) selectToolInfos(userInput string) []tools.ToolInfo {
+	if a.tools == nil {
+		return nil
+	}
+
+	allTools := a.visibleToolInfos()
+	if len(allTools) == 0 {
+		return nil
+	}
+
+	query := normalizeToolSelectionText(userInput)
+	if !shouldExposeToolsForInput(query, allTools) && !a.shouldExposeCLIHubIntentTools(userInput) {
+		return nil
+	}
+
+	coreExact := map[string]struct{}{
+		"read_file":                {},
+		"write_file":               {},
+		"list_directory":           {},
+		"search_files":             {},
+		"run_command":              {},
+		"memory_search":            {},
+		"memory_get":               {},
+		"web_search":               {},
+		"fetch_url":                {},
+		"clihub_catalog":           {},
+		"clihub_exec":              {},
+		"intent_route":             {},
+		"intent_list_capabilities": {},
+		"claw_bridge_context":      {},
+		"delegate_task":            {},
+	}
+	corePrefixes := []string{"browser_", "desktop_", "skill_"}
+	appPrefixes := matchedToolPrefixes(query, allTools)
+
+	selected := make([]tools.ToolInfo, 0, len(allTools))
+	seen := make(map[string]struct{})
+	for _, tool := range allTools {
+		if _, ok := coreExact[tool.Name]; ok {
+			selected = append(selected, tool)
+			seen[tool.Name] = struct{}{}
+			continue
+		}
+		if hasAnyToolPrefix(tool.Name, corePrefixes) || hasAnyToolPrefix(tool.Name, appPrefixes) {
+			if _, ok := seen[tool.Name]; ok {
+				continue
+			}
+			selected = append(selected, tool)
+			seen[tool.Name] = struct{}{}
+		}
+	}
+
+	return selected
+}
+
+func (a *Agent) shouldExposeCLIHubIntentTools(userInput string) bool {
+	if a.intentPreprocessor == nil {
+		return false
+	}
+	result := a.intentPreprocessor.Preprocess(userInput, nil)
+	return result != nil && result.Handled && result.Capability != nil && result.Confidence >= intentCapabilityThreshold
+}
+
+func (a *Agent) tryAutoRouteCLIHubIntent(ctx context.Context, userInput string) (string, bool, error) {
+	if a.intentPreprocessor == nil || a.tools == nil {
+		return "", false, nil
+	}
+	if _, ok := a.tools.Get("intent_route"); !ok {
+		return "", false, nil
+	}
+
+	result := a.intentPreprocessor.Preprocess(userInput, nil)
+	if result == nil || !result.Handled || result.Capability == nil || result.Confidence < intentAutoExecuteThreshold {
+		return "", false, nil
+	}
+
+	args := map[string]any{
+		"intent": strings.TrimSpace(userInput),
+		"json":   true,
+	}
+	execResult, err := a.tools.Call(a.toolCallContext(ctx), "intent_route", args)
+	if err != nil {
+		a.recordToolActivity(ToolActivity{ToolName: "intent_route", Args: args, Error: err.Error()})
+		return "", false, nil
+	}
+
+	a.recordToolActivity(ToolActivity{ToolName: "intent_route", Args: args, Result: execResult})
+	a.appendHistoryMessage(ctx, "user", userInput)
+	a.appendHistoryMessage(ctx, "assistant", execResult)
+	a.recordConversation(userInput, execResult)
+	return execResult, true, nil
+}
+
+func shouldExposeToolsForInput(query string, toolList []tools.ToolInfo) bool {
+	if strings.TrimSpace(query) == "" {
+		return false
+	}
+	if matched := matchedToolPrefixes(query, toolList); len(matched) > 0 {
+		return true
+	}
+	if strings.Contains(query, "http://") || strings.Contains(query, "https://") {
+		return true
+	}
+	if strings.Contains(query, `\`) || strings.Contains(query, "/") || strings.Contains(query, ".md") || strings.Contains(query, ".go") || strings.Contains(query, ".json") {
+		return true
+	}
+	if containsCJKActionIntent(query) {
+		return true
+	}
+	if containsNaturalActionIntent(query) {
+		return true
+	}
+
+	keywords := []string{
+		"open", "read", "write", "edit", "update", "change", "create", "delete", "remove", "search", "find",
+		"run", "execute", "list", "browse", "click", "type", "send", "install", "fix", "implement", "code",
+		"file", "folder", "directory", "command", "terminal", "shell", "browser", "app", "website", "url",
+		"ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â°ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¼ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¨ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¯ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â»ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã¢â‚¬Å“", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¾ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¼ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã¢â‚¬Å“ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¨ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¾ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¹Ãƒâ€¦Ã¢â‚¬Å“", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¤ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¿ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â®ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¹", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂºÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â´ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã¢â‚¬Å“ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â°", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¹ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂºÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â»ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Âº", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¹ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â©ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¾ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¤", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¦ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã¢â‚¬Å“ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â´ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¦ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¸ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â°ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¾", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¨ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¿ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¨ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¦ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÂ¢Ã¢â‚¬Å¾Ã‚Â¢", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â°ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¨ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¦ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÂ¢Ã¢â‚¬Å¾Ã‚Â¢", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¹ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚ÂÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Âº",
+		"ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂµÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¨ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¹ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â ", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¹ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â»", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¨ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¾ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¹Ãƒâ€¦Ã¢â‚¬Å“ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â©ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â®ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â°ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¨ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â£ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¤ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¿ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â®ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¤ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â®ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¦ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¾ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¦ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â½ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â°", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¤ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â»ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â£ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã¢â‚¬Å“ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¤ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â»ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¶", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂºÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â®ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â½ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã¢â‚¬Å“ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¤ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â»ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¶ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¤ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¹", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¹Ãƒâ€¦Ã¢â‚¬Å“ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â½ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¤ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â»ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¤", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â»ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¹ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â«ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¯",
+		"ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂµÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¨ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¹ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¾ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¨", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂºÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¨", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â½ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¹Ãƒâ€¦Ã¢â‚¬Å“ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â§ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â«ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¾ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â©ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¾ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¦ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â½ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¹ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂªÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚ÂºÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¾", "ocr", "ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¨ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â®ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â°ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¥ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¿ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â ", "memory",
+	}
+	for _, keyword := range keywords {
+		if keyword != "" && strings.Contains(query, keyword) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsCJKActionIntent(query string) bool {
+	if strings.TrimSpace(query) == "" {
+		return false
+	}
+
+	hasCJK := false
+	for _, r := range query {
+		if unicode.Is(unicode.Han, r) {
+			hasCJK = true
+			break
+		}
+	}
+	if !hasCJK {
+		return false
+	}
+
+	actionTerms := []string{
+		"打开", "启动", "运行", "执行", "搜索", "查找", "读取", "查看",
+		"编辑", "修改", "创建", "删除", "发送", "点击", "输入", "截图",
+		"浏览", "访问", "安装", "修复", "实现", "编写", "帮我", "请帮我",
+	}
+	for _, term := range actionTerms {
+		if strings.Contains(query, term) {
+			return true
+		}
+	}
+
+	// Keep a clean UTF-8 fallback list for common Chinese action verbs.
+	// Some older entries above came from legacy prompt heuristics and do not
+	// reliably cover everyday phrasings such as "建立一个文件夹".
+	fallbackActionTerms := []string{
+		"打开", "启动", "运行", "执行", "搜索", "查找", "读取", "查看",
+		"编辑", "修改", "创建", "建立", "新建", "删除", "发送", "点击",
+		"输入", "截图", "浏览", "访问", "安装", "修复", "实现", "编写",
+		"帮我", "请帮我",
+	}
+	for _, term := range fallbackActionTerms {
+		if strings.Contains(query, term) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsNaturalActionIntent(query string) bool {
+	if strings.TrimSpace(query) == "" {
+		return false
+	}
+
+	keywords := []string{
+		"export", "render", "timeline", "project", "model", "spreadsheet", "presentation",
+		"导出", "渲染", "时间线", "项目", "模型", "表格", "演示文稿", "视频", "音频",
+	}
+	for _, keyword := range keywords {
+		if strings.Contains(query, keyword) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchedToolPrefixes(query string, toolList []tools.ToolInfo) []string {
+	if strings.TrimSpace(query) == "" {
+		return nil
+	}
+
+	prefixes := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, tool := range toolList {
+		prefix := toolPrefix(tool.Name)
+		if prefix == "" || isCoreToolPrefix(prefix) {
+			continue
+		}
+		normalizedPrefix := normalizeToolSelectionText(prefix)
+		if normalizedPrefix != "" && strings.Contains(query, normalizedPrefix) {
+			if _, ok := seen[prefix]; ok {
+				continue
+			}
+			seen[prefix] = struct{}{}
+			prefixes = append(prefixes, prefix+"_")
+		}
+	}
+	return prefixes
+}
+
+func toolPrefix(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	idx := strings.Index(name, "_")
+	if idx <= 0 {
+		return ""
+	}
+	return strings.TrimSpace(name[:idx])
+}
+
+func isCoreToolPrefix(prefix string) bool {
+	switch prefix {
+	case "browser", "desktop", "skill", "memory", "intent", "clihub", "claw", "read", "write", "list", "search", "run", "web", "fetch":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasAnyToolPrefix(name string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if prefix != "" && strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeToolSelectionText(input string) string {
+	replacer := strings.NewReplacer("_", " ", "-", " ", "/", " ", `\`, " ", ".", " ", ":", " ")
+	return strings.ToLower(strings.TrimSpace(replacer.Replace(input)))
+}
+
+func (a *Agent) visibleToolInfos() []tools.ToolInfo {
+	if a.tools == nil {
+		return nil
+	}
+	return a.tools.ListForRole(a.config.IsSubAgent)
+}
+
+func (a *Agent) toolCallContext(ctx context.Context) context.Context {
+	role := tools.ToolCallerRoleMainAgent
+	if a.config.IsSubAgent {
+		role = tools.ToolCallerRoleSubAgent
+	}
+	return tools.WithToolCaller(ctx, tools.ToolCaller{
+		Role:      role,
+		AgentName: strings.TrimSpace(a.config.Name),
+	})
+}
+
+func (a *Agent) buildMessages(systemPrompt string) []llm.Message {
+	messages := make([]llm.Message, 0, 2+len(a.history))
+	if systemPrompt != "" {
+		messages = append(messages, llm.Message{Role: "system", Content: systemPrompt})
+	}
+	for _, msg := range a.history {
+		messages = append(messages, llm.Message{Role: msg.Role, Content: msg.Content})
+	}
+	return messages
+}
+
+func (a *Agent) buildToolDefinitions() []llm.ToolDefinition {
+	if a.tools == nil {
+		return nil
+	}
+	return buildToolDefinitionsFromInfos(a.visibleToolInfos())
+}
+
+func buildToolDefinitionsFromInfos(toolList []tools.ToolInfo) []llm.ToolDefinition {
+	defs := make([]llm.ToolDefinition, 0, len(toolList))
+	for _, t := range toolList {
+		defs = append(defs, llm.ToolDefinition{
+			Type: "function",
+			Function: llm.ToolFunctionDefinition{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  t.InputSchema,
+			},
+		})
+	}
+	return defs
+}
+
+func mustJSON(v any) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "{}"
+	}
+	return string(data)
+}
+
+func familyNames(items []clawbridge.FamilySummary, limit int) []string {
+	if limit > 0 && limit < len(items) {
+		items = items[:limit]
+	}
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, fmt.Sprintf("%s (%d)", item.Name, item.Count))
+	}
+	return names
+}
+
+func subsystemNames(items []clawbridge.SubsystemSummary, limit int) []string {
+	if limit > 0 && limit < len(items) {
+		items = items[:limit]
+	}
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, fmt.Sprintf("%s (%d)", item.Name, item.ModuleCount))
+	}
+	return names
+}
+
+func categoryNames(items []clihub.CategoryHit, limit int) []string {
+	if limit > 0 && limit < len(items) {
+		items = items[:limit]
+	}
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, fmt.Sprintf("%s (%d)", item.Name, item.Count))
+	}
+	return names
+}
+
+func cliHubEntryNames(items []clihub.EntryStatus, limit int) []string {
+	if limit > 0 && limit < len(items) {
+		items = items[:limit]
+	}
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+	return names
+}
+
+func cliHubCapabilityExamples(items []clihub.Capability, limit int) []string {
+	if limit > 0 && limit < len(items) {
+		items = items[:limit]
+	}
+	examples := make([]string, 0, len(items))
+	for _, item := range items {
+		parts := compactStrings(item.Harness, item.Group, item.Command)
+		if len(parts) == 0 {
+			continue
+		}
+		examples = append(examples, strings.Join(parts, " "))
+	}
+	return examples
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func sanitizeBrowserSessionID(input string) string {
+	input = strings.ToLower(strings.TrimSpace(input))
+	if input == "" {
+		return "default"
+	}
+	replacer := strings.NewReplacer(" ", "-", "/", "-", "\\", "-", ":", "-", "?", "", "&", "-")
+	input = replacer.Replace(input)
+	if len(input) > 48 {
+		input = input[:48]
+	}
+	input = strings.Trim(input, "-.")
+	if input == "" {
+		return "default"
+	}
+	return input
+}
+
+func extractProtocolPayloads(content string) [][]byte {
+	items := make([][]byte, 0, 2)
+	seen := map[string]bool{}
+	appendCandidate := func(candidate string) {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || seen[candidate] {
+			return
+		}
+		seen[candidate] = true
+		items = append(items, []byte(candidate))
+	}
+	appendCandidate(content)
+	for _, match := range codeBlockRegex.FindAllStringSubmatch(content, -1) {
+		if len(match) > 1 {
+			appendCandidate(match[1])
+		}
+	}
+	return items
+}
+
+func compactStrings(items ...string) []string {
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func limitStrings(items []string, limit int) []string {
+	if limit <= 0 || len(items) <= limit {
+		return append([]string(nil), items...)
+	}
+	result := append([]string(nil), items[:limit]...)
+	result = append(result, fmt.Sprintf("...and %d more result(s)", len(items)-limit))
+	return result
+}
+
+func (a *Agent) ShowMemory() (string, error) {
+	return a.memory.FormatAsMarkdown()
+}
+
+func (a *Agent) recordConversation(userInput string, response string) {
+	if a.memory == nil {
+		return
+	}
+	_ = a.memory.Add(memory.MemoryEntry{Type: "conversation", Role: "user", Content: userInput})
+	_ = a.memory.Add(memory.MemoryEntry{Type: "conversation", Role: "assistant", Content: response})
+}
+
+func (a *Agent) ListSkills() []skills.SkillInfo {
+	list := a.skills.List()
+	result := make([]skills.SkillInfo, len(list))
+	for i, s := range list {
+		result[i] = skills.SkillInfo{Name: s.Name, Description: s.Description, Version: s.Version, Permissions: append([]string(nil), s.Permissions...), Entrypoint: s.Entrypoint, Registry: s.Registry, Source: s.Source, InstallHint: s.InstallCommand}
+	}
+	return result
+}
+
+func (a *Agent) ListTools() []tools.ToolInfo {
+	if a.tools == nil {
+		return nil
+	}
+	return a.visibleToolInfos()
+}
+
+func (a *Agent) ClearHistory() {
+	a.history = a.history[:0]
+}
+
+func (a *Agent) GetHistory() []prompt.Message {
+	return a.history
+}
+
+func (a *Agent) SetHistory(history []prompt.Message) {
+	if len(history) == 0 {
+		a.history = nil
+		return
+	}
+	a.history = append([]prompt.Message(nil), history...)
+}
+
+func (a *Agent) SetTools(registry *tools.Registry) {
+	a.tools = registry
+}
+
+func (a *Agent) SetContextEngine(engine ctxpkg.ContextEngine) {
+	if a.contextRuntime == nil {
+		a.contextRuntime = newContextRuntime(a.config)
+	}
+	a.contextRuntime.setContextEngine(engine)
+}
+
+func (a *Agent) appendHistoryMessage(ctx context.Context, role string, content string) {
+	a.history = append(a.history, prompt.Message{Role: role, Content: content})
+	if a.contextRuntime != nil {
+		a.contextRuntime.storeConversation(ctx, a.config.Name, a.workingDir, role, content)
+	}
+}
+
+func (a *Agent) loadBootstrapFiles() ([]workspace.BootstrapFile, error) {
+	if a.contextRuntime != nil {
+		return a.contextRuntime.loadBootstrapFiles(a.workingDir)
+	}
+	return workspace.LoadBootstrapFiles(a.workingDir, workspace.BootstrapOptions{})
+}
+
+func (a *Agent) prepareSystemPrompt(ctx context.Context, selectedTools []tools.ToolInfo) (string, error) {
+	if a.contextRuntime != nil {
+		compacted, err := a.contextRuntime.compactHistory(ctx, a.history, a.llm)
+		if err != nil {
+			return "", fmt.Errorf("failed to compact history: %w", err)
+		}
+		a.history = compacted
+	}
+
+	systemPrompt, err := a.buildSystemPromptForToolInfos(selectedTools)
+	if err != nil {
+		return "", fmt.Errorf("failed to build system prompt: %w", err)
+	}
+
+	if a.contextRuntime != nil {
+		trimmed, err := a.contextRuntime.enforceTokenLimit(systemPrompt, a.history)
+		if err != nil {
+			return "", err
+		}
+		a.history = trimmed
+	}
+
+	return systemPrompt, nil
+}
+
+func (a *Agent) acquireContextExecution(ctx context.Context, userInput string) (*contextExecution, error) {
+	if a.contextRuntime == nil {
+		return &contextExecution{}, nil
+	}
+	return a.contextRuntime.acquire(ctx, firstNonEmpty(a.config.Name, userInput))
+}
+
+func (a *Agent) heartbeatContextExecution(exec *contextExecution) {
+	if a.contextRuntime == nil {
+		return
+	}
+	a.contextRuntime.heartbeat(exec)
+}
+
+func (a *Agent) releaseContextExecution(exec *contextExecution) {
+	if a.contextRuntime == nil {
+		return
+	}
+	a.contextRuntime.release(exec)
+}

--- a/pkg/capability/agents/agent_test.go
+++ b/pkg/capability/agents/agent_test.go
@@ -1,0 +1,1120 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/capability/agents/prompt"
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+	"github.com/1024XEngineer/anyclaw/pkg/capability/skills"
+	"github.com/1024XEngineer/anyclaw/pkg/capability/tools"
+	"github.com/1024XEngineer/anyclaw/pkg/clawbridge"
+	"github.com/1024XEngineer/anyclaw/pkg/state/memory"
+	"github.com/1024XEngineer/anyclaw/pkg/workspace"
+)
+
+type stubAgentLLM struct {
+	responses []*llm.Response
+	index     int
+	messages  [][]llm.Message
+	toolDefs  [][]llm.ToolDefinition
+}
+
+func (s *stubAgentLLM) Chat(ctx context.Context, messages []llm.Message, toolDefs []llm.ToolDefinition) (*llm.Response, error) {
+	s.messages = append(s.messages, append([]llm.Message(nil), messages...))
+	s.toolDefs = append(s.toolDefs, append([]llm.ToolDefinition(nil), toolDefs...))
+	if s.index >= len(s.responses) {
+		return &llm.Response{Content: "done"}, nil
+	}
+	resp := s.responses[s.index]
+	s.index++
+	return resp, nil
+}
+
+func (s *stubAgentLLM) StreamChat(ctx context.Context, messages []llm.Message, toolDefs []llm.ToolDefinition, onChunk func(string)) error {
+	resp, err := s.Chat(ctx, messages, toolDefs)
+	if err != nil {
+		return err
+	}
+	if resp != nil && onChunk != nil {
+		onChunk(resp.Content)
+	}
+	return nil
+}
+
+func (s *stubAgentLLM) Name() string {
+	return "stub"
+}
+
+type compactionAwareLLM struct {
+	mu       sync.Mutex
+	messages [][]llm.Message
+}
+
+func (s *compactionAwareLLM) Chat(ctx context.Context, messages []llm.Message, toolDefs []llm.ToolDefinition) (*llm.Response, error) {
+	s.mu.Lock()
+	s.messages = append(s.messages, append([]llm.Message(nil), messages...))
+	s.mu.Unlock()
+
+	if len(messages) > 0 && messages[0].Role == "system" && strings.Contains(messages[0].Content, "conversation summarizer") {
+		return &llm.Response{Content: "condensed prior work"}, nil
+	}
+	return &llm.Response{Content: "final response"}, nil
+}
+
+func (s *compactionAwareLLM) StreamChat(ctx context.Context, messages []llm.Message, toolDefs []llm.ToolDefinition, onChunk func(string)) error {
+	resp, err := s.Chat(ctx, messages, toolDefs)
+	if err != nil {
+		return err
+	}
+	if onChunk != nil {
+		onChunk(resp.Content)
+	}
+	return nil
+}
+
+func (s *compactionAwareLLM) Name() string { return "compaction-aware" }
+
+type blockingAgentLLM struct {
+	mu      sync.Mutex
+	entered chan int
+	gates   []chan struct{}
+}
+
+func newBlockingAgentLLM() *blockingAgentLLM {
+	return &blockingAgentLLM{
+		entered: make(chan int, 4),
+		gates:   make([]chan struct{}, 0, 4),
+	}
+}
+
+func (s *blockingAgentLLM) Chat(ctx context.Context, messages []llm.Message, toolDefs []llm.ToolDefinition) (*llm.Response, error) {
+	s.mu.Lock()
+	idx := len(s.gates)
+	gate := make(chan struct{})
+	s.gates = append(s.gates, gate)
+	s.mu.Unlock()
+
+	s.entered <- idx
+
+	select {
+	case <-gate:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	return &llm.Response{Content: fmt.Sprintf("response-%d", idx)}, nil
+}
+
+func (s *blockingAgentLLM) StreamChat(ctx context.Context, messages []llm.Message, toolDefs []llm.ToolDefinition, onChunk func(string)) error {
+	resp, err := s.Chat(ctx, messages, toolDefs)
+	if err != nil {
+		return err
+	}
+	if onChunk != nil {
+		onChunk(resp.Content)
+	}
+	return nil
+}
+
+func (s *blockingAgentLLM) Name() string { return "blocking" }
+
+func (s *blockingAgentLLM) Release(idx int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if idx < 0 || idx >= len(s.gates) {
+		return
+	}
+	select {
+	case <-s.gates[idx]:
+	default:
+		close(s.gates[idx])
+	}
+}
+
+func TestBuildSystemPromptIncludesPersonalityAndAnyClawCore(t *testing.T) {
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+	registry := tools.NewRegistry()
+	registry.RegisterTool("app_qq_workflow_send_message", "Send a message through QQ", map[string]any{}, nil)
+	registry.RegisterTool("desktop_resolve_target", "Resolve a local app target", map[string]any{}, nil)
+	registry.RegisterTool("desktop_activate_target", "Activate a local app target", map[string]any{}, nil)
+	registry.RegisterTool("desktop_set_target_value", "Set a value on a local app target", map[string]any{}, nil)
+	registry.RegisterTool("desktop_wait_text", "Wait for local app text", map[string]any{}, nil)
+
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		Personality: "Operate like an execution-focused local app agent.",
+		Memory:      mem,
+		Skills:      skills.NewSkillsManager(""),
+		Tools:       registry,
+	})
+
+	systemPrompt, err := ag.buildSystemPrompt()
+	if err != nil {
+		t.Fatalf("buildSystemPrompt: %v", err)
+	}
+	if !strings.Contains(systemPrompt, "execution-focused local app agent") {
+		t.Fatalf("expected personality to be injected into the system prompt, got %q", systemPrompt)
+	}
+	if !strings.Contains(systemPrompt, "## AnyClaw Core") {
+		t.Fatalf("expected AnyClaw core operating section, got %q", systemPrompt)
+	}
+	if !strings.Contains(systemPrompt, "app_qq_workflow_send_message") {
+		t.Fatalf("expected workflow tool guidance in system prompt, got %q", systemPrompt)
+	}
+	if !strings.Contains(systemPrompt, "desktop_activate_target") || !strings.Contains(systemPrompt, "desktop_set_target_value") {
+		t.Fatalf("expected target-based desktop guidance in system prompt, got %q", systemPrompt)
+	}
+	if !strings.Contains(systemPrompt, "Work in loops: inspect the current state") {
+		t.Fatalf("expected iterative execution guidance in system prompt, got %q", systemPrompt)
+	}
+	if !strings.Contains(systemPrompt, "verify the requested deliverable with observable evidence") {
+		t.Fatalf("expected verification guidance in system prompt, got %q", systemPrompt)
+	}
+}
+
+func TestBuildSystemPromptHandlesNilDependencies(t *testing.T) {
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		Personality: "Stay calm and action-oriented.",
+	})
+
+	systemPrompt, err := ag.buildSystemPrompt()
+	if err != nil {
+		t.Fatalf("buildSystemPrompt: %v", err)
+	}
+	if !strings.Contains(systemPrompt, "Stay calm and action-oriented.") {
+		t.Fatalf("expected personality text in prompt, got %q", systemPrompt)
+	}
+	if strings.Contains(systemPrompt, "## AnyClaw Core") {
+		t.Fatalf("did not expect AnyClaw core section without execution tools, got %q", systemPrompt)
+	}
+}
+
+func TestBuildSystemPromptLimitsInjectedMemory(t *testing.T) {
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+
+	for i := 0; i < 12; i++ {
+		if err := mem.Add(memory.MemoryEntry{
+			Type:      memory.TypeConversation,
+			Timestamp: time.Unix(int64(i+1), 0),
+			Content:   fmt.Sprintf("conversation-%02d %s", i, strings.Repeat("x", 900)),
+		}); err != nil {
+			t.Fatalf("add conversation memory %d: %v", i, err)
+		}
+	}
+	if err := mem.Add(memory.MemoryEntry{
+		Type:      memory.TypeFact,
+		Timestamp: time.Unix(100, 0),
+		Content:   "stable-fact " + strings.Repeat("y", 900),
+	}); err != nil {
+		t.Fatalf("add fact memory: %v", err)
+	}
+
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		Memory:      mem,
+		Skills:      skills.NewSkillsManager(""),
+		Tools:       tools.NewRegistry(),
+	})
+
+	systemPrompt, err := ag.buildSystemPrompt()
+	if err != nil {
+		t.Fatalf("buildSystemPrompt: %v", err)
+	}
+	if len(systemPrompt) > 12000 {
+		t.Fatalf("expected bounded prompt length, got %d characters", len(systemPrompt))
+	}
+	if !strings.Contains(systemPrompt, "stable-fact") {
+		t.Fatalf("expected stable memory to be retained, got %q", systemPrompt)
+	}
+	if strings.Contains(systemPrompt, "conversation-11") || strings.Contains(systemPrompt, "conversation-00") {
+		t.Fatalf("expected conversation memories to stay out of prompt injection, got %q", systemPrompt)
+	}
+	if !strings.Contains(systemPrompt, "Prompt memory limited.") {
+		t.Fatalf("expected truncated memory notice, got %q", systemPrompt)
+	}
+}
+
+func TestSelectToolInfosSkipsBulkToolsForCasualQuestion(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.RegisterTool("read_file", "Read a file", map[string]any{}, nil)
+	registry.RegisterTool("desktop_open", "Open a desktop app", map[string]any{}, nil)
+	registry.RegisterTool("browser_navigate", "Open a page", map[string]any{}, nil)
+	registry.RegisterTool("blender_open", "Open Blender", map[string]any{}, nil)
+
+	ag := New(Config{Tools: registry})
+
+	casual := ag.selectToolInfos("你是谁")
+	if len(casual) != 0 {
+		t.Fatalf("expected no tools for casual question, got %#v", casual)
+	}
+
+	actionable := ag.selectToolInfos("请打开 blender 并读取文件")
+	names := make([]string, 0, len(actionable))
+	for _, tool := range actionable {
+		names = append(names, tool.Name)
+	}
+	got := strings.Join(names, ",")
+	if !strings.Contains(got, "read_file") || !strings.Contains(got, "desktop_open") || !strings.Contains(got, "blender_open") {
+		t.Fatalf("expected core and matched app tools, got %q", got)
+	}
+}
+
+func TestSelectToolInfosHandlesChineseDesktopRequest(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.RegisterTool("desktop_open", "Open a desktop app", map[string]any{}, nil)
+	registry.RegisterTool("desktop_list_windows", "List desktop windows", map[string]any{}, nil)
+	registry.RegisterTool("skill_app-controller", "Desktop app control guidance", map[string]any{}, nil)
+
+	ag := New(Config{Tools: registry})
+
+	actionable := ag.selectToolInfos("帮我打开steam")
+	names := make([]string, 0, len(actionable))
+	for _, tool := range actionable {
+		names = append(names, tool.Name)
+	}
+	got := strings.Join(names, ",")
+	if !strings.Contains(got, "desktop_open") || !strings.Contains(got, "desktop_list_windows") || !strings.Contains(got, "skill_app-controller") {
+		t.Fatalf("expected desktop and skill tools for Chinese open-app request, got %q", got)
+	}
+}
+
+func TestSelectToolInfosHandlesChineseCreateFolderRequest(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.RegisterTool("read_file", "Read a file", map[string]any{}, nil)
+	registry.RegisterTool("write_file", "Write a file", map[string]any{}, nil)
+	registry.RegisterTool("list_directory", "List a directory", map[string]any{}, nil)
+	registry.RegisterTool("search_files", "Search files", map[string]any{}, nil)
+	registry.RegisterTool("run_command", "Run a command", map[string]any{}, nil)
+
+	ag := New(Config{Tools: registry})
+
+	actionable := ag.selectToolInfos("在桌面创建文件夹哈喽")
+	names := make([]string, 0, len(actionable))
+	for _, tool := range actionable {
+		names = append(names, tool.Name)
+	}
+	got := strings.Join(names, ",")
+	if !strings.Contains(got, "run_command") || !strings.Contains(got, "write_file") || !strings.Contains(got, "list_directory") {
+		t.Fatalf("expected core file and command tools for Chinese create-folder request, got %q", got)
+	}
+}
+
+func TestAgentRunUsesToolsForNaturalChineseCreateFolderRequest(t *testing.T) {
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+
+	registry := tools.NewRegistry()
+	registry.RegisterTool("read_file", "Read a file", map[string]any{}, nil)
+	registry.RegisterTool("write_file", "Write a file", map[string]any{}, nil)
+	registry.RegisterTool("list_directory", "List a directory", map[string]any{}, nil)
+	registry.RegisterTool("search_files", "Search files", map[string]any{}, nil)
+	registry.RegisterTool("run_command", "Run a command", map[string]any{}, nil)
+
+	llmStub := &stubAgentLLM{responses: []*llm.Response{
+		{Content: "可以帮你创建。"},
+	}}
+
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		LLM:         llmStub,
+		Memory:      mem,
+		Skills:      skills.NewSkillsManager(""),
+		Tools:       registry,
+	})
+
+	if _, err := ag.Run(context.Background(), "在桌面建立一个叫哈喽的文件夹"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(llmStub.messages) == 0 {
+		t.Fatalf("expected llm to receive at least one message batch")
+	}
+	if len(llmStub.toolDefs) == 0 {
+		t.Fatalf("expected llm to receive tool definitions")
+	}
+
+	systemPrompt := ""
+	for _, msg := range llmStub.messages[0] {
+		if msg.Role == "system" {
+			systemPrompt = msg.Content
+			break
+		}
+	}
+	if systemPrompt == "" {
+		t.Fatalf("expected system prompt to be present")
+	}
+	if strings.Contains(systemPrompt, "No tools selected for this turn") {
+		t.Fatalf("expected actionable Chinese request to expose tools, got system prompt %q", systemPrompt)
+	}
+
+	names := make([]string, 0, len(llmStub.toolDefs[0]))
+	for _, def := range llmStub.toolDefs[0] {
+		names = append(names, def.Function.Name)
+	}
+	got := strings.Join(names, ",")
+	if !strings.Contains(got, "run_command") || !strings.Contains(got, "write_file") || !strings.Contains(got, "list_directory") {
+		t.Fatalf("expected run path to pass core tool definitions, got %q", got)
+	}
+}
+
+func TestSelectToolInfosExposesCLIHubIntentToolsForNaturalLanguage(t *testing.T) {
+	hubRoot := filepath.Join(t.TempDir(), "CLI-Anything-0.2.0")
+	if err := writeCLIHubFixture(hubRoot); err != nil {
+		t.Fatalf("writeCLIHubFixture: %v", err)
+	}
+
+	registry := tools.NewRegistry()
+	registry.RegisterTool("intent_route", "Auto-route a CLI Hub request", map[string]any{}, nil)
+	registry.RegisterTool("intent_list_capabilities", "List matching CLI Hub capabilities", map[string]any{}, nil)
+	registry.RegisterTool("clihub_exec", "Execute a CLI Hub harness", map[string]any{}, nil)
+
+	ag := New(Config{
+		Tools:      registry,
+		CLIHubRoot: hubRoot,
+	})
+
+	selected := ag.selectToolInfos("帮我用 shotcut 新建一个项目")
+	names := make([]string, 0, len(selected))
+	for _, tool := range selected {
+		names = append(names, tool.Name)
+	}
+	got := strings.Join(names, ",")
+	if !strings.Contains(got, "intent_route") || !strings.Contains(got, "intent_list_capabilities") || !strings.Contains(got, "clihub_exec") {
+		t.Fatalf("expected CLI Hub intent tools to be exposed, got %q", got)
+	}
+}
+
+func TestBuildSystemPromptInjectsWorkspaceBootstrapFiles(t *testing.T) {
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+	workingDir := t.TempDir()
+	if err := workspace.EnsureBootstrap(workingDir, workspace.BootstrapOptions{
+		AgentName:        "assistant",
+		AgentDescription: "Local execution helper",
+	}); err != nil {
+		t.Fatalf("EnsureBootstrap: %v", err)
+	}
+
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		Personality: "Operate like an execution-focused local app agent.",
+		Memory:      mem,
+		Skills:      skills.NewSkillsManager(""),
+		Tools:       tools.NewRegistry(),
+		WorkingDir:  workingDir,
+	})
+
+	systemPrompt, err := ag.buildSystemPrompt()
+	if err != nil {
+		t.Fatalf("buildSystemPrompt: %v", err)
+	}
+	if !strings.Contains(systemPrompt, "## Workspace") || !strings.Contains(systemPrompt, workingDir) {
+		t.Fatalf("expected workspace section in system prompt, got %q", systemPrompt)
+	}
+	if !strings.Contains(systemPrompt, "## Project Context") {
+		t.Fatalf("expected project context section in system prompt, got %q", systemPrompt)
+	}
+	if !strings.Contains(systemPrompt, "### AGENTS.md") || !strings.Contains(systemPrompt, "### MEMORY.md") {
+		t.Fatalf("expected bootstrap files to be injected, got %q", systemPrompt)
+	}
+}
+
+func TestBuildSystemPromptInjectsCLIHubContext(t *testing.T) {
+	hubRoot := filepath.Join(t.TempDir(), "CLI-Anything-0.2.0")
+	if err := writeCLIHubFixture(hubRoot); err != nil {
+		t.Fatalf("writeCLIHubFixture: %v", err)
+	}
+	t.Setenv("ANYCLAW_CLI_ANYTHING_ROOT", hubRoot)
+
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+	registry := tools.NewRegistry()
+	registry.RegisterTool("clihub_catalog", "Search local CLI Hub entries", map[string]any{}, nil)
+	registry.RegisterTool("clihub_exec", "Execute local CLI Hub entries", map[string]any{}, nil)
+
+	workingDir := filepath.Join(t.TempDir(), "workspace")
+	if err := os.MkdirAll(workingDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		Personality: "Operate like an execution-focused local app agent.",
+		Memory:      mem,
+		Skills:      skills.NewSkillsManager(""),
+		Tools:       registry,
+		WorkingDir:  workingDir,
+	})
+
+	systemPrompt, err := ag.buildSystemPrompt()
+	if err != nil {
+		t.Fatalf("buildSystemPrompt: %v", err)
+	}
+	if !strings.Contains(systemPrompt, "## CLI Hub") {
+		t.Fatalf("expected CLI Hub section in prompt, got %q", systemPrompt)
+	}
+	if !strings.Contains(systemPrompt, hubRoot) {
+		t.Fatalf("expected hub root in prompt, got %q", systemPrompt)
+	}
+	if !strings.Contains(systemPrompt, "office (2)") || !strings.Contains(systemPrompt, "video (1)") {
+		t.Fatalf("expected category summary in prompt, got %q", systemPrompt)
+	}
+}
+
+func TestBuildSystemPromptHighlightsIntentRoutingWhenAvailable(t *testing.T) {
+	hubRoot := filepath.Join(t.TempDir(), "CLI-Anything-0.2.0")
+	if err := writeCLIHubFixture(hubRoot); err != nil {
+		t.Fatalf("writeCLIHubFixture: %v", err)
+	}
+	t.Setenv("ANYCLAW_CLI_ANYTHING_ROOT", hubRoot)
+
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+	registry := tools.NewRegistry()
+	registry.RegisterTool("intent_route", "Route a natural-language request", map[string]any{}, nil)
+	registry.RegisterTool("intent_list_capabilities", "List matching capabilities", map[string]any{}, nil)
+	registry.RegisterTool("clihub_exec", "Execute local CLI Hub entries", map[string]any{}, nil)
+
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		Memory:      mem,
+		Skills:      skills.NewSkillsManager(""),
+		Tools:       registry,
+		WorkingDir:  filepath.Join(t.TempDir(), "workspace"),
+	})
+
+	systemPrompt, err := ag.buildSystemPrompt()
+	if err != nil {
+		t.Fatalf("buildSystemPrompt: %v", err)
+	}
+	if !strings.Contains(systemPrompt, "prefer intent_route first") {
+		t.Fatalf("expected intent_route guidance in prompt, got %q", systemPrompt)
+	}
+	if !strings.Contains(systemPrompt, "intent_list_capabilities") {
+		t.Fatalf("expected intent_list_capabilities guidance in prompt, got %q", systemPrompt)
+	}
+}
+
+func TestBuildSystemPromptInjectsClawBridgeContext(t *testing.T) {
+	bridgeRoot := filepath.Join(t.TempDir(), "claw-code-main")
+	if err := writeAgentBridgeFixture(bridgeRoot); err != nil {
+		t.Fatalf("writeAgentBridgeFixture: %v", err)
+	}
+	t.Setenv(clawbridge.EnvRoot, bridgeRoot)
+
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+	registry := tools.NewRegistry()
+	registry.RegisterTool("run_command", "Run a shell command", map[string]any{}, nil)
+
+	workingDir := filepath.Join(t.TempDir(), "workspace")
+	if err := os.MkdirAll(workingDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		Personality: "Operate like an execution-focused local app agent.",
+		Memory:      mem,
+		Skills:      skills.NewSkillsManager(""),
+		Tools:       registry,
+		WorkingDir:  workingDir,
+	})
+
+	systemPrompt, err := ag.buildSystemPrompt()
+	if err != nil {
+		t.Fatalf("buildSystemPrompt: %v", err)
+	}
+	if !strings.Contains(systemPrompt, "## Claw Bridge") {
+		t.Fatalf("expected claw bridge section in prompt, got %q", systemPrompt)
+	}
+	if !strings.Contains(systemPrompt, bridgeRoot) {
+		t.Fatalf("expected bridge root in prompt, got %q", systemPrompt)
+	}
+	if !strings.Contains(systemPrompt, "agents (2)") || !strings.Contains(systemPrompt, "AgentTool (2)") {
+		t.Fatalf("expected command and tool family summaries in prompt, got %q", systemPrompt)
+	}
+}
+
+func TestAgentRunAutoRoutesCLIHubIntentBeforeLLM(t *testing.T) {
+	hubRoot := filepath.Join(t.TempDir(), "CLI-Anything-0.2.0")
+	if err := writeCLIHubFixture(hubRoot); err != nil {
+		t.Fatalf("writeCLIHubFixture: %v", err)
+	}
+
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+
+	llmStub := &stubAgentLLM{responses: []*llm.Response{{Content: "llm fallback"}}}
+	registry := tools.NewRegistry()
+	var called bool
+	var captured map[string]any
+	registry.RegisterTool("intent_route", "Route a natural-language request", map[string]any{}, func(ctx context.Context, input map[string]any) (string, error) {
+		called = true
+		captured = input
+		return `{"status":"ok","command":"shotcut render"}`, nil
+	})
+
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		LLM:         llmStub,
+		Memory:      mem,
+		Skills:      skills.NewSkillsManager(""),
+		Tools:       registry,
+		CLIHubRoot:  hubRoot,
+	})
+
+	query := "export the current shotcut project"
+	result, err := ag.Run(context.Background(), query)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result != `{"status":"ok","command":"shotcut render"}` {
+		t.Fatalf("unexpected result: %q", result)
+	}
+	if !called {
+		t.Fatal("expected intent_route to be called")
+	}
+	if captured["intent"] != query || captured["json"] != true {
+		t.Fatalf("unexpected intent_route input: %#v", captured)
+	}
+	if len(llmStub.messages) != 0 {
+		t.Fatalf("expected llm to be skipped, got %d calls", len(llmStub.messages))
+	}
+	activities := ag.GetLastToolActivities()
+	if len(activities) != 1 || activities[0].ToolName != "intent_route" {
+		t.Fatalf("expected intent_route activity, got %#v", activities)
+	}
+}
+
+func TestAgentRunFallsBackToLLMWhenAutoRouteFails(t *testing.T) {
+	hubRoot := filepath.Join(t.TempDir(), "CLI-Anything-0.2.0")
+	if err := writeCLIHubFixture(hubRoot); err != nil {
+		t.Fatalf("writeCLIHubFixture: %v", err)
+	}
+
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+
+	llmStub := &stubAgentLLM{responses: []*llm.Response{{Content: "fallback after route failure"}}}
+	registry := tools.NewRegistry()
+	registry.RegisterTool("intent_route", "Route a natural-language request", map[string]any{}, func(ctx context.Context, input map[string]any) (string, error) {
+		return "", fmt.Errorf("boom")
+	})
+
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		LLM:         llmStub,
+		Memory:      mem,
+		Skills:      skills.NewSkillsManager(""),
+		Tools:       registry,
+		CLIHubRoot:  hubRoot,
+	})
+
+	result, err := ag.Run(context.Background(), "export the current shotcut project")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result != "fallback after route failure" {
+		t.Fatalf("unexpected result: %q", result)
+	}
+	if len(llmStub.messages) != 1 {
+		t.Fatalf("expected llm fallback after route failure, got %d calls", len(llmStub.messages))
+	}
+	activities := ag.GetLastToolActivities()
+	if len(activities) == 0 || activities[0].ToolName != "intent_route" || activities[0].Error == "" {
+		t.Fatalf("expected failed intent_route activity, got %#v", activities)
+	}
+}
+
+func TestAgentRunExecutesProtocolPlanAndReturnsFollowupResponse(t *testing.T) {
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+	registry := tools.NewRegistry()
+	var called []string
+	registry.RegisterTool("desktop_activate_target", "Activate a target", map[string]any{}, func(ctx context.Context, input map[string]any) (string, error) {
+		called = append(called, fmt.Sprintf("%v:%v", input["title"], input["text"]))
+		return "clicked", nil
+	})
+
+	llmStub := &stubAgentLLM{responses: []*llm.Response{
+		{Content: "```json\n{\"protocol\":\"anyclaw.app.desktop.v1\",\"summary\":\"plan complete\",\"steps\":[{\"label\":\"Click send\",\"target\":{\"title\":\"QQ\",\"text\":\"发送\"}}]}\n```"},
+		{Content: "已经完成了，本地应用里的发送步骤执行成功。"},
+	}}
+
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		Personality: "Operate like an execution-focused local app agent.",
+		LLM:         llmStub,
+		Memory:      mem,
+		Skills:      skills.NewSkillsManager(""),
+		Tools:       registry,
+	})
+
+	var approvals []tools.ToolApprovalCall
+	ctx := tools.WithToolApprovalHook(context.Background(), func(ctx context.Context, call tools.ToolApprovalCall) error {
+		approvals = append(approvals, call)
+		return nil
+	})
+
+	result, err := ag.Run(ctx, "帮我在QQ里发送消息")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result != "已经完成了，本地应用里的发送步骤执行成功。" {
+		t.Fatalf("unexpected final result: %q", result)
+	}
+	if strings.Join(called, ",") != "QQ:发送" {
+		t.Fatalf("expected protocol step to activate QQ send target, got %v", called)
+	}
+	if len(approvals) != 1 || approvals[0].Name != "desktop_plan" {
+		t.Fatalf("expected one desktop_plan approval, got %#v", approvals)
+	}
+	if len(llmStub.messages) < 2 {
+		t.Fatalf("expected follow-up LLM turn after plan execution, got %d message batches", len(llmStub.messages))
+	}
+	foundExecutionResult := false
+	for _, msg := range llmStub.messages[1] {
+		if msg.Role == "user" && strings.Contains(msg.Content, "Desktop plan execution result:") && strings.Contains(msg.Content, "Click send: clicked") && strings.Contains(msg.Content, "Treat this as observable evidence") {
+			foundExecutionResult = true
+			break
+		}
+	}
+	if !foundExecutionResult {
+		t.Fatalf("expected second LLM turn to receive desktop plan result, got %#v", llmStub.messages[1])
+	}
+}
+
+func TestAgentRunAddsObservationAndVerificationPromptAfterToolResults(t *testing.T) {
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+	registry := tools.NewRegistry()
+	registry.RegisterTool("run_command", "Run a shell command", map[string]any{}, func(ctx context.Context, input map[string]any) (string, error) {
+		return "build succeeded", nil
+	})
+
+	llmStub := &stubAgentLLM{responses: []*llm.Response{
+		{
+			ToolCalls: []llm.ToolCall{
+				{
+					ID:   "tool-1",
+					Type: "function",
+					Function: llm.FunctionCall{
+						Name:      "run_command",
+						Arguments: `{"command":"go test ./..."}`,
+					},
+				},
+			},
+		},
+		{Content: "测试已完成并验证通过。"},
+	}}
+
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		Personality: "Operate like an execution-focused local app agent.",
+		LLM:         llmStub,
+		Memory:      mem,
+		Skills:      skills.NewSkillsManager(""),
+		Tools:       registry,
+	})
+
+	result, err := ag.Run(context.Background(), "帮我跑测试并确认是否通过")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result != "测试已完成并验证通过。" {
+		t.Fatalf("unexpected result: %q", result)
+	}
+	if len(llmStub.messages) < 2 {
+		t.Fatalf("expected second llm turn after tool call, got %d", len(llmStub.messages))
+	}
+	foundFollowup := false
+	for _, msg := range llmStub.messages[1] {
+		if msg.Role == "user" && strings.Contains(msg.Content, "Tool results above are evidence about the current world state") && strings.Contains(msg.Content, "Before claiming completion, verify the outcome") {
+			foundFollowup = true
+			break
+		}
+	}
+	if !foundFollowup {
+		t.Fatalf("expected observation/verification follow-up prompt, got %#v", llmStub.messages[1])
+	}
+}
+
+func writeAgentBridgeFixture(root string) error {
+	if err := os.MkdirAll(filepath.Join(root, "src", "reference_data", "subsystems"), 0o755); err != nil {
+		return err
+	}
+	commands := []map[string]string{
+		{"name": "agents", "source_hint": "commands/agents/index.ts"},
+		{"name": "agents", "source_hint": "commands/agents/agents.tsx"},
+		{"name": "tasks", "source_hint": "commands/tasks/index.ts"},
+	}
+	toolItems := []map[string]string{
+		{"name": "AgentTool", "source_hint": "tools/AgentTool/AgentTool.tsx"},
+		{"name": "agentMemory", "source_hint": "tools/AgentTool/agentMemory.ts"},
+		{"name": "ReadFileTool", "source_hint": "tools/ReadFileTool/ReadFileTool.tsx"},
+	}
+	subsystem := map[string]any{
+		"archive_name": "assistant",
+		"module_count": 12,
+		"sample_files": []string{"assistant/sessionHistory.ts"},
+	}
+	if err := writeAgentJSON(filepath.Join(root, "src", "reference_data", "commands_snapshot.json"), commands); err != nil {
+		return err
+	}
+	if err := writeAgentJSON(filepath.Join(root, "src", "reference_data", "tools_snapshot.json"), toolItems); err != nil {
+		return err
+	}
+	return writeAgentJSON(filepath.Join(root, "src", "reference_data", "subsystems", "assistant.json"), subsystem)
+}
+
+func writeAgentJSON(path string, value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func writeCLIHubFixture(root string) error {
+	shotcutRoot := filepath.Join(root, "shotcut", "agent-harness", "cli_anything", "shotcut")
+	if err := os.MkdirAll(filepath.Join(shotcutRoot, "skills"), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(shotcutRoot, "__main__.py"), []byte("print('ok')"), 0o644); err != nil {
+		return err
+	}
+	skill := `---
+name: Shotcut CLI
+description: Video editing harness
+---
+
+## Project Group
+| Command | Description |
+| --- | --- |
+| new | Create a new project |
+| info | Show current project info |
+
+## Export Group
+| Command | Description |
+| --- | --- |
+| render | Export the current project |
+`
+	if err := os.WriteFile(filepath.Join(shotcutRoot, "skills", "SKILL.md"), []byte(skill), 0o644); err != nil {
+		return err
+	}
+	payload := map[string]any{
+		"meta": map[string]any{
+			"repo":        "https://example.com/CLI-Anything",
+			"description": "CLI-Hub",
+			"updated":     "2026-03-29",
+		},
+		"clis": []map[string]any{
+			{"name": "libreoffice", "display_name": "LibreOffice", "description": "Office suite", "category": "office", "entry_point": "cli-anything-libreoffice"},
+			{"name": "zotero", "display_name": "Zotero", "description": "References", "category": "office", "entry_point": "cli-anything-zotero"},
+			{"name": "shotcut", "display_name": "Shotcut", "description": "Video editing", "category": "video", "entry_point": "cli-anything-shotcut", "skill_md": "shotcut/agent-harness/cli_anything/shotcut/skills/SKILL.md"},
+		},
+	}
+	return writeAgentJSON(filepath.Join(root, "registry.json"), payload)
+}
+
+func TestAgentRunCompletesBootstrapRitualBeforeCallingLLM(t *testing.T) {
+	workDir := t.TempDir()
+	mem := memory.NewFileMemory(workDir)
+	mem.SetDailyDir(filepath.Join(workDir, "workspace", "memory"))
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+	workingDir := filepath.Join(workDir, "workspace")
+	if err := workspace.EnsureBootstrap(workingDir, workspace.BootstrapOptions{
+		AgentName:        "assistant",
+		AgentDescription: "Local execution helper",
+	}); err != nil {
+		t.Fatalf("EnsureBootstrap: %v", err)
+	}
+
+	llmStub := &stubAgentLLM{responses: []*llm.Response{{Content: "normal task response"}}}
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		LLM:         llmStub,
+		Memory:      mem,
+		Skills:      skills.NewSkillsManager(""),
+		Tools:       tools.NewRegistry(),
+		WorkingDir:  workingDir,
+	})
+
+	answer, err := ag.Run(context.Background(), "help me with this repo")
+	if err != nil {
+		t.Fatalf("Run(q1): %v", err)
+	}
+	if !strings.Contains(answer, "Question 1/4") {
+		t.Fatalf("expected bootstrap question, got %q", answer)
+	}
+	if len(llmStub.messages) != 0 {
+		t.Fatalf("expected llm not to be called during bootstrap, got %d calls", len(llmStub.messages))
+	}
+
+	sequence := []string{
+		"Call me Alex and default to Chinese.",
+		"Mainly help with Go coding and local automation.",
+		"Be concise, proactive, and optimize for correctness first.",
+		"Do not use destructive commands without explicit confirmation.",
+	}
+	for i, input := range sequence {
+		answer, err = ag.Run(context.Background(), input)
+		if err != nil {
+			t.Fatalf("Run(answer %d): %v", i+1, err)
+		}
+	}
+
+	if !strings.Contains(answer, "Workspace bootstrap complete") {
+		t.Fatalf("expected bootstrap completion message, got %q", answer)
+	}
+	if _, err := os.Stat(filepath.Join(workingDir, "BOOTSTRAP.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected BOOTSTRAP.md to be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workingDir, ".anyclaw-bootstrap-state.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected bootstrap state file to be removed, stat err=%v", err)
+	}
+
+	identityData, err := os.ReadFile(filepath.Join(workingDir, "IDENTITY.md"))
+	if err != nil {
+		t.Fatalf("ReadFile(IDENTITY.md): %v", err)
+	}
+	if !strings.Contains(string(identityData), "Mainly help with Go coding and local automation.") {
+		t.Fatalf("expected IDENTITY.md to include bootstrap answer, got %q", string(identityData))
+	}
+
+	normalResponse, err := ag.Run(context.Background(), "now answer normally")
+	if err != nil {
+		t.Fatalf("Run(normal): %v", err)
+	}
+	if normalResponse != "normal task response" {
+		t.Fatalf("expected normal llm response after bootstrap, got %q", normalResponse)
+	}
+	if len(llmStub.messages) != 1 {
+		t.Fatalf("expected one llm call after bootstrap, got %d", len(llmStub.messages))
+	}
+}
+
+func TestAgentRunCompactsHistoryAndEnforcesWindowLimit(t *testing.T) {
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+
+	llmStub := &compactionAwareLLM{}
+	ag := New(Config{
+		Name:             "assistant",
+		Description:      "General helper",
+		LLM:              llmStub,
+		Memory:           mem,
+		Skills:           skills.NewSkillsManager(""),
+		Tools:            tools.NewRegistry(),
+		MaxContextTokens: 700,
+	})
+
+	history := make([]prompt.Message, 0, 16)
+	for i := 0; i < 8; i++ {
+		history = append(history,
+			prompt.Message{Role: "user", Content: fmt.Sprintf("old-user-%d %s", i, strings.Repeat("x", 120))},
+			prompt.Message{Role: "assistant", Content: fmt.Sprintf("old-assistant-%d %s", i, strings.Repeat("y", 120))},
+		)
+	}
+	ag.SetHistory(history)
+
+	result, err := ag.Run(context.Background(), "latest request")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result != "final response" {
+		t.Fatalf("unexpected response: %q", result)
+	}
+
+	if len(llmStub.messages) < 2 {
+		t.Fatalf("expected summarizer call and main call, got %d batches", len(llmStub.messages))
+	}
+
+	mainBatch := llmStub.messages[len(llmStub.messages)-1]
+	foundSummary := false
+	foundOldest := false
+	for _, msg := range mainBatch {
+		if msg.Role == "system" && strings.Contains(msg.Content, "[Summary of previous conversation]") {
+			foundSummary = true
+		}
+		if strings.Contains(msg.Content, "old-user-0") {
+			foundOldest = true
+		}
+	}
+	if !foundSummary {
+		t.Fatalf("expected compacted history summary in main batch, got %#v", mainBatch)
+	}
+	if foundOldest {
+		t.Fatalf("expected oldest history to be compacted away, got %#v", mainBatch)
+	}
+}
+
+func TestBuildSystemPromptHotReloadsBootstrapFiles(t *testing.T) {
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+
+	workingDir := t.TempDir()
+	if err := workspace.EnsureBootstrap(workingDir, workspace.BootstrapOptions{
+		AgentName:        "assistant",
+		AgentDescription: "Local execution helper",
+	}); err != nil {
+		t.Fatalf("EnsureBootstrap: %v", err)
+	}
+
+	ag := New(Config{
+		Name:                   "assistant",
+		Description:            "General helper",
+		Memory:                 mem,
+		Skills:                 skills.NewSkillsManager(""),
+		Tools:                  tools.NewRegistry(),
+		WorkingDir:             workingDir,
+		BootstrapWatchInterval: 20 * time.Millisecond,
+	})
+
+	initialPrompt, err := ag.buildSystemPrompt()
+	if err != nil {
+		t.Fatalf("buildSystemPrompt(initial): %v", err)
+	}
+	if !strings.Contains(initialPrompt, "Complete the user's task safely") {
+		t.Fatalf("expected initial bootstrap content, got %q", initialPrompt)
+	}
+
+	newAgents := "# AGENTS\n\n## Primary Agent\n- Goal: Prefer verifiable Go refactors.\n"
+	if err := os.WriteFile(filepath.Join(workingDir, "AGENTS.md"), []byte(newAgents), 0o644); err != nil {
+		t.Fatalf("WriteFile(AGENTS.md): %v", err)
+	}
+
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		reloadedPrompt, err := ag.buildSystemPrompt()
+		if err != nil {
+			t.Fatalf("buildSystemPrompt(reloaded): %v", err)
+		}
+		if strings.Contains(reloadedPrompt, "Prefer verifiable Go refactors.") {
+			return
+		}
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	t.Fatal("expected bootstrap watcher to refresh AGENTS.md content")
+}
+
+func TestAgentRunUsesExclusiveSlotToSerializeConcurrentExecutions(t *testing.T) {
+	mem := memory.NewFileMemory(t.TempDir())
+	if err := mem.Init(); err != nil {
+		t.Fatalf("memory init: %v", err)
+	}
+
+	llmStub := newBlockingAgentLLM()
+	ag := New(Config{
+		Name:        "assistant",
+		Description: "General helper",
+		LLM:         llmStub,
+		Memory:      mem,
+		Skills:      skills.NewSkillsManager(""),
+		Tools:       tools.NewRegistry(),
+	})
+
+	results := make(chan string, 2)
+	errs := make(chan error, 2)
+
+	go func() {
+		result, err := ag.Run(context.Background(), "first request")
+		results <- result
+		errs <- err
+	}()
+
+	select {
+	case idx := <-llmStub.entered:
+		if idx != 0 {
+			t.Fatalf("expected first llm call index 0, got %d", idx)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first run to enter llm")
+	}
+
+	go func() {
+		result, err := ag.Run(context.Background(), "second request")
+		results <- result
+		errs <- err
+	}()
+
+	select {
+	case idx := <-llmStub.entered:
+		t.Fatalf("second run entered llm before first released (idx=%d)", idx)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	llmStub.Release(0)
+
+	select {
+	case idx := <-llmStub.entered:
+		if idx != 1 {
+			t.Fatalf("expected second llm call index 1 after release, got %d", idx)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for second run to enter llm")
+	}
+
+	llmStub.Release(1)
+
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("Run error: %v", err)
+		}
+		<-results
+	}
+}

--- a/pkg/capability/agents/approval.go
+++ b/pkg/capability/agents/approval.go
@@ -1,0 +1,22 @@
+package agent
+
+import "context"
+
+type ToolApprovalHook func(ctx context.Context, tc ToolCall) error
+
+type toolApprovalHookKey struct{}
+
+func WithToolApprovalHook(ctx context.Context, hook ToolApprovalHook) context.Context {
+	if hook == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, toolApprovalHookKey{}, hook)
+}
+
+func toolApprovalHookFromContext(ctx context.Context) ToolApprovalHook {
+	if ctx == nil {
+		return nil
+	}
+	hook, _ := ctx.Value(toolApprovalHookKey{}).(ToolApprovalHook)
+	return hook
+}

--- a/pkg/capability/agents/approval_resume.go
+++ b/pkg/capability/agents/approval_resume.go
@@ -1,0 +1,135 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+)
+
+type ApprovalResumeState struct {
+	Messages         []llm.Message `json:"messages,omitempty"`
+	AssistantMessage llm.Message   `json:"assistant_message"`
+	ToolMessages     []llm.Message `json:"tool_messages,omitempty"`
+	Results          []string      `json:"results,omitempty"`
+	PendingTool      ToolCall      `json:"pending_tool"`
+}
+
+type ApprovalPauseError struct {
+	State ApprovalResumeState
+	Cause error
+}
+
+func (e *ApprovalPauseError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Cause != nil {
+		return e.Cause.Error()
+	}
+	return "approval required"
+}
+
+func (e *ApprovalPauseError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+func (a *Agent) ResumeAfterApproval(ctx context.Context, resume ApprovalResumeState) (string, error) {
+	if a == nil {
+		return "", errors.New("agent is not initialized")
+	}
+	if strings.TrimSpace(resume.PendingTool.Name) == "" {
+		return "", errors.New("approval resume missing pending tool")
+	}
+
+	a.resetToolActivities()
+
+	messages := cloneLLMMessages(resume.Messages)
+	assistantMessage := cloneLLMMessage(resume.AssistantMessage)
+	if strings.TrimSpace(assistantMessage.Role) == "" {
+		assistantMessage.Role = "assistant"
+	}
+	messages = append(messages, assistantMessage)
+	if len(resume.ToolMessages) > 0 {
+		messages = append(messages, cloneLLMMessages(resume.ToolMessages)...)
+	}
+
+	results := append([]string(nil), resume.Results...)
+	pendingTool := cloneToolCall(resume.PendingTool)
+
+	if result, err := a.executeTool(ctx, pendingTool); err != nil {
+		results = append(results, fmt.Sprintf("[%s] Error: %v", pendingTool.Name, err))
+		a.recordToolActivity(ToolActivity{ToolName: pendingTool.Name, Args: pendingTool.Args, Error: err.Error()})
+		messages = append(messages, llm.Message{
+			Role:       "tool",
+			ToolCallID: pendingTool.ID,
+			Name:       pendingTool.Name,
+			Content:    fmt.Sprintf("error: %v", err),
+		})
+	} else {
+		results = append(results, fmt.Sprintf("[%s] %s", pendingTool.Name, result))
+		a.recordToolActivity(ToolActivity{ToolName: pendingTool.Name, Args: pendingTool.Args, Result: result})
+		messages = append(messages, llm.Message{
+			Role:       "tool",
+			ToolCallID: pendingTool.ID,
+			Name:       pendingTool.Name,
+			Content:    result,
+		})
+	}
+
+	messages = append(messages, llm.Message{Role: "user", Content: a.toolContinuationPrompt(results)})
+	toolDefs := buildToolDefinitionsFromInfos(a.selectToolInfos(a.latestUserInput()))
+
+	response, err := a.chatWithTools(ctx, messages, toolDefs)
+	if err != nil {
+		return "", err
+	}
+
+	a.appendHistoryMessage(ctx, "assistant", response)
+	userInput := a.latestUserInput()
+	a.recordConversation(userInput, response)
+
+	if a.preferenceLearner != nil {
+		if prefResponse, learned := a.preferenceLearner.Learn(userInput, response); learned {
+			response = prefResponse + "\n\n" + response
+		}
+	}
+
+	return response, nil
+}
+
+func cloneLLMMessages(messages []llm.Message) []llm.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	cloned := make([]llm.Message, 0, len(messages))
+	for _, message := range messages {
+		cloned = append(cloned, cloneLLMMessage(message))
+	}
+	return cloned
+}
+
+func cloneLLMMessage(message llm.Message) llm.Message {
+	cloned := message
+	if len(message.ToolCalls) > 0 {
+		cloned.ToolCalls = make([]llm.ToolCall, len(message.ToolCalls))
+		copy(cloned.ToolCalls, message.ToolCalls)
+	}
+	return cloned
+}
+
+func cloneToolCall(tc ToolCall) ToolCall {
+	cloned := tc
+	if tc.Args != nil {
+		cloned.Args = make(map[string]any, len(tc.Args))
+		for key, value := range tc.Args {
+			cloned.Args[key] = value
+		}
+	}
+	return cloned
+}

--- a/pkg/capability/agents/compaction.go
+++ b/pkg/capability/agents/compaction.go
@@ -1,0 +1,249 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/1024XEngineer/anyclaw/pkg/capability/agents/prompt"
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+)
+
+// CompactionConfig controls context window management
+type CompactionConfig struct {
+	Enabled          bool    `json:"enabled"`
+	MaxTokens        int     `json:"max_tokens"`
+	SummaryThreshold int     `json:"summary_threshold"`
+	SafetyMargin     float64 `json:"safety_margin"`
+	KeepLastN        int     `json:"keep_last_n"`
+	SummaryModel     string  `json:"summary_model,omitempty"`
+}
+
+// DefaultCompactionConfig returns sensible defaults
+func DefaultCompactionConfig() CompactionConfig {
+	return CompactionConfig{
+		Enabled:          true,
+		MaxTokens:        8000,
+		SummaryThreshold: 6000,
+		SafetyMargin:     0.8,
+		KeepLastN:        4,
+	}
+}
+
+// Compactor handles context window compaction
+type Compactor struct {
+	config     CompactionConfig
+	llm        LLMCaller
+	mu         sync.RWMutex
+	summaries  []string
+	totalSaved int
+}
+
+// NewCompactor creates a new compactor
+func NewCompactor(config CompactionConfig, llm LLMCaller) *Compactor {
+	return &Compactor{
+		config: config,
+		llm:    llm,
+	}
+}
+
+// CompactHistory compacts history if it exceeds thresholds
+func (c *Compactor) CompactHistory(ctx context.Context, history []prompt.Message) ([]prompt.Message, error) {
+	if !c.config.Enabled || len(history) == 0 {
+		return history, nil
+	}
+
+	// Estimate token count
+	tokenCount := estimateTokens(history)
+
+	// Check if compaction is needed
+	threshold := int(float64(c.config.SummaryThreshold) * c.config.SafetyMargin)
+	if tokenCount < threshold {
+		return history, nil
+	}
+
+	// Keep last N messages untouched
+	keepN := c.config.KeepLastN
+	if keepN <= 0 {
+		keepN = 4
+	}
+	if len(history) <= keepN {
+		return history, nil
+	}
+
+	// Split: older messages to summarize, recent to keep
+	toSummarize := history[:len(history)-keepN]
+	toKeep := history[len(history)-keepN:]
+
+	// Generate summary
+	summary, err := c.summarizeMessages(ctx, toSummarize)
+	if err != nil {
+		// Fallback: just truncate
+		return toKeep, nil
+	}
+
+	// Build compacted history
+	compacted := []prompt.Message{
+		{Role: "system", Content: fmt.Sprintf("[Conversation Summary]\n%s", summary)},
+	}
+	compacted = append(compacted, toKeep...)
+
+	c.mu.Lock()
+	c.summaries = append(c.summaries, summary)
+	c.totalSaved += len(toSummarize)
+	c.mu.Unlock()
+
+	return compacted, nil
+}
+
+// summarizeMessages generates a summary of messages
+func (c *Compactor) summarizeMessages(ctx context.Context, messages []prompt.Message) (string, error) {
+	if c.llm == nil {
+		return c.fallbackSummary(messages), nil
+	}
+
+	// Build summarization prompt
+	var conversation strings.Builder
+	for _, msg := range messages {
+		role := msg.Role
+		if role == "" {
+			role = "user"
+		}
+		conversation.WriteString(fmt.Sprintf("%s: %s\n", role, msg.Content))
+	}
+
+	summarizePrompt := []llm.Message{
+		{Role: "system", Content: "You are a conversation summarizer. Summarize the following conversation concisely, preserving key facts, decisions, and context. Be brief but comprehensive."},
+		{Role: "user", Content: fmt.Sprintf("Summarize this conversation:\n\n%s", conversation.String())},
+	}
+
+	response, err := c.llm.Chat(ctx, summarizePrompt, nil)
+	if err != nil {
+		return c.fallbackSummary(messages), nil
+	}
+
+	return response.Content, nil
+}
+
+// fallbackSummary generates a simple summary without LLM
+func (c *Compactor) fallbackSummary(messages []prompt.Message) string {
+	var parts []string
+	for _, msg := range messages {
+		content := msg.Content
+		if len(content) > 200 {
+			content = content[:200] + "..."
+		}
+		parts = append(parts, fmt.Sprintf("[%s] %s", msg.Role, content))
+	}
+	return fmt.Sprintf("Previous conversation (%d messages): %s", len(messages), strings.Join(parts, "\n"))
+}
+
+// estimateTokens estimates token count from messages
+func estimateTokens(messages []prompt.Message) int {
+	total := 0
+	for _, msg := range messages {
+		// Rough estimate: 1 token per 4 characters
+		total += len(msg.Content) / 4
+		total += len(msg.Role) / 4
+		total += 4 // overhead per message
+	}
+	return total
+}
+
+// GetStats returns compaction statistics
+func (c *Compactor) GetStats() map[string]any {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return map[string]any{
+		"summaries_count": len(c.summaries),
+		"total_saved":     c.totalSaved,
+	}
+}
+
+// SessionWriteLock provides concurrency control for session writes
+type SessionWriteLock struct {
+	mu       sync.Mutex
+	sessions map[string]*sync.Mutex
+}
+
+// NewSessionWriteLock creates a new session write lock manager
+func NewSessionWriteLock() *SessionWriteLock {
+	return &SessionWriteLock{
+		sessions: make(map[string]*sync.Mutex),
+	}
+}
+
+// Lock acquires a write lock for a session
+func (swl *SessionWriteLock) Lock(sessionID string) {
+	swl.mu.Lock()
+	lock, ok := swl.sessions[sessionID]
+	if !ok {
+		lock = &sync.Mutex{}
+		swl.sessions[sessionID] = lock
+	}
+	swl.mu.Unlock()
+	lock.Lock()
+}
+
+// Unlock releases a write lock for a session
+func (swl *SessionWriteLock) Unlock(sessionID string) {
+	swl.mu.Lock()
+	lock, ok := swl.sessions[sessionID]
+	swl.mu.Unlock()
+	if ok {
+		lock.Unlock()
+	}
+}
+
+// ToolLoopDetector detects and prevents infinite tool call loops
+type ToolLoopDetector struct {
+	mu         sync.RWMutex
+	maxRepeats int
+	history    map[string][]string // sessionID -> recent tool calls
+}
+
+// NewToolLoopDetector creates a new loop detector
+func NewToolLoopDetector(maxRepeats int) *ToolLoopDetector {
+	if maxRepeats <= 0 {
+		maxRepeats = 3
+	}
+	return &ToolLoopDetector{
+		maxRepeats: maxRepeats,
+		history:    make(map[string][]string),
+	}
+}
+
+// Check detects if a tool call would create a loop
+func (tld *ToolLoopDetector) Check(sessionID string, toolName string, argsHash string) bool {
+	tld.mu.Lock()
+	defer tld.mu.Unlock()
+
+	key := toolName + ":" + argsHash
+	recent := tld.history[sessionID]
+
+	// Count occurrences
+	count := 0
+	for _, call := range recent {
+		if call == key {
+			count++
+		}
+	}
+
+	// Add to history
+	tld.history[sessionID] = append(recent, key)
+
+	// Keep only last 20 entries
+	if len(tld.history[sessionID]) > 20 {
+		tld.history[sessionID] = tld.history[sessionID][len(tld.history[sessionID])-20:]
+	}
+
+	return count >= tld.maxRepeats
+}
+
+// Reset clears detection history for a session
+func (tld *ToolLoopDetector) Reset(sessionID string) {
+	tld.mu.Lock()
+	defer tld.mu.Unlock()
+	delete(tld.history, sessionID)
+}

--- a/pkg/capability/agents/context_runtime.go
+++ b/pkg/capability/agents/context_runtime.go
@@ -1,0 +1,383 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/capability/agents/prompt"
+	bootstrapwatch "github.com/1024XEngineer/anyclaw/pkg/runtime/context/bootstrapwatch"
+	ctxpkg "github.com/1024XEngineer/anyclaw/pkg/runtime/context/store"
+	ctxengine "github.com/1024XEngineer/anyclaw/pkg/runtime/context/window"
+	"github.com/1024XEngineer/anyclaw/pkg/workspace"
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+)
+
+const (
+	defaultContextMaxTokens     = 4096
+	defaultRecentHistoryToKeep  = 4
+	defaultBootstrapCharsFactor = 8
+)
+
+type contextRuntime struct {
+	slot              *ctxengine.ExclusiveSlot
+	estimator         ctxengine.TokenEstimator
+	maxTokens         int
+	safetyMargin      int
+	bootstrapMaxRunes int
+
+	contextEngine ctxpkg.ContextEngine
+
+	bootstrapMu    sync.RWMutex
+	bootstrapCache []workspace.BootstrapFile
+	bootstrapDirty bool
+	bootstrapWatch *bootstrapwatch.Watcher
+	executionSeq   atomic.Uint64
+}
+
+type contextExecution struct {
+	id string
+}
+
+func newContextRuntime(cfg Config) *contextRuntime {
+	maxTokens := cfg.MaxContextTokens
+	if maxTokens <= 0 {
+		maxTokens = defaultContextMaxTokens
+	}
+
+	safetyMargin := cfg.ContextSafetyMargin
+	if safetyMargin < 0 {
+		safetyMargin = 0
+	}
+	if safetyMargin == 0 {
+		safetyMargin = ctxengine.DefaultGuardConfig(maxTokens).SafetyMargin
+	}
+
+	slotCfg := ctxengine.DefaultSlotConfig()
+	slotCfg.MaxIdle = 30 * time.Minute
+	slotCfg.MaxDuration = 2 * time.Hour
+
+	runtime := &contextRuntime{
+		slot:              ctxengine.NewExclusiveSlot(slotCfg),
+		estimator:         ctxengine.SimpleTokenEstimator(4),
+		maxTokens:         maxTokens,
+		safetyMargin:      safetyMargin,
+		bootstrapMaxRunes: maxTokens * defaultBootstrapCharsFactor,
+		contextEngine:     normalizeContextEngine(cfg.ContextEngine),
+		bootstrapDirty:    true,
+	}
+
+	if runtime.bootstrapMaxRunes <= 0 || runtime.bootstrapMaxRunes > workspace.DefaultBootstrapMaxChars {
+		runtime.bootstrapMaxRunes = workspace.DefaultBootstrapMaxChars
+	}
+
+	runtime.startBootstrapWatcher(cfg.WorkingDir, cfg.BootstrapWatchInterval)
+	return runtime
+}
+
+func (r *contextRuntime) startBootstrapWatcher(workingDir string, interval time.Duration) {
+	workingDir = strings.TrimSpace(workingDir)
+	if workingDir == "" {
+		return
+	}
+
+	cfg := bootstrapwatch.DefaultWatcherConfig(workingDir)
+	if interval > 0 {
+		cfg.PollInterval = interval
+	}
+	cfg.Files = bootstrapWatcherFiles()
+	cfg.OnChange = func(event bootstrapwatch.ChangeEvent) {
+		r.bootstrapMu.Lock()
+		r.bootstrapDirty = true
+		r.bootstrapMu.Unlock()
+	}
+
+	watcher := bootstrapwatch.NewWatcher(cfg)
+	if err := watcher.Start(); err != nil {
+		return
+	}
+
+	r.bootstrapMu.Lock()
+	r.bootstrapWatch = watcher
+	r.bootstrapMu.Unlock()
+}
+
+func bootstrapWatcherFiles() []bootstrapwatch.FileType {
+	return []bootstrapwatch.FileType{
+		bootstrapwatch.FileAgents,
+		bootstrapwatch.FileSoul,
+		bootstrapwatch.FileTools,
+		bootstrapwatch.FileIdentity,
+		bootstrapwatch.FileUser,
+		bootstrapwatch.FileHeartbeat,
+		bootstrapwatch.FileBootstrap,
+		bootstrapwatch.FileMemory,
+	}
+}
+
+func (r *contextRuntime) acquire(ctx context.Context, owner string) (*contextExecution, error) {
+	if r == nil || r.slot == nil {
+		return &contextExecution{}, nil
+	}
+
+	id := fmt.Sprintf("%s-%d-%d", sanitizeBrowserSessionID(owner), time.Now().UnixNano(), r.executionSeq.Add(1))
+	result, err := r.slot.Acquire(ctx, id, ctxengine.ContextConfig{
+		MaxAge:          2 * time.Hour,
+		AutoExpire:      true,
+		CleanupInterval: time.Minute,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result == nil || !result.Granted {
+		if result != nil && result.Error != nil {
+			return nil, result.Error
+		}
+		return nil, fmt.Errorf("context slot was not granted")
+	}
+	return &contextExecution{id: id}, nil
+}
+
+func (r *contextRuntime) heartbeat(exec *contextExecution) {
+	if r == nil || r.slot == nil || exec == nil || strings.TrimSpace(exec.id) == "" {
+		return
+	}
+	_ = r.slot.Heartbeat(exec.id)
+}
+
+func (r *contextRuntime) release(exec *contextExecution) {
+	if r == nil || r.slot == nil || exec == nil || strings.TrimSpace(exec.id) == "" {
+		return
+	}
+	r.slot.Release(exec.id)
+}
+
+func (r *contextRuntime) setContextEngine(engine ctxpkg.ContextEngine) {
+	if r == nil {
+		return
+	}
+	r.contextEngine = normalizeContextEngine(engine)
+}
+
+func (r *contextRuntime) storeConversation(ctx context.Context, agentName string, workingDir string, role string, content string) {
+	if r == nil || normalizeContextEngine(r.contextEngine) == nil {
+		return
+	}
+
+	content = strings.TrimSpace(content)
+	role = strings.TrimSpace(role)
+	if content == "" || role == "" {
+		return
+	}
+
+	doc := ctxpkg.Document{
+		ID:      fmt.Sprintf("%s_%d", role, time.Now().UnixNano()),
+		Content: content,
+		Metadata: map[string]any{
+			"role":        role,
+			"agent_name":  agentName,
+			"working_dir": workingDir,
+			"source":      "agent.run",
+		},
+	}
+	_ = r.contextEngine.AddDocument(ctx, doc)
+}
+
+func normalizeContextEngine(engine ctxpkg.ContextEngine) ctxpkg.ContextEngine {
+	if engine == nil {
+		return nil
+	}
+	value := reflect.ValueOf(engine)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		if value.IsNil() {
+			return nil
+		}
+	}
+	return engine
+}
+
+func (r *contextRuntime) loadBootstrapFiles(workingDir string) ([]workspace.BootstrapFile, error) {
+	if r == nil {
+		return nil, nil
+	}
+
+	workingDir = strings.TrimSpace(workingDir)
+	if workingDir == "" {
+		return nil, nil
+	}
+
+	r.bootstrapMu.RLock()
+	if !r.bootstrapDirty && len(r.bootstrapCache) > 0 {
+		files := copyBootstrapFiles(r.bootstrapCache)
+		r.bootstrapMu.RUnlock()
+		return files, nil
+	}
+	r.bootstrapMu.RUnlock()
+
+	files, err := workspace.LoadBootstrapFiles(workingDir, workspace.BootstrapOptions{
+		BootstrapMaxChars: r.bootstrapMaxRunes,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	r.bootstrapMu.Lock()
+	r.bootstrapCache = copyBootstrapFiles(files)
+	r.bootstrapDirty = false
+	r.bootstrapMu.Unlock()
+	return files, nil
+}
+
+func copyBootstrapFiles(files []workspace.BootstrapFile) []workspace.BootstrapFile {
+	if len(files) == 0 {
+		return nil
+	}
+	cloned := make([]workspace.BootstrapFile, len(files))
+	copy(cloned, files)
+	return cloned
+}
+
+func (r *contextRuntime) compactHistory(ctx context.Context, history []prompt.Message, llmCaller LLMCaller) ([]prompt.Message, error) {
+	if r == nil || len(history) == 0 {
+		return history, nil
+	}
+
+	guard := ctxengine.NewWindowGuard(ctxengine.GuardConfig{
+		MaxTokens:    r.maxTokens,
+		SafetyMargin: r.safetyMargin,
+		HardLimit:    false,
+	})
+	compactor := ctxengine.NewCompactor(guard, ctxengine.DefaultCompactionConfig())
+
+	now := time.Now()
+	for i, msg := range history {
+		compactor.Add(&ctxengine.Message{
+			ID:         fmt.Sprintf("history_%d", i),
+			Role:       msg.Role,
+			Content:    msg.Content,
+			Tokens:     r.messageTokens(msg),
+			Pinned:     msg.Role == "system" || i >= len(history)-defaultRecentHistoryToKeep,
+			CreatedAt:  now.Add(time.Duration(i) * time.Millisecond),
+			AccessedAt: now.Add(time.Duration(i) * time.Millisecond),
+		})
+	}
+
+	if !compactor.NeedsCompaction() {
+		return history, nil
+	}
+
+	_, err := compactor.Compact(ctx, llmSummarizer{llm: llmCaller})
+	if err != nil {
+		return history, nil
+	}
+
+	return toPromptMessages(compactor.Messages()), nil
+}
+
+func (r *contextRuntime) enforceTokenLimit(systemPrompt string, history []prompt.Message) ([]prompt.Message, error) {
+	if r == nil {
+		return history, nil
+	}
+
+	guard := ctxengine.NewWindowGuard(ctxengine.GuardConfig{
+		MaxTokens:    r.maxTokens,
+		SafetyMargin: r.safetyMargin,
+		HardLimit:    true,
+	})
+
+	systemTokens := r.estimator(systemPrompt)
+	if err := guard.Add(systemTokens); err != nil {
+		return nil, fmt.Errorf("context window exceeded by system prompt: %w", err)
+	}
+
+	selected := make([]prompt.Message, 0, len(history))
+	selectedSystem := make([]prompt.Message, 0, 2)
+	for _, msg := range history {
+		if msg.Role != "system" {
+			continue
+		}
+		tokens := r.messageTokens(msg)
+		if !guard.Check(tokens) {
+			continue
+		}
+		if err := guard.Add(tokens); err != nil {
+			continue
+		}
+		selectedSystem = append(selectedSystem, msg)
+	}
+
+	for i := len(history) - 1; i >= 0; i-- {
+		msg := history[i]
+		if msg.Role == "system" {
+			continue
+		}
+		tokens := r.messageTokens(msg)
+		if !guard.Check(tokens) {
+			continue
+		}
+		if err := guard.Add(tokens); err != nil {
+			continue
+		}
+		selected = append(selected, msg)
+	}
+
+	for left, right := 0, len(selected)-1; left < right; left, right = left+1, right-1 {
+		selected[left], selected[right] = selected[right], selected[left]
+	}
+
+	return append(selectedSystem, selected...), nil
+}
+
+func (r *contextRuntime) messageTokens(msg prompt.Message) int {
+	if r == nil {
+		return 0
+	}
+	return r.estimator(msg.Role) + r.estimator(msg.Content) + 4
+}
+
+func toPromptMessages(messages []*ctxengine.Message) []prompt.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	result := make([]prompt.Message, 0, len(messages))
+	for _, msg := range messages {
+		if msg == nil {
+			continue
+		}
+		result = append(result, prompt.Message{
+			Role:    msg.Role,
+			Content: msg.Content,
+		})
+	}
+	return result
+}
+
+type llmSummarizer struct {
+	llm LLMCaller
+}
+
+func (s llmSummarizer) Summarize(ctx context.Context, text string) (string, error) {
+	if s.llm == nil {
+		return "", fmt.Errorf("llm unavailable")
+	}
+
+	resp, err := s.llm.Chat(ctx, []llm.Message{
+		{
+			Role:    "system",
+			Content: "You are a conversation summarizer. Summarize the following conversation concisely, preserving key facts, decisions, and pending work.",
+		},
+		{
+			Role:    "user",
+			Content: text,
+		},
+	}, nil)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(resp.Content), nil
+}

--- a/pkg/capability/agents/intent_preprocessor.go
+++ b/pkg/capability/agents/intent_preprocessor.go
@@ -1,0 +1,209 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/capability/agents/prompt"
+	"github.com/1024XEngineer/anyclaw/pkg/clihub"
+)
+
+type IntentPreprocessor struct {
+	registry  *clihub.CapabilityRegistry
+	execFunc  func([]string, string) (string, error)
+	shellName string
+}
+
+const (
+	intentCapabilityThreshold  = 0.15
+	intentAutoExecuteThreshold = 0.45
+)
+
+func NewIntentPreprocessor(root string, execFunc func([]string, string) (string, error)) (*IntentPreprocessor, error) {
+	registry, err := clihub.LoadCapabilityRegistry(root)
+	if err != nil {
+		return nil, err
+	}
+	return &IntentPreprocessor{
+		registry:  registry,
+		execFunc:  execFunc,
+		shellName: "powershell",
+	}, nil
+}
+
+type PreprocessResult struct {
+	Handled     bool
+	Result      string
+	Capability  *clihub.Capability
+	Confidence  float64
+	Description string
+}
+
+func (p *IntentPreprocessor) Preprocess(userInput string, args []string) *PreprocessResult {
+	query := strings.TrimSpace(userInput)
+	if query == "" {
+		return nil
+	}
+
+	matches := p.registry.FindByIntent(query)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	var (
+		cap        *clihub.Capability
+		confidence float64
+	)
+	for i := range matches {
+		match := &matches[i]
+		score := intentMatchConfidence(query, match)
+		if score > confidence {
+			confidence = score
+			cap = match
+		}
+	}
+
+	if cap == nil || confidence < intentCapabilityThreshold {
+		return nil
+	}
+
+	description := fmt.Sprintf("Auto-routing %s to %s/%s", query, cap.Harness, cap.Command)
+
+	return &PreprocessResult{
+		Handled:     true,
+		Capability:  cap,
+		Confidence:  confidence,
+		Description: description,
+	}
+}
+
+func (p *IntentPreprocessor) Execute(result *PreprocessResult, additionalArgs []string) (string, error) {
+	if result == nil || result.Capability == nil {
+		return "", fmt.Errorf("no result to execute")
+	}
+	if p.execFunc == nil {
+		return "", fmt.Errorf("intent execution function is not configured")
+	}
+
+	cap := result.Capability
+
+	cmdArgs, cwd, err := clihub.ResolveCapabilityPath("", *cap)
+	if err != nil {
+		return "", err
+	}
+
+	fullArgs := append([]string{}, cmdArgs...)
+	fullArgs = append(fullArgs, cap.Command, "--json")
+	fullArgs = append(fullArgs, additionalArgs...)
+
+	return p.execFunc(fullArgs, cwd)
+}
+
+func (p *IntentPreprocessor) GetCapability(name string) *clihub.Capability {
+	for _, cap := range p.registry.All() {
+		fullName := fmt.Sprintf("%s_%s", cap.Harness, cap.Command)
+		if strings.EqualFold(fullName, name) {
+			return &cap
+		}
+	}
+	return nil
+}
+
+func (p *IntentPreprocessor) ListCapabilities() []clihub.Capability {
+	return p.registry.All()
+}
+
+func (p *IntentPreprocessor) Count() int {
+	return p.registry.Count()
+}
+
+type AgentWithIntent struct {
+	*Agent
+	intent *IntentPreprocessor
+}
+
+func NewAgentWithIntent(cfg Config, intent *IntentPreprocessor) *AgentWithIntent {
+	return &AgentWithIntent{
+		Agent:  New(cfg),
+		intent: intent,
+	}
+}
+
+func (a *AgentWithIntent) RunWithIntent(ctx context.Context, userInput string, autoArgs ...string) (string, error) {
+	if a.intent == nil {
+		return a.Agent.Run(ctx, userInput)
+	}
+
+	result := a.intent.Preprocess(userInput, autoArgs)
+	if result == nil || !result.Handled || result.Confidence < intentAutoExecuteThreshold {
+		return a.Agent.Run(ctx, userInput)
+	}
+
+	execResult, err := a.intent.Execute(result, autoArgs)
+	if err != nil {
+		return fmt.Sprintf("[Intent Auto-Failed] %v", err), nil
+	}
+
+	a.history = append(a.history, prompt.Message{Role: "user", Content: userInput})
+	a.history = append(a.history, prompt.Message{Role: "assistant", Content: execResult})
+
+	return execResult, nil
+}
+
+func (a *AgentWithIntent) CanHandleIntent(query string) bool {
+	result := a.intent.Preprocess(query, nil)
+	return result != nil && result.Handled && result.Confidence >= intentCapabilityThreshold
+}
+
+func intentMatchConfidence(query string, cap *clihub.Capability) float64 {
+	if cap == nil {
+		return 0
+	}
+
+	normalizedQuery := normalizeIntentText(query)
+	if normalizedQuery == "" {
+		return 0
+	}
+
+	score := 0.0
+	if containsIntentFragment(normalizedQuery, cap.Harness) {
+		score += 3
+	}
+	if containsIntentFragment(normalizedQuery, cap.Command) {
+		score += 3
+	}
+	if containsIntentFragment(normalizedQuery, cap.Group) {
+		score += 2
+	}
+	if containsIntentFragment(normalizedQuery, cap.Category) {
+		score += 1
+	}
+
+	keywordHits := 0
+	for _, kw := range cap.Keywords {
+		if containsIntentFragment(normalizedQuery, kw) {
+			keywordHits++
+			if keywordHits >= 3 {
+				break
+			}
+		}
+	}
+	score += float64(keywordHits)
+
+	confidence := score / 10.0
+	if confidence > 1 {
+		return 1
+	}
+	return confidence
+}
+
+func normalizeIntentText(input string) string {
+	replacer := strings.NewReplacer("_", " ", "-", " ", "/", " ", `\`, " ", ".", " ", ":", " ")
+	return strings.ToLower(strings.TrimSpace(replacer.Replace(input)))
+}
+
+func containsIntentFragment(query string, value string) bool {
+	value = normalizeIntentText(value)
+	return value != "" && strings.Contains(query, value)
+}

--- a/pkg/capability/agents/observer.go
+++ b/pkg/capability/agents/observer.go
@@ -1,0 +1,43 @@
+package agent
+
+type ToolActivity struct {
+	ToolName string         `json:"tool_name"`
+	Args     map[string]any `json:"args"`
+	Result   string         `json:"result,omitempty"`
+	Error    string         `json:"error,omitempty"`
+}
+
+type Observer interface {
+	OnToolActivity(activity ToolActivity)
+}
+
+func (a *Agent) SetObserver(observer Observer) {
+	a.observerMu.Lock()
+	a.observer = observer
+	a.observerMu.Unlock()
+}
+
+func (a *Agent) GetLastToolActivities() []ToolActivity {
+	a.observerMu.RLock()
+	defer a.observerMu.RUnlock()
+	return append([]ToolActivity(nil), a.lastToolActivities...)
+}
+
+func (a *Agent) resetToolActivities() {
+	a.observerMu.Lock()
+	a.lastToolActivities = nil
+	a.observerMu.Unlock()
+}
+
+func (a *Agent) recordToolActivity(activity ToolActivity) {
+	a.observerMu.Lock()
+	a.lastToolActivities = append(a.lastToolActivities, activity)
+	if len(a.lastToolActivities) > 50 {
+		a.lastToolActivities = a.lastToolActivities[len(a.lastToolActivities)-50:]
+	}
+	observer := a.observer
+	a.observerMu.Unlock()
+	if observer != nil {
+		observer.OnToolActivity(activity)
+	}
+}

--- a/pkg/capability/agents/personality.go
+++ b/pkg/capability/agents/personality.go
@@ -1,0 +1,36 @@
+package agent
+
+import (
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+func BuildPersonalityPrompt(spec config.PersonalitySpec) string {
+	parts := make([]string, 0, 8)
+	if v := strings.TrimSpace(spec.Template); v != "" {
+		parts = append(parts, "Personality template: "+v)
+	}
+	if v := strings.TrimSpace(spec.Tone); v != "" {
+		parts = append(parts, "Tone: "+v)
+	}
+	if v := strings.TrimSpace(spec.Style); v != "" {
+		parts = append(parts, "Style: "+v)
+	}
+	if v := strings.TrimSpace(spec.GoalOrientation); v != "" {
+		parts = append(parts, "Goal orientation: "+v)
+	}
+	if v := strings.TrimSpace(spec.ConstraintMode); v != "" {
+		parts = append(parts, "Constraint mode: "+v)
+	}
+	if v := strings.TrimSpace(spec.ResponseVerbosity); v != "" {
+		parts = append(parts, "Response verbosity: "+v)
+	}
+	if len(spec.Traits) > 0 {
+		parts = append(parts, "Traits: "+strings.Join(spec.Traits, ", "))
+	}
+	if v := strings.TrimSpace(spec.CustomInstructions); v != "" {
+		parts = append(parts, "Custom instructions: "+v)
+	}
+	return strings.Join(parts, "\n")
+}

--- a/pkg/capability/agents/pi/pi.go
+++ b/pkg/capability/agents/pi/pi.go
@@ -1,0 +1,251 @@
+package pi
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	agent "github.com/1024XEngineer/anyclaw/pkg/capability/agents"
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+	"github.com/1024XEngineer/anyclaw/pkg/capability/skills"
+	"github.com/1024XEngineer/anyclaw/pkg/capability/tools"
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	"github.com/1024XEngineer/anyclaw/pkg/state/memory"
+)
+
+type UserID string
+
+type PiAgent struct {
+	id       UserID
+	name     string
+	config   *PiAgentConfig
+	agent    *agent.Agent
+	memory   memory.MemoryBackend
+	skills   *skills.SkillsManager
+	tools    *tools.Registry
+	workDir  string
+	userDir  string
+	mu       sync.RWMutex
+	llm      *llm.ClientWrapper
+	sessions map[string]*UserSession
+}
+
+type PiAgentConfig struct {
+	Name         string `json:"name"`
+	Description  string `json:"description"`
+	MaxHistory   int    `json:"max_history"`
+	EnableMemory bool   `json:"enable_memory"`
+	EnableSkills bool   `json:"enable_skills"`
+	PrivacyMode  bool   `json:"privacy_mode"`
+	MaxToolCalls int    `json:"max_tool_calls"`
+	SystemPrompt string `json:"system_prompt"`
+	Model        string `json:"model"`
+	Provider     string `json:"provider"`
+}
+
+type UserSession struct {
+	ID        string
+	UserID    UserID
+	CreatedAt int64
+	History   []SessionMessage
+	Context   map[string]interface{}
+}
+
+type SessionMessage struct {
+	Role    string   `json:"role"`
+	Content string   `json:"content"`
+	Tools   []string `json:"tools,omitempty"`
+}
+
+var (
+	defaultConfig = PiAgentConfig{
+		Name:         "Pi",
+		Description:  "Personal Intelligence Agent",
+		MaxHistory:   100,
+		EnableMemory: true,
+		EnableSkills: true,
+		PrivacyMode:  true,
+		MaxToolCalls: 10,
+	}
+	agents     = make(map[UserID]*PiAgent)
+	agentsLock sync.RWMutex
+)
+
+func NewPiAgent(userID UserID, cfg PiAgentConfig, appCfg *config.Config, workDir string) (*PiAgent, error) {
+	agentsLock.Lock()
+	defer agentsLock.Unlock()
+
+	if existing, ok := agents[userID]; ok {
+		return existing, nil
+	}
+
+	if cfg.Name == "" {
+		cfg.Name = defaultConfig.Name
+	}
+	if cfg.MaxHistory <= 0 {
+		cfg.MaxHistory = defaultConfig.MaxHistory
+	}
+	if cfg.MaxToolCalls <= 0 {
+		cfg.MaxToolCalls = defaultConfig.MaxToolCalls
+	}
+
+	userDir := filepath.Join(workDir, "users", string(userID))
+	if err := os.MkdirAll(userDir, 0755); err != nil {
+		return nil, fmt.Errorf("create user dir: %w", err)
+	}
+
+	pi := &PiAgent{
+		id:       userID,
+		name:     cfg.Name,
+		config:   &cfg,
+		workDir:  workDir,
+		userDir:  userDir,
+		sessions: make(map[string]*UserSession),
+	}
+
+	agentCfg := agent.Config{
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		WorkDir:     filepath.Join(userDir, ".anyclaw"),
+		WorkingDir:  workDir,
+	}
+
+	pi.agent = agent.New(agentCfg)
+
+	agents[userID] = pi
+	return pi, nil
+}
+
+func GetPiAgent(userID UserID) (*PiAgent, bool) {
+	agentsLock.RLock()
+	defer agentsLock.RUnlock()
+	ag, ok := agents[userID]
+	return ag, ok
+}
+
+func DeletePiAgent(userID UserID) error {
+	agentsLock.Lock()
+	defer agentsLock.Unlock()
+	if _, ok := agents[userID]; !ok {
+		return fmt.Errorf("agent not found: %s", userID)
+	}
+	delete(agents, userID)
+	return nil
+}
+
+func (p *PiAgent) ID() UserID {
+	return p.id
+}
+
+func (p *PiAgent) Name() string {
+	return p.name
+}
+
+func (p *PiAgent) Run(ctx context.Context, input string) (string, error) {
+	if p.agent == nil {
+		return "", fmt.Errorf("agent not initialized")
+	}
+	return p.agent.Run(ctx, input)
+}
+
+func (p *PiAgent) RunSession(ctx context.Context, sessionID string, input string) (string, error) {
+	p.mu.Lock()
+	session, ok := p.sessions[sessionID]
+	if !ok {
+		session = &UserSession{
+			ID:      sessionID,
+			UserID:  p.id,
+			Context: make(map[string]interface{}),
+		}
+		p.sessions[sessionID] = session
+	}
+	p.mu.Unlock()
+
+	response, err := p.Run(ctx, input)
+	if err != nil {
+		return "", err
+	}
+
+	p.mu.Lock()
+	session.History = append(session.History, SessionMessage{
+		Role:    "user",
+		Content: input,
+	})
+	session.History = append(session.History, SessionMessage{
+		Role:    "assistant",
+		Content: response,
+	})
+	if len(session.History) > p.config.MaxHistory*2 {
+		session.History = session.History[len(session.History)-p.config.MaxHistory*2:]
+	}
+	p.mu.Unlock()
+
+	return response, nil
+}
+
+func (p *PiAgent) GetSession(sessionID string) (*UserSession, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	session, ok := p.sessions[sessionID]
+	return session, ok
+}
+
+func (p *PiAgent) ListSessions() []*UserSession {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	sessions := make([]*UserSession, 0, len(p.sessions))
+	for _, s := range p.sessions {
+		sessions = append(sessions, s)
+	}
+	return sessions
+}
+
+func (p *PiAgent) DeleteSession(sessionID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if _, ok := p.sessions[sessionID]; !ok {
+		return fmt.Errorf("session not found: %s", sessionID)
+	}
+	delete(p.sessions, sessionID)
+	return nil
+}
+
+func (p *PiAgent) GetHistory(sessionID string) []SessionMessage {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	session, ok := p.sessions[sessionID]
+	if !ok {
+		return nil
+	}
+	return session.History
+}
+
+func (p *PiAgent) ClearHistory(sessionID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if _, ok := p.sessions[sessionID]; !ok {
+		return fmt.Errorf("session not found: %s", sessionID)
+	}
+	p.sessions[sessionID].History = nil
+	return nil
+}
+
+func (p *PiAgent) UserDir() string {
+	return p.userDir
+}
+
+func (p *PiAgent) IsPrivacyMode() bool {
+	return p.config.PrivacyMode
+}
+
+func ListAllPiAgents() []*PiAgent {
+	agentsLock.RLock()
+	defer agentsLock.RUnlock()
+	list := make([]*PiAgent, 0, len(agents))
+	for _, a := range agents {
+		list = append(list, a)
+	}
+	return list
+}

--- a/pkg/capability/agents/pi/rpc.go
+++ b/pkg/capability/agents/pi/rpc.go
@@ -1,0 +1,288 @@
+package pi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+const rpcAPIVersion = "2026.3.13"
+
+type RPCServer struct {
+	addr       string
+	httpServer *http.Server
+	workDir    string
+	appCfg     *config.Config
+	mu         sync.RWMutex
+	running    bool
+}
+
+type RPCRequest struct {
+	UserID    string `json:"user_id"`
+	SessionID string `json:"session_id,omitempty"`
+	Command   string `json:"command"`
+	Input     string `json:"input,omitempty"`
+}
+
+type RPCResponse struct {
+	Success bool        `json:"success"`
+	Data    interface{} `json:"data,omitempty"`
+	Error   string      `json:"error,omitempty"`
+}
+
+func NewRPCServer(addr string, workDir string, appCfg *config.Config) *RPCServer {
+	return &RPCServer{
+		addr:    addr,
+		workDir: workDir,
+		appCfg:  appCfg,
+	}
+}
+
+func (s *RPCServer) Start() error {
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return fmt.Errorf("server already running")
+	}
+	s.running = true
+	s.mu.Unlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/chat", s.handleChat)
+	mux.HandleFunc("/v1/sessions", s.handleSessions)
+	mux.HandleFunc("/v1/sessions/", s.handleSessionByID)
+	mux.HandleFunc("/v1/agents", s.handleAgents)
+	mux.HandleFunc("/v1/agents/", s.handleAgentByID)
+	mux.HandleFunc("/v1/health", s.handleHealth)
+	mux.HandleFunc("/", s.handleRoot)
+
+	s.httpServer = &http.Server{
+		Addr:    s.addr,
+		Handler: mux,
+	}
+
+	err := s.httpServer.ListenAndServe()
+	s.mu.Lock()
+	s.running = false
+	s.mu.Unlock()
+	return err
+}
+
+func (s *RPCServer) Stop() error {
+	s.mu.RLock()
+	if !s.running || s.httpServer == nil {
+		s.mu.RUnlock()
+		return nil
+	}
+	s.mu.RUnlock()
+	return s.httpServer.Shutdown(context.Background())
+}
+
+func (s *RPCServer) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	json.NewEncoder(w).Encode(RPCResponse{Success: true, Data: map[string]interface{}{
+		"status": "ok",
+		"agents": len(ListAllPiAgents()),
+	}})
+}
+
+func (s *RPCServer) handleRoot(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"name":    "AnyClaw Pi Agent RPC",
+		"version": rpcAPIVersion,
+		"endpoints": []string{
+			"/v1/chat",
+			"/v1/sessions",
+			"/v1/agents",
+			"/v1/health",
+		},
+	})
+}
+
+func (s *RPCServer) handleChat(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req RPCRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		json.NewEncoder(w).Encode(RPCResponse{Success: false, Error: "invalid request"})
+		return
+	}
+
+	if req.UserID == "" {
+		json.NewEncoder(w).Encode(RPCResponse{Success: false, Error: "user_id required"})
+		return
+	}
+
+	userID := UserID(req.UserID)
+	pi, ok := GetPiAgent(userID)
+	if !ok {
+		cfg := defaultConfig
+		var err error
+		pi, err = NewPiAgent(userID, cfg, s.appCfg, s.workDir)
+		if err != nil {
+			json.NewEncoder(w).Encode(RPCResponse{Success: false, Error: err.Error()})
+			return
+		}
+	}
+
+	sessionID := req.SessionID
+	if sessionID == "" {
+		sessionID = generateSessionID()
+	}
+
+	response, err := pi.RunSession(r.Context(), sessionID, req.Input)
+	if err != nil {
+		json.NewEncoder(w).Encode(RPCResponse{Success: false, Error: err.Error()})
+		return
+	}
+
+	json.NewEncoder(w).Encode(RPCResponse{
+		Success: true,
+		Data: map[string]interface{}{
+			"response":   response,
+			"session_id": sessionID,
+			"user_id":    req.UserID,
+		},
+	})
+}
+
+func (s *RPCServer) handleSessions(w http.ResponseWriter, r *http.Request) {
+	userID := r.URL.Query().Get("user_id")
+	if userID == "" {
+		json.NewEncoder(w).Encode(RPCResponse{Success: false, Error: "user_id required"})
+		return
+	}
+
+	pi, ok := GetPiAgent(UserID(userID))
+	if !ok {
+		json.NewEncoder(w).Encode(RPCResponse{Success: false, Error: "user not found"})
+		return
+	}
+
+	if r.Method == http.MethodGet {
+		sessions := pi.ListSessions()
+		data := make([]map[string]interface{}, 0, len(sessions))
+		for _, sess := range sessions {
+			data = append(data, map[string]interface{}{
+				"id":            sess.ID,
+				"user_id":       sess.UserID,
+				"created_at":    sess.CreatedAt,
+				"message_count": len(sess.History) / 2,
+			})
+		}
+		json.NewEncoder(w).Encode(RPCResponse{Success: true, Data: data})
+		return
+	}
+
+	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+}
+
+func (s *RPCServer) handleSessionByID(w http.ResponseWriter, r *http.Request) {
+	userID := r.URL.Query().Get("user_id")
+	if userID == "" {
+		json.NewEncoder(w).Encode(RPCResponse{Success: false, Error: "user_id required"})
+		return
+	}
+
+	pi, ok := GetPiAgent(UserID(userID))
+	if !ok {
+		json.NewEncoder(w).Encode(RPCResponse{Success: false, Error: "user not found"})
+		return
+	}
+
+	sessionID := r.URL.Path[len("/v1/sessions/"):]
+	if sessionID == "" {
+		json.NewEncoder(w).Encode(RPCResponse{Success: false, Error: "session_id required"})
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		history := pi.GetHistory(sessionID)
+		json.NewEncoder(w).Encode(RPCResponse{Success: true, Data: history})
+
+	case http.MethodDelete:
+		if err := pi.ClearHistory(sessionID); err != nil {
+			json.NewEncoder(w).Encode(RPCResponse{Success: false, Error: err.Error()})
+			return
+		}
+		json.NewEncoder(w).Encode(RPCResponse{Success: true})
+
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *RPCServer) handleAgents(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		agents := ListAllPiAgents()
+		data := make([]map[string]interface{}, 0, len(agents))
+		for _, a := range agents {
+			data = append(data, map[string]interface{}{
+				"id":            a.ID(),
+				"name":          a.Name(),
+				"session_count": len(a.ListSessions()),
+				"privacy_mode":  a.IsPrivacyMode(),
+			})
+		}
+		json.NewEncoder(w).Encode(RPCResponse{Success: true, Data: data})
+		return
+	}
+
+	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+}
+
+func (s *RPCServer) handleAgentByID(w http.ResponseWriter, r *http.Request) {
+	userID := r.URL.Path[len("/v1/agents/"):]
+	if userID == "" {
+		json.NewEncoder(w).Encode(RPCResponse{Success: false, Error: "user_id required"})
+		return
+	}
+
+	pi, ok := GetPiAgent(UserID(userID))
+	if !ok {
+		json.NewEncoder(w).Encode(RPCResponse{Success: false, Error: "agent not found"})
+		return
+	}
+
+	if r.Method == http.MethodDelete {
+		if err := DeletePiAgent(UserID(userID)); err != nil {
+			json.NewEncoder(w).Encode(RPCResponse{Success: false, Error: err.Error()})
+			return
+		}
+		json.NewEncoder(w).Encode(RPCResponse{Success: true})
+		return
+	}
+
+	if r.Method == http.MethodGet {
+		json.NewEncoder(w).Encode(RPCResponse{Success: true, Data: map[string]interface{}{
+			"id":           pi.ID(),
+			"name":         pi.Name(),
+			"user_dir":     pi.UserDir(),
+			"privacy_mode": pi.IsPrivacyMode(),
+			"sessions":     len(pi.ListSessions()),
+		}})
+		return
+	}
+
+	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+}
+
+func generateSessionID() string {
+	return fmt.Sprintf("sess-%d", time.Now().UnixMilli())
+}

--- a/pkg/capability/agents/preference_learner.go
+++ b/pkg/capability/agents/preference_learner.go
@@ -1,0 +1,175 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type PreferenceLearner struct {
+	workingDir string
+}
+
+type LearnedPreference struct {
+	Name        string
+	Description string
+	Style       string
+	Boundary    string
+}
+
+var (
+	namePatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?:我叫|名字是|你可以叫我|叫我)\s*([^，。,\s]+)`),
+		regexp.MustCompile(`(?:我的名字|名字)\s*叫\s*([^，。,\s]+)`),
+	}
+	stylePatterns = []*regexp.Regexp{
+		regexp.MustCompile(`喜欢(?:用|说|看|听)(.*?)[，。,\s]|$`),
+		regexp.MustCompile(`(?:风格|语气|方式)\s*(?:是|要)?(.*?)[，。,\s]|$`),
+	}
+	boundaryPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?:不要|别|尽量不要|尽量避免)(.*?)[，。,\s]|$`),
+	}
+)
+
+func NewPreferenceLearner(workingDir string) *PreferenceLearner {
+	return &PreferenceLearner{workingDir: workingDir}
+}
+
+func (p *PreferenceLearner) Learn(userInput, assistantResponse string) (string, bool) {
+	if p.workingDir == "" {
+		return "", false
+	}
+
+	pref := p.extractPreferences(userInput)
+	if pref.Name == "" && pref.Style == "" && pref.Boundary == "" {
+		return "", false
+	}
+
+	changed := false
+	var messages []string
+
+	if pref.Name != "" {
+		if p.updateAgentName(pref.Name) {
+			messages = append(messages, fmt.Sprintf("好的，以后叫我「%s」", pref.Name))
+			changed = true
+		}
+	}
+
+	if pref.Style != "" {
+		if p.updateUserStyle(pref.Style) {
+			messages = append(messages, fmt.Sprintf("知道了，我会%s", pref.Style))
+			changed = true
+		}
+	}
+
+	if pref.Boundary != "" {
+		if p.updateBoundary(pref.Boundary) {
+			messages = append(messages, fmt.Sprintf("好的，我会%s", pref.Boundary))
+			changed = true
+		}
+	}
+
+	if len(messages) > 0 {
+		return strings.Join(messages, "，") + "。", changed
+	}
+	return "", false
+}
+
+func (p *PreferenceLearner) extractPreferences(userInput string) LearnedPreference {
+	pref := LearnedPreference{}
+
+	for _, pattern := range namePatterns {
+		if match := pattern.FindStringSubmatch(userInput); len(match) > 1 {
+			pref.Name = strings.TrimSpace(match[1])
+			break
+		}
+	}
+
+	for _, pattern := range stylePatterns {
+		if match := pattern.FindStringSubmatch(userInput); len(match) > 1 {
+			pref.Style = strings.TrimSpace(match[1])
+			break
+		}
+	}
+
+	for _, pattern := range boundaryPatterns {
+		if match := pattern.FindStringSubmatch(userInput); len(match) > 1 {
+			pref.Boundary = strings.TrimSpace(match[1])
+			break
+		}
+	}
+
+	return pref
+}
+
+func (p *PreferenceLearner) updateAgentName(name string) bool {
+	agentsFile := filepath.Join(p.workingDir, "AGENTS.md")
+	if _, err := os.Stat(agentsFile); err != nil {
+		return false
+	}
+
+	content, err := os.ReadFile(agentsFile)
+	if err != nil {
+		return false
+	}
+
+	oldContent := string(content)
+	newContent := strings.Replace(oldContent,
+		"- Name: "+strings.Split(strings.Split(oldContent, "- Name: ")[1], "\n")[0],
+		"- Name: "+name,
+		1)
+
+	if newContent == oldContent {
+		return false
+	}
+
+	return os.WriteFile(agentsFile, []byte(newContent), 0644) == nil
+}
+
+func (p *PreferenceLearner) updateUserStyle(style string) bool {
+	userFile := filepath.Join(p.workingDir, "USER.md")
+	if _, err := os.Stat(userFile); err != nil {
+		return false
+	}
+
+	content, err := os.ReadFile(userFile)
+	if err != nil {
+		return false
+	}
+
+	oldContent := string(content)
+	styleLine := fmt.Sprintf("- Style: %s", style)
+
+	if strings.Contains(oldContent, styleLine) {
+		return false
+	}
+
+	newContent := oldContent + "\n" + styleLine
+
+	return os.WriteFile(userFile, []byte(newContent), 0644) == nil
+}
+
+func (p *PreferenceLearner) updateBoundary(boundary string) bool {
+	userFile := filepath.Join(p.workingDir, "USER.md")
+	if _, err := os.Stat(userFile); err != nil {
+		return false
+	}
+
+	content, err := os.ReadFile(userFile)
+	if err != nil {
+		return false
+	}
+
+	oldContent := string(content)
+	boundaryLine := fmt.Sprintf("- Avoid: %s", boundary)
+
+	if strings.Contains(oldContent, boundaryLine) {
+		return false
+	}
+
+	newContent := oldContent + "\n" + boundaryLine
+
+	return os.WriteFile(userFile, []byte(newContent), 0644) == nil
+}

--- a/pkg/capability/agents/prompt/prompt.go
+++ b/pkg/capability/agents/prompt/prompt.go
@@ -1,0 +1,559 @@
+package prompt
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+type SystemPromptBuilder struct {
+	name        string
+	description string
+	templates   map[string]*template.Template
+}
+
+func NewSystemPromptBuilder(name, description string) *SystemPromptBuilder {
+	return &SystemPromptBuilder{
+		name:        name,
+		description: description,
+		templates:   make(map[string]*template.Template),
+	}
+}
+
+func (b *SystemPromptBuilder) RegisterTemplate(name string, tmpl string) error {
+	t, err := template.New(name).Parse(tmpl)
+	if err != nil {
+		return err
+	}
+	b.templates[name] = t
+	return nil
+}
+
+func (b *SystemPromptBuilder) Build(data PromptData) (string, error) {
+	var parts []string
+
+	parts = append(parts, b.buildHeader())
+	parts = append(parts, b.buildIdentity())
+	parts = append(parts, b.buildCapabilities(data))
+	if cliHub := b.buildCLIHub(data); cliHub != "" {
+		parts = append(parts, cliHub)
+	}
+	if clawBridge := b.buildClawBridge(data); clawBridge != "" {
+		parts = append(parts, clawBridge)
+	}
+	if operatingMode := b.buildOperatingMode(data); operatingMode != "" {
+		parts = append(parts, operatingMode)
+	}
+	if workspace := b.buildWorkspace(data); workspace != "" {
+		parts = append(parts, workspace)
+	}
+	if workspaceFiles := b.buildWorkspaceFiles(data); workspaceFiles != "" {
+		parts = append(parts, workspaceFiles)
+	}
+	if memoryRecall := b.buildMemoryRecall(data); memoryRecall != "" {
+		parts = append(parts, memoryRecall)
+	}
+	parts = append(parts, b.buildMemory(data))
+	parts = append(parts, b.buildSkills(data))
+	parts = append(parts, b.buildGuidelines())
+	parts = append(parts, b.buildInstructions())
+
+	return strings.Join(parts, "\n\n"), nil
+}
+
+func (b *SystemPromptBuilder) buildHeader() string {
+	return `You are AnyClaw, a local-first execution agent focused on safely completing real tasks instead of only answering about them.`
+}
+
+func (b *SystemPromptBuilder) buildIdentity() string {
+	var parts []string
+
+	if b.name != "" {
+		parts = append(parts, fmt.Sprintf("Your name is %s.", b.name))
+	}
+	if b.description != "" {
+		parts = append(parts, b.description)
+	}
+	parts = append(parts, "You have a configurable personality profile. Follow the tone, style, constraints, and operating traits provided in your identity description.")
+	parts = append(parts, "Operate like a careful human teammate on the local machine: move the task forward, observe what changed, and adapt until the deliverable is actually complete or clearly blocked.")
+
+	return strings.Join(parts, " ")
+}
+
+func (b *SystemPromptBuilder) buildCapabilities(data PromptData) string {
+	parts := []string{
+		"You can use structured tools when the task requires inspecting files, running commands, browsing the web, or interacting with local apps.",
+	}
+
+	if len(data.Tools) == 0 {
+		parts = append(parts, "(No tools selected for this turn)")
+		return strings.Join(parts, "\n")
+	}
+
+	if len(data.Tools) <= 12 {
+		parts = append(parts, "Tools available right now:")
+		for _, tool := range data.Tools {
+			parts = append(parts, fmt.Sprintf("- %s: %s", tool.Name, tool.Description))
+		}
+		return strings.Join(parts, "\n")
+	}
+
+	parts = append(parts, fmt.Sprintf("There are %d tools selected for this turn.", len(data.Tools)))
+	if families := summarizeToolFamilies(data.Tools, 8); len(families) > 0 {
+		parts = append(parts, "Relevant tool families: "+strings.Join(families, ", ")+".")
+	}
+	parts = append(parts, "Representative tools:")
+	for _, tool := range data.Tools[:minInt(len(data.Tools), 12)] {
+		parts = append(parts, fmt.Sprintf("- %s: %s", tool.Name, tool.Description))
+	}
+
+	return strings.Join(parts, "\n")
+}
+
+func (b *SystemPromptBuilder) buildClawBridge(data PromptData) string {
+	if data.ClawBridge == nil {
+		return ""
+	}
+
+	lines := []string{
+		"## Claw Bridge",
+		fmt.Sprintf("A local claw-code-main reference surface is available at: %s", data.ClawBridge.Root),
+		fmt.Sprintf("- Snapshot size: %d command entries, %d tool entries, %d mirrored subsystems.", data.ClawBridge.CommandsCount, data.ClawBridge.ToolsCount, data.ClawBridge.SubsystemsCount),
+		"- Use it as a thinking aid for end-to-end execution, not as a requirement to mimic every archived name literally.",
+		"- Favor an execution loop like: inspect -> plan -> execute -> verify -> review -> adapt.",
+	}
+
+	if len(data.ClawBridge.CommandFamilies) > 0 {
+		lines = append(lines, "- Command domains to think with: "+strings.Join(data.ClawBridge.CommandFamilies, ", ")+".")
+	}
+	if len(data.ClawBridge.ToolFamilies) > 0 {
+		lines = append(lines, "- Tool families worth remembering: "+strings.Join(data.ClawBridge.ToolFamilies, ", ")+".")
+	}
+	if len(data.ClawBridge.Subsystems) > 0 {
+		lines = append(lines, "- High-signal subsystems: "+strings.Join(data.ClawBridge.Subsystems, ", ")+".")
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (b *SystemPromptBuilder) buildCLIHub(data PromptData) string {
+	if data.CLIHub == nil {
+		return ""
+	}
+
+	lines := []string{
+		"## CLI Hub",
+		fmt.Sprintf("A local CLI-Anything catalog is available at: %s", data.CLIHub.Root),
+		fmt.Sprintf("- Catalog size: %d harness entries across %d categories.", data.CLIHub.EntriesCount, len(data.CLIHub.Categories)),
+		fmt.Sprintf("- Runnable harnesses visible from this runtime: %d.", data.CLIHub.RunnableCount),
+		fmt.Sprintf("- Installed harnesses visible from this runtime: %d.", data.CLIHub.InstalledCount),
+		"- When a task maps well to a known harness, prefer clihub_catalog to inspect options and clihub_exec to run the harness instead of composing raw shell manually.",
+		"- CLI-Anything harnesses are designed for agent use: structured commands, JSON output, stateful workflows, and real backend integration.",
+	}
+	if data.CLIHub.CapabilitiesCount > 0 {
+		lines = append(lines, fmt.Sprintf("- Auto-routable capabilities indexed: %d.", data.CLIHub.CapabilitiesCount))
+	}
+	if hasTool(data.Tools, "intent_route") {
+		lines = append(lines, "- For concrete software actions stated in natural language, prefer intent_route first so the agent can auto-pick the right harness and execute it directly.")
+	}
+	if hasTool(data.Tools, "intent_list_capabilities") {
+		lines = append(lines, "- If the intent is ambiguous, call intent_list_capabilities with the user's wording to inspect the best matching capabilities before falling back to clihub_exec.")
+	}
+	if len(data.CLIHub.Categories) > 0 {
+		lines = append(lines, "- Strong categories in this catalog: "+strings.Join(data.CLIHub.Categories, ", ")+".")
+	}
+	if len(data.CLIHub.Runnable) > 0 {
+		lines = append(lines, "- Harnesses ready right now (installed or local source): "+strings.Join(data.CLIHub.Runnable, ", ")+".")
+	}
+	if len(data.CLIHub.Installed) > 0 {
+		lines = append(lines, "- Installed harnesses ready right now: "+strings.Join(data.CLIHub.Installed, ", ")+".")
+	}
+	if len(data.CLIHub.SkillCommands) > 0 {
+		lines = append(lines, "- Available direct skill commands: "+strings.Join(data.CLIHub.SkillCommands, ", ")+".")
+		lines = append(lines, "- Use these direct skill tools instead of clihub_exec when available.")
+	}
+	if len(data.CLIHub.IntentExamples) > 0 {
+		lines = append(lines, "- Example routed capabilities from this catalog: "+strings.Join(data.CLIHub.IntentExamples, ", ")+".")
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+type executionToolCatalog struct {
+	AppWorkflowTools   []ToolInfo
+	AppActionTools     []ToolInfo
+	BrowserTools       []ToolInfo
+	BrowserObservation []ToolInfo
+	DesktopTarget      []ToolInfo
+	DesktopObservation []ToolInfo
+	DesktopLowLevel    []ToolInfo
+	FileStateTools     []ToolInfo
+	CommandTools       []ToolInfo
+}
+
+func (b *SystemPromptBuilder) buildOperatingMode(data PromptData) string {
+	catalog := classifyExecutionTools(data.Tools)
+	if !catalog.HasCoreExecutionTools() {
+		return ""
+	}
+
+	lines := []string{
+		"## AnyClaw Core",
+		"You are a human-like local execution agent. Your primary job is to complete the user's task safely on this machine, not merely explain how it could be done.",
+		"If a person could safely do the task locally without harming the computer or exposing protected/private data, prefer completing it.",
+		"Execution contract:",
+		"- Treat tool outputs as evidence about the current world state.",
+		"- Do not guess the state of files, commands, webpages, windows, or apps when you can inspect them.",
+		"- Work in loops: inspect the current state, choose the next best action, execute it, inspect again, and adapt until the requested outcome is complete.",
+		"- Before declaring success, verify the requested deliverable with observable evidence. If any part remains unverified, say exactly what is done and what is still unconfirmed.",
+	}
+
+	observationLines := buildObservationLines(catalog)
+	if len(observationLines) > 0 {
+		lines = append(lines, "Current-state observation sources:")
+		lines = append(lines, observationLines...)
+	}
+
+	lines = append(lines, "Execution order:")
+	hasSpecificOrder := false
+
+	if len(catalog.AppWorkflowTools) > 0 {
+		lines = append(lines, fmt.Sprintf("1. Prefer higher-level app workflow tools first when they fit the goal: %s.", formatToolNameList(catalog.AppWorkflowTools, 8)))
+		hasSpecificOrder = true
+	} else if len(catalog.AppActionTools) > 0 {
+		lines = append(lines, fmt.Sprintf("1. Prefer higher-level app connector tools before low-level desktop actions: %s.", formatToolNameList(catalog.AppActionTools, 8)))
+		hasSpecificOrder = true
+	}
+
+	if len(catalog.BrowserTools) > 0 {
+		lines = append(lines, fmt.Sprintf("2. For web apps, prefer browser tools over desktop clicking when the same task can be completed in the browser: %s.", formatToolNameList(catalog.BrowserTools, 6)))
+		lines = append(lines, "- Important: browser tools are for browser automation sessions. When the user explicitly wants a visible browser window or asks to open a URL on the desktop, prefer desktop_open instead of browser_navigate.")
+		hasSpecificOrder = true
+	}
+
+	if len(catalog.DesktopTarget) > 0 {
+		lines = append(lines, fmt.Sprintf("3. For local apps, prefer target-based desktop tools instead of raw coordinates: %s.", formatToolNameList(catalog.DesktopTarget, 6)))
+		lines = append(lines, "Inside target-based desktop work, prefer stable selectors first: UI automation, then visible text/OCR, then image matching, then window-only fallback.")
+		hasSpecificOrder = true
+	}
+
+	if len(catalog.DesktopLowLevel) > 0 {
+		lines = append(lines, fmt.Sprintf("4. Use low-level desktop tools only as a fallback when target-based tools cannot complete the step reliably: %s.", formatToolNameList(catalog.DesktopLowLevel, 8)))
+		hasSpecificOrder = true
+	}
+
+	if len(catalog.DesktopObservation) > 0 {
+		lines = append(lines, fmt.Sprintf("5. After important actions, verify the result with observation tools instead of assuming success: %s.", formatToolNameList(catalog.DesktopObservation, 8)))
+		hasSpecificOrder = true
+	} else {
+		lines = append(lines, "5. After important actions, check whether the requested outcome actually appeared before moving on.")
+		hasSpecificOrder = true
+	}
+
+	if !hasSpecificOrder {
+		lines = append(lines, "1. Start from the available evidence, make the next necessary change, then inspect again before deciding the task is done.")
+	}
+
+	lines = append(lines,
+		"Approval and recovery:",
+		"- When approvals are required, prepare a concise action plan, request approval, and resume execution after approval instead of abandoning the task.",
+		"- If the user already explicitly requested a local action and the tool approval prompt will capture consent, do not ask an extra conversational confirmation unless some detail is genuinely ambiguous.",
+		"- If a step fails or the observed state does not match the goal, retry with a more reliable selector, a higher-level workflow, or a different tactic before falling back to raw mouse and keyboard actions.",
+		"- When a task needs a multi-step local app procedure, you may emit a structured anyclaw.app.desktop.v1 plan instead of narrating raw step-by-step instructions.",
+		"- Prefer completing the requested deliverable and reporting what changed, what was verified, and what remains blocked or unverified.",
+	)
+
+	return strings.Join(lines, "\n")
+}
+
+func (b *SystemPromptBuilder) buildWorkspace(data PromptData) string {
+	if strings.TrimSpace(data.WorkingDir) == "" {
+		return ""
+	}
+	return fmt.Sprintf(`## Workspace
+Working directory: %s`, data.WorkingDir)
+}
+
+func (b *SystemPromptBuilder) buildWorkspaceFiles(data PromptData) string {
+	if len(data.WorkspaceFiles) == 0 {
+		return ""
+	}
+
+	parts := []string{"## Project Context"}
+	for _, file := range data.WorkspaceFiles {
+		name := strings.TrimSpace(file.Name)
+		if name == "" {
+			continue
+		}
+		content := strings.TrimSpace(file.Content)
+		if content == "" {
+			content = "(empty)"
+		}
+		parts = append(parts, fmt.Sprintf("### %s\n%s", name, content))
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func (b *SystemPromptBuilder) buildMemoryRecall(data PromptData) string {
+	if !hasTool(data.Tools, "memory_search") && !hasTool(data.Tools, "memory_get") {
+		return ""
+	}
+	return `## Memory Recall
+Daily memory files under workspace/memory are not injected automatically.
+Use memory_search to find relevant days and memory_get to open a specific daily memory file when older context is needed.`
+}
+
+func (b *SystemPromptBuilder) buildMemory(data PromptData) string {
+	if data.Memory == "" {
+		return ""
+	}
+
+	return fmt.Sprintf(`## Memory
+%s`, data.Memory)
+}
+
+func (b *SystemPromptBuilder) buildSkills(data PromptData) string {
+	if len(data.SkillPrompts) == 0 {
+		return ""
+	}
+
+	var parts []string
+	parts = append(parts, "## Active Skills")
+
+	for _, prompt := range data.SkillPrompts {
+		parts = append(parts, prompt)
+	}
+
+	return strings.Join(parts, "\n\n")
+}
+
+func (b *SystemPromptBuilder) buildGuidelines() string {
+	return `## Guidelines
+- Be helpful, harmless, honest, and completion-oriented
+- Think step by step using observable evidence
+- When using tools, explain what you're doing
+- If a tool fails, explain the error and suggest alternatives
+- When tools are available and the user wants a task completed, take action instead of stopping at advice
+- Base progress claims on inspected state, not assumptions
+- If the task is partly done but not yet verified, keep working or clearly mark the remaining uncertainty
+- Store important information in memory for future reference`
+}
+
+func (b *SystemPromptBuilder) buildInstructions() string {
+	return `## Instructions
+- Always respond in the same language as the user
+- If tools are available, prefer native structured tool calls; only fall back to textual tool_call JSON if the model cannot emit native tool calls
+- After completing a task, summarize what was done, what was verified, and any remaining blocked or unverified part
+- Do not say a task is complete unless the requested outcome has been checked against observable evidence or you explicitly state what could not be verified`
+}
+
+func summarizeToolFamilies(tools []ToolInfo, limit int) []string {
+	if len(tools) == 0 || limit <= 0 {
+		return nil
+	}
+	families := make([]string, 0, limit)
+	seen := make(map[string]struct{})
+	for _, tool := range tools {
+		family := toolFamilyName(tool.Name)
+		if family == "" {
+			continue
+		}
+		if _, ok := seen[family]; ok {
+			continue
+		}
+		seen[family] = struct{}{}
+		families = append(families, family)
+		if len(families) >= limit {
+			break
+		}
+	}
+	return families
+}
+
+func toolFamilyName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	if idx := strings.Index(name, "_"); idx > 0 {
+		return name[:idx]
+	}
+	return name
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+type PromptData struct {
+	Name           string
+	Description    string
+	WorkingDir     string
+	Memory         string
+	Skills         []string
+	SkillPrompts   []string
+	Tools          []ToolInfo
+	CLIHub         *CLIHubInfo
+	ClawBridge     *ClawBridgeInfo
+	WorkspaceFiles []WorkspaceFile
+	History        []Message
+}
+
+type WorkspaceFile struct {
+	Name    string
+	Content string
+}
+
+type ToolInfo struct {
+	Name        string
+	Description string
+	InputSchema map[string]any
+}
+
+type CLIHubInfo struct {
+	Root              string
+	EntriesCount      int
+	RunnableCount     int
+	InstalledCount    int
+	CapabilitiesCount int
+	Categories        []string
+	Runnable          []string
+	Installed         []string
+	SkillCommands     []string
+	IntentExamples    []string
+}
+
+type ClawBridgeInfo struct {
+	Root            string
+	CommandsCount   int
+	ToolsCount      int
+	SubsystemsCount int
+	CommandFamilies []string
+	ToolFamilies    []string
+	Subsystems      []string
+}
+
+type Message struct {
+	Role    string
+	Content string
+}
+
+func BuildSystemPrompt(name, description string, data PromptData) (string, error) {
+	if strings.TrimSpace(data.Description) != "" {
+		description = data.Description
+	}
+	b := NewSystemPromptBuilder(name, description)
+	return b.Build(data)
+}
+
+func classifyExecutionTools(tools []ToolInfo) executionToolCatalog {
+	catalog := executionToolCatalog{}
+	for _, tool := range tools {
+		name := strings.TrimSpace(strings.ToLower(tool.Name))
+		switch {
+		case name == "read_file" || name == "list_directory" || name == "search_files":
+			catalog.FileStateTools = append(catalog.FileStateTools, tool)
+		case name == "run_command":
+			catalog.CommandTools = append(catalog.CommandTools, tool)
+		case strings.HasPrefix(name, "app_") && strings.Contains(name, "_workflow_"):
+			catalog.AppWorkflowTools = append(catalog.AppWorkflowTools, tool)
+		case strings.HasPrefix(name, "app_"):
+			catalog.AppActionTools = append(catalog.AppActionTools, tool)
+		case name == "browser_snapshot" || name == "browser_eval" || name == "browser_screenshot" || name == "browser_wait" || name == "browser_tab_list":
+			catalog.BrowserObservation = append(catalog.BrowserObservation, tool)
+			catalog.BrowserTools = append(catalog.BrowserTools, tool)
+		case strings.HasPrefix(name, "browser_"):
+			catalog.BrowserTools = append(catalog.BrowserTools, tool)
+		case name == "desktop_resolve_target" || name == "desktop_activate_target" || name == "desktop_set_target_value":
+			catalog.DesktopTarget = append(catalog.DesktopTarget, tool)
+		case name == "desktop_wait_text" || name == "desktop_wait_image" || name == "desktop_verify_text" || name == "desktop_ocr" || name == "desktop_find_text" || name == "desktop_match_image" || name == "desktop_list_windows" || name == "desktop_wait_window" || name == "desktop_inspect_ui":
+			catalog.DesktopObservation = append(catalog.DesktopObservation, tool)
+		case strings.HasPrefix(name, "desktop_"):
+			catalog.DesktopLowLevel = append(catalog.DesktopLowLevel, tool)
+		}
+	}
+	return catalog
+}
+
+func (c executionToolCatalog) HasCoreExecutionTools() bool {
+	return len(c.FileStateTools) > 0 || len(c.CommandTools) > 0 || len(c.AppWorkflowTools) > 0 || len(c.AppActionTools) > 0 || len(c.BrowserTools) > 0 || len(c.DesktopTarget) > 0 || len(c.DesktopObservation) > 0 || len(c.DesktopLowLevel) > 0
+}
+
+func formatToolNameList(tools []ToolInfo, limit int) string {
+	if len(tools) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		if strings.TrimSpace(tool.Name) != "" {
+			names = append(names, tool.Name)
+		}
+	}
+	if limit > 0 && len(names) > limit {
+		remaining := len(names) - limit
+		names = append(names[:limit], fmt.Sprintf("and %d more", remaining))
+	}
+	return strings.Join(names, ", ")
+}
+
+func hasTool(tools []ToolInfo, name string) bool {
+	for _, tool := range tools {
+		if strings.EqualFold(strings.TrimSpace(tool.Name), strings.TrimSpace(name)) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildObservationLines(catalog executionToolCatalog) []string {
+	lines := []string{}
+	if len(catalog.FileStateTools) > 0 {
+		lines = append(lines, fmt.Sprintf("- Workspace and file state: %s.", formatToolNameList(catalog.FileStateTools, 6)))
+	}
+	if len(catalog.CommandTools) > 0 {
+		lines = append(lines, fmt.Sprintf("- Command and system output: %s.", formatToolNameList(catalog.CommandTools, 4)))
+	}
+	if len(catalog.BrowserObservation) > 0 {
+		lines = append(lines, fmt.Sprintf("- Browser and page state: %s.", formatToolNameList(catalog.BrowserObservation, 6)))
+	}
+	if len(catalog.AppWorkflowTools) > 0 || len(catalog.AppActionTools) > 0 {
+		lines = append(lines, fmt.Sprintf("- App-specific actions and state via connectors: %s.", formatToolNameList(append(append([]ToolInfo{}, catalog.AppWorkflowTools...), catalog.AppActionTools...), 8)))
+	}
+	if len(catalog.DesktopObservation) > 0 {
+		lines = append(lines, fmt.Sprintf("- Desktop UI, OCR, screenshots, and window state: %s.", formatToolNameList(catalog.DesktopObservation, 8)))
+	}
+	return lines
+}
+
+func BuildConversationPrompt(messages []Message, systemPrompt string) []map[string]string {
+	var result []map[string]string
+
+	if systemPrompt != "" {
+		result = append(result, map[string]string{
+			"role":    "system",
+			"content": systemPrompt,
+		})
+	}
+
+	for _, msg := range messages {
+		result = append(result, map[string]string{
+			"role":    msg.Role,
+			"content": msg.Content,
+		})
+	}
+
+	return result
+}
+
+func FormatToolCall(toolName string, args map[string]any) (string, error) {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Tool: %s\n", toolName))
+	sb.WriteString("Arguments:\n")
+	for k, v := range args {
+		sb.WriteString(fmt.Sprintf("  %s: %v\n", k, v))
+	}
+	return sb.String(), nil
+}


### PR DESCRIPTION
## 🚀 功能说明
新增 capability 层的 agents 模块，实现 Agent 的核心能力，包括上下文管理、意图处理及相关扩展组件。

## 📦 主要改动
- 新增 Agent 核心实现（agent.go）
- 新增上下文运行时管理（context_runtime）
- 新增意图预处理模块（intent_preprocessor）
- 新增 observer 机制
- 新增 personality 与偏好学习模块
- 新增 approval 与 compaction 相关逻辑
- 新增 PI 接口及 RPC 支持
- 补充 agents 模块单元测试

## 🎯 目的
为 capability 系统提供 Agent 执行层，使其能够：
- 管理上下文
- 处理用户意图
- 与 skills / tools 模块进行协作

## 🧪 测试方式
```bash
go test ./pkg/capability/agents/...