### PR TITLE
feat(models):add capability models module

### DIFF
--- a/pkg/capability/models/client.go
+++ b/pkg/capability/models/client.go
@@ -1,0 +1,747 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type Config struct {
+	Provider    string
+	Model       string
+	APIKey      string
+	BaseURL     string
+	Proxy       string
+	MaxTokens   int
+	Temperature float64
+	Extra       map[string]string
+}
+
+type Client interface {
+	Chat(ctx context.Context, messages []Message, tools []ToolDefinition) (*Response, error)
+	StreamChat(ctx context.Context, messages []Message, tools []ToolDefinition, onChunk func(string)) error
+	Name() string
+}
+
+type Message struct {
+	Role          string         `json:"role"`
+	Content       string         `json:"content"`
+	Name          string         `json:"name,omitempty"`
+	ToolCallID    string         `json:"tool_call_id,omitempty"`
+	ToolCalls     []ToolCall     `json:"tool_calls,omitempty"`
+	contentBlocks []ContentBlock `json:"-"`
+}
+
+type Response struct {
+	Content     string
+	RawResponse any
+	Usage       Usage
+	StopReason  string
+	ToolCalls   []ToolCall
+}
+
+type ToolDefinition struct {
+	Type     string                 `json:"type"`
+	Function ToolFunctionDefinition `json:"function"`
+}
+
+type ToolFunctionDefinition struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+}
+
+type Usage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+type ToolCall struct {
+	ID       string       `json:"id"`
+	Type     string       `json:"type"`
+	Function FunctionCall `json:"function"`
+}
+
+type FunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type ToolChoice struct {
+	Type     string         `json:"type"`
+	Function FunctionChoice `json:"function,omitempty"`
+}
+
+type FunctionChoice struct {
+	Name string `json:"name"`
+}
+
+type client struct {
+	provider    string
+	model       string
+	apiKey      string
+	baseURL     string
+	proxyURL    string
+	maxTokens   int
+	temperature float64
+	httpClient  *http.Client
+}
+
+type configurationRequiredClient struct {
+	provider string
+	err      error
+}
+
+func (c *configurationRequiredClient) Chat(_ context.Context, _ []Message, _ []ToolDefinition) (*Response, error) {
+	return nil, c.err
+}
+
+func (c *configurationRequiredClient) StreamChat(_ context.Context, _ []Message, _ []ToolDefinition, _ func(string)) error {
+	return c.err
+}
+
+func (c *configurationRequiredClient) Name() string {
+	return c.provider
+}
+
+func NormalizeProviderName(provider string) string {
+	return normalizeProvider(provider)
+}
+
+func ProviderRequiresAPIKey(provider string) bool {
+	switch normalizeProvider(provider) {
+	case "ollama":
+		return false
+	default:
+		return true
+	}
+}
+
+func newHTTPClient(proxyURL string) *http.Client {
+	transport := &http.Transport{}
+
+	if proxyURL != "" {
+		if proxyURL == "system" {
+			// Use system proxy
+		} else {
+			transport.Proxy = func(req *http.Request) (*url.URL, error) {
+				return url.Parse(proxyURL)
+			}
+		}
+	}
+
+	return &http.Client{Transport: transport}
+}
+
+func NewClient(cfg Config) (Client, error) {
+	c := &client{
+		provider:    cfg.Provider,
+		model:       cfg.Model,
+		apiKey:      cfg.APIKey,
+		baseURL:     cfg.BaseURL,
+		proxyURL:    cfg.Proxy,
+		maxTokens:   cfg.MaxTokens,
+		temperature: cfg.Temperature,
+		httpClient:  newHTTPClient(cfg.Proxy),
+	}
+
+	if ProviderRequiresAPIKey(c.provider) && c.apiKey == "" {
+		return &configurationRequiredClient{
+			provider: normalizeProvider(c.provider),
+			err:      fmt.Errorf("API key is required. Configure a model provider before chatting"),
+		}, nil
+	}
+
+	if c.baseURL == "" {
+		c.baseURL = getDefaultBaseURL(c.provider)
+	}
+
+	return c, nil
+}
+
+func getDefaultBaseURL(provider string) string {
+	provider = normalizeProvider(provider)
+	switch provider {
+	case "openai":
+		return "https://api.openai.com/v1"
+	case "anthropic":
+		return "https://api.anthropic.com/v1"
+	case "ollama":
+		return "http://localhost:11434/v1"
+	case "qwen":
+		return "https://dashscope.aliyuncs.com/compatible-mode/v1"
+	default:
+		return "https://api.openai.com/v1"
+	}
+}
+
+func normalizeProvider(provider string) string {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if strings.Contains(provider, "qwen") || strings.Contains(provider, "dashscope") || strings.Contains(provider, "alibaba") {
+		return "qwen"
+	}
+	if strings.Contains(provider, "anthropic") || strings.Contains(provider, "claude") {
+		return "anthropic"
+	}
+	if strings.Contains(provider, "ollama") {
+		return "ollama"
+	}
+	if strings.Contains(provider, "compatible") {
+		return "compatible"
+	}
+	return "openai"
+}
+
+func (c *client) Name() string {
+	return c.provider
+}
+
+func (c *client) Chat(ctx context.Context, messages []Message, tools []ToolDefinition) (*Response, error) {
+	provider := normalizeProvider(c.provider)
+	switch provider {
+	case "openai", "ollama", "compatible", "qwen":
+		return c.chatOpenAICompatible(ctx, messages, tools)
+	case "anthropic":
+		return c.chatAnthropic(ctx, messages, tools)
+	default:
+		return c.chatOpenAICompatible(ctx, messages, tools)
+	}
+}
+
+func (c *client) StreamChat(ctx context.Context, messages []Message, tools []ToolDefinition, onChunk func(string)) error {
+	provider := normalizeProvider(c.provider)
+	switch provider {
+	case "openai", "ollama", "compatible", "qwen":
+		return c.streamOpenAICompatible(ctx, messages, tools, onChunk)
+	case "anthropic":
+		return c.streamAnthropic(ctx, messages, tools, onChunk)
+	default:
+		return c.streamOpenAICompatible(ctx, messages, tools, onChunk)
+	}
+}
+
+func (c *client) chatOpenAICompatible(ctx context.Context, messages []Message, tools []ToolDefinition) (*Response, error) {
+	url := fmt.Sprintf("%s/chat/completions", c.baseURL)
+
+	serializedMessages := serializeMessagesOpenAI(messages)
+
+	payload := map[string]any{
+		"model":       c.model,
+		"messages":    serializedMessages,
+		"max_tokens":  c.maxTokens,
+		"temperature": c.temperature,
+	}
+	if len(tools) > 0 {
+		payload["tools"] = tools
+		payload["tool_choice"] = "auto"
+	}
+
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API error: %s - %s", resp.Status, string(respBody))
+	}
+
+	var result struct {
+		Choices []struct {
+			Message struct {
+				Content   json.RawMessage `json:"content"`
+				ToolCalls []ToolCall      `json:"tool_calls"`
+			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+		} `json:"usage"`
+	}
+
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, err
+	}
+
+	if len(result.Choices) == 0 {
+		return nil, fmt.Errorf("no response from API")
+	}
+
+	content := extractOpenAICompatibleContent(result.Choices[0].Message.Content)
+	if strings.TrimSpace(content) == "" && len(result.Choices[0].Message.ToolCalls) == 0 {
+		return nil, fmt.Errorf("empty response content from API; provider/model may be incompatible with chat/completions")
+	}
+
+	return &Response{
+		Content:     content,
+		ToolCalls:   result.Choices[0].Message.ToolCalls,
+		RawResponse: result,
+		Usage: Usage{
+			InputTokens:  result.Usage.PromptTokens,
+			OutputTokens: result.Usage.CompletionTokens,
+		},
+		StopReason: result.Choices[0].FinishReason,
+	}, nil
+}
+
+func (c *client) streamOpenAICompatible(ctx context.Context, messages []Message, tools []ToolDefinition, onChunk func(string)) error {
+	url := fmt.Sprintf("%s/chat/completions", c.baseURL)
+
+	serializedMessages := serializeMessagesOpenAI(messages)
+
+	payload := map[string]any{
+		"model":       c.model,
+		"messages":    serializedMessages,
+		"max_tokens":  c.maxTokens,
+		"temperature": c.temperature,
+		"stream":      true,
+	}
+	if len(tools) > 0 {
+		payload["tools"] = tools
+		payload["tool_choice"] = "auto"
+	}
+
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	decoder := NewDecoder(resp.Body)
+	for {
+		data, err := decoder.Decode()
+		if err != nil {
+			break
+		}
+		if data.Type == "chunk" && data.Delta.Content != "" {
+			onChunk(data.Delta.Content)
+		}
+		if data.Type == "done" {
+			break
+		}
+	}
+
+	return nil
+}
+
+func extractOpenAICompatibleContent(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+
+	var blocks []map[string]any
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return ""
+	}
+
+	var parts []string
+	for _, block := range blocks {
+		if s, ok := block["text"].(string); ok && strings.TrimSpace(s) != "" {
+			parts = append(parts, s)
+			continue
+		}
+		if textObj, ok := block["text"].(map[string]any); ok {
+			if s, ok := textObj["value"].(string); ok && strings.TrimSpace(s) != "" {
+				parts = append(parts, s)
+			}
+		}
+	}
+
+	return strings.Join(parts, "")
+}
+
+func (c *client) streamAnthropic(ctx context.Context, messages []Message, tools []ToolDefinition, onChunk func(string)) error {
+	url := "https://api.anthropic.com/v1/messages"
+
+	filteredMessages, systemPrompt := serializeMessagesAnthropic(messages)
+
+	payload := map[string]any{
+		"model":       c.model,
+		"messages":    filteredMessages,
+		"max_tokens":  c.maxTokens,
+		"temperature": c.temperature,
+		"stream":      true,
+	}
+	if systemPrompt != "" {
+		payload["system"] = systemPrompt
+	}
+	if len(tools) > 0 {
+		payloadTools := make([]map[string]any, 0, len(tools))
+		for _, tool := range tools {
+			payloadTools = append(payloadTools, map[string]any{
+				"name":         tool.Function.Name,
+				"description":  tool.Function.Description,
+				"input_schema": tool.Function.Parameters,
+			})
+		}
+		payload["tools"] = payloadTools
+	}
+
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	decoder := NewAnthropicDecoder(resp.Body)
+	for {
+		data, err := decoder.Decode()
+		if err != nil {
+			break
+		}
+		if data.Type == "content_block_delta" && data.Delta.Type == "text_delta" && data.Delta.Text != "" {
+			onChunk(data.Delta.Text)
+		}
+		if data.Type == "message_stop" {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (c *client) chatAnthropic(ctx context.Context, messages []Message, tools []ToolDefinition) (*Response, error) {
+	url := "https://api.anthropic.com/v1/messages"
+
+	filteredMessages, systemPrompt := serializeMessagesAnthropic(messages)
+
+	payload := map[string]any{
+		"model":       c.model,
+		"messages":    filteredMessages,
+		"max_tokens":  c.maxTokens,
+		"temperature": c.temperature,
+	}
+	if systemPrompt != "" {
+		payload["system"] = systemPrompt
+	}
+	if len(tools) > 0 {
+		payloadTools := make([]map[string]any, 0, len(tools))
+		for _, tool := range tools {
+			payloadTools = append(payloadTools, map[string]any{
+				"name":         tool.Function.Name,
+				"description":  tool.Function.Description,
+				"input_schema": tool.Function.Parameters,
+			})
+		}
+		payload["tools"] = payloadTools
+	}
+
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API error: %s - %s", resp.Status, string(respBody))
+	}
+
+	var result struct {
+		Content []struct {
+			Type  string         `json:"type"`
+			Text  string         `json:"text,omitempty"`
+			ID    string         `json:"id,omitempty"`
+			Name  string         `json:"name,omitempty"`
+			Input map[string]any `json:"input,omitempty"`
+		} `json:"content"`
+		StopReason string `json:"stop_reason"`
+		Usage      struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	}
+
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, err
+	}
+
+	content := ""
+	toolCalls := []ToolCall{}
+	for _, block := range result.Content {
+		if block.Type == "text" {
+			content += block.Text
+		}
+		if block.Type == "tool_use" && block.Name != "" {
+			args, _ := json.Marshal(block.Input)
+			toolCalls = append(toolCalls, ToolCall{ID: block.ID, Type: "function", Function: FunctionCall{Name: block.Name, Arguments: string(args)}})
+		}
+	}
+
+	return &Response{
+		Content:     strings.TrimSpace(content),
+		ToolCalls:   toolCalls,
+		RawResponse: result,
+		Usage: Usage{
+			InputTokens:  result.Usage.InputTokens,
+			OutputTokens: result.Usage.OutputTokens,
+		},
+		StopReason: result.StopReason,
+	}, nil
+}
+
+type ClientWrapper struct {
+	client      Client
+	provider    string
+	model       string
+	apiKey      string
+	baseURL     string
+	proxyURL    string
+	maxTokens   int
+	temperature float64
+}
+
+func NewClientWrapper(cfg Config) (*ClientWrapper, error) {
+	maxTokens := cfg.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = 4096
+	}
+	c := &ClientWrapper{
+		provider:    normalizeProvider(cfg.Provider),
+		model:       cfg.Model,
+		apiKey:      cfg.APIKey,
+		baseURL:     cfg.BaseURL,
+		proxyURL:    cfg.Proxy,
+		maxTokens:   maxTokens,
+		temperature: cfg.Temperature,
+	}
+
+	if c.baseURL == "" {
+		c.baseURL = getDefaultBaseURL(cfg.Provider)
+	}
+
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func (w *ClientWrapper) initClient() error {
+	client, err := NewClient(Config{
+		Provider:    w.provider,
+		Model:       w.model,
+		APIKey:      w.apiKey,
+		BaseURL:     w.baseURL,
+		Proxy:       w.proxyURL,
+		MaxTokens:   w.maxTokens,
+		Temperature: w.temperature,
+	})
+	if err != nil {
+		return err
+	}
+	w.client = client
+	return nil
+}
+
+func (w *ClientWrapper) Chat(ctx context.Context, messages []Message, tools []ToolDefinition) (*Response, error) {
+	return w.client.Chat(ctx, messages, tools)
+}
+
+func (w *ClientWrapper) StreamChat(ctx context.Context, messages []Message, tools []ToolDefinition, onChunk func(string)) error {
+	return w.client.StreamChat(ctx, messages, tools, onChunk)
+}
+
+func (w *ClientWrapper) Name() string {
+	return w.provider
+}
+
+func (w *ClientWrapper) SwitchProvider(provider string) error {
+	w.provider = normalizeProvider(provider)
+	if w.baseURL == "" {
+		w.baseURL = getDefaultBaseURL(provider)
+	}
+	return w.initClient()
+}
+
+func (w *ClientWrapper) SwitchModel(model string) error {
+	w.model = model
+	return w.initClient()
+}
+
+func (w *ClientWrapper) SetAPIKey(apiKey string) error {
+	w.apiKey = apiKey
+	return w.initClient()
+}
+
+func (w *ClientWrapper) SetTemperature(temp float64) {
+	w.temperature = temp
+}
+
+func (w *ClientWrapper) SetBaseURL(url string) {
+	w.baseURL = url
+}
+
+func serializeMessagesOpenAI(messages []Message) []map[string]any {
+	result := make([]map[string]any, 0, len(messages))
+	for _, msg := range messages {
+		if msg.contentBlocks != nil && len(msg.contentBlocks) > 0 {
+			blocks := make([]map[string]any, 0, len(msg.contentBlocks))
+			for _, b := range msg.contentBlocks {
+				block := serializeContentBlockOpenAI(b)
+				if block != nil {
+					blocks = append(blocks, block)
+				}
+			}
+			if len(blocks) == 0 {
+				blocks = append(blocks, map[string]any{"type": "text", "text": msg.Content})
+			}
+			entry := map[string]any{
+				"role":    msg.Role,
+				"content": blocks,
+			}
+			if msg.Name != "" {
+				entry["name"] = msg.Name
+			}
+			if msg.ToolCallID != "" {
+				entry["tool_call_id"] = msg.ToolCallID
+			}
+			if len(msg.ToolCalls) > 0 {
+				entry["tool_calls"] = msg.ToolCalls
+			}
+			result = append(result, entry)
+		} else {
+			entry := map[string]any{
+				"role":    msg.Role,
+				"content": msg.Content,
+			}
+			if msg.Name != "" {
+				entry["name"] = msg.Name
+			}
+			if msg.ToolCallID != "" {
+				entry["tool_call_id"] = msg.ToolCallID
+			}
+			if len(msg.ToolCalls) > 0 {
+				entry["tool_calls"] = msg.ToolCalls
+			}
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+func serializeContentBlockOpenAI(b ContentBlock) map[string]any {
+	switch b.Type {
+	case ContentTypeText:
+		return map[string]any{"type": "text", "text": b.Text}
+	case ContentTypeImageURL:
+		img := map[string]any{"url": b.ImageURL.URL}
+		if b.ImageURL.Detail != "" {
+			img["detail"] = b.ImageURL.Detail
+		}
+		return map[string]any{"type": "image_url", "image_url": img}
+	case ContentTypeImage:
+		dataURL := fmt.Sprintf("data:%s;base64,%s", b.Image.Source.MediaType, b.Image.Source.Data)
+		img := map[string]any{"url": dataURL}
+		return map[string]any{"type": "image_url", "image_url": img}
+	default:
+		return nil
+	}
+}
+
+func serializeMessagesAnthropic(messages []Message) ([]map[string]any, string) {
+	systemPrompt := ""
+	result := make([]map[string]any, 0, len(messages))
+	for _, msg := range messages {
+		if msg.Role == "system" {
+			systemPrompt += msg.Content + "\n"
+			continue
+		}
+
+		if msg.contentBlocks != nil && len(msg.contentBlocks) > 0 {
+			blocks := make([]map[string]any, 0, len(msg.contentBlocks))
+			for _, b := range msg.contentBlocks {
+				block := serializeContentBlockAnthropic(b)
+				if block != nil {
+					blocks = append(blocks, block)
+				}
+			}
+			if len(blocks) == 0 && msg.Content != "" {
+				blocks = append(blocks, map[string]any{"type": "text", "text": msg.Content})
+			}
+			entry := map[string]any{
+				"role":    msg.Role,
+				"content": blocks,
+			}
+			result = append(result, entry)
+		} else {
+			entry := map[string]any{
+				"role":    msg.Role,
+				"content": msg.Content,
+			}
+			result = append(result, entry)
+		}
+	}
+	return result, strings.TrimSpace(systemPrompt)
+}
+
+func serializeContentBlockAnthropic(b ContentBlock) map[string]any {
+	switch b.Type {
+	case ContentTypeText:
+		return map[string]any{"type": "text", "text": b.Text}
+	case ContentTypeImageURL:
+		return map[string]any{"type": "image", "source": map[string]any{
+			"type": "url",
+			"url":  b.ImageURL.URL,
+		}}
+	case ContentTypeImage:
+		return map[string]any{"type": "image", "source": map[string]any{
+			"type":       "base64",
+			"media_type": b.Image.Source.MediaType,
+			"data":       b.Image.Source.Data,
+		}}
+	default:
+		return nil
+	}
+}

--- a/pkg/capability/models/client_test.go
+++ b/pkg/capability/models/client_test.go
@@ -1,0 +1,131 @@
+package llm
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProviderRequiresAPIKey(t *testing.T) {
+	if ProviderRequiresAPIKey("ollama") {
+		t.Fatal("expected ollama to work without an API key")
+	}
+	if !ProviderRequiresAPIKey("openai") {
+		t.Fatal("expected openai to require an API key")
+	}
+}
+
+func TestNewClientAllowsOllamaWithoutAPIKey(t *testing.T) {
+	client, err := NewClient(Config{
+		Provider: "ollama",
+		Model:    "llama3.2",
+	})
+	if err != nil {
+		t.Fatalf("expected ollama client without API key to succeed: %v", err)
+	}
+	if client.Name() != "ollama" {
+		t.Fatalf("expected ollama client, got %q", client.Name())
+	}
+}
+
+func TestNewClientAllowsConfigurationPlaceholderWithoutAPIKey(t *testing.T) {
+	client, err := NewClient(Config{
+		Provider: "compatible",
+		Model:    "demo-model",
+	})
+	if err != nil {
+		t.Fatalf("expected placeholder client without API key to succeed: %v", err)
+	}
+	if client.Name() != "compatible" {
+		t.Fatalf("expected compatible client placeholder, got %q", client.Name())
+	}
+
+	_, err = client.Chat(context.Background(), []Message{{Role: "user", Content: "hi"}}, nil)
+	if err == nil {
+		t.Fatal("expected placeholder client to reject chat before API key is configured")
+	}
+	if got := err.Error(); got != "API key is required. Configure a model provider before chatting" {
+		t.Fatalf("unexpected placeholder error: %v", err)
+	}
+}
+
+func TestChatOpenAICompatibleRejectsEmptyMessageContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"choices": [
+				{
+					"message": {"role": "assistant"},
+					"finish_reason": "stop"
+				}
+			],
+			"usage": {
+				"prompt_tokens": 1,
+				"completion_tokens": 1
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		Provider: "compatible",
+		Model:    "demo-model",
+		APIKey:   "test-key",
+		BaseURL:  server.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), []Message{{Role: "user", Content: "hi"}}, nil)
+	if err == nil {
+		t.Fatal("expected empty content response to fail")
+	}
+	if got := err.Error(); got != "empty response content from API; provider/model may be incompatible with chat/completions" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestChatOpenAICompatibleSupportsContentBlocks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"choices": [
+				{
+					"message": {
+						"role": "assistant",
+						"content": [
+							{"type": "text", "text": "hello"},
+							{"type": "text", "text": " world"}
+						]
+					},
+					"finish_reason": "stop"
+				}
+			],
+			"usage": {
+				"prompt_tokens": 1,
+				"completion_tokens": 2
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		Provider: "compatible",
+		Model:    "demo-model",
+		APIKey:   "test-key",
+		BaseURL:  server.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	resp, err := client.Chat(context.Background(), []Message{{Role: "user", Content: "hi"}}, nil)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "hello world" {
+		t.Fatalf("expected merged block text, got %q", resp.Content)
+	}
+}

--- a/pkg/capability/models/client_wrapper_test.go
+++ b/pkg/capability/models/client_wrapper_test.go
@@ -1,0 +1,19 @@
+package llm
+
+import "testing"
+
+func TestNewClientWrapperPreservesConfiguredMaxTokens(t *testing.T) {
+	wrapper, err := NewClientWrapper(Config{
+		Provider:  "qwen",
+		Model:     "qwen-math-turbo",
+		APIKey:    "test-key",
+		MaxTokens: 3072,
+	})
+	if err != nil {
+		t.Fatalf("NewClientWrapper: %v", err)
+	}
+
+	if wrapper.maxTokens != 3072 {
+		t.Fatalf("expected maxTokens=3072, got %d", wrapper.maxTokens)
+	}
+}

--- a/pkg/capability/models/failover.go
+++ b/pkg/capability/models/failover.go
@@ -1,0 +1,325 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// FailoverConfig configures model failover behavior
+type FailoverConfig struct {
+	Enabled        bool            `json:"enabled"`
+	MaxRetries     int             `json:"max_retries"`
+	RetryDelay     time.Duration   `json:"retry_delay"`
+	CooldownPeriod time.Duration   `json:"cooldown_period"`
+	FallbackModels []FallbackModel `json:"fallback_models"`
+}
+
+// FallbackModel defines a fallback model configuration
+type FallbackModel struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+	Priority int    `json:"priority"` // Lower = higher priority
+}
+
+// FailoverClient wraps a Client with failover support
+type FailoverClient struct {
+	mu          sync.RWMutex
+	config      FailoverConfig
+	primary     Client
+	fallbacks   []Client
+	cooldowns   map[string]time.Time
+	currentIdx  int
+	errorCounts map[string]int
+	lastError   map[string]error
+}
+
+// NewFailoverClient creates a new failover client
+func NewFailoverClient(primary Client, config FailoverConfig) *FailoverClient {
+	if config.MaxRetries <= 0 {
+		config.MaxRetries = 3
+	}
+	if config.RetryDelay <= 0 {
+		config.RetryDelay = time.Second
+	}
+	if config.CooldownPeriod <= 0 {
+		config.CooldownPeriod = 5 * time.Minute
+	}
+
+	return &FailoverClient{
+		config:      config,
+		primary:     primary,
+		cooldowns:   make(map[string]time.Time),
+		errorCounts: make(map[string]int),
+		lastError:   make(map[string]error),
+	}
+}
+
+// AddFallback adds a fallback client
+func (fc *FailoverClient) AddFallback(client Client) {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	fc.fallbacks = append(fc.fallbacks, client)
+}
+
+// Chat implements the Client interface with failover
+func (fc *FailoverClient) Chat(ctx context.Context, messages []Message, tools []ToolDefinition) (*Response, error) {
+	if !fc.config.Enabled {
+		return fc.primary.Chat(ctx, messages, tools)
+	}
+
+	// Try primary first
+	resp, err := fc.tryClient(ctx, fc.primary, messages, tools)
+	if err == nil {
+		return resp, nil
+	}
+
+	// Try fallbacks
+	for _, fallback := range fc.fallbacks {
+		resp, err = fc.tryClient(ctx, fallback, messages, tools)
+		if err == nil {
+			return resp, nil
+		}
+	}
+
+	return nil, fmt.Errorf("all providers failed: %w", err)
+}
+
+// StreamChat implements streaming with failover
+func (fc *FailoverClient) StreamChat(ctx context.Context, messages []Message, tools []ToolDefinition, onChunk func(string)) error {
+	if !fc.config.Enabled {
+		return fc.primary.StreamChat(ctx, messages, tools, onChunk)
+	}
+
+	// Try primary
+	err := fc.primary.StreamChat(ctx, messages, tools, onChunk)
+	if err == nil {
+		return nil
+	}
+
+	// Try fallbacks
+	for _, fallback := range fc.fallbacks {
+		err = fallback.StreamChat(ctx, messages, tools, onChunk)
+		if err == nil {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("all providers failed: %w", err)
+}
+
+// Name returns the client name
+func (fc *FailoverClient) Name() string {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return fc.primary.Name()
+}
+
+// tryClient attempts to use a client with retry and cooldown
+func (fc *FailoverClient) tryClient(ctx context.Context, client Client, messages []Message, tools []ToolDefinition) (*Response, error) {
+	clientName := client.Name()
+
+	// Check cooldown
+	fc.mu.RLock()
+	cooldown, inCooldown := fc.cooldowns[clientName]
+	fc.mu.RUnlock()
+
+	if inCooldown && time.Now().Before(cooldown) {
+		return nil, fmt.Errorf("client %s is in cooldown until %v", clientName, cooldown)
+	}
+
+	// Try with retries
+	var lastErr error
+	for i := 0; i <= fc.config.MaxRetries; i++ {
+		resp, err := client.Chat(ctx, messages, tools)
+		if err == nil {
+			// Reset error count on success
+			fc.mu.Lock()
+			fc.errorCounts[clientName] = 0
+			delete(fc.cooldowns, clientName)
+			fc.mu.Unlock()
+			return resp, nil
+		}
+
+		lastErr = err
+
+		// Check if error is retryable
+		if !isRetryableError(err) {
+			break
+		}
+
+		// Wait before retry
+		if i < fc.config.MaxRetries {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(fc.config.RetryDelay * time.Duration(i+1)):
+			}
+		}
+	}
+
+	// Set cooldown
+	fc.mu.Lock()
+	fc.errorCounts[clientName]++
+	fc.lastError[clientName] = lastErr
+	if fc.errorCounts[clientName] >= 2 {
+		fc.cooldowns[clientName] = time.Now().Add(fc.config.CooldownPeriod)
+	}
+	fc.mu.Unlock()
+
+	return nil, lastErr
+}
+
+// isRetryableError checks if an error is retryable
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := err.Error()
+	// Rate limit errors
+	if contains(errStr, "rate limit") || contains(errStr, "429") {
+		return true
+	}
+	// Timeout errors
+	if contains(errStr, "timeout") || contains(errStr, "deadline") {
+		return true
+	}
+	// Server errors
+	if contains(errStr, "500") || contains(errStr, "502") || contains(errStr, "503") {
+		return true
+	}
+	// Connection errors
+	if contains(errStr, "connection") || contains(errStr, "refused") {
+		return true
+	}
+	return false
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsImpl(s, substr))
+}
+
+func containsImpl(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// GetStatus returns failover status
+func (fc *FailoverClient) GetStatus() map[string]any {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+
+	status := map[string]any{
+		"enabled": fc.config.Enabled,
+		"primary": fc.primary.Name(),
+	}
+
+	fallbackNames := make([]string, len(fc.fallbacks))
+	for i, f := range fc.fallbacks {
+		fallbackNames[i] = f.Name()
+	}
+	status["fallbacks"] = fallbackNames
+
+	cooldowns := make(map[string]string)
+	for name, until := range fc.cooldowns {
+		if time.Now().Before(until) {
+			cooldowns[name] = until.Format(time.RFC3339)
+		}
+	}
+	status["cooldowns"] = cooldowns
+	status["error_counts"] = fc.errorCounts
+
+	return status
+}
+
+// ModelDiscovery discovers available models from providers
+type ModelDiscovery struct {
+	mu        sync.RWMutex
+	models    map[string][]ModelInfo
+	providers []Provider
+}
+
+// ModelInfo represents information about a model
+type ModelInfo struct {
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	Provider     string   `json:"provider"`
+	MaxTokens    int      `json:"max_tokens"`
+	Capabilities []string `json:"capabilities"` // chat, completion, vision, tools, reasoning
+}
+
+// Provider represents an LLM provider for discovery
+type Provider interface {
+	Name() string
+	ListModels(ctx context.Context) ([]ModelInfo, error)
+}
+
+// NewModelDiscovery creates a new model discovery
+func NewModelDiscovery() *ModelDiscovery {
+	return &ModelDiscovery{
+		models: make(map[string][]ModelInfo),
+	}
+}
+
+// RegisterProvider registers a provider for discovery
+func (md *ModelDiscovery) RegisterProvider(provider Provider) {
+	md.mu.Lock()
+	defer md.mu.Unlock()
+	md.providers = append(md.providers, provider)
+}
+
+// DiscoverModels discovers models from all providers
+func (md *ModelDiscovery) DiscoverModels(ctx context.Context) error {
+	md.mu.Lock()
+	defer md.mu.Unlock()
+
+	for _, provider := range md.providers {
+		models, err := provider.ListModels(ctx)
+		if err != nil {
+			continue
+		}
+		md.models[provider.Name()] = models
+	}
+
+	return nil
+}
+
+// ListModels returns all discovered models
+func (md *ModelDiscovery) ListModels() map[string][]ModelInfo {
+	md.mu.RLock()
+	defer md.mu.RUnlock()
+
+	result := make(map[string][]ModelInfo)
+	for k, v := range md.models {
+		result[k] = v
+	}
+	return result
+}
+
+// FindModel finds a model by name or capability
+func (md *ModelDiscovery) FindModel(name string, capability string) *ModelInfo {
+	md.mu.RLock()
+	defer md.mu.RUnlock()
+
+	for _, models := range md.models {
+		for _, model := range models {
+			if model.ID == name || model.Name == name {
+				return &model
+			}
+			if capability != "" {
+				for _, cap := range model.Capabilities {
+					if cap == capability {
+						return &model
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/capability/models/multimodal.go
+++ b/pkg/capability/models/multimodal.go
@@ -1,0 +1,235 @@
+package llm
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type ContentType string
+
+const (
+	ContentTypeText     ContentType = "text"
+	ContentTypeImageURL ContentType = "image_url"
+	ContentTypeImage    ContentType = "image"
+	ContentTypeFile     ContentType = "file"
+)
+
+type ContentBlock struct {
+	Type     ContentType    `json:"type"`
+	Text     string         `json:"text,omitempty"`
+	ImageURL *ImageURLBlock `json:"image_url,omitempty"`
+	Image    *ImageBlock    `json:"image,omitempty"`
+	File     *FileBlock     `json:"file,omitempty"`
+}
+
+type ImageURLBlock struct {
+	URL    string `json:"url"`
+	Detail string `json:"detail,omitempty"`
+}
+
+type ImageBlock struct {
+	Source ImageSource `json:"source"`
+}
+
+type ImageSource struct {
+	Type      string `json:"type"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
+}
+
+type FileBlock struct {
+	Filename string `json:"filename"`
+	Data     string `json:"data"`
+	MimeType string `json:"mime_type"`
+}
+
+func (m *Message) UnmarshalContent() ([]ContentBlock, error) {
+	if m.contentBlocks != nil && len(m.contentBlocks) > 0 {
+		return m.contentBlocks, nil
+	}
+
+	if m.Content == "" {
+		return nil, nil
+	}
+
+	return []ContentBlock{
+		{Type: ContentTypeText, Text: m.Content},
+	}, nil
+}
+
+func (m *Message) SetContentBlocks(blocks []ContentBlock) {
+	m.contentBlocks = blocks
+	if len(blocks) == 1 && blocks[0].Type == ContentTypeText {
+		m.Content = blocks[0].Text
+	} else {
+		m.Content = ""
+	}
+}
+
+func (m *Message) AppendText(text string) {
+	if m.contentBlocks == nil || len(m.contentBlocks) == 0 {
+		if m.Content != "" {
+			m.contentBlocks = []ContentBlock{{Type: ContentTypeText, Text: m.Content}}
+		} else {
+			m.contentBlocks = []ContentBlock{}
+		}
+	}
+
+	if len(m.contentBlocks) > 0 && m.contentBlocks[len(m.contentBlocks)-1].Type == ContentTypeText {
+		m.contentBlocks[len(m.contentBlocks)-1].Text += text
+	} else {
+		m.contentBlocks = append(m.contentBlocks, ContentBlock{Type: ContentTypeText, Text: text})
+	}
+}
+
+func (m *Message) AppendImageURL(url string, detail string) {
+	block := ContentBlock{
+		Type:     ContentTypeImageURL,
+		ImageURL: &ImageURLBlock{URL: url},
+	}
+	if detail != "" {
+		block.ImageURL.Detail = detail
+	}
+	m.contentBlocks = append(m.contentBlocks, block)
+}
+
+func (m *Message) AppendImageBase64(data []byte, mimeType string) {
+	encoded := base64.StdEncoding.EncodeToString(data)
+	m.contentBlocks = append(m.contentBlocks, ContentBlock{
+		Type: ContentTypeImage,
+		Image: &ImageBlock{
+			Source: ImageSource{
+				Type:      "base64",
+				MediaType: mimeType,
+				Data:      encoded,
+			},
+		},
+	})
+}
+
+func (m *Message) AppendImageFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read image file: %w", err)
+	}
+
+	mimeType := mimeTypeFromPath(path)
+	if mimeType == "" {
+		mimeType = "image/png"
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(data)
+	m.contentBlocks = append(m.contentBlocks, ContentBlock{
+		Type: ContentTypeImage,
+		Image: &ImageBlock{
+			Source: ImageSource{
+				Type:      "base64",
+				MediaType: mimeType,
+				Data:      encoded,
+			},
+		},
+	})
+	return nil
+}
+
+func NewUserMessage(parts ...ContentBlock) Message {
+	m := Message{Role: "user"}
+	if len(parts) > 0 {
+		m.SetContentBlocks(parts)
+	}
+	return m
+}
+
+func NewTextMessage(role, text string) Message {
+	return Message{Role: role, Content: text}
+}
+
+func TextBlock(text string) ContentBlock {
+	return ContentBlock{Type: ContentTypeText, Text: text}
+}
+
+func ImageURLBlockFromURL(url string, detail string) ContentBlock {
+	block := ContentBlock{Type: ContentTypeImageURL, ImageURL: &ImageURLBlock{URL: url}}
+	if detail != "" {
+		block.ImageURL.Detail = detail
+	}
+	return block
+}
+
+func ImageBlockFromBase64(data []byte, mimeType string) ContentBlock {
+	return ContentBlock{
+		Type: ContentTypeImage,
+		Image: &ImageBlock{
+			Source: ImageSource{
+				Type:      "base64",
+				MediaType: mimeType,
+				Data:      base64.StdEncoding.EncodeToString(data),
+			},
+		},
+	}
+}
+
+func ImageBlockFromFile(path string) (ContentBlock, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ContentBlock{}, fmt.Errorf("read image file: %w", err)
+	}
+
+	mimeType := mimeTypeFromPath(path)
+	if mimeType == "" {
+		mimeType = "image/png"
+	}
+
+	return ContentBlock{
+		Type: ContentTypeImage,
+		Image: &ImageBlock{
+			Source: ImageSource{
+				Type:      "base64",
+				MediaType: mimeType,
+				Data:      base64.StdEncoding.EncodeToString(data),
+			},
+		},
+	}, nil
+}
+
+func mimeTypeFromPath(path string) string {
+	ext := strings.ToLower(path)
+	switch {
+	case strings.HasSuffix(ext, ".jpg"), strings.HasSuffix(ext, ".jpeg"):
+		return "image/jpeg"
+	case strings.HasSuffix(ext, ".png"):
+		return "image/png"
+	case strings.HasSuffix(ext, ".gif"):
+		return "image/gif"
+	case strings.HasSuffix(ext, ".webp"):
+		return "image/webp"
+	case strings.HasSuffix(ext, ".bmp"):
+		return "image/bmp"
+	default:
+		return ""
+	}
+}
+
+func IsVisionCapableModel(model string) bool {
+	model = strings.ToLower(model)
+
+	visionModels := []string{
+		"gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-4-vision",
+		"claude-3-sonnet", "claude-3-haiku", "claude-3-opus",
+		"claude-3-5-sonnet", "claude-3-5-haiku", "claude-3-7-sonnet",
+		"gemini-1.5-pro", "gemini-1.5-flash", "gemini-2.0",
+		"qwen-vl", "qwen2-vl", "qwen2.5-vl",
+		"llava", "moondream", "bakllava",
+		"pixtral",
+	}
+
+	for _, vm := range visionModels {
+		if strings.Contains(model, vm) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/capability/models/multimodal_test.go
+++ b/pkg/capability/models/multimodal_test.go
@@ -1,0 +1,333 @@
+package llm
+
+import (
+	"testing"
+)
+
+func TestMessage_AppendText(t *testing.T) {
+	m := Message{Role: "user"}
+	m.AppendText("Hello")
+	m.AppendText(" World")
+
+	blocks, err := m.UnmarshalContent()
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0].Text != "Hello World" {
+		t.Errorf("expected 'Hello World', got '%s'", blocks[0].Text)
+	}
+}
+
+func TestMessage_AppendImageURL(t *testing.T) {
+	m := Message{Role: "user"}
+	m.AppendText("Describe this:")
+	m.AppendImageURL("https://example.com/img.jpg", "high")
+
+	blocks, err := m.UnmarshalContent()
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+	if blocks[0].Type != ContentTypeText {
+		t.Errorf("expected text block, got %s", blocks[0].Type)
+	}
+	if blocks[1].Type != ContentTypeImageURL {
+		t.Errorf("expected image_url block, got %s", blocks[1].Type)
+	}
+	if blocks[1].ImageURL.URL != "https://example.com/img.jpg" {
+		t.Errorf("wrong URL: %s", blocks[1].ImageURL.URL)
+	}
+	if blocks[1].ImageURL.Detail != "high" {
+		t.Errorf("wrong detail: %s", blocks[1].ImageURL.Detail)
+	}
+}
+
+func TestMessage_AppendImageBase64(t *testing.T) {
+	m := Message{Role: "user"}
+	m.AppendText("What is this?")
+	m.AppendImageBase64([]byte("fake-image-data"), "image/png")
+
+	blocks, err := m.UnmarshalContent()
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+	if blocks[1].Type != ContentTypeImage {
+		t.Errorf("expected image block, got %s", blocks[1].Type)
+	}
+	if blocks[1].Image.Source.MediaType != "image/png" {
+		t.Errorf("wrong media type: %s", blocks[1].Image.Source.MediaType)
+	}
+}
+
+func TestMessage_SetContentBlocks(t *testing.T) {
+	m := Message{Role: "user"}
+	m.SetContentBlocks([]ContentBlock{
+		{Type: ContentTypeText, Text: "Hello"},
+		{Type: ContentTypeImageURL, ImageURL: &ImageURLBlock{URL: "https://example.com/img.jpg"}},
+	})
+
+	if m.Content != "" {
+		t.Error("Content should be empty for multi-block messages")
+	}
+	if m.contentBlocks == nil || len(m.contentBlocks) != 2 {
+		t.Fatalf("expected 2 content blocks, got %d", len(m.contentBlocks))
+	}
+}
+
+func TestNewUserMessage(t *testing.T) {
+	m := NewUserMessage(
+		TextBlock("Describe this image:"),
+		ImageURLBlockFromURL("https://example.com/test.jpg", "auto"),
+	)
+
+	if m.Role != "user" {
+		t.Errorf("expected role 'user', got '%s'", m.Role)
+	}
+	if m.contentBlocks == nil || len(m.contentBlocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(m.contentBlocks))
+	}
+}
+
+func TestTextBlock(t *testing.T) {
+	b := TextBlock("Hello")
+	if b.Type != ContentTypeText {
+		t.Errorf("expected text type, got %s", b.Type)
+	}
+	if b.Text != "Hello" {
+		t.Errorf("expected 'Hello', got '%s'", b.Text)
+	}
+}
+
+func TestImageBlockFromBase64(t *testing.T) {
+	b := ImageBlockFromBase64([]byte("data"), "image/jpeg")
+	if b.Type != ContentTypeImage {
+		t.Errorf("expected image type, got %s", b.Type)
+	}
+	if b.Image.Source.Type != "base64" {
+		t.Errorf("expected base64 source type, got %s", b.Image.Source.Type)
+	}
+	if b.Image.Source.MediaType != "image/jpeg" {
+		t.Errorf("expected image/jpeg, got %s", b.Image.Source.MediaType)
+	}
+}
+
+func TestMimeTypeFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"photo.jpg", "image/jpeg"},
+		{"photo.jpeg", "image/jpeg"},
+		{"icon.png", "image/png"},
+		{"anim.gif", "image/gif"},
+		{"pic.webp", "image/webp"},
+		{"scan.bmp", "image/bmp"},
+		{"unknown.xyz", ""},
+	}
+
+	for _, tt := range tests {
+		got := mimeTypeFromPath(tt.path)
+		if got != tt.want {
+			t.Errorf("mimeTypeFromPath(%s) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestIsVisionCapableModel(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"gpt-4o", true},
+		{"gpt-4o-mini", true},
+		{"gpt-4-turbo", true},
+		{"gpt-4-vision-preview", true},
+		{"claude-3-sonnet-20240229", true},
+		{"claude-3-opus-20240229", true},
+		{"claude-3-haiku-20240307", true},
+		{"claude-3-5-sonnet-20241022", true},
+		{"gemini-1.5-pro", true},
+		{"gemini-1.5-flash", true},
+		{"qwen2.5-vl-72b", true},
+		{"gpt-3.5-turbo", false},
+		{"gpt-4", false},
+		{"llama-3-70b", false},
+		{"mistral-large", false},
+	}
+
+	for _, tt := range tests {
+		got := IsVisionCapableModel(tt.model)
+		if got != tt.want {
+			t.Errorf("IsVisionCapableModel(%s) = %v, want %v", tt.model, got, tt.want)
+		}
+	}
+}
+
+func TestSerializeMessagesOpenAI_TextOnly(t *testing.T) {
+	messages := []Message{
+		{Role: "system", Content: "You are helpful"},
+		{Role: "user", Content: "Hello"},
+	}
+
+	serialized := serializeMessagesOpenAI(messages)
+
+	if len(serialized) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(serialized))
+	}
+	if serialized[0]["role"] != "system" {
+		t.Errorf("expected system role, got %v", serialized[0]["role"])
+	}
+	if serialized[0]["content"] != "You are helpful" {
+		t.Errorf("wrong content: %v", serialized[0]["content"])
+	}
+	if serialized[1]["content"] != "Hello" {
+		t.Errorf("wrong content: %v", serialized[1]["content"])
+	}
+}
+
+func TestSerializeMessagesOpenAI_Multimodal(t *testing.T) {
+	m := NewUserMessage(
+		TextBlock("What's in this image?"),
+		ImageURLBlockFromURL("https://example.com/test.jpg", "auto"),
+	)
+
+	serialized := serializeMessagesOpenAI([]Message{m})
+
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(serialized))
+	}
+
+	content, ok := serialized[0]["content"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected content to be array, got %T", serialized[0]["content"])
+	}
+
+	if len(content) != 2 {
+		t.Fatalf("expected 2 content blocks, got %d", len(content))
+	}
+
+	if content[0]["type"] != "text" {
+		t.Errorf("expected text type, got %v", content[0]["type"])
+	}
+	if content[1]["type"] != "image_url" {
+		t.Errorf("expected image_url type, got %v", content[1]["type"])
+	}
+}
+
+func TestSerializeMessagesOpenAI_Base64Image(t *testing.T) {
+	m := NewUserMessage(
+		TextBlock("Describe:"),
+		ImageBlockFromBase64([]byte("img-data"), "image/png"),
+	)
+
+	serialized := serializeMessagesOpenAI([]Message{m})
+
+	content := serialized[0]["content"].([]map[string]any)
+	if len(content) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(content))
+	}
+
+	imgBlock := content[1]["image_url"].(map[string]any)
+	url := imgBlock["url"].(string)
+	if url != "data:image/png;base64,aW1nLWRhdGE=" {
+		t.Errorf("wrong data URL: %s", url)
+	}
+}
+
+func TestSerializeMessagesAnthropic_TextOnly(t *testing.T) {
+	messages := []Message{
+		{Role: "system", Content: "You are helpful"},
+		{Role: "user", Content: "Hello"},
+	}
+
+	serialized, systemPrompt := serializeMessagesAnthropic(messages)
+
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(serialized))
+	}
+	if systemPrompt != "You are helpful" {
+		t.Errorf("expected system prompt 'You are helpful', got '%s'", systemPrompt)
+	}
+	if serialized[0]["content"] != "Hello" {
+		t.Errorf("wrong content: %v", serialized[0]["content"])
+	}
+}
+
+func TestSerializeMessagesAnthropic_Multimodal(t *testing.T) {
+	m := NewUserMessage(
+		TextBlock("What is this?"),
+		ImageBlockFromBase64([]byte("img-data"), "image/png"),
+	)
+
+	serialized, _ := serializeMessagesAnthropic([]Message{m})
+
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(serialized))
+	}
+
+	content := serialized[0]["content"].([]map[string]any)
+	if len(content) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(content))
+	}
+
+	if content[1]["type"] != "image" {
+		t.Errorf("expected image type, got %v", content[1]["type"])
+	}
+
+	source := content[1]["source"].(map[string]any)
+	if source["type"] != "base64" {
+		t.Errorf("expected base64 source, got %v", source["type"])
+	}
+	if source["media_type"] != "image/png" {
+		t.Errorf("expected image/png, got %v", source["media_type"])
+	}
+}
+
+func TestContentBlock_RoundTrip(t *testing.T) {
+	m := Message{Role: "user"}
+	m.AppendText("Test")
+	m.AppendImageURL("https://example.com/img.jpg", "")
+	m.AppendText(" More text")
+
+	blocks, err := m.UnmarshalContent()
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(blocks) != 3 {
+		t.Fatalf("expected 3 blocks, got %d", len(blocks))
+	}
+
+	if blocks[0].Text != "Test" {
+		t.Errorf("expected 'Test', got '%s'", blocks[0].Text)
+	}
+	if blocks[2].Text != " More text" {
+		t.Errorf("expected ' More text', got '%s'", blocks[2].Text)
+	}
+}
+
+func TestImageBlockFromFile_NotFound(t *testing.T) {
+	_, err := ImageBlockFromFile("/nonexistent/file.jpg")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestMessage_AppendImageFile_NotFound(t *testing.T) {
+	m := Message{Role: "user"}
+	err := m.AppendImageFile("/nonexistent/file.jpg")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}

--- a/pkg/capability/models/stream.go
+++ b/pkg/capability/models/stream.go
@@ -1,0 +1,128 @@
+package llm
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type StreamChunk struct {
+	Type   string   `json:"type"`
+	Delta  Delta    `json:"delta,omitempty"`
+	Choice []Choice `json:"choices,omitempty"`
+}
+
+type Delta struct {
+	Content string `json:"content,omitempty"`
+	Role    string `json:"role,omitempty"`
+}
+
+type Choice struct {
+	Delta        Delta  `json:"delta"`
+	FinishReason string `json:"finish_reason,omitempty"`
+}
+
+type OpenAIDecoder struct {
+	scanner *bufio.Scanner
+}
+
+func NewDecoder(r io.Reader) *OpenAIDecoder {
+	return &OpenAIDecoder{
+		scanner: bufio.NewScanner(r),
+	}
+}
+
+func (d *OpenAIDecoder) Decode() (*StreamChunk, error) {
+	for d.scanner.Scan() {
+		line := d.scanner.Text()
+		line = strings.TrimPrefix(line, "data: ")
+
+		if line == "" {
+			continue
+		}
+
+		if line == "[DONE]" {
+			return &StreamChunk{Type: "done"}, nil
+		}
+
+		var chunk StreamChunk
+		if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+			continue
+		}
+
+		if len(chunk.Choice) > 0 {
+			chunk.Delta = chunk.Choice[0].Delta
+		}
+
+		chunk.Type = "chunk"
+		return &chunk, nil
+	}
+
+	if err := d.scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return &StreamChunk{Type: "done"}, nil
+}
+
+type AnthropicChunk struct {
+	Type              string            `json:"type"`
+	Delta             AnthropicDelta    `json:"delta,omitempty"`
+	ContentBlockDelta ContentBlockDelta `json:"content_block_delta,omitempty"`
+	Index             int               `json:"index,omitempty"`
+}
+
+type AnthropicDelta struct {
+	Type string `json:"type,omitempty"`
+	Text string `json:"text,omitempty"`
+}
+
+type ContentBlockDelta struct {
+	Type string `json:"type,omitempty"`
+	Text string `json:"text,omitempty"`
+}
+
+type AnthropicDecoder struct {
+	scanner *bufio.Scanner
+}
+
+func NewAnthropicDecoder(r io.Reader) *AnthropicDecoder {
+	return &AnthropicDecoder{
+		scanner: bufio.NewScanner(r),
+	}
+}
+
+func (d *AnthropicDecoder) Decode() (*AnthropicChunk, error) {
+	for d.scanner.Scan() {
+		line := d.scanner.Text()
+		line = strings.TrimPrefix(line, "data: ")
+
+		if line == "" {
+			continue
+		}
+
+		var chunk AnthropicChunk
+		if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+			continue
+		}
+
+		switch chunk.Type {
+		case "content_block_delta":
+			chunk.Delta.Type = chunk.ContentBlockDelta.Type
+			chunk.Delta.Text = chunk.ContentBlockDelta.Text
+			return &chunk, nil
+		case "message_stop":
+			return &chunk, nil
+		case "error":
+			return nil, fmt.Errorf("anthropic error: %s", line)
+		}
+	}
+
+	if err := d.scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return nil, io.EOF
+}


### PR DESCRIPTION
## 🚀 功能说明
新增 capability 层 models 模块，实现模型客户端封装、多模型支持及相关能力。

## 📦 主要改动
- 新增模型客户端（client）
- 新增多模型支持（multimodal）
- 新增 failover 机制
- 新增流式处理（stream）
- 补充单元测试

## 🎯 目的
为系统提供统一的模型调用接口，支持多模型扩展与容错能力。

## 🧪 测试方式
go test ./pkg/capability/models/...

## ⚠️ 说明
- 无破坏性变更