### PR TITLE
feat(tools):add capability tools module

### DIFF
--- a/pkg/capability/tools/approval.go
+++ b/pkg/capability/tools/approval.go
@@ -1,0 +1,61 @@
+package tools
+
+import "context"
+
+type ToolApprovalCall struct {
+	Name string
+	Args map[string]any
+}
+
+type ToolApprovalHook func(ctx context.Context, call ToolApprovalCall) error
+
+type ToolCallerRole string
+
+const (
+	ToolCallerRoleUnknown   ToolCallerRole = ""
+	ToolCallerRoleMainAgent ToolCallerRole = "main_agent"
+	ToolCallerRoleSubAgent  ToolCallerRole = "sub_agent"
+	ToolCallerRoleSystem    ToolCallerRole = "system"
+)
+
+type ToolCaller struct {
+	Role        ToolCallerRole
+	AgentName   string
+	ExecutionID string
+}
+
+type toolApprovalHookKey struct{}
+type toolCallerKey struct{}
+
+func WithToolApprovalHook(ctx context.Context, hook ToolApprovalHook) context.Context {
+	if hook == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, toolApprovalHookKey{}, hook)
+}
+
+func RequestToolApproval(ctx context.Context, name string, args map[string]any) error {
+	if ctx == nil {
+		return nil
+	}
+	hook, _ := ctx.Value(toolApprovalHookKey{}).(ToolApprovalHook)
+	if hook == nil {
+		return nil
+	}
+	return hook(ctx, ToolApprovalCall{Name: name, Args: args})
+}
+
+func WithToolCaller(ctx context.Context, caller ToolCaller) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, toolCallerKey{}, caller)
+}
+
+func ToolCallerFromContext(ctx context.Context) ToolCaller {
+	if ctx == nil {
+		return ToolCaller{}
+	}
+	caller, _ := ctx.Value(toolCallerKey{}).(ToolCaller)
+	return caller
+}

--- a/pkg/capability/tools/approval_test.go
+++ b/pkg/capability/tools/approval_test.go
@@ -1,0 +1,24 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRequestToolApprovalInvokesHook(t *testing.T) {
+	var called ToolApprovalCall
+	ctx := WithToolApprovalHook(context.Background(), func(ctx context.Context, call ToolApprovalCall) error {
+		called = call
+		return nil
+	})
+
+	if err := RequestToolApproval(ctx, "desktop_plan", map[string]any{"summary": "demo"}); err != nil {
+		t.Fatalf("RequestToolApproval: %v", err)
+	}
+	if called.Name != "desktop_plan" {
+		t.Fatalf("expected desktop_plan, got %q", called.Name)
+	}
+	if called.Args["summary"] != "demo" {
+		t.Fatalf("unexpected args: %#v", called.Args)
+	}
+}

--- a/pkg/capability/tools/browser.go
+++ b/pkg/capability/tools/browser.go
@@ -1,0 +1,762 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/chromedp"
+)
+
+type browserSessionContextKey struct{}
+
+func WithBrowserSession(ctx context.Context, sessionID string) context.Context {
+	if strings.TrimSpace(sessionID) == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, browserSessionContextKey{}, strings.TrimSpace(sessionID))
+}
+
+func browserSessionFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if v, ok := ctx.Value(browserSessionContextKey{}).(string); ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
+}
+
+func resolveBrowserSessionID(ctx context.Context, input map[string]any) string {
+	if input != nil {
+		if sessionID, _ := input["session_id"].(string); strings.TrimSpace(sessionID) != "" {
+			return strings.TrimSpace(sessionID)
+		}
+	}
+	if sessionID := browserSessionFromContext(ctx); sessionID != "" {
+		if input != nil {
+			input["session_id"] = sessionID
+		}
+		return sessionID
+	}
+	if input != nil {
+		input["session_id"] = "default"
+	}
+	return "default"
+}
+
+type browserSession struct {
+	id        string
+	allocCtx  context.Context
+	rootCtx   context.Context
+	cancel    context.CancelFunc
+	started   time.Time
+	pages     map[string]*browserPage
+	activeTab string
+}
+
+type browserPage struct {
+	id      string
+	ctx     context.Context
+	cancel  context.CancelFunc
+	created time.Time
+	lastURL string
+}
+
+var (
+	browserMu       sync.Mutex
+	browserSessions = map[string]*browserSession{}
+)
+
+func getBrowserSession(sessionID string) (*browserSession, error) {
+	browserMu.Lock()
+	defer browserMu.Unlock()
+	if sessionID == "" {
+		sessionID = "default"
+	}
+	if existing, ok := browserSessions[sessionID]; ok {
+		return existing, nil
+	}
+	allocOpts := append(chromedp.DefaultExecAllocatorOptions[:], chromedp.Headless, chromedp.DisableGPU)
+	if browserPath := findChromedpBrowserExecutable(); browserPath != "" {
+		allocOpts = append(allocOpts, chromedp.ExecPath(browserPath))
+	}
+	allocCtx, _ := chromedp.NewExecAllocator(context.Background(), allocOpts...)
+	rootCtx, cancel := chromedp.NewContext(allocCtx)
+	bs := &browserSession{id: sessionID, allocCtx: allocCtx, rootCtx: rootCtx, cancel: cancel, started: time.Now().UTC(), pages: map[string]*browserPage{}}
+	page, err := bs.newPage("tab-1")
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	bs.activeTab = page.id
+	browserSessions[sessionID] = bs
+	return bs, nil
+}
+
+func findChromedpBrowserExecutable() string {
+	candidates := []string{}
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		candidates = append(candidates, value)
+	}
+
+	switch runtime.GOOS {
+	case "windows":
+		programFiles := strings.TrimSpace(os.Getenv("ProgramFiles"))
+		programFilesX86 := strings.TrimSpace(os.Getenv("ProgramFiles(x86)"))
+		add(filepath.Join(programFilesX86, "Microsoft", "Edge", "Application", "msedge.exe"))
+		add(filepath.Join(programFiles, "Microsoft", "Edge", "Application", "msedge.exe"))
+		add(filepath.Join(programFiles, "Google", "Chrome", "Application", "chrome.exe"))
+		add(filepath.Join(programFilesX86, "Google", "Chrome", "Application", "chrome.exe"))
+		add("msedge.exe")
+		add("chrome.exe")
+	case "darwin":
+		add("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
+		add("/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge")
+		add("Google Chrome")
+		add("Microsoft Edge")
+	default:
+		add("google-chrome")
+		add("microsoft-edge")
+		add("microsoft-edge-stable")
+		add("chromium")
+		add("chromium-browser")
+		add("msedge")
+	}
+
+	for _, candidate := range candidates {
+		if filepath.IsAbs(candidate) {
+			if _, err := os.Stat(candidate); err == nil {
+				return candidate
+			}
+			continue
+		}
+		if resolved, err := exec.LookPath(candidate); err == nil {
+			return resolved
+		}
+	}
+	return ""
+}
+
+func (s *browserSession) newPage(tabID string) (*browserPage, error) {
+	if strings.TrimSpace(tabID) == "" {
+		tabID = fmt.Sprintf("tab-%d", len(s.pages)+1)
+	}
+	ctx, cancel := chromedp.NewContext(s.rootCtx)
+	page := &browserPage{id: tabID, ctx: ctx, cancel: cancel, created: time.Now().UTC()}
+	s.pages[tabID] = page
+	return page, nil
+}
+
+func (s *browserSession) ensurePage(tabID string) (*browserPage, error) {
+	if strings.TrimSpace(tabID) == "" {
+		tabID = s.activeTab
+	}
+	if page, ok := s.pages[tabID]; ok {
+		return page, nil
+	}
+	page, err := s.newPage(tabID)
+	if err != nil {
+		return nil, err
+	}
+	s.activeTab = page.id
+	return page, nil
+}
+
+func resolveBrowserTabID(input map[string]any) string {
+	if input == nil {
+		return ""
+	}
+	tabID, _ := input["tab_id"].(string)
+	return strings.TrimSpace(tabID)
+}
+
+func getBrowserPage(sessionID string, tabID string) (*browserSession, *browserPage, error) {
+	bs, err := getBrowserSession(sessionID)
+	if err != nil {
+		return nil, nil, err
+	}
+	browserMu.Lock()
+	defer browserMu.Unlock()
+	page, err := bs.ensurePage(tabID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if page != nil {
+		bs.activeTab = page.id
+	}
+	return bs, page, nil
+}
+
+func BrowserNavigateTool(ctx context.Context, input map[string]any) (string, error) {
+	urlStr, _ := input["url"].(string)
+	sessionID := resolveBrowserSessionID(ctx, input)
+	if strings.TrimSpace(urlStr) == "" {
+		return "", fmt.Errorf("url is required")
+	}
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	var title string
+	err = chromedp.Run(pageCtx.ctx,
+		chromedp.Navigate(urlStr),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+		chromedp.Title(&title),
+	)
+	if err != nil {
+		return "", err
+	}
+	pageCtx.lastURL = urlStr
+	return fmt.Sprintf("Navigated tab %s to %s (title: %s)", pageCtx.id, urlStr, title), nil
+}
+
+func BrowserClickTool(ctx context.Context, input map[string]any) (string, error) {
+	selector, _ := input["selector"].(string)
+	sessionID := resolveBrowserSessionID(ctx, input)
+	if strings.TrimSpace(selector) == "" {
+		return "", fmt.Errorf("selector is required")
+	}
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	err = chromedp.Run(pageCtx.ctx,
+		chromedp.WaitVisible(selector, chromedp.ByQuery),
+		chromedp.Click(selector, chromedp.ByQuery),
+	)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Clicked %s", selector), nil
+}
+
+func BrowserTypeTool(ctx context.Context, input map[string]any) (string, error) {
+	selector, _ := input["selector"].(string)
+	text, _ := input["text"].(string)
+	sessionID := resolveBrowserSessionID(ctx, input)
+	if strings.TrimSpace(selector) == "" {
+		return "", fmt.Errorf("selector is required")
+	}
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	err = chromedp.Run(pageCtx.ctx,
+		chromedp.WaitVisible(selector, chromedp.ByQuery),
+		chromedp.SetValue(selector, "", chromedp.ByQuery),
+		chromedp.SendKeys(selector, text, chromedp.ByQuery),
+	)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Typed into %s", selector), nil
+}
+
+func BrowserScreenshotTool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	path, _ := input["path"].(string)
+	selector, _ := input["selector"].(string)
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	var buf []byte
+	if strings.TrimSpace(selector) != "" {
+		err = chromedp.Run(pageCtx.ctx, chromedp.Screenshot(selector, &buf, chromedp.NodeVisible, chromedp.ByQuery))
+	} else {
+		err = chromedp.Run(pageCtx.ctx, chromedp.FullScreenshot(&buf, 90))
+	}
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Saved screenshot to %s", path), nil
+}
+
+func BrowserScreenshotToolWithPolicy(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	path, _ := input["path"].(string)
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	resolved := normalizePolicyArtifactPath(path, opts.WorkingDir)
+	if opts.Policy != nil {
+		if err := opts.Policy.CheckWritePath(resolved); err != nil {
+			return "", err
+		}
+	} else if err := validateProtectedPath(resolved, opts.ProtectedPaths); err != nil {
+		return "", err
+	}
+	cloned := cloneBrowserInput(input)
+	cloned["path"] = resolved
+	return BrowserScreenshotTool(ctx, cloned)
+}
+
+func BrowserUploadTool(ctx context.Context, input map[string]any) (string, error) {
+	selector, _ := input["selector"].(string)
+	path, _ := input["path"].(string)
+	sessionID := resolveBrowserSessionID(ctx, input)
+	if strings.TrimSpace(selector) == "" || strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("selector and path are required")
+	}
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	err = chromedp.Run(pageCtx.ctx,
+		chromedp.WaitVisible(selector, chromedp.ByQuery),
+		chromedp.SetUploadFiles(selector, []string{absPath}, chromedp.ByQuery),
+	)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Uploaded %s via %s", absPath, selector), nil
+}
+
+func BrowserUploadToolWithPolicy(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	selector, _ := input["selector"].(string)
+	path, _ := input["path"].(string)
+	sessionID := resolveBrowserSessionID(ctx, input)
+	if strings.TrimSpace(selector) == "" || strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("selector and path are required")
+	}
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	resolved := normalizePolicyArtifactPath(path, opts.WorkingDir)
+	if opts.Policy != nil {
+		if err := opts.Policy.CheckBrowserUpload(resolved, pageCtx.lastURL); err != nil {
+			return "", err
+		}
+	} else if err := validateProtectedPath(resolved, opts.ProtectedPaths); err != nil {
+		return "", err
+	}
+	cloned := cloneBrowserInput(input)
+	cloned["path"] = resolved
+	return BrowserUploadTool(ctx, cloned)
+}
+
+func BrowserEvaluateTool(ctx context.Context, input map[string]any) (string, error) {
+	expression, _ := input["expression"].(string)
+	sessionID := resolveBrowserSessionID(ctx, input)
+	if strings.TrimSpace(expression) == "" {
+		return "", fmt.Errorf("expression is required")
+	}
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	var result any
+	err = chromedp.Run(pageCtx.ctx, chromedp.Evaluate(expression, &result))
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%v", result), nil
+}
+
+func BrowserSnapshotTool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	var html string
+	var title string
+	var currentURL string
+	err = chromedp.Run(pageCtx.ctx,
+		chromedp.Location(&currentURL),
+		chromedp.Title(&title),
+		chromedp.OuterHTML("html", &html, chromedp.ByQuery),
+	)
+	if err != nil {
+		return "", err
+	}
+	if len(html) > 8000 {
+		html = html[:8000] + "..."
+	}
+	return fmt.Sprintf("Tab: %s\nURL: %s\nTitle: %s\nHTML:\n%s", pageCtx.id, currentURL, title, html), nil
+}
+
+func BrowserCloseTool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	if sessionID == "" {
+		sessionID = "default"
+	}
+	browserMu.Lock()
+	defer browserMu.Unlock()
+	bs, ok := browserSessions[sessionID]
+	if !ok {
+		return "Browser session already closed", nil
+	}
+	for _, page := range bs.pages {
+		page.cancel()
+	}
+	bs.cancel()
+	delete(browserSessions, sessionID)
+	return fmt.Sprintf("Closed browser session %s", sessionID), nil
+}
+
+func BrowserPDFTool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	path, _ := input["path"].(string)
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	var pdf []byte
+	err = chromedp.Run(pageCtx.ctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		buf, _, err := page.PrintToPDF().WithPrintBackground(true).Do(ctx)
+		if err != nil {
+			return err
+		}
+		pdf = buf
+		return nil
+	}))
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, pdf, 0o644); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Saved PDF to %s", path), nil
+}
+
+func BrowserPDFToolWithPolicy(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	path, _ := input["path"].(string)
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	resolved := normalizePolicyArtifactPath(path, opts.WorkingDir)
+	if opts.Policy != nil {
+		if err := opts.Policy.CheckWritePath(resolved); err != nil {
+			return "", err
+		}
+	} else if err := validateProtectedPath(resolved, opts.ProtectedPaths); err != nil {
+		return "", err
+	}
+	cloned := cloneBrowserInput(input)
+	cloned["path"] = resolved
+	return BrowserPDFTool(ctx, cloned)
+}
+
+func BrowserScreenshotBase64Tool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	var buf []byte
+	err = chromedp.Run(pageCtx.ctx, chromedp.FullScreenshot(&buf, 90))
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(buf), nil
+}
+
+func BrowserWaitTool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	selector, _ := input["selector"].(string)
+	state, _ := input["state"].(string)
+	timeoutMs, _ := input["timeout_ms"].(float64)
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	if timeoutMs <= 0 {
+		timeoutMs = 10000
+	}
+	waitCtx, cancel := context.WithTimeout(pageCtx.ctx, time.Duration(timeoutMs)*time.Millisecond)
+	defer cancel()
+	if strings.TrimSpace(selector) == "" {
+		selector = "body"
+	}
+	state = strings.ToLower(strings.TrimSpace(state))
+	if state == "" {
+		state = "visible"
+	}
+	var action chromedp.Action
+	switch state {
+	case "ready":
+		action = chromedp.WaitReady(selector, chromedp.ByQuery)
+	case "enabled":
+		action = chromedp.WaitEnabled(selector, chromedp.ByQuery)
+	default:
+		action = chromedp.WaitVisible(selector, chromedp.ByQuery)
+	}
+	if err := chromedp.Run(waitCtx, action); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Waited for %s to become %s", selector, state), nil
+}
+
+func BrowserSelectTool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	selector, _ := input["selector"].(string)
+	value, _ := input["value"].(string)
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(selector) == "" || strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("selector and value are required")
+	}
+	if err := chromedp.Run(pageCtx.ctx,
+		chromedp.WaitVisible(selector, chromedp.ByQuery),
+		chromedp.SetValue(selector, value, chromedp.ByQuery),
+	); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Selected %s on %s", value, selector), nil
+}
+
+func BrowserPressTool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	selector, _ := input["selector"].(string)
+	key, _ := input["key"].(string)
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(key) == "" {
+		return "", fmt.Errorf("key is required")
+	}
+	actions := []chromedp.Action{}
+	if strings.TrimSpace(selector) != "" {
+		actions = append(actions, chromedp.WaitVisible(selector, chromedp.ByQuery), chromedp.Focus(selector, chromedp.ByQuery))
+	}
+	actions = append(actions, chromedp.KeyEvent(key))
+	if err := chromedp.Run(pageCtx.ctx, actions...); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Pressed %s", key), nil
+}
+
+func BrowserScrollTool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	selector, _ := input["selector"].(string)
+	direction, _ := input["direction"].(string)
+	pixels, _ := input["pixels"].(float64)
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	if pixels == 0 {
+		pixels = 600
+	}
+	if strings.EqualFold(strings.TrimSpace(direction), "up") {
+		pixels = -pixels
+	}
+	var script string
+	if strings.TrimSpace(selector) != "" {
+		script = fmt.Sprintf(`(() => { const el = document.querySelector(%q); if (!el) return "missing"; el.scrollBy(0, %d); return "ok"; })()`, selector, int(pixels))
+	} else {
+		script = fmt.Sprintf(`(() => { window.scrollBy(0, %d); return "ok"; })()`, int(pixels))
+	}
+	var result string
+	if err := chromedp.Run(pageCtx.ctx, chromedp.Evaluate(script, &result)); err != nil {
+		return "", err
+	}
+	if result == "missing" {
+		return "", fmt.Errorf("selector not found: %s", selector)
+	}
+	return fmt.Sprintf("Scrolled by %d pixels", int(pixels)), nil
+}
+
+func BrowserDownloadTool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	selector, _ := input["selector"].(string)
+	urlStr, _ := input["url"].(string)
+	path, _ := input["path"].(string)
+	_, pageCtx, err := getBrowserPage(sessionID, resolveBrowserTabID(input))
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if strings.TrimSpace(urlStr) == "" && strings.TrimSpace(selector) != "" {
+		if err := chromedp.Run(pageCtx.ctx, chromedp.AttributeValue(selector, "href", &urlStr, nil, chromedp.ByQuery)); err != nil || strings.TrimSpace(urlStr) == "" {
+			_ = chromedp.Run(pageCtx.ctx, chromedp.AttributeValue(selector, "src", &urlStr, nil, chromedp.ByQuery))
+		}
+	}
+	if strings.TrimSpace(urlStr) == "" {
+		return "", fmt.Errorf("url or selector with href/src is required")
+	}
+	var base64Content string
+	fetchJS := fmt.Sprintf(`(async () => { const res = await fetch(%q, {credentials: 'include'}); const buf = await res.arrayBuffer(); let binary=''; const bytes = new Uint8Array(buf); const chunk = 0x8000; for (let i = 0; i < bytes.length; i += chunk) { binary += String.fromCharCode(...bytes.slice(i, i+chunk)); } return btoa(binary); })()`, urlStr)
+	if err := chromedp.Run(pageCtx.ctx, chromedp.Evaluate(fetchJS, &base64Content)); err != nil {
+		return "", err
+	}
+	data, err := base64.StdEncoding.DecodeString(base64Content)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Downloaded %s to %s", urlStr, path), nil
+}
+
+func BrowserDownloadToolWithPolicy(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	path, _ := input["path"].(string)
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	resolved := normalizePolicyArtifactPath(path, opts.WorkingDir)
+	if opts.Policy != nil {
+		if err := opts.Policy.CheckWritePath(resolved); err != nil {
+			return "", err
+		}
+	} else if err := validateProtectedPath(resolved, opts.ProtectedPaths); err != nil {
+		return "", err
+	}
+	cloned := cloneBrowserInput(input)
+	cloned["path"] = resolved
+	return BrowserDownloadTool(ctx, cloned)
+}
+
+func BrowserTabNewTool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	tabID, _ := input["tab_id"].(string)
+	urlStr, _ := input["url"].(string)
+	bs, err := getBrowserSession(sessionID)
+	if err != nil {
+		return "", err
+	}
+	browserMu.Lock()
+	page, err := bs.newPage(strings.TrimSpace(tabID))
+	if err == nil {
+		bs.activeTab = page.id
+	}
+	browserMu.Unlock()
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(urlStr) != "" {
+		_, err = BrowserNavigateTool(ctx, map[string]any{"session_id": sessionID, "tab_id": page.id, "url": urlStr})
+		if err != nil {
+			return "", err
+		}
+	}
+	return fmt.Sprintf("Created tab %s in browser session %s", page.id, sessionID), nil
+}
+
+func BrowserTabListTool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	bs, err := getBrowserSession(sessionID)
+	if err != nil {
+		return "", err
+	}
+	browserMu.Lock()
+	defer browserMu.Unlock()
+	rows := make([]string, 0, len(bs.pages))
+	for id, page := range bs.pages {
+		marker := " "
+		if id == bs.activeTab {
+			marker = "*"
+		}
+		rows = append(rows, fmt.Sprintf("%s %s %s", marker, id, strings.TrimSpace(page.lastURL)))
+	}
+	if len(rows) == 0 {
+		return "No tabs", nil
+	}
+	return strings.Join(rows, "\n"), nil
+}
+
+func BrowserTabSwitchTool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	tabID, _ := input["tab_id"].(string)
+	if strings.TrimSpace(tabID) == "" {
+		return "", fmt.Errorf("tab_id is required")
+	}
+	bs, err := getBrowserSession(sessionID)
+	if err != nil {
+		return "", err
+	}
+	browserMu.Lock()
+	defer browserMu.Unlock()
+	if _, ok := bs.pages[tabID]; !ok {
+		return "", fmt.Errorf("tab not found: %s", tabID)
+	}
+	bs.activeTab = tabID
+	return fmt.Sprintf("Switched to tab %s", tabID), nil
+}
+
+func BrowserTabCloseTool(ctx context.Context, input map[string]any) (string, error) {
+	sessionID := resolveBrowserSessionID(ctx, input)
+	tabID, _ := input["tab_id"].(string)
+	if strings.TrimSpace(tabID) == "" {
+		return "", fmt.Errorf("tab_id is required")
+	}
+	bs, err := getBrowserSession(sessionID)
+	if err != nil {
+		return "", err
+	}
+	browserMu.Lock()
+	defer browserMu.Unlock()
+	page, ok := bs.pages[tabID]
+	if !ok {
+		return "", fmt.Errorf("tab not found: %s", tabID)
+	}
+	page.cancel()
+	delete(bs.pages, tabID)
+	if bs.activeTab == tabID {
+		bs.activeTab = ""
+		for id := range bs.pages {
+			bs.activeTab = id
+			break
+		}
+		if bs.activeTab == "" {
+			newPage, err := bs.newPage("tab-1")
+			if err == nil {
+				bs.activeTab = newPage.id
+			}
+		}
+	}
+	return fmt.Sprintf("Closed tab %s", tabID), nil
+}
+
+func cloneBrowserInput(input map[string]any) map[string]any {
+	if input == nil {
+		return map[string]any{}
+	}
+	cloned := make(map[string]any, len(input))
+	for key, value := range input {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/pkg/capability/tools/builtins.go
+++ b/pkg/capability/tools/builtins.go
@@ -1,0 +1,644 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	webtool "github.com/1024XEngineer/anyclaw/pkg/capability/tools/web"
+)
+
+func resolvePath(path string, cwd string) string {
+	if cwd == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(cwd, path)
+}
+
+var imageExtensions = map[string]bool{
+	".png":  true,
+	".jpg":  true,
+	".jpeg": true,
+	".gif":  true,
+	".bmp":  true,
+	".webp": true,
+	".svg":  true,
+	".ico":  true,
+	".tiff": true,
+	".tif":  true,
+}
+
+func isImageFile(filename string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	return imageExtensions[ext]
+}
+
+func ReadFileTool(ctx context.Context, input map[string]any) (string, error) {
+	return ReadFileToolWithCwd(ctx, input, "")
+}
+
+func ReadFileToolWithPolicy(ctx context.Context, input map[string]any, cwd string, opts BuiltinOptions) (string, error) {
+	path, ok := input["path"].(string)
+	if !ok {
+		return "", fmt.Errorf("path is required")
+	}
+	resolved := resolvePath(path, cwd)
+	if opts.Policy != nil {
+		if err := opts.Policy.CheckReadPath(resolved); err != nil {
+			return "", err
+		}
+	} else if err := validateProtectedPath(resolved, opts.ProtectedPaths); err != nil {
+		return "", err
+	}
+	return ReadFileToolWithCwd(ctx, input, cwd)
+}
+
+func ReadFileToolWithCwd(ctx context.Context, input map[string]any, cwd string) (string, error) {
+	path, ok := input["path"].(string)
+	if !ok {
+		return "", fmt.Errorf("path is required")
+	}
+
+	resolvedPath := resolvePath(path, cwd)
+
+	if isImageFile(path) || isImageFile(resolvedPath) {
+		info, err := os.Stat(resolvedPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to read file: %w", err)
+		}
+		return "", fmt.Errorf("无法读取图片文件 \"%s\"：当前模型不支持图片输入。请使用支持视觉的模型（如 gpt-4o、claude-opus-4-5）或将图片转为文字描述", info.Name())
+	}
+
+	data, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+
+	return string(data), nil
+}
+
+func WriteFileTool(ctx context.Context, input map[string]any) (string, error) {
+	return WriteFileToolWithCwd(ctx, input, "", "full")
+}
+
+func WriteFileToolWithCwd(ctx context.Context, input map[string]any, cwd string, permissionLevel string) (string, error) {
+	path, ok := input["path"].(string)
+	if !ok {
+		return "", fmt.Errorf("path is required")
+	}
+
+	content, ok := input["content"].(string)
+	if !ok {
+		return "", fmt.Errorf("content is required")
+	}
+
+	path = resolvePath(path, cwd)
+	if err := ensureWriteAllowed(path, cwd, permissionLevel); err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return "", fmt.Errorf("failed to write file: %w", err)
+	}
+
+	return fmt.Sprintf("Written to %s", path), nil
+}
+
+func WriteFileToolWithPolicy(ctx context.Context, input map[string]any, cwd string, opts BuiltinOptions) (string, error) {
+	path, ok := input["path"].(string)
+	if !ok {
+		return "", fmt.Errorf("path is required")
+	}
+	resolved := resolvePath(path, cwd)
+	if opts.Policy != nil {
+		if err := opts.Policy.CheckWritePath(resolved); err != nil {
+			return "", err
+		}
+	} else {
+		if err := validateProtectedPath(resolved, opts.ProtectedPaths); err != nil {
+			return "", err
+		}
+	}
+	return WriteFileToolWithCwd(ctx, input, cwd, opts.PermissionLevel)
+}
+
+func ListDirectoryTool(ctx context.Context, input map[string]any) (string, error) {
+	return ListDirectoryToolWithCwd(ctx, input, "")
+}
+
+func ListDirectoryToolWithPolicy(ctx context.Context, input map[string]any, cwd string, opts BuiltinOptions) (string, error) {
+	path, ok := input["path"].(string)
+	if !ok {
+		path = cwd
+	}
+	resolved := resolvePath(path, cwd)
+	if opts.Policy != nil {
+		if err := opts.Policy.CheckReadPath(resolved); err != nil {
+			return "", err
+		}
+	} else if err := validateProtectedPath(resolved, opts.ProtectedPaths); err != nil {
+		return "", err
+	}
+	return ListDirectoryToolWithCwd(ctx, input, cwd)
+}
+
+func ListDirectoryToolWithCwd(ctx context.Context, input map[string]any, cwd string) (string, error) {
+	path, ok := input["path"].(string)
+	if !ok {
+		path = cwd
+	}
+
+	path = resolvePath(path, cwd)
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	if len(entries) == 0 {
+		return "Empty directory", nil
+	}
+
+	result := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			info = nil
+		}
+		if entry.IsDir() {
+			result = append(result, fmt.Sprintf("d %s/", entry.Name()))
+		} else if info != nil {
+			result = append(result, fmt.Sprintf("- %s (%d bytes)", entry.Name(), info.Size()))
+		} else {
+			result = append(result, fmt.Sprintf("- %s", entry.Name()))
+		}
+	}
+
+	out, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return string(out), nil
+}
+
+func SearchFilesTool(ctx context.Context, input map[string]any) (string, error) {
+	return SearchFilesToolWithCwd(ctx, input, "")
+}
+
+func SearchFilesToolWithPolicy(ctx context.Context, input map[string]any, cwd string, opts BuiltinOptions) (string, error) {
+	root, ok := input["path"].(string)
+	if !ok {
+		root = cwd
+	}
+	resolved := resolvePath(root, cwd)
+	if opts.Policy != nil {
+		if err := opts.Policy.CheckReadPath(resolved); err != nil {
+			return "", err
+		}
+	} else if err := validateProtectedPath(resolved, opts.ProtectedPaths); err != nil {
+		return "", err
+	}
+	return SearchFilesToolWithCwd(ctx, input, cwd)
+}
+
+func SearchFilesToolWithCwd(ctx context.Context, input map[string]any, cwd string) (string, error) {
+	root, ok := input["path"].(string)
+	if !ok {
+		root = cwd
+	}
+
+	root = resolvePath(root, cwd)
+	pattern, ok := input["pattern"].(string)
+	if !ok {
+		return "", fmt.Errorf("pattern is required")
+	}
+
+	var matches []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		name := filepath.Base(path)
+		if matched, err := filepath.Match(pattern, name); err == nil && matched {
+			matches = append(matches, path)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("search failed: %w", err)
+	}
+
+	if len(matches) == 0 {
+		return "No matches found", nil
+	}
+
+	out, err := json.Marshal(matches)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal results: %w", err)
+	}
+	return string(out), nil
+}
+
+func RunCommandTool(ctx context.Context, input map[string]any) (string, error) {
+	return RunCommandToolWithPolicy(ctx, input, BuiltinOptions{})
+}
+
+func RunCommandToolWithPolicy(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	cmdStr, ok := input["command"].(string)
+	if !ok {
+		return "", fmt.Errorf("command is required")
+	}
+
+	cwd, _ := input["cwd"].(string)
+	shellName, _ := input["shell"].(string)
+	if cwd == "" {
+		cwd = opts.WorkingDir
+	}
+	if isDangerousCommand(cmdStr, opts.DangerousPatterns) && opts.ConfirmDangerousCommand != nil {
+		if !opts.ConfirmDangerousCommand(cmdStr) {
+			return "", fmt.Errorf("dangerous command cancelled by user")
+		}
+	}
+	if opts.PermissionLevel == "read-only" {
+		return "", fmt.Errorf("permission denied: current agent is read-only")
+	}
+	if opts.Policy != nil {
+		if err := opts.Policy.CheckCommandCwd(firstNonEmptyCommandCwd(cwd, opts.WorkingDir)); err != nil {
+			return "", err
+		}
+	}
+	if err := reviewCommandExecution(cmdStr, cwd, opts); err != nil {
+		return "", err
+	}
+
+	if opts.CommandTimeoutSeconds > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(opts.CommandTimeoutSeconds)*time.Second)
+		defer cancel()
+	}
+
+	resolvedCwd := cwd
+	commandFactory := func(cmdCtx context.Context, command string) (*exec.Cmd, error) {
+		return shellCommandWithShell(cmdCtx, command, shellName)
+	}
+	applyDir := true
+	if opts.Sandbox != nil {
+		sandboxCwd, factory, err := opts.Sandbox.ResolveExecution(ctx, cwd)
+		if err != nil {
+			return "", err
+		}
+		if factory != nil {
+			commandFactory = factory
+			applyDir = false
+		}
+		if sandboxCwd != "" {
+			resolvedCwd = sandboxCwd
+		}
+	}
+
+	cmd, err := commandFactory(ctx, cmdStr)
+	if err != nil {
+		return "", err
+	}
+	if resolvedCwd != "" && applyDir {
+		cmd.Dir = resolvedCwd
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("command failed: %w - %s", err, string(output))
+	}
+
+	return string(output), nil
+}
+
+func firstNonEmptyCommandCwd(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func shellCommand(ctx context.Context, command string) *exec.Cmd {
+	cmd, err := shellCommandWithShell(ctx, command, "")
+	if err != nil {
+		if runtime.GOOS == "windows" {
+			return exec.CommandContext(ctx, "cmd", "/C", command)
+		}
+		return exec.CommandContext(ctx, "sh", "-c", command)
+	}
+	return cmd
+}
+
+func shellCommandWithShell(ctx context.Context, command string, shellName string) (*exec.Cmd, error) {
+	switch normalizeShellName(shellName) {
+	case "", "auto":
+		if runtime.GOOS == "windows" {
+			return exec.CommandContext(ctx, "cmd", "/C", command), nil
+		}
+		return exec.CommandContext(ctx, "sh", "-c", command), nil
+	case "cmd":
+		if runtime.GOOS != "windows" {
+			return nil, fmt.Errorf("shell cmd is only supported on Windows")
+		}
+		return exec.CommandContext(ctx, "cmd", "/C", command), nil
+	case "powershell":
+		exe, err := findShellExecutable("pwsh", "powershell")
+		if err != nil {
+			return nil, err
+		}
+		return exec.CommandContext(ctx, exe, "-NoProfile", "-Command", command), nil
+	case "pwsh":
+		exe, err := findShellExecutable("pwsh")
+		if err != nil {
+			return nil, err
+		}
+		return exec.CommandContext(ctx, exe, "-NoProfile", "-Command", command), nil
+	case "sh":
+		return exec.CommandContext(ctx, "sh", "-c", command), nil
+	case "bash":
+		return exec.CommandContext(ctx, "bash", "-lc", command), nil
+	default:
+		return nil, fmt.Errorf("unsupported shell: %s", shellName)
+	}
+}
+
+func normalizeShellName(shellName string) string {
+	return strings.ToLower(strings.TrimSpace(shellName))
+}
+
+func findShellExecutable(candidates ...string) (string, error) {
+	for _, candidate := range candidates {
+		if strings.TrimSpace(candidate) == "" {
+			continue
+		}
+		if path, err := exec.LookPath(candidate); err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("shell executable not found: %s", strings.Join(candidates, ", "))
+}
+
+func ensureWriteAllowed(targetPath string, workingDir string, permissionLevel string) error {
+	level := strings.TrimSpace(strings.ToLower(permissionLevel))
+	if level == "" || level == "limited" {
+		base := workingDir
+		if base == "" {
+			base = "."
+		}
+		absBase, err := filepath.Abs(base)
+		if err != nil {
+			return fmt.Errorf("failed to resolve working dir: %w", err)
+		}
+		absTarget, err := filepath.Abs(targetPath)
+		if err != nil {
+			return fmt.Errorf("failed to resolve target path: %w", err)
+		}
+		rel, err := filepath.Rel(absBase, absTarget)
+		if err != nil {
+			return fmt.Errorf("failed to validate path: %w", err)
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("permission denied: limited agent can only write inside working directory")
+		}
+		return nil
+	}
+	if level == "read-only" {
+		return fmt.Errorf("permission denied: current agent is read-only")
+	}
+	return nil
+}
+
+func isDangerousCommand(command string, patterns []string) bool {
+	lower := strings.ToLower(strings.TrimSpace(command))
+	for _, pattern := range patterns {
+		if strings.Contains(lower, strings.ToLower(strings.TrimSpace(pattern))) {
+			return true
+		}
+	}
+	return false
+}
+
+func reviewCommandExecution(command string, cwd string, opts BuiltinOptions) error {
+	mode := strings.TrimSpace(strings.ToLower(opts.ExecutionMode))
+	if mode == "" {
+		mode = "sandbox"
+	}
+	sandboxEnabled := opts.Sandbox != nil && opts.Sandbox.Enabled()
+	if mode == "sandbox" && !sandboxEnabled {
+		return fmt.Errorf("host execution denied: sandbox.execution_mode is sandbox and sandbox is not enabled")
+	}
+	if mode != "host-reviewed" || sandboxEnabled {
+		return nil
+	}
+	if strings.TrimSpace(cwd) != "" {
+		if err := validateProtectedPath(resolvePath(cwd, opts.WorkingDir), opts.ProtectedPaths); err != nil {
+			return fmt.Errorf("host execution denied: %w", err)
+		}
+	}
+	allowedCommandPaths := mergePathLists(opts.WorkingDir, opts.AllowedReadPaths, opts.AllowedWritePaths)
+	if err := validateCommandAgainstProtectedPaths(command, opts.ProtectedPaths, allowedCommandPaths); err != nil {
+		return fmt.Errorf("host execution denied: %w", err)
+	}
+	return nil
+}
+
+func validateProtectedPath(targetPath string, protectedPaths []string) error {
+	targetPath = strings.TrimSpace(targetPath)
+	if targetPath == "" {
+		return nil
+	}
+	targetNorm, err := normalizePathForCompare(targetPath)
+	if err != nil {
+		return err
+	}
+	for _, protected := range protectedPaths {
+		protectedNorm, err := normalizePathForCompare(protected)
+		if err != nil || protectedNorm == "" {
+			continue
+		}
+		if pathWithin(targetNorm, protectedNorm) {
+			return fmt.Errorf("access to protected path is denied: %s", targetPath)
+		}
+	}
+	return nil
+}
+
+func validateCommandAgainstProtectedPaths(command string, protectedPaths []string, allowedPaths []string) error {
+	normalizedCommand := normalizeCommandForCompare(command)
+	for _, protected := range protectedPaths {
+		if isProtectedPathExplicitlyAllowed(protected, allowedPaths) {
+			continue
+		}
+		for _, token := range protectedPathTokens(protected) {
+			if token != "" && strings.Contains(normalizedCommand, token) {
+				return fmt.Errorf("command references protected path: %s", protected)
+			}
+		}
+	}
+	return nil
+}
+
+func isProtectedPathExplicitlyAllowed(protected string, allowedPaths []string) bool {
+	protectedNorm, err := normalizePathForCompare(protected)
+	if err != nil || protectedNorm == "" {
+		return false
+	}
+	for _, allowed := range allowedPaths {
+		allowedNorm, err := normalizePathForCompare(allowed)
+		if err != nil || allowedNorm == "" {
+			continue
+		}
+		if pathWithin(allowedNorm, protectedNorm) || pathWithin(protectedNorm, allowedNorm) {
+			return true
+		}
+	}
+	return false
+}
+
+func mergePathLists(workingDir string, lists ...[]string) []string {
+	items := make([]string, 0, 1)
+	if strings.TrimSpace(workingDir) != "" {
+		items = append(items, workingDir)
+	}
+	for _, list := range lists {
+		for _, item := range list {
+			if strings.TrimSpace(item) != "" {
+				items = append(items, item)
+			}
+		}
+	}
+	return items
+}
+
+func normalizePathForCompare(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", nil
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve path %q: %w", path, err)
+	}
+	cleaned := filepath.Clean(absPath)
+	if runtime.GOOS == "windows" {
+		cleaned = strings.ToLower(cleaned)
+	}
+	return cleaned, nil
+}
+
+func pathWithin(target string, base string) bool {
+	if target == base {
+		return true
+	}
+	return strings.HasPrefix(target, base+string(filepath.Separator))
+}
+
+func normalizeCommandForCompare(command string) string {
+	normalized := strings.ToLower(strings.TrimSpace(command))
+	normalized = strings.ReplaceAll(normalized, "\\", "/")
+	for strings.Contains(normalized, "//") {
+		normalized = strings.ReplaceAll(normalized, "//", "/")
+	}
+	return normalized
+}
+
+func protectedPathTokens(path string) []string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	tokens := map[string]bool{}
+	add := func(value string) {
+		value = normalizeCommandForCompare(value)
+		if value != "" {
+			tokens[value] = true
+		}
+	}
+	add(path)
+	base := strings.ToLower(filepath.Base(path))
+	home, _ := os.UserHomeDir()
+	if home != "" {
+		if rel, err := filepath.Rel(home, path); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+			rel = normalizeCommandForCompare(rel)
+			add("~/" + rel)
+			add("$home/" + rel)
+			if runtime.GOOS == "windows" {
+				add("%userprofile%/" + rel)
+				add("%homepath%/" + rel)
+			}
+		}
+	}
+	switch base {
+	case "documents", "desktop", "downloads", "pictures", "videos", "music", ".ssh", "appdata", "ntuser.dat", ".gnupg", ".config":
+		add(base)
+	}
+	items := make([]string, 0, len(tokens))
+	for token := range tokens {
+		items = append(items, token)
+	}
+	return items
+}
+
+func GetTimeTool(ctx context.Context, input map[string]any) (string, error) {
+	format, ok := input["format"].(string)
+	if !ok || format == "" {
+		format = time.RFC3339
+	}
+
+	now := time.Now()
+	return now.Format(format), nil
+}
+
+func WebSearchTool(ctx context.Context, input map[string]any) (string, error) {
+	query, ok := input["query"].(string)
+	if !ok {
+		return "", fmt.Errorf("query is required")
+	}
+
+	maxResults := 5
+	if n, ok := input["max_results"].(float64); ok && n > 0 {
+		maxResults = int(n)
+	}
+
+	results, err := webtool.Search(ctx, query, maxResults)
+	if err != nil {
+		return "", fmt.Errorf("search failed: %w", err)
+	}
+
+	if len(results) == 0 {
+		return "No results found", nil
+	}
+
+	output := make([]string, len(results))
+	for i, r := range results {
+		output[i] = fmt.Sprintf("[%d] %s\n   %s\n   %s", i+1, r.Title, r.URL, r.Description)
+	}
+
+	return strings.Join(output, "\n\n"), nil
+}
+
+func FetchURLTool(ctx context.Context, input map[string]any) (string, error) {
+	urlStr, ok := input["url"].(string)
+	if !ok {
+		return "", fmt.Errorf("url is required")
+	}
+
+	content, err := webtool.Fetch(ctx, urlStr)
+	if err != nil {
+		return "", fmt.Errorf("fetch failed: %w", err)
+	}
+
+	return content, nil
+}

--- a/pkg/capability/tools/builtins_test.go
+++ b/pkg/capability/tools/builtins_test.go
@@ -1,0 +1,166 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestShellCommandWithShellAuto(t *testing.T) {
+	cmd, err := shellCommandWithShell(context.Background(), "echo hello", "auto")
+	if err != nil {
+		t.Fatalf("shellCommandWithShell(auto) returned error: %v", err)
+	}
+	if len(cmd.Args) == 0 {
+		t.Fatalf("expected command args")
+	}
+	if runtime.GOOS == "windows" && cmd.Args[0] != "cmd" {
+		t.Fatalf("expected cmd on windows, got %q", cmd.Args[0])
+	}
+	if runtime.GOOS != "windows" && cmd.Args[0] != "sh" {
+		t.Fatalf("expected sh on non-windows, got %q", cmd.Args[0])
+	}
+}
+
+func TestShellCommandWithShellRejectsUnsupportedShell(t *testing.T) {
+	if _, err := shellCommandWithShell(context.Background(), "echo hello", "fish"); err == nil {
+		t.Fatal("expected unsupported shell error")
+	}
+}
+
+func TestReviewCommandExecutionRequiresSandboxByDefault(t *testing.T) {
+	err := reviewCommandExecution("echo hello", "", BuiltinOptions{ExecutionMode: "sandbox"})
+	if err == nil {
+		t.Fatal("expected sandbox-only mode to deny host execution without sandbox")
+	}
+}
+
+func TestWriteFileToolWithPolicyBlocksProtectedPath(t *testing.T) {
+	tempDir := t.TempDir()
+	protected := filepath.Join(tempDir, "private")
+	if err := os.MkdirAll(protected, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	_, err := WriteFileToolWithPolicy(context.Background(), map[string]any{
+		"path":    filepath.Join(protected, "secret.txt"),
+		"content": "x",
+	}, tempDir, BuiltinOptions{
+		PermissionLevel: "full",
+		ProtectedPaths:  []string{protected},
+	})
+	if err == nil {
+		t.Fatal("expected protected path write to be denied")
+	}
+}
+
+func TestReadFileToolWithPolicyBlocksOutsideWorkingDir(t *testing.T) {
+	workspace := t.TempDir()
+	outsideDir := t.TempDir()
+	target := filepath.Join(outsideDir, "notes.txt")
+	if err := os.WriteFile(target, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	_, err := ReadFileToolWithPolicy(context.Background(), map[string]any{
+		"path": target,
+	}, workspace, BuiltinOptions{
+		WorkingDir: workspace,
+		Policy:     NewPolicyEngine(PolicyOptions{WorkingDir: workspace}),
+	})
+	if err == nil {
+		t.Fatal("expected read outside working directory to be denied")
+	}
+}
+
+func TestReviewCommandExecutionBlocksProtectedPathReference(t *testing.T) {
+	tempDir := t.TempDir()
+	protected := filepath.Join(tempDir, "Documents")
+	if err := os.MkdirAll(protected, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	err := reviewCommandExecution("type "+filepath.Join(protected, "secret.txt"), "", BuiltinOptions{
+		ExecutionMode: "host-reviewed",
+		ProtectedPaths: []string{
+			protected,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected command referencing protected path to be denied")
+	}
+}
+
+func TestReviewCommandExecutionAllowsExplicitlyAllowedProtectedPathReference(t *testing.T) {
+	tempDir := t.TempDir()
+	protected := filepath.Join(tempDir, "Desktop")
+	if err := os.MkdirAll(protected, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	err := reviewCommandExecution("mkdir "+filepath.Join(protected, "hello"), "", BuiltinOptions{
+		ExecutionMode:  "host-reviewed",
+		ProtectedPaths: []string{protected},
+		AllowedWritePaths: []string{
+			protected,
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected explicitly allowed protected path reference to pass review, got %v", err)
+	}
+}
+
+func TestRunCommandToolWithPolicyBlocksOutsideWorkingDirCwd(t *testing.T) {
+	workspace := t.TempDir()
+	outsideDir := t.TempDir()
+
+	_, err := RunCommandToolWithPolicy(context.Background(), map[string]any{
+		"command": "echo hello",
+		"cwd":     outsideDir,
+	}, BuiltinOptions{
+		WorkingDir:      workspace,
+		ExecutionMode:   "host-reviewed",
+		PermissionLevel: "limited",
+		Policy:          NewPolicyEngine(PolicyOptions{WorkingDir: workspace, PermissionLevel: "limited"}),
+	})
+	if err == nil {
+		t.Fatal("expected command cwd outside working directory to be denied")
+	}
+}
+
+func TestEnsureDesktopAllowedRequiresHostReviewed(t *testing.T) {
+	err := ensureDesktopAllowed("desktop_click", BuiltinOptions{ExecutionMode: "sandbox", PermissionLevel: "limited"}, false)
+	if err == nil {
+		t.Fatal("expected desktop tool to require host-reviewed mode")
+	}
+}
+
+func TestMemoryToolsSearchAndGetDailyFiles(t *testing.T) {
+	workspace := t.TempDir()
+	memoryDir := filepath.Join(workspace, "memory")
+	if err := os.MkdirAll(memoryDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(memoryDir, "2026-03-29.md"), []byte("# Daily Memory 2026-03-29\n\nRelease checklist completed."), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	registry := NewRegistry()
+	RegisterBuiltins(registry, BuiltinOptions{WorkingDir: workspace})
+
+	searchResult, err := registry.Call(context.Background(), "memory_search", map[string]any{"query": "checklist"})
+	if err != nil {
+		t.Fatalf("memory_search: %v", err)
+	}
+	if !strings.Contains(searchResult, "2026-03-29") {
+		t.Fatalf("expected search result to mention date, got %q", searchResult)
+	}
+
+	getResult, err := registry.Call(context.Background(), "memory_get", map[string]any{"date": "2026-03-29"})
+	if err != nil {
+		t.Fatalf("memory_get: %v", err)
+	}
+	if !strings.Contains(getResult, "Release checklist completed.") {
+		t.Fatalf("expected memory_get output, got %q", getResult)
+	}
+}

--- a/pkg/capability/tools/canvas.go
+++ b/pkg/capability/tools/canvas.go
@@ -1,0 +1,309 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+type CanvasTool struct {
+	config     *config.Config
+	apiToken   string
+	gatewayURL string
+}
+
+func NewCanvasTool(cfg *config.Config) *CanvasTool {
+	tool := &CanvasTool{config: cfg}
+	if cfg != nil {
+		tool.apiToken = cfg.Security.APIToken
+		tool.gatewayURL = tool.buildGatewayURL()
+	}
+	return tool
+}
+
+func (t *CanvasTool) Register(registry *Registry) {
+	registry.RegisterTool("canvas_push", "Push content to the canvas", map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"content": map[string]any{"type": "string", "description": "HTML, A2UI JSON, or markdown content"},
+			"id":      map[string]any{"type": "string", "description": "Canvas entry ID (auto-generated if empty)"},
+			"name":    map[string]any{"type": "string", "description": "Display name for the canvas entry"},
+			"type":    map[string]any{"type": "string", "enum": []string{"html", "a2ui", "markdown", "json", "text"}, "description": "Content type"},
+			"reset":   map[string]any{"type": "boolean", "description": "Reset canvas before pushing"},
+		},
+		"required": []string{"content"},
+	}, t.canvasPush)
+
+	registry.RegisterTool("canvas_eval", "Evaluate JavaScript on the canvas", map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"code": map[string]any{"type": "string", "description": "JavaScript code to evaluate"},
+			"id":   map[string]any{"type": "string", "description": "Canvas entry ID"},
+		},
+		"required": []string{"code"},
+	}, t.canvasEval)
+
+	registry.RegisterTool("canvas_snapshot", "Take a snapshot of the canvas", map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"id":        map[string]any{"type": "string", "description": "Canvas entry ID"},
+			"full_page": map[string]any{"type": "boolean", "description": "Capture full page"},
+		},
+	}, t.canvasSnapshot)
+
+	registry.RegisterTool("canvas_reset", "Reset the canvas to empty state", map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"id": map[string]any{"type": "string", "description": "Canvas entry ID to reset"},
+		},
+	}, t.canvasReset)
+
+	registry.RegisterTool("canvas_list", "List all canvas entries", map[string]any{
+		"type":       "object",
+		"properties": map[string]any{},
+	}, t.canvasList)
+
+	registry.RegisterTool("canvas_get", "Get a specific canvas entry", map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"id": map[string]any{"type": "string", "description": "Canvas entry ID"},
+		},
+		"required": []string{"id"},
+	}, t.canvasGet)
+
+	registry.RegisterTool("canvas_versions", "Get version history for a canvas entry", map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"id":    map[string]any{"type": "string", "description": "Canvas entry ID"},
+			"limit": map[string]any{"type": "number", "description": "Max versions to return"},
+		},
+		"required": []string{"id"},
+	}, t.canvasVersions)
+}
+
+func (t *CanvasTool) canvasPush(ctx context.Context, input map[string]any) (string, error) {
+	content, ok := input["content"].(string)
+	if !ok {
+		return "", fmt.Errorf("content is required")
+	}
+
+	id, _ := input["id"].(string)
+	name, _ := input["name"].(string)
+	contentType, _ := input["type"].(string)
+	reset, _ := input["reset"].(bool)
+
+	if t.gatewayURL == "" {
+		return t.mockPushResult(id, content, contentType, reset)
+	}
+
+	reqBody := map[string]any{
+		"id":      id,
+		"name":    name,
+		"content": content,
+		"type":    contentType,
+		"reset":   reset,
+	}
+
+	resp, err := t.doRequest(ctx, http.MethodPost, "/api/canvas", reqBody)
+	if err != nil {
+		return t.mockPushResult(id, content, contentType, reset)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return fmt.Sprintf(`{"error": "canvas push failed: %s", "status": %d}`, string(body), resp.StatusCode), nil
+	}
+
+	return string(body), nil
+}
+
+func (t *CanvasTool) canvasEval(ctx context.Context, input map[string]any) (string, error) {
+	code, ok := input["code"].(string)
+	if !ok {
+		return "", fmt.Errorf("code is required")
+	}
+
+	id, _ := input["id"].(string)
+
+	result := map[string]any{
+		"evaluated": true,
+		"code":      code,
+		"canvas_id": id,
+		"note":      "JavaScript evaluation requires a browser context. Use canvas_push with HTML content containing <script> tags instead.",
+	}
+
+	data, _ := json.Marshal(result)
+	return string(data), nil
+}
+
+func (t *CanvasTool) canvasSnapshot(ctx context.Context, input map[string]any) (string, error) {
+	id, _ := input["id"].(string)
+	fullPage, _ := input["full_page"].(bool)
+
+	result := map[string]any{
+		"canvas_id": id,
+		"full_page": fullPage,
+		"note":      "Screenshot capture requires a headless browser. View the canvas at /canvas/view/{id} or /canvas/a2ui/{id}.",
+	}
+
+	data, _ := json.Marshal(result)
+	return string(data), nil
+}
+
+func (t *CanvasTool) canvasReset(ctx context.Context, input map[string]any) (string, error) {
+	id, _ := input["id"].(string)
+
+	if id == "" {
+		return `{"error": "id is required for canvas_reset"}`, nil
+	}
+
+	if t.gatewayURL == "" {
+		result, _ := json.Marshal(map[string]any{"reset": true, "id": id, "note": "canvas not available, simulated reset"})
+		return string(result), nil
+	}
+
+	reqBody := map[string]any{"id": id}
+	resp, err := t.doRequest(ctx, http.MethodPost, "/api/canvas/"+id+"/reset", reqBody)
+	if err != nil {
+		result, _ := json.Marshal(map[string]any{"reset": true, "id": id, "note": "reset simulated, gateway unreachable"})
+		return string(result), nil
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	return string(body), nil
+}
+
+func (t *CanvasTool) canvasList(ctx context.Context, input map[string]any) (string, error) {
+	if t.gatewayURL == "" {
+		return `{"entries": [], "note": "canvas not available"}`, nil
+	}
+
+	resp, err := t.doRequest(ctx, http.MethodGet, "/api/canvas", nil)
+	if err != nil {
+		return `{"entries": [], "note": "failed to fetch canvas entries"}`, nil
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	return string(body), nil
+}
+
+func (t *CanvasTool) canvasGet(ctx context.Context, input map[string]any) (string, error) {
+	id, ok := input["id"].(string)
+	if !ok || id == "" {
+		return `{"error": "id is required"}`, nil
+	}
+
+	if t.gatewayURL == "" {
+		return fmt.Sprintf(`{"error": "canvas not available", "id": "%s"}`, id), nil
+	}
+
+	resp, err := t.doRequest(ctx, http.MethodGet, "/api/canvas/"+id, nil)
+	if err != nil {
+		return fmt.Sprintf(`{"error": "failed to fetch entry", "id": "%s"}`, id), nil
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	return string(body), nil
+}
+
+func (t *CanvasTool) canvasVersions(ctx context.Context, input map[string]any) (string, error) {
+	id, ok := input["id"].(string)
+	if !ok || id == "" {
+		return `{"error": "id is required"}`, nil
+	}
+
+	limit := 10
+	if l, ok := input["limit"].(float64); ok && l > 0 {
+		limit = int(l)
+	}
+
+	if t.gatewayURL == "" {
+		return fmt.Sprintf(`{"versions": [], "id": "%s", "note": "canvas not available"}`, id), nil
+	}
+
+	url := fmt.Sprintf("/api/canvas/%s/versions?limit=%d", id, limit)
+	resp, err := t.doRequest(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Sprintf(`{"versions": [], "id": "%s", "note": "failed to fetch versions"}`, id), nil
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	return string(body), nil
+}
+
+func (t *CanvasTool) doRequest(ctx context.Context, method string, path string, body any) (*http.Response, error) {
+	var reqBody io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reqBody = bytes.NewReader(data)
+	}
+
+	url := t.gatewayURL + path
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if t.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+t.apiToken)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	return client.Do(req)
+}
+
+func (t *CanvasTool) mockPushResult(id string, content string, contentType string, reset bool) (string, error) {
+	if id == "" {
+		id = "canvas-mock"
+	}
+	if contentType == "" {
+		contentType = "html"
+	}
+	result, _ := json.Marshal(map[string]any{
+		"pushed":   true,
+		"id":       id,
+		"type":     contentType,
+		"reset":    reset,
+		"length":   len(content),
+		"view_url": fmt.Sprintf("/canvas/view/%s", id),
+		"note":     "canvas pushed locally (gateway not reachable)",
+	})
+	return string(result), nil
+}
+
+func (t *CanvasTool) buildGatewayURL() string {
+	if t.config == nil {
+		return ""
+	}
+
+	scheme := "http"
+	host := "localhost"
+	port := 8080
+
+	if t.config.Gateway.Port > 0 {
+		port = t.config.Gateway.Port
+	}
+	if t.config.Gateway.Host != "" {
+		host = t.config.Gateway.Host
+	}
+
+	return fmt.Sprintf("%s://%s:%d", scheme, host, port)
+}

--- a/pkg/capability/tools/claw_bridge.go
+++ b/pkg/capability/tools/claw_bridge.go
@@ -1,0 +1,94 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/1024XEngineer/anyclaw/pkg/clawbridge"
+)
+
+func RegisterClawBridgeTools(r *Registry, opts BuiltinOptions) {
+	root, ok := clawbridge.DiscoverRoot(opts.WorkingDir)
+	if !ok {
+		return
+	}
+
+	r.Register(&Tool{
+		Name:        "claw_bridge_context",
+		Description: "Read the integrated claw-code-main capability surface and orchestration hints available in this workspace.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"section": map[string]string{"type": "string", "description": "summary, commands, tools, or subsystems"},
+				"family":  map[string]string{"type": "string", "description": "Optional command/tool family or subsystem name"},
+				"limit":   map[string]string{"type": "number", "description": "Maximum items to return"},
+			},
+		},
+		Category:    ToolCategoryCustom,
+		AccessLevel: ToolAccessPublic,
+		Handler: func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "claw_bridge_context", input, func(ctx context.Context, input map[string]any) (string, error) {
+				summary, err := clawbridge.Load(root)
+				if err != nil {
+					return "", err
+				}
+				section, _ := input["section"].(string)
+				family, _ := input["family"].(string)
+				limit := intFromAny(input["limit"], 6)
+				return clawbridge.RenderJSON(summary, section, family, limit)
+			})(ctx, input)
+		},
+	})
+}
+
+func intFromAny(value any, fallback int) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case json.Number:
+		i, err := v.Int64()
+		if err == nil {
+			return int(i)
+		}
+	case string:
+		var n json.Number = json.Number(v)
+		i, err := n.Int64()
+		if err == nil {
+			return int(i)
+		}
+	}
+	return fallback
+}
+
+func ClawBridgeStatus(root string) (string, error) {
+	summary, err := clawbridge.Load(root)
+	if err != nil {
+		return "", err
+	}
+	return clawbridge.HumanSummary(summary), nil
+}
+
+func ClawBridgeLookup(root string, section string, family string, limit int) (string, error) {
+	summary, err := clawbridge.Load(root)
+	if err != nil {
+		return "", err
+	}
+	output, err := clawbridge.RenderJSON(summary, section, family, limit)
+	if err != nil {
+		return "", err
+	}
+	return output, nil
+}
+
+func RequireClawBridgeRoot(start string) (string, error) {
+	root, ok := clawbridge.DiscoverRoot(start)
+	if !ok {
+		return "", fmt.Errorf("claw-code-main reference not found; set %s or run from a workspace that contains a sibling claw-code-main directory", clawbridge.EnvRoot)
+	}
+	return root, nil
+}

--- a/pkg/capability/tools/claw_bridge_test.go
+++ b/pkg/capability/tools/claw_bridge_test.go
@@ -1,0 +1,70 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/clawbridge"
+)
+
+func TestRegisterClawBridgeToolsRegistersContextToolWhenBridgeExists(t *testing.T) {
+	bridgeRoot := filepath.Join(t.TempDir(), "claw-code-main")
+	if err := writeToolBridgeFixture(bridgeRoot); err != nil {
+		t.Fatalf("writeToolBridgeFixture: %v", err)
+	}
+	t.Setenv(clawbridge.EnvRoot, bridgeRoot)
+
+	registry := NewRegistry()
+	RegisterClawBridgeTools(registry, BuiltinOptions{WorkingDir: t.TempDir()})
+
+	tool, ok := registry.Get("claw_bridge_context")
+	if !ok {
+		t.Fatalf("expected claw_bridge_context to be registered")
+	}
+	result, err := tool.Handler(context.Background(), map[string]any{"section": "summary", "limit": 2})
+	if err != nil {
+		t.Fatalf("tool.Handler: %v", err)
+	}
+	if !strings.Contains(result, "\"commands_count\": 3") || !strings.Contains(result, "\"top_tools\"") {
+		t.Fatalf("unexpected tool output: %s", result)
+	}
+}
+
+func writeToolBridgeFixture(root string) error {
+	if err := os.MkdirAll(filepath.Join(root, "src", "reference_data", "subsystems"), 0o755); err != nil {
+		return err
+	}
+	commands := []map[string]string{
+		{"name": "agents", "source_hint": "commands/agents/index.ts"},
+		{"name": "tasks", "source_hint": "commands/tasks/index.ts"},
+		{"name": "tasks", "source_hint": "commands/tasks/tasks.tsx"},
+	}
+	toolItems := []map[string]string{
+		{"name": "AgentTool", "source_hint": "tools/AgentTool/AgentTool.tsx"},
+		{"name": "agentMemory", "source_hint": "tools/AgentTool/agentMemory.ts"},
+	}
+	subsystem := map[string]any{
+		"archive_name": "cli",
+		"module_count": 19,
+		"sample_files": []string{"cli/handlers/agents.ts"},
+	}
+	if err := writeToolJSON(filepath.Join(root, "src", "reference_data", "commands_snapshot.json"), commands); err != nil {
+		return err
+	}
+	if err := writeToolJSON(filepath.Join(root, "src", "reference_data", "tools_snapshot.json"), toolItems); err != nil {
+		return err
+	}
+	return writeToolJSON(filepath.Join(root, "src", "reference_data", "subsystems", "cli.json"), subsystem)
+}
+
+func writeToolJSON(path string, value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/pkg/capability/tools/clihub.go
+++ b/pkg/capability/tools/clihub.go
@@ -1,0 +1,219 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/clihub"
+)
+
+type CLIHubExecOptions struct {
+	AutoInstall       bool
+	PreferLocalSrc    bool
+	RetryAfterInstall bool
+}
+
+func RegisterCLIHubTools(r *Registry, opts BuiltinOptions) {
+	root, ok := clihub.DiscoverRoot(opts.WorkingDir)
+	if !ok {
+		return
+	}
+
+	RegisterCLIHubSkillTools(r, root, opts)
+	RegisterIntentRouterTool(r, root, opts)
+
+	r.Register(&Tool{
+		Name:        "clihub_catalog",
+		Description: "Search the local CLI-Anything catalog, inspect install hints, and see which harnesses are already available to AnyClaw.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query":          map[string]string{"type": "string", "description": "Search query"},
+				"category":       map[string]string{"type": "string", "description": "Optional category filter"},
+				"installed_only": map[string]string{"type": "boolean", "description": "Return only installed harnesses"},
+				"limit":          map[string]string{"type": "number", "description": "Maximum number of results"},
+			},
+		},
+		Category:    ToolCategoryCustom,
+		AccessLevel: ToolAccessPublic,
+		Handler: func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "clihub_catalog", input, func(ctx context.Context, input map[string]any) (string, error) {
+				cat, err := clihub.Load(root)
+				if err != nil {
+					return "", err
+				}
+				query, _ := input["query"].(string)
+				category, _ := input["category"].(string)
+				installedOnly, _ := input["installed_only"].(bool)
+				limit := intFromAny(input["limit"], 8)
+				results := clihub.Search(cat, query, category, installedOnly, limit)
+				return mustMarshalJSON(map[string]any{
+					"root":           cat.Root,
+					"updated":        cat.Updated,
+					"query":          strings.TrimSpace(query),
+					"category":       strings.TrimSpace(category),
+					"installed_only": installedOnly,
+					"count":          len(results),
+					"results":        results,
+				})
+			})(ctx, input)
+		},
+	})
+
+	r.Register(&Tool{
+		Name:        "clihub_exec",
+		Description: "Execute a discovered CLI-Anything harness with JSON-first defaults and safer fallback behavior than raw shell usage. Supports auto-install and local source fallback.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]string{"type": "string", "description": "Catalog name, display name, or entry point"},
+				"args": map[string]any{
+					"type":        "array",
+					"description": "CLI arguments after the executable name",
+					"items":       map[string]string{"type": "string"},
+				},
+				"cwd":          map[string]string{"type": "string", "description": "Optional working directory override for installed commands"},
+				"json":         map[string]string{"type": "boolean", "description": "Inject --json when appropriate (default true)"},
+				"auto_install": map[string]string{"type": "boolean", "description": "Auto-install if not installed and install_cmd available (default false)"},
+			},
+			"required": []string{"name", "args"},
+		},
+		Category:    ToolCategoryCustom,
+		AccessLevel: ToolAccessPublic,
+		Handler: func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "clihub_exec", input, func(ctx context.Context, input map[string]any) (string, error) {
+				cat, err := clihub.Load(root)
+				if err != nil {
+					return "", err
+				}
+				name, _ := input["name"].(string)
+				status, ok := clihub.Find(cat, name)
+				if !ok {
+					return "", fmt.Errorf("CLI Hub entry not found: %s", name)
+				}
+
+				args, err := stringSliceFromAny(input["args"])
+				if err != nil {
+					return "", err
+				}
+				if len(args) == 0 {
+					return "", fmt.Errorf("args are required; CLI-Anything defaults to interactive REPL when no command is provided")
+				}
+
+				jsonMode := true
+				if raw, exists := input["json"]; exists {
+					if value, ok := raw.(bool); ok {
+						jsonMode = value
+					}
+				}
+
+				autoInstall := false
+				if raw, exists := input["auto_install"]; exists {
+					if value, ok := raw.(bool); ok {
+						autoInstall = value
+					}
+				}
+
+				execOpts := CLIHubExecOptions{
+					AutoInstall:       autoInstall,
+					PreferLocalSrc:    true,
+					RetryAfterInstall: true,
+				}
+
+				command, cwd, shellName, err := buildCLIHubCommand(status, args, jsonMode, stringValueCLIHub(input["cwd"]), opts, execOpts)
+				if err != nil {
+					return "", err
+				}
+				return RunCommandToolWithPolicy(ctx, map[string]any{
+					"command": command,
+					"cwd":     cwd,
+					"shell":   shellName,
+				}, opts)
+			})(ctx, input)
+		},
+	})
+}
+
+func buildCLIHubCommand(status clihub.EntryStatus, args []string, jsonMode bool, requestedCwd string, opts BuiltinOptions, execOpts CLIHubExecOptions) (string, string, string, error) {
+	resolved, err := clihub.ResolveCommand(status, args, clihub.ExecOptions{
+		JSON:              jsonMode,
+		AutoInstall:       execOpts.AutoInstall,
+		PreferLocalSrc:    execOpts.PreferLocalSrc,
+		RetryAfterInstall: execOpts.RetryAfterInstall,
+		RequestedCwd:      requestedCwd,
+	})
+	if err != nil {
+		return "", "", "", err
+	}
+
+	command := resolved.ShellCommand()
+	if err := reviewCommandExecution(command, resolved.Cwd, opts); err != nil {
+		return "", "", "", err
+	}
+	return command, resolved.Cwd, resolved.Shell, nil
+}
+
+func resolveCLIHubInvocation(status clihub.EntryStatus, requestedCwd string, execOpts CLIHubExecOptions) ([]string, string, error) {
+	return clihub.ResolveInvocation(status, requestedCwd, clihub.ExecOptions{
+		AutoInstall:       execOpts.AutoInstall,
+		PreferLocalSrc:    execOpts.PreferLocalSrc,
+		RetryAfterInstall: execOpts.RetryAfterInstall,
+	})
+}
+
+func runCLIHubInstall(installCmd string, name string) error {
+	return clihub.RunInstall(clihub.EntryStatus{
+		Entry: clihub.Entry{
+			Name:       name,
+			InstallCmd: installCmd,
+		},
+	})
+}
+
+func shouldInjectCLIHubJSON(args []string) bool {
+	return clihub.ShouldInjectJSON(args)
+}
+
+func defaultCLIHubShell() string {
+	return clihub.DefaultShell()
+}
+
+func joinArgsForShell(args []string, shellName string) string {
+	return clihub.JoinArgsForShell(args, shellName)
+}
+
+func quoteArgForShell(value string, shellName string) string {
+	return clihub.QuoteArgForShell(value, shellName)
+}
+
+func stringSliceFromAny(value any) ([]string, error) {
+	switch v := value.(type) {
+	case []string:
+		return append([]string(nil), v...), nil
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			out = append(out, fmt.Sprint(item))
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("args must be an array of strings")
+	}
+}
+
+func stringValueCLIHub(value any) string {
+	if str, ok := value.(string); ok {
+		return str
+	}
+	return ""
+}
+
+func mustMarshalJSON(value any) (string, error) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/pkg/capability/tools/clihub_intent.go
+++ b/pkg/capability/tools/clihub_intent.go
@@ -1,0 +1,149 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/clihub"
+)
+
+type IntentRouterTool struct {
+	router *clihub.IntentRouter
+	opts   BuiltinOptions
+}
+
+func RegisterIntentRouterTool(r *Registry, root string, opts BuiltinOptions) {
+	router, err := clihub.NewIntentRouter(root)
+	if err != nil {
+		return
+	}
+
+	tool := &IntentRouterTool{
+		router: router,
+		opts:   opts,
+	}
+
+	r.Register(&Tool{
+		Name:        "intent_route",
+		Description: "Route a natural language request to the appropriate CLI Hub capability and execute it automatically.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"intent": map[string]string{"type": "string", "description": "Natural language intent (e.g., 'create a new video project', 'list all models')"},
+				"args": map[string]any{
+					"type":        "array",
+					"description": "Additional command arguments",
+					"items":       map[string]string{"type": "string"},
+				},
+				"json": map[string]string{"type": "boolean", "description": "Request JSON output (default true)"},
+			},
+			"required": []string{"intent"},
+		},
+		Category:    ToolCategoryCustom,
+		AccessLevel: ToolAccessPublic,
+		Handler: func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "intent_route", input, func(ctx context.Context, input map[string]any) (string, error) {
+				intentStr, _ := input["intent"].(string)
+				if intentStr == "" {
+					return "", fmt.Errorf("intent is required")
+				}
+
+				args, _ := input["args"].([]string)
+				if args == nil {
+					if raw, ok := input["args"].([]any); ok {
+						args = make([]string, len(raw))
+						for i, v := range raw {
+							args[i] = fmt.Sprint(v)
+						}
+					}
+				}
+
+				jsonMode := true
+				if raw, exists := input["json"]; exists {
+					if b, ok := raw.(bool); ok {
+						jsonMode = b
+					}
+				}
+
+				cap := tool.router.Registry.BestMatch(intentStr)
+				if cap == nil {
+					matches := tool.router.Registry.FindByIntent(intentStr)
+					if len(matches) == 0 {
+						return "", fmt.Errorf("no matching capability found for: %s", intentStr)
+					}
+					cap = &matches[0]
+				}
+
+				if jsonMode {
+					args = append([]string{"--json"}, args...)
+				}
+
+				cmdArgs, cwd, err := clihub.ResolveCapabilityPath("", *cap)
+				if err != nil {
+					return "", err
+				}
+
+				fullArgs := append(cmdArgs, cap.Command)
+				fullArgs = append(fullArgs, args...)
+
+				shellName := defaultCLIHubShell()
+				command := joinArgsForShell(fullArgs, shellName)
+
+				return RunCommandToolWithPolicy(ctx, map[string]any{
+					"command": command,
+					"cwd":     cwd,
+					"shell":   shellName,
+				}, opts)
+			})(ctx, input)
+		},
+	})
+
+	r.Register(&Tool{
+		Name:        "intent_list_capabilities",
+		Description: "List all available CLI Hub capabilities that can be auto-routed.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query":   map[string]string{"type": "string", "description": "Optional search query to filter capabilities"},
+				"harness": map[string]string{"type": "string", "description": "Optional harness name to filter by"},
+				"limit":   map[string]string{"type": "number", "description": "Maximum number of results (default 20)"},
+			},
+		},
+		Category:    ToolCategoryCustom,
+		AccessLevel: ToolAccessPublic,
+		Handler: func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "intent_list_capabilities", input, func(ctx context.Context, input map[string]any) (string, error) {
+				query, _ := input["query"].(string)
+				harness, _ := input["harness"].(string)
+				limit := intFromAny(input["limit"], 20)
+
+				var caps []clihub.Capability
+				if query != "" {
+					caps = tool.router.Registry.FindByIntent(query)
+				} else if harness != "" {
+					caps = tool.router.Registry.FindByHarness(harness)
+				} else {
+					caps = tool.router.Registry.All()
+				}
+
+				if limit > 0 && len(caps) > limit {
+					caps = caps[:limit]
+				}
+
+				return mustMarshalJSON(map[string]any{
+					"count":        len(caps),
+					"capabilities": caps,
+				})
+			})(ctx, input)
+		},
+	})
+}
+
+func RegisterIntentRouterToolIfNeeded(r *Registry, root string, opts BuiltinOptions) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return
+	}
+	RegisterIntentRouterTool(r, root, opts)
+}

--- a/pkg/capability/tools/clihub_skills.go
+++ b/pkg/capability/tools/clihub_skills.go
@@ -1,0 +1,123 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/clihub"
+)
+
+func RegisterCLIHubSkillTools(r *Registry, root string, opts BuiltinOptions) {
+	cat, err := clihub.Load(root)
+	if err != nil {
+		return
+	}
+
+	skills := clihub.LoadSkillsForCatalog(cat)
+	for name, skill := range skills {
+		registerSkillTools(r, name, skill, root, opts)
+	}
+}
+
+func registerSkillTools(r *Registry, harnessName string, skill *clihub.Skill, root string, opts BuiltinOptions) {
+	for _, cmd := range skill.Commands {
+		toolName := fmt.Sprintf("%s_%s", harnessName, cmd.Name)
+		toolDesc := fmt.Sprintf("[%s] %s", cmd.Group, cmd.Description)
+
+		r.Register(&Tool{
+			Name:        toolName,
+			Description: toolDesc,
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"args": map[string]any{
+						"type":        "array",
+						"description": "Additional arguments for " + cmd.Name,
+						"items":       map[string]string{"type": "string"},
+					},
+				},
+			},
+			Category:    ToolCategoryCustom,
+			AccessLevel: ToolAccessPublic,
+			Handler: func(ctx context.Context, input map[string]any) (string, error) {
+				return auditCall(opts, toolName, input, func(ctx context.Context, input map[string]any) (string, error) {
+					args, err := stringSliceFromAny(input["args"])
+					if err != nil {
+						return "", err
+					}
+
+					fullArgs := []string{cmd.Name}
+					fullArgs = append(fullArgs, args...)
+
+					status := clihub.EntryStatus{
+						Entry: clihub.Entry{
+							Name:       harnessName,
+							EntryPoint: harnessName,
+						},
+						SourcePath: skill.SourcePath,
+						DevModule:  resolveDevModuleForHarness(root, harnessName),
+					}
+
+					execOpts := CLIHubExecOptions{
+						PreferLocalSrc:    true,
+						RetryAfterInstall: true,
+					}
+
+					command, cwd, shellName, err := buildCLIHubCommand(status, fullArgs, true, "", opts, execOpts)
+					if err != nil {
+						return "", err
+					}
+
+					return RunCommandToolWithPolicy(ctx, map[string]any{
+						"command": command,
+						"cwd":     cwd,
+						"shell":   shellName,
+					}, opts)
+				})(ctx, input)
+			},
+		})
+	}
+}
+
+func resolveDevModuleForHarness(root string, name string) string {
+	cat, err := clihub.Load(root)
+	if err != nil {
+		return ""
+	}
+	status, ok := clihub.Find(cat, name)
+	if !ok {
+		return ""
+	}
+	return status.DevModule
+}
+
+func BuildSkillSummaryForPrompt(cat *clihub.Catalog) string {
+	if cat == nil {
+		return ""
+	}
+
+	skills := clihub.LoadSkillsForCatalog(cat)
+	if len(skills) == 0 {
+		return ""
+	}
+
+	var lines []string
+	lines = append(lines, "## Available CLI Hub Skills")
+
+	for name, skill := range skills {
+		if len(skill.Commands) == 0 {
+			continue
+		}
+
+		var cmds []string
+		for _, cmd := range skill.Commands {
+			cmds = append(cmds, cmd.Name)
+		}
+		lines = append(lines, fmt.Sprintf("- %s: %s", name, strings.Join(cmds, ", ")))
+	}
+
+	lines = append(lines, "Use these tools directly instead of calling clihub_exec manually.")
+
+	return strings.Join(lines, "\n")
+}

--- a/pkg/capability/tools/clihub_test.go
+++ b/pkg/capability/tools/clihub_test.go
@@ -1,0 +1,112 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/clihub"
+)
+
+func TestRegisterCLIHubToolsRegistersCatalogTool(t *testing.T) {
+	hubRoot := filepath.Join(t.TempDir(), "CLI-Anything-0.2.0")
+	if err := writeCLIHubToolFixture(hubRoot); err != nil {
+		t.Fatalf("writeCLIHubToolFixture: %v", err)
+	}
+	t.Setenv("ANYCLAW_CLI_ANYTHING_ROOT", hubRoot)
+
+	registry := NewRegistry()
+	RegisterCLIHubTools(registry, BuiltinOptions{WorkingDir: t.TempDir(), ExecutionMode: "host-reviewed"})
+
+	tool, ok := registry.Get("clihub_catalog")
+	if !ok {
+		t.Fatalf("expected clihub_catalog to be registered")
+	}
+	result, err := tool.Handler(context.Background(), map[string]any{"query": "office", "limit": 5})
+	if err != nil {
+		t.Fatalf("tool.Handler: %v", err)
+	}
+	if !strings.Contains(result, "\"count\": 2") || !strings.Contains(result, "\"libreoffice\"") {
+		t.Fatalf("unexpected catalog output: %s", result)
+	}
+}
+
+func TestBuildCLIHubCommandInjectsJSONAndUsesDevModuleFallback(t *testing.T) {
+	status := clihub.EntryStatus{
+		Entry: clihub.Entry{
+			Name:       "shotcut",
+			InstallCmd: "pip install ...",
+		},
+		SourcePath: `D:\tmp\shotcut\agent-harness`,
+		DevModule:  "cli_anything.shotcut",
+	}
+
+	command, cwd, shellName, err := buildCLIHubCommand(status, []string{"project", "info"}, true, "", BuiltinOptions{
+		ExecutionMode: "host-reviewed",
+		WorkingDir:    `D:\tmp`,
+	}, CLIHubExecOptions{
+		PreferLocalSrc: true,
+	})
+	if err != nil {
+		t.Fatalf("buildCLIHubCommand: %v", err)
+	}
+	if cwd != status.SourcePath {
+		t.Fatalf("expected cwd %q, got %q", status.SourcePath, cwd)
+	}
+	if shellName == "" {
+		t.Fatalf("expected shell name to be set")
+	}
+	if !strings.Contains(command, "--json") || !strings.Contains(command, "cli_anything.shotcut") || !(strings.Contains(command, "python") || strings.Contains(command, "py")) {
+		t.Fatalf("unexpected command: %s", command)
+	}
+}
+
+func TestBuildCLIHubCommandRequiresInstallWhenNoExecutableOrDevModule(t *testing.T) {
+	_, _, _, err := buildCLIHubCommand(clihub.EntryStatus{
+		Entry: clihub.Entry{
+			Name:       "zotero",
+			InstallCmd: "pip install example",
+		},
+	}, []string{"library", "list"}, true, "", BuiltinOptions{
+		ExecutionMode: "host-reviewed",
+		WorkingDir:    `D:\tmp`,
+	}, CLIHubExecOptions{
+		AutoInstall: false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "install it first") {
+		t.Fatalf("expected install hint error, got %v", err)
+	}
+}
+
+func writeCLIHubToolFixture(root string) error {
+	if err := os.MkdirAll(filepath.Join(root, "shotcut", "agent-harness", "cli_anything", "shotcut"), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(root, "shotcut", "agent-harness", "cli_anything", "shotcut", "__main__.py"), []byte("print('ok')"), 0o644); err != nil {
+		return err
+	}
+	payload := map[string]any{
+		"meta": map[string]any{
+			"repo":        "https://example.com/CLI-Anything",
+			"description": "CLI-Hub",
+			"updated":     "2026-03-29",
+		},
+		"clis": []map[string]any{
+			{"name": "libreoffice", "display_name": "LibreOffice", "description": "Office suite", "category": "office", "entry_point": "cli-anything-libreoffice"},
+			{"name": "zotero", "display_name": "Zotero", "description": "References", "category": "office", "entry_point": "cli-anything-zotero"},
+			{"name": "shotcut", "display_name": "Shotcut", "description": "Video editing", "category": "video", "entry_point": "cli-anything-shotcut"},
+		},
+	}
+	return writeCLIHubToolJSON(filepath.Join(root, "registry.json"), payload)
+}
+
+func writeCLIHubToolJSON(path string, value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/pkg/capability/tools/desktop.go
+++ b/pkg/capability/tools/desktop.go
@@ -1,0 +1,817 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func DesktopOpenTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	target, ok := input["target"].(string)
+	if !ok || strings.TrimSpace(target) == "" {
+		return "", fmt.Errorf("target is required")
+	}
+	kind, _ := input["kind"].(string)
+	if err := ensureDesktopAllowed("desktop_open", opts, false); err != nil {
+		return "", err
+	}
+	if kind == "file" || kind == "app" {
+		if err := validateProtectedPath(target, opts.ProtectedPaths); err != nil {
+			return "", err
+		}
+	}
+	command := desktopOpenCommand(strings.TrimSpace(target), strings.TrimSpace(kind))
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopTypeTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	text, ok := input["text"].(string)
+	if !ok || text == "" {
+		return "", fmt.Errorf("text is required")
+	}
+	if err := ensureDesktopAllowed("desktop_type", opts, false); err != nil {
+		return "", err
+	}
+	command := fmt.Sprintf(`Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.SendKeys]::SendWait(%s); "typed"`, powerShellString(sendKeysEscape(text)))
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopTypeHumanTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	text, ok := input["text"].(string)
+	if !ok || text == "" {
+		return "", fmt.Errorf("text is required")
+	}
+	if err := ensureDesktopAllowed("desktop_type_human", opts, false); err != nil {
+		return "", err
+	}
+	delayMS, ok := numberInput(input["delay_ms"])
+	if !ok || delayMS < 0 {
+		delayMS = 45
+	}
+	jitterMS, ok := numberInput(input["jitter_ms"])
+	if !ok || jitterMS < 0 {
+		jitterMS = 35
+	}
+	pauseEvery, ok := numberInput(input["pause_every"])
+	if !ok || pauseEvery < 0 {
+		pauseEvery = 18
+	}
+	pauseMS, ok := numberInput(input["pause_ms"])
+	if !ok || pauseMS < 0 {
+		pauseMS = 220
+	}
+	submit, _ := input["submit"].(bool)
+	parts := make([]string, 0, len([]rune(text)))
+	for _, r := range []rune(text) {
+		parts = append(parts, sendKeysEscape(string(r)))
+	}
+	payload, err := json.Marshal(parts)
+	if err != nil {
+		return "", err
+	}
+	command := fmt.Sprintf(`
+Add-Type -AssemblyName System.Windows.Forms;
+$items = ConvertFrom-Json %s;
+$baseDelay = %d;
+$jitterDelay = %d;
+$pauseEvery = %d;
+$pauseDelay = %d;
+$submit = %s;
+$rand = New-Object System.Random;
+for ($i = 0; $i -lt $items.Count; $i++) {
+  [System.Windows.Forms.SendKeys]::SendWait([string]$items[$i]);
+  $sleep = $baseDelay;
+  if ($jitterDelay -gt 0) {
+    $sleep += $rand.Next(0, $jitterDelay + 1);
+  }
+  if ($pauseEvery -gt 0 -and (($i + 1) %% $pauseEvery) -eq 0) {
+    $sleep += $pauseDelay;
+  }
+  if ($sleep -gt 0) {
+    Start-Sleep -Milliseconds $sleep;
+  }
+}
+if ($submit) {
+  Start-Sleep -Milliseconds 90;
+  [System.Windows.Forms.SendKeys]::SendWait("{ENTER}");
+}
+"typed human"
+`, powerShellString(string(payload)), delayMS, jitterMS, pauseEvery, pauseMS, powerShellBool(submit))
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopHotkeyTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	keys, _ := input["keys"].([]any)
+	if len(keys) == 0 {
+		if single, ok := input["keys"].([]string); ok && len(single) > 0 {
+			keys = make([]any, 0, len(single))
+			for _, item := range single {
+				keys = append(keys, item)
+			}
+		}
+	}
+	if len(keys) == 0 {
+		return "", fmt.Errorf("keys is required")
+	}
+	if err := ensureDesktopAllowed("desktop_hotkey", opts, false); err != nil {
+		return "", err
+	}
+	parts := make([]string, 0, len(keys))
+	for _, item := range keys {
+		parts = append(parts, fmt.Sprint(item))
+	}
+	command := fmt.Sprintf(`Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.SendKeys]::SendWait(%s); "hotkey sent"`, powerShellString(hotkeyToSendKeys(parts)))
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopClipboardSetTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	text, ok := input["text"].(string)
+	if !ok {
+		return "", fmt.Errorf("text is required")
+	}
+	if err := ensureDesktopAllowed("desktop_clipboard_set", opts, false); err != nil {
+		return "", err
+	}
+	command := fmt.Sprintf(`
+Set-Clipboard -Value %s;
+"clipboard set"
+`, powerShellString(text))
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopClipboardGetTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_clipboard_get", opts, true); err != nil {
+		return "", err
+	}
+	command := `
+$text = "";
+try {
+  $raw = Get-Clipboard -Raw -TextFormatType Text -ErrorAction Stop;
+  if ($null -ne $raw) {
+    $text = [string]$raw;
+  }
+} catch {
+  Add-Type -AssemblyName System.Windows.Forms;
+  $text = [System.Windows.Forms.Clipboard]::GetText();
+}
+$text
+`
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopPasteTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	text, _ := input["text"].(string)
+	submit, _ := input["submit"].(bool)
+	waitMS, ok := numberInput(input["wait_ms"])
+	if !ok || waitMS < 0 {
+		waitMS = 90
+	}
+	if err := ensureDesktopAllowed("desktop_paste", opts, false); err != nil {
+		return "", err
+	}
+	setClipboard := ""
+	if text != "" {
+		setClipboard = fmt.Sprintf("Set-Clipboard -Value %s;", powerShellString(text))
+	}
+	command := fmt.Sprintf(`
+Add-Type -AssemblyName System.Windows.Forms;
+%s
+if (%d -gt 0) {
+  Start-Sleep -Milliseconds %d;
+}
+[System.Windows.Forms.SendKeys]::SendWait("^v");
+if (%s) {
+  Start-Sleep -Milliseconds 90;
+  [System.Windows.Forms.SendKeys]::SendWait("{ENTER}");
+}
+"pasted"
+`, setClipboard, waitMS, waitMS, powerShellBool(submit))
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopClickTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	x, okX := numberInput(input["x"])
+	y, okY := numberInput(input["y"])
+	if !okX || !okY {
+		return "", fmt.Errorf("x and y are required")
+	}
+	if err := ensureDesktopAllowed("desktop_click", opts, false); err != nil {
+		return "", err
+	}
+	button := strings.ToLower(strings.TrimSpace(fmt.Sprint(input["button"])))
+	if button == "" {
+		button = "left"
+	}
+	if boolValue(input["human_like"]) {
+		command, err := desktopHumanClickCommand(
+			x,
+			y,
+			button,
+			false,
+			intNumberWithDefault(input["duration_ms"], 280),
+			intNumberWithDefault(input["steps"], 18),
+			intNumberWithDefault(input["jitter_px"], 3),
+			intNumberWithDefault(input["settle_ms"], 70),
+			0,
+		)
+		if err != nil {
+			return "", err
+		}
+		return runDesktopPowerShell(ctx, command)
+	}
+	downFlag, upFlag, err := mouseFlags(button)
+	if err != nil {
+		return "", err
+	}
+	command := fmt.Sprintf(`
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class DesktopNative {
+  [DllImport("user32.dll")] public static extern bool SetCursorPos(int X, int Y);
+  [DllImport("user32.dll")] public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, UIntPtr dwExtraInfo);
+}
+"@;
+[DesktopNative]::SetCursorPos(%d, %d) | Out-Null;
+[DesktopNative]::mouse_event(%d, 0, 0, 0, [UIntPtr]::Zero);
+[DesktopNative]::mouse_event(%d, 0, 0, 0, [UIntPtr]::Zero);
+"clicked"
+`, x, y, downFlag, upFlag)
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopMoveTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	x, okX := numberInput(input["x"])
+	y, okY := numberInput(input["y"])
+	if !okX || !okY {
+		return "", fmt.Errorf("x and y are required")
+	}
+	if err := ensureDesktopAllowed("desktop_move", opts, false); err != nil {
+		return "", err
+	}
+	command := fmt.Sprintf(`
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class DesktopNative {
+  [DllImport("user32.dll")] public static extern bool SetCursorPos(int X, int Y);
+}
+"@;
+[DesktopNative]::SetCursorPos(%d, %d) | Out-Null;
+"moved"
+`, x, y)
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopDoubleClickTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	x, okX := numberInput(input["x"])
+	y, okY := numberInput(input["y"])
+	if !okX || !okY {
+		return "", fmt.Errorf("x and y are required")
+	}
+	if err := ensureDesktopAllowed("desktop_double_click", opts, false); err != nil {
+		return "", err
+	}
+	button := strings.ToLower(strings.TrimSpace(fmt.Sprint(input["button"])))
+	if button == "" {
+		button = "left"
+	}
+	intervalMS, ok := numberInput(input["interval_ms"])
+	if !ok || intervalMS <= 0 {
+		intervalMS = 120
+	}
+	if boolValue(input["human_like"]) {
+		command, err := desktopHumanClickCommand(
+			x,
+			y,
+			button,
+			true,
+			intNumberWithDefault(input["duration_ms"], 320),
+			intNumberWithDefault(input["steps"], 20),
+			intNumberWithDefault(input["jitter_px"], 3),
+			intNumberWithDefault(input["settle_ms"], 80),
+			intervalMS,
+		)
+		if err != nil {
+			return "", err
+		}
+		return runDesktopPowerShell(ctx, command)
+	}
+	downFlag, upFlag, err := mouseFlags(button)
+	if err != nil {
+		return "", err
+	}
+	command := fmt.Sprintf(`
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class DesktopNative {
+  [DllImport("user32.dll")] public static extern bool SetCursorPos(int X, int Y);
+  [DllImport("user32.dll")] public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, UIntPtr dwExtraInfo);
+}
+"@;
+[DesktopNative]::SetCursorPos(%d, %d) | Out-Null;
+[DesktopNative]::mouse_event(%d, 0, 0, 0, [UIntPtr]::Zero);
+[DesktopNative]::mouse_event(%d, 0, 0, 0, [UIntPtr]::Zero);
+Start-Sleep -Milliseconds %d;
+[DesktopNative]::mouse_event(%d, 0, 0, 0, [UIntPtr]::Zero);
+[DesktopNative]::mouse_event(%d, 0, 0, 0, [UIntPtr]::Zero);
+"double-clicked"
+`, x, y, downFlag, upFlag, intervalMS, downFlag, upFlag)
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopScrollTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_scroll", opts, false); err != nil {
+		return "", err
+	}
+	delta, ok := numberInput(input["delta"])
+	if !ok || delta == 0 {
+		direction := strings.ToLower(strings.TrimSpace(fmt.Sprint(input["direction"])))
+		clicks, okClicks := numberInput(input["clicks"])
+		if !okClicks || clicks <= 0 {
+			clicks = 3
+		}
+		delta = clicks * 120
+		if direction == "down" {
+			delta = -delta
+		}
+		if direction != "" && direction != "up" && direction != "down" {
+			return "", fmt.Errorf("direction must be up or down")
+		}
+	}
+	x, hasX := numberInput(input["x"])
+	y, hasY := numberInput(input["y"])
+	if hasX != hasY {
+		return "", fmt.Errorf("x and y must be provided together")
+	}
+	moveCursor := ""
+	if hasX && hasY {
+		moveCursor = fmt.Sprintf("[DesktopNative]::SetCursorPos(%d, %d) | Out-Null;", x, y)
+	}
+	command := fmt.Sprintf(`
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class DesktopNative {
+  [DllImport("user32.dll")] public static extern bool SetCursorPos(int X, int Y);
+  [DllImport("user32.dll")] public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, UIntPtr dwExtraInfo);
+}
+"@;
+%s
+[DesktopNative]::mouse_event(0x0800, 0, 0, %d, [UIntPtr]::Zero);
+"scrolled"
+`, moveCursor, delta)
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopDragTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	x1, okX1 := numberInput(input["x1"])
+	y1, okY1 := numberInput(input["y1"])
+	x2, okX2 := numberInput(input["x2"])
+	y2, okY2 := numberInput(input["y2"])
+	if !okX1 || !okY1 || !okX2 || !okY2 {
+		return "", fmt.Errorf("x1, y1, x2, and y2 are required")
+	}
+	if err := ensureDesktopAllowed("desktop_drag", opts, false); err != nil {
+		return "", err
+	}
+	button := strings.ToLower(strings.TrimSpace(fmt.Sprint(input["button"])))
+	if button == "" {
+		button = "left"
+	}
+	steps, ok := numberInput(input["steps"])
+	if !ok || steps <= 0 {
+		steps = 12
+	}
+	durationMS, ok := numberInput(input["duration_ms"])
+	if !ok || durationMS <= 0 {
+		durationMS = 300
+	}
+	delay := durationMS / steps
+	if delay <= 0 {
+		delay = 1
+	}
+	downFlag, upFlag, err := mouseFlags(button)
+	if err != nil {
+		return "", err
+	}
+	command := fmt.Sprintf(`
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class DesktopNative {
+  [DllImport("user32.dll")] public static extern bool SetCursorPos(int X, int Y);
+  [DllImport("user32.dll")] public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, UIntPtr dwExtraInfo);
+}
+"@;
+[DesktopNative]::SetCursorPos(%d, %d) | Out-Null;
+[DesktopNative]::mouse_event(%d, 0, 0, 0, [UIntPtr]::Zero);
+for ($i = 1; $i -le %d; $i++) {
+  $x = [int][Math]::Round(%d + ((%d - %d) * $i / %d));
+  $y = [int][Math]::Round(%d + ((%d - %d) * $i / %d));
+  [DesktopNative]::SetCursorPos($x, $y) | Out-Null;
+  Start-Sleep -Milliseconds %d;
+}
+[DesktopNative]::mouse_event(%d, 0, 0, 0, [UIntPtr]::Zero);
+"dragged"
+`, x1, y1, downFlag, steps, x1, x2, x1, steps, y1, y2, y1, steps, delay, upFlag)
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopWaitTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	waitMS, ok := numberInput(input["wait_ms"])
+	if !ok || waitMS < 0 {
+		return "", fmt.Errorf("wait_ms is required")
+	}
+	if err := ensureDesktopAllowed("desktop_wait", opts, false); err != nil {
+		return "", err
+	}
+	command := fmt.Sprintf(`Start-Sleep -Milliseconds %d; "waited"`, waitMS)
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopFocusWindowTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	title, _ := input["title"].(string)
+	processName, _ := input["process_name"].(string)
+	if strings.TrimSpace(title) == "" && strings.TrimSpace(processName) == "" {
+		return "", fmt.Errorf("title or process_name is required")
+	}
+	if err := ensureDesktopAllowed("desktop_focus_window", opts, false); err != nil {
+		return "", err
+	}
+	match := strings.ToLower(strings.TrimSpace(fmt.Sprint(input["match"])))
+	if match == "" {
+		match = "contains"
+	}
+	if match != "contains" && match != "exact" {
+		return "", fmt.Errorf("match must be contains or exact")
+	}
+	command := fmt.Sprintf(`
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class DesktopNative {
+  [DllImport("user32.dll")] public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
+}
+"@;
+$title = %s;
+$processName = %s;
+$match = %s;
+$target = $null;
+if ($title -ne "") {
+  $windows = Get-Process | Where-Object { $_.MainWindowHandle -ne 0 -and $_.MainWindowTitle -ne "" };
+  if ($match -eq "exact") {
+    $target = $windows | Where-Object { $_.MainWindowTitle -eq $title } | Select-Object -First 1;
+  } else {
+    $target = $windows | Where-Object { $_.MainWindowTitle -like ("*" + $title + "*") } | Select-Object -First 1;
+  }
+}
+if (-not $target -and $processName -ne "") {
+  $target = Get-Process -Name $processName -ErrorAction SilentlyContinue | Where-Object { $_.MainWindowHandle -ne 0 } | Select-Object -First 1;
+}
+if (-not $target) {
+  throw "window not found";
+}
+[DesktopNative]::ShowWindowAsync($target.MainWindowHandle, 5) | Out-Null;
+Start-Sleep -Milliseconds 100;
+if (-not [DesktopNative]::SetForegroundWindow($target.MainWindowHandle)) {
+  $wshell = New-Object -ComObject WScript.Shell;
+  $null = $wshell.AppActivate($target.Id);
+}
+"focused"
+`, powerShellString(strings.TrimSpace(title)), powerShellString(strings.TrimSpace(processName)), powerShellString(match))
+	return runDesktopPowerShell(ctx, command)
+}
+
+func DesktopScreenshotTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	path, ok := input["path"].(string)
+	if !ok || strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if err := ensureDesktopAllowed("desktop_screenshot", opts, true); err != nil {
+		return "", err
+	}
+	resolved := resolvePath(path, opts.WorkingDir)
+	if err := validateProtectedPath(resolved, opts.ProtectedPaths); err != nil {
+		return "", err
+	}
+	if err := ensureWriteAllowed(resolved, opts.WorkingDir, opts.PermissionLevel); err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(resolved), 0o755); err != nil {
+		return "", fmt.Errorf("failed to create screenshot dir: %w", err)
+	}
+	output, err := captureDesktopScreenshotToPath(ctx, resolved)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s to %s", strings.TrimSpace(output), resolved), nil
+}
+
+func DesktopScreenshotWindowTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	path, ok := input["path"].(string)
+	if !ok || strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if err := ensureDesktopAllowed("desktop_screenshot_window", opts, true); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(fmt.Sprint(input["title"])) == "" &&
+		strings.TrimSpace(fmt.Sprint(input["process_name"])) == "" {
+		if handle, ok := numberInput(input["handle"]); !ok || handle <= 0 {
+			return "", fmt.Errorf("title, process_name, or handle is required")
+		}
+	}
+	resolved := resolvePath(path, opts.WorkingDir)
+	if err := validateProtectedPath(resolved, opts.ProtectedPaths); err != nil {
+		return "", err
+	}
+	if err := ensureWriteAllowed(resolved, opts.WorkingDir, opts.PermissionLevel); err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(resolved), 0o755); err != nil {
+		return "", fmt.Errorf("failed to create screenshot dir: %w", err)
+	}
+
+	windows, err := runDesktopWindowQuery(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	if len(windows) == 0 {
+		return "", fmt.Errorf("window not found")
+	}
+	window := windows[0]
+
+	fullFile, err := os.CreateTemp("", "anyclaw-desktop-window-full-*.png")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp screenshot file: %w", err)
+	}
+	fullPath := fullFile.Name()
+	_ = fullFile.Close()
+	defer func() { _ = os.Remove(fullPath) }()
+
+	if _, err := captureDesktopScreenshotToPath(ctx, fullPath); err != nil {
+		return "", err
+	}
+	croppedPath, _, _, cleanup, err := cropDesktopTargetImageToWindow(fullPath, window)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+	data, err := os.ReadFile(croppedPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read cropped screenshot: %w", err)
+	}
+	if err := os.WriteFile(resolved, data, 0o644); err != nil {
+		return "", fmt.Errorf("failed to write window screenshot: %w", err)
+	}
+	return fmt.Sprintf("saved window screenshot to %s", resolved), nil
+}
+
+func captureDesktopScreenshotToPath(ctx context.Context, resolved string) (string, error) {
+	command := fmt.Sprintf(`
+Add-Type -AssemblyName System.Windows.Forms;
+Add-Type -AssemblyName System.Drawing;
+$bounds = [System.Windows.Forms.SystemInformation]::VirtualScreen;
+$bitmap = New-Object System.Drawing.Bitmap $bounds.Width, $bounds.Height;
+$graphics = [System.Drawing.Graphics]::FromImage($bitmap);
+$graphics.CopyFromScreen($bounds.Left, $bounds.Top, 0, 0, $bitmap.Size);
+$bitmap.Save(%s, [System.Drawing.Imaging.ImageFormat]::Png);
+$graphics.Dispose();
+$bitmap.Dispose();
+"saved"
+`, powerShellString(resolved))
+	return runDesktopPowerShell(ctx, command)
+}
+
+func ensureDesktopAllowed(toolName string, opts BuiltinOptions, allowReadOnly bool) error {
+	if runtime.GOOS != "windows" {
+		return fmt.Errorf("%s is currently supported on Windows host mode only", toolName)
+	}
+	mode := strings.TrimSpace(strings.ToLower(opts.ExecutionMode))
+	if mode != "host-reviewed" {
+		return fmt.Errorf("%s requires sandbox.execution_mode=host-reviewed", toolName)
+	}
+	if !allowReadOnly && strings.TrimSpace(strings.ToLower(opts.PermissionLevel)) == "read-only" {
+		return fmt.Errorf("permission denied: current agent is read-only")
+	}
+	return nil
+}
+
+func runDesktopPowerShell(ctx context.Context, script string) (string, error) {
+	encoded := base64.StdEncoding.EncodeToString(utf16LE(script))
+	cmd, err := shellCommandWithShell(ctx, fmt.Sprintf("[Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('%s')) | Invoke-Expression", encoded), "powershell")
+	if err != nil {
+		return "", err
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("desktop action failed: %w - %s", err, string(output))
+	}
+	return string(output), nil
+}
+
+func utf16LE(s string) []byte {
+	runes := []rune(s)
+	buf := make([]byte, 0, len(runes)*2)
+	for _, r := range runes {
+		if r > 0xFFFF {
+			r = '?'
+		}
+		buf = append(buf, byte(r), byte(r>>8))
+	}
+	return buf
+}
+
+func desktopOpenCommand(target string, kind string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "url":
+		return fmt.Sprintf(`Start-Process %s; "opened url"`, powerShellString(target))
+	case "file":
+		return fmt.Sprintf(`Invoke-Item %s; "opened file"`, powerShellString(target))
+	case "app":
+		return fmt.Sprintf(`Start-Process %s; "started app"`, powerShellString(target))
+	default:
+		return fmt.Sprintf(`Start-Process %s; "opened target"`, powerShellString(target))
+	}
+}
+
+func powerShellString(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func sendKeysEscape(text string) string {
+	replacer := strings.NewReplacer(
+		"{", "{{}",
+		"}", "{}}",
+		"+", "{+}",
+		"^", "{^}",
+		"%", "{%}",
+		"~", "{~}",
+		"(", "{(}",
+		")", "{)}",
+		"[", "{[}",
+		"]", "{]}",
+	)
+	return replacer.Replace(text)
+}
+
+func hotkeyToSendKeys(keys []string) string {
+	modifiers := ""
+	plain := make([]string, 0, len(keys))
+	for _, key := range keys {
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "ctrl", "control":
+			modifiers += "^"
+		case "alt":
+			modifiers += "%"
+		case "shift":
+			modifiers += "+"
+		case "win", "windows", "meta":
+			plain = append(plain, "{LWIN}")
+		default:
+			plain = append(plain, formatSendKey(strings.TrimSpace(key)))
+		}
+	}
+	return modifiers + strings.Join(plain, "")
+}
+
+func formatSendKey(key string) string {
+	if len(key) == 1 {
+		return sendKeysEscape(key)
+	}
+	upper := strings.ToUpper(strings.TrimSpace(key))
+	switch upper {
+	case "ENTER", "TAB", "ESC", "ESCAPE", "UP", "DOWN", "LEFT", "RIGHT", "BACKSPACE", "DELETE", "HOME", "END", "PGUP", "PGDN":
+		return "{" + upper + "}"
+	default:
+		return "{" + upper + "}"
+	}
+}
+
+func mouseFlags(button string) (int, int, error) {
+	switch button {
+	case "left":
+		return 0x0002, 0x0004, nil
+	case "right":
+		return 0x0008, 0x0010, nil
+	case "middle":
+		return 0x0020, 0x0040, nil
+	default:
+		return 0, 0, fmt.Errorf("unsupported button: %s", button)
+	}
+}
+
+func desktopHumanClickCommand(x int, y int, button string, doubleClick bool, durationMS int, steps int, jitterPX int, settleMS int, intervalMS int) (string, error) {
+	if durationMS <= 0 {
+		durationMS = 280
+	}
+	if steps <= 0 {
+		steps = 18
+	}
+	if jitterPX < 0 {
+		jitterPX = 0
+	}
+	if settleMS < 0 {
+		settleMS = 0
+	}
+	if intervalMS <= 0 {
+		intervalMS = 120
+	}
+	downFlag, upFlag, err := mouseFlags(button)
+	if err != nil {
+		return "", err
+	}
+	delay := durationMS / steps
+	if delay <= 0 {
+		delay = 1
+	}
+	command := fmt.Sprintf(`
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public struct DesktopPoint {
+  public int X;
+  public int Y;
+}
+public static class DesktopNative {
+  [DllImport("user32.dll")] public static extern bool SetCursorPos(int X, int Y);
+  [DllImport("user32.dll")] public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, UIntPtr dwExtraInfo);
+  [DllImport("user32.dll")] public static extern bool GetCursorPos(out DesktopPoint lpPoint);
+}
+"@;
+$targetX = %d;
+$targetY = %d;
+$steps = %d;
+$delay = %d;
+$jitter = %d;
+$settle = %d;
+$doubleClick = %s;
+$interval = %d;
+$rand = New-Object System.Random;
+$point = New-Object DesktopPoint;
+[DesktopNative]::GetCursorPos([ref]$point) | Out-Null;
+$startX = [int]$point.X;
+$startY = [int]$point.Y;
+if ($jitter -gt 0) {
+  $targetX += $rand.Next(-$jitter, $jitter + 1);
+  $targetY += $rand.Next(-$jitter, $jitter + 1);
+}
+for ($i = 1; $i -le $steps; $i++) {
+  $x = [int][Math]::Round($startX + (($targetX - $startX) * $i / $steps));
+  $y = [int][Math]::Round($startY + (($targetY - $startY) * $i / $steps));
+  [DesktopNative]::SetCursorPos($x, $y) | Out-Null;
+  Start-Sleep -Milliseconds $delay;
+}
+if ($settle -gt 0) {
+  Start-Sleep -Milliseconds $settle;
+}
+[DesktopNative]::mouse_event(%d, 0, 0, 0, [UIntPtr]::Zero);
+[DesktopNative]::mouse_event(%d, 0, 0, 0, [UIntPtr]::Zero);
+if ($doubleClick) {
+  Start-Sleep -Milliseconds $interval;
+  [DesktopNative]::mouse_event(%d, 0, 0, 0, [UIntPtr]::Zero);
+  [DesktopNative]::mouse_event(%d, 0, 0, 0, [UIntPtr]::Zero);
+  "double-clicked human"
+} else {
+  "clicked human"
+}
+`, x, y, steps, delay, jitterPX, settleMS, powerShellBool(doubleClick), intervalMS, downFlag, upFlag, downFlag, upFlag)
+	return command, nil
+}
+
+func intNumberWithDefault(value any, fallback int) int {
+	n, ok := numberInput(value)
+	if !ok {
+		return fallback
+	}
+	return n
+}
+
+func numberInput(value any) (int, bool) {
+	switch v := value.(type) {
+	case float64:
+		return int(v), true
+	case float32:
+		return int(v), true
+	case int:
+		return v, true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	case string:
+		var out int
+		_, err := fmt.Sscanf(strings.TrimSpace(v), "%d", &out)
+		return out, err == nil
+	default:
+		return 0, false
+	}
+}

--- a/pkg/capability/tools/desktop_target.go
+++ b/pkg/capability/tools/desktop_target.go
@@ -1,0 +1,742 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"image"
+	"image/draw"
+	"image/png"
+	"os"
+	"strings"
+)
+
+type desktopTargetResolution struct {
+	Found    bool                      `json:"found"`
+	Strategy string                    `json:"strategy,omitempty"`
+	Action   string                    `json:"action,omitempty"`
+	X        int                       `json:"x,omitempty"`
+	Y        int                       `json:"y,omitempty"`
+	Width    int                       `json:"width,omitempty"`
+	Height   int                       `json:"height,omitempty"`
+	CenterX  int                       `json:"center_x,omitempty"`
+	CenterY  int                       `json:"center_y,omitempty"`
+	Window   *desktopWindowInfo        `json:"window,omitempty"`
+	Element  *desktopAutomationElement `json:"element,omitempty"`
+	Text     *ocrTextMatchResult       `json:"text,omitempty"`
+	Image    *imageMatchResult         `json:"image,omitempty"`
+	Meta     map[string]any            `json:"meta,omitempty"`
+}
+
+type desktopVisionSource struct {
+	Path    string
+	OffsetX int
+	OffsetY int
+	Cleanup func()
+}
+
+func DesktopResolveTargetTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_resolve_target", opts, true); err != nil {
+		return "", err
+	}
+	result, err := resolveDesktopTarget(ctx, input, opts)
+	if err != nil {
+		return "", err
+	}
+	if boolValue(input["require_found"]) && !result.Found {
+		return "", desktopTargetNotFoundError(result)
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func DesktopActivateTargetTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_activate_target", opts, false); err != nil {
+		return "", err
+	}
+	result, err := resolveDesktopTarget(ctx, input, opts)
+	if err != nil {
+		return "", err
+	}
+	if !result.Found {
+		return "", desktopTargetNotFoundError(result)
+	}
+	action, err := normalizeDesktopTargetAction(stringValue(input["action"]))
+	if err != nil {
+		return "", err
+	}
+	switch result.Strategy {
+	case "ui":
+		uiInput := cloneInputMap(input)
+		switch action {
+		case "auto", "click", "focus", "invoke", "select", "expand", "collapse", "toggle":
+			uiInput["action"] = action
+		case "double_click":
+			if _, err := DesktopDoubleClickTool(ctx, map[string]any{
+				"x": result.CenterX,
+				"y": result.CenterY,
+			}, opts); err != nil {
+				return "", err
+			}
+			result.Action = "double_click"
+		default:
+			return "", fmt.Errorf("unsupported action for ui target: %s", action)
+		}
+		if result.Action == "" {
+			if boolValue(input["human_like"]) && (action == "auto" || action == "click" || action == "invoke") {
+				clickInput := map[string]any{
+					"x":          result.CenterX,
+					"y":          result.CenterY,
+					"button":     firstNonEmpty(stringValue(input["button"]), "left"),
+					"human_like": true,
+				}
+				for _, key := range []string{"duration_ms", "steps", "jitter_px", "settle_ms"} {
+					if value, ok := input[key]; ok {
+						clickInput[key] = value
+					}
+				}
+				if _, err := DesktopClickTool(ctx, clickInput, opts); err != nil {
+					return "", err
+				}
+				result.Action = "click"
+			}
+		}
+		if result.Action == "" {
+			raw, err := DesktopInvokeUITool(ctx, uiInput, opts)
+			if err != nil {
+				return "", err
+			}
+			var uiResult desktopAutomationActionResult
+			if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &uiResult); err == nil {
+				result.Action = uiResult.Action
+				if uiResult.Element != nil {
+					result.Element = uiResult.Element
+					applyDesktopElementBounds(&result, *uiResult.Element)
+				}
+			} else {
+				result.Action = action
+				result.Meta = mergeMeta(result.Meta, map[string]any{"activation_result": raw})
+			}
+		}
+	case "text", "image":
+		if err := focusDesktopTargetWindow(ctx, input, result.Window, opts); err != nil {
+			return "", err
+		}
+		switch action {
+		case "focus":
+			result.Action = "focus"
+		case "auto", "click", "invoke":
+			clickInput := map[string]any{
+				"x":      result.CenterX,
+				"y":      result.CenterY,
+				"button": firstNonEmpty(stringValue(input["button"]), "left"),
+			}
+			for _, key := range []string{"human_like", "duration_ms", "steps", "jitter_px", "settle_ms"} {
+				if value, ok := input[key]; ok {
+					clickInput[key] = value
+				}
+			}
+			if _, err := DesktopClickTool(ctx, clickInput, opts); err != nil {
+				return "", err
+			}
+			result.Action = "click"
+		case "double_click":
+			doubleInput := map[string]any{
+				"x":      result.CenterX,
+				"y":      result.CenterY,
+				"button": firstNonEmpty(stringValue(input["button"]), "left"),
+			}
+			for _, key := range []string{"human_like", "duration_ms", "steps", "jitter_px", "settle_ms", "interval_ms"} {
+				if value, ok := input[key]; ok {
+					doubleInput[key] = value
+				}
+			}
+			if _, err := DesktopDoubleClickTool(ctx, doubleInput, opts); err != nil {
+				return "", err
+			}
+			result.Action = "double_click"
+		default:
+			return "", fmt.Errorf("unsupported action for %s target: %s", result.Strategy, action)
+		}
+	case "window":
+		if result.Window == nil {
+			return "", fmt.Errorf("window target is missing window details")
+		}
+		switch action {
+		case "auto", "focus":
+			if err := focusDesktopTargetWindow(ctx, input, result.Window, opts); err != nil {
+				return "", err
+			}
+			result.Action = "focus"
+		case "click", "invoke":
+			if err := focusDesktopTargetWindow(ctx, input, result.Window, opts); err != nil {
+				return "", err
+			}
+			clickInput := map[string]any{"x": result.CenterX, "y": result.CenterY}
+			for _, key := range []string{"button", "human_like", "duration_ms", "steps", "jitter_px", "settle_ms"} {
+				if value, ok := input[key]; ok {
+					clickInput[key] = value
+				}
+			}
+			if _, err := DesktopClickTool(ctx, clickInput, opts); err != nil {
+				return "", err
+			}
+			result.Action = "click"
+		case "double_click":
+			if err := focusDesktopTargetWindow(ctx, input, result.Window, opts); err != nil {
+				return "", err
+			}
+			doubleInput := map[string]any{"x": result.CenterX, "y": result.CenterY}
+			for _, key := range []string{"button", "human_like", "duration_ms", "steps", "jitter_px", "settle_ms", "interval_ms"} {
+				if value, ok := input[key]; ok {
+					doubleInput[key] = value
+				}
+			}
+			if _, err := DesktopDoubleClickTool(ctx, doubleInput, opts); err != nil {
+				return "", err
+			}
+			result.Action = "double_click"
+		default:
+			return "", fmt.Errorf("unsupported action for window target: %s", action)
+		}
+	default:
+		return "", fmt.Errorf("unsupported target strategy: %s", result.Strategy)
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func DesktopSetTargetValueTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_set_target_value", opts, false); err != nil {
+		return "", err
+	}
+	value := stringValue(input["value"])
+	if value == "" {
+		return "", fmt.Errorf("value is required")
+	}
+	result, err := resolveDesktopTarget(ctx, input, opts)
+	if err != nil {
+		return "", err
+	}
+	if !result.Found {
+		return "", desktopTargetNotFoundError(result)
+	}
+	appendValue := boolValue(input["append"])
+	submit := boolValue(input["submit"])
+	switch result.Strategy {
+	case "ui":
+		raw, err := DesktopSetValueUITool(ctx, input, opts)
+		if err != nil {
+			return "", err
+		}
+		var uiResult desktopAutomationActionResult
+		if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &uiResult); err == nil {
+			result.Action = uiResult.Action
+			if uiResult.Element != nil {
+				result.Element = uiResult.Element
+				applyDesktopElementBounds(&result, *uiResult.Element)
+			}
+		} else {
+			result.Action = "value"
+			result.Meta = mergeMeta(result.Meta, map[string]any{"set_value_result": raw})
+		}
+	case "text", "image", "window":
+		if err := focusDesktopTargetWindow(ctx, input, result.Window, opts); err != nil {
+			return "", err
+		}
+		if _, err := DesktopClickTool(ctx, map[string]any{"x": result.CenterX, "y": result.CenterY}, opts); err != nil {
+			return "", err
+		}
+		if !appendValue {
+			if _, err := DesktopHotkeyTool(ctx, map[string]any{"keys": []any{"ctrl", "a"}}, opts); err != nil {
+				return "", err
+			}
+		}
+		if _, err := DesktopTypeTool(ctx, map[string]any{"text": value}, opts); err != nil {
+			return "", err
+		}
+		if submit {
+			if _, err := DesktopHotkeyTool(ctx, map[string]any{"keys": []any{"enter"}}, opts); err != nil {
+				return "", err
+			}
+		}
+		result.Action = "type"
+		result.Meta = mergeMeta(result.Meta, map[string]any{"fallback": "click_and_type"})
+	default:
+		return "", fmt.Errorf("unsupported target strategy: %s", result.Strategy)
+	}
+	result.Meta = mergeMeta(result.Meta, map[string]any{
+		"value":  value,
+		"append": appendValue,
+		"submit": submit,
+	})
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func resolveDesktopTarget(ctx context.Context, input map[string]any, opts BuiltinOptions) (desktopTargetResolution, error) {
+	strategies, err := resolveDesktopTargetStrategies(input)
+	if err != nil {
+		return desktopTargetResolution{}, err
+	}
+	result := desktopTargetResolution{
+		Meta: map[string]any{
+			"strategies": strategies,
+		},
+	}
+	window, windowErr := resolveDesktopTargetWindow(ctx, input)
+	if window != nil {
+		result.Window = window
+	}
+	var failures []string
+	for _, strategy := range strategies {
+		switch strategy {
+		case "ui":
+			element, err := findDesktopTargetAutomationElement(ctx, input, opts)
+			if err != nil {
+				failures = append(failures, "ui: "+err.Error())
+				continue
+			}
+			result.Found = true
+			result.Strategy = "ui"
+			result.Element = element
+			applyDesktopElementBounds(&result, *element)
+			result.Meta = mergeMeta(result.Meta, map[string]any{"matched_strategy": "ui"})
+			return result, nil
+		case "text":
+			textResult, err := runDesktopTargetTextMatch(ctx, input, opts, window)
+			if err != nil {
+				failures = append(failures, "text: "+err.Error())
+				continue
+			}
+			if !textResult.Found {
+				failures = append(failures, "text: text not found")
+				continue
+			}
+			result.Found = true
+			result.Strategy = "text"
+			result.Text = &textResult
+			applyDesktopTextBounds(&result, textResult)
+			result.Meta = mergeMeta(result.Meta, map[string]any{"matched_strategy": "text"})
+			return result, nil
+		case "image":
+			imageResult, err := runDesktopTargetImageMatch(ctx, input, opts, window)
+			if err != nil {
+				failures = append(failures, "image: "+err.Error())
+				continue
+			}
+			if !imageResult.Found {
+				failures = append(failures, fmt.Sprintf("image: best score %.4f below threshold %.4f", imageResult.Score, imageResult.Threshold))
+				continue
+			}
+			result.Found = true
+			result.Strategy = "image"
+			result.Image = &imageResult
+			applyDesktopImageBounds(&result, imageResult)
+			result.Meta = mergeMeta(result.Meta, map[string]any{"matched_strategy": "image"})
+			return result, nil
+		case "window":
+			if windowErr != nil {
+				failures = append(failures, "window: "+windowErr.Error())
+				continue
+			}
+			if window == nil {
+				failures = append(failures, "window: window not found")
+				continue
+			}
+			result.Found = true
+			result.Strategy = "window"
+			applyDesktopWindowBounds(&result, *window)
+			result.Meta = mergeMeta(result.Meta, map[string]any{"matched_strategy": "window"})
+			return result, nil
+		}
+	}
+	if len(failures) > 0 {
+		result.Meta = mergeMeta(result.Meta, map[string]any{"last_error": strings.Join(failures, "; ")})
+	}
+	return result, nil
+}
+
+func resolveDesktopTargetStrategies(input map[string]any) ([]string, error) {
+	if raw, ok := input["strategies"]; ok {
+		items, err := normalizeDesktopTargetStrategies(raw)
+		if err != nil {
+			return nil, err
+		}
+		if len(items) == 1 && items[0] == "auto" {
+			return inferDesktopTargetStrategies(input)
+		}
+		for _, item := range items {
+			if item == "auto" {
+				return nil, fmt.Errorf("auto cannot be combined with other strategies")
+			}
+		}
+		return dedupeDesktopTargetStrategies(items), nil
+	}
+	if raw := strings.TrimSpace(strings.ToLower(stringValue(input["strategy"]))); raw != "" {
+		if raw == "auto" {
+			return inferDesktopTargetStrategies(input)
+		}
+		return normalizeDesktopTargetStrategies(raw)
+	}
+	return inferDesktopTargetStrategies(input)
+}
+
+func inferDesktopTargetStrategies(input map[string]any) ([]string, error) {
+	strategies := make([]string, 0, 4)
+	if desktopTargetUISelectionProvided(input) && desktopTargetWindowSelectionProvided(input) {
+		strategies = append(strategies, "ui")
+	}
+	if strings.TrimSpace(stringValue(input["text"])) != "" {
+		strategies = append(strategies, "text")
+	}
+	if strings.TrimSpace(stringValue(input["template_path"])) != "" {
+		strategies = append(strategies, "image")
+	}
+	if desktopTargetWindowSelectionProvided(input) {
+		strategies = append(strategies, "window")
+	}
+	strategies = dedupeDesktopTargetStrategies(strategies)
+	if len(strategies) == 0 {
+		return nil, fmt.Errorf("a target selector is required: provide window, ui, text, or template_path criteria")
+	}
+	return strategies, nil
+}
+
+func normalizeDesktopTargetStrategies(value any) ([]string, error) {
+	rawItems := make([]string, 0)
+	switch v := value.(type) {
+	case string:
+		for _, item := range strings.Split(v, ",") {
+			item = strings.TrimSpace(item)
+			if item != "" {
+				rawItems = append(rawItems, item)
+			}
+		}
+	case []string:
+		rawItems = append(rawItems, v...)
+	case []any:
+		for _, item := range v {
+			rawItems = append(rawItems, fmt.Sprint(item))
+		}
+	default:
+		return nil, fmt.Errorf("strategies must be a string or string array")
+	}
+	if len(rawItems) == 0 {
+		return nil, fmt.Errorf("at least one strategy is required")
+	}
+	items := make([]string, 0, len(rawItems))
+	for _, item := range rawItems {
+		normalized := strings.TrimSpace(strings.ToLower(item))
+		switch normalized {
+		case "auto", "window", "ui", "text", "image":
+			items = append(items, normalized)
+		default:
+			return nil, fmt.Errorf("unsupported target strategy: %s", item)
+		}
+	}
+	return dedupeDesktopTargetStrategies(items), nil
+}
+
+func dedupeDesktopTargetStrategies(items []string) []string {
+	seen := map[string]bool{}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(strings.ToLower(item))
+		if item == "" || seen[item] {
+			continue
+		}
+		seen[item] = true
+		result = append(result, item)
+	}
+	return result
+}
+
+func desktopTargetWindowSelectionProvided(input map[string]any) bool {
+	selector, _ := resolveDesktopAutomationSelector(input, false)
+	return desktopWindowSelectionProvided(selector)
+}
+
+func desktopTargetUISelectionProvided(input map[string]any) bool {
+	selector, _ := resolveDesktopAutomationSelector(input, false)
+	return desktopAutomationFilterProvided(selector)
+}
+
+func desktopAutomationFilterProvided(selector desktopAutomationSelector) bool {
+	return selector.Name != "" || selector.AutomationID != "" || selector.ClassName != "" || selector.ControlType != ""
+}
+
+func resolveDesktopTargetWindow(ctx context.Context, input map[string]any) (*desktopWindowInfo, error) {
+	if !desktopTargetWindowSelectionProvided(input) {
+		return nil, nil
+	}
+	windows, err := runDesktopWindowQuery(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	if len(windows) == 0 {
+		return nil, nil
+	}
+	window := windows[0]
+	return &window, nil
+}
+
+func findDesktopTargetAutomationElement(ctx context.Context, input map[string]any, opts BuiltinOptions) (*desktopAutomationElement, error) {
+	selector, err := resolveDesktopAutomationSelector(input, true)
+	if err != nil {
+		return nil, err
+	}
+	if !desktopAutomationFilterProvided(selector) {
+		return nil, fmt.Errorf("ui target requires name, automation_id, class_name, or control_type")
+	}
+	inspectInput := cloneInputMap(input)
+	inspectInput["max_elements"] = selector.Index
+	raw, err := DesktopInspectUITool(ctx, inspectInput, opts)
+	if err != nil {
+		return nil, err
+	}
+	elements := []desktopAutomationElement{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &elements); err != nil {
+		return nil, err
+	}
+	if len(elements) < selector.Index {
+		return nil, fmt.Errorf("automation element not found")
+	}
+	element := elements[selector.Index-1]
+	return &element, nil
+}
+
+func runDesktopTargetTextMatch(ctx context.Context, input map[string]any, opts BuiltinOptions, window *desktopWindowInfo) (ocrTextMatchResult, error) {
+	source, err := resolveDesktopTargetVisionSource(ctx, input, opts, window)
+	if err != nil {
+		return ocrTextMatchResult{}, err
+	}
+	defer source.Cleanup()
+	matchInput := cloneInputMap(input)
+	matchInput["path"] = source.Path
+	result, err := runDesktopTextMatch(ctx, matchInput, opts)
+	if err != nil {
+		return ocrTextMatchResult{}, err
+	}
+	applyTextMatchOffset(&result, source.OffsetX, source.OffsetY)
+	return result, nil
+}
+
+func runDesktopTargetImageMatch(ctx context.Context, input map[string]any, opts BuiltinOptions, window *desktopWindowInfo) (imageMatchResult, error) {
+	source, err := resolveDesktopTargetVisionSource(ctx, input, opts, window)
+	if err != nil {
+		return imageMatchResult{}, err
+	}
+	defer source.Cleanup()
+	matchInput := cloneInputMap(input)
+	matchInput["path"] = source.Path
+	result, err := runDesktopImageMatch(ctx, matchInput, opts)
+	if err != nil {
+		return imageMatchResult{}, err
+	}
+	applyImageMatchOffset(&result, source.OffsetX, source.OffsetY)
+	return result, nil
+}
+
+func resolveDesktopTargetVisionSource(ctx context.Context, input map[string]any, opts BuiltinOptions, window *desktopWindowInfo) (desktopVisionSource, error) {
+	path, cleanup, err := resolveDesktopVisionSource(ctx, input, opts)
+	if err != nil {
+		return desktopVisionSource{}, err
+	}
+	source := desktopVisionSource{
+		Path:    path,
+		Cleanup: cleanup,
+	}
+	if !shouldCropDesktopTargetToWindow(input, window) {
+		return source, nil
+	}
+	croppedPath, offsetX, offsetY, cropCleanup, err := cropDesktopTargetImageToWindow(path, *window)
+	if err != nil {
+		cleanup()
+		return desktopVisionSource{}, err
+	}
+	source.Path = croppedPath
+	source.OffsetX = offsetX
+	source.OffsetY = offsetY
+	source.Cleanup = func() {
+		cropCleanup()
+		cleanup()
+	}
+	return source, nil
+}
+
+func shouldCropDesktopTargetToWindow(input map[string]any, window *desktopWindowInfo) bool {
+	if window == nil {
+		return false
+	}
+	if hasDesktopSearchBounds(input) {
+		return false
+	}
+	if raw, ok := input["crop_to_window"]; ok {
+		return boolValue(raw)
+	}
+	return strings.TrimSpace(stringValue(input["path"])) == ""
+}
+
+func hasDesktopSearchBounds(input map[string]any) bool {
+	_, hasX := numberInput(input["search_x"])
+	_, hasY := numberInput(input["search_y"])
+	_, hasWidth := numberInput(input["search_width"])
+	_, hasHeight := numberInput(input["search_height"])
+	return hasX || hasY || hasWidth || hasHeight
+}
+
+func cropDesktopTargetImageToWindow(path string, window desktopWindowInfo) (string, int, int, func(), error) {
+	img, err := loadImageFile(path)
+	if err != nil {
+		return "", 0, 0, nil, err
+	}
+	bounds := normalizeBounds(img.Bounds())
+	cropRect := image.Rect(window.X, window.Y, window.X+window.Width, window.Y+window.Height).Intersect(bounds)
+	if cropRect.Empty() {
+		return "", 0, 0, nil, fmt.Errorf("window bounds are outside the captured desktop image")
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, cropRect.Dx(), cropRect.Dy()))
+	draw.Draw(dst, dst.Bounds(), img, cropRect.Min, draw.Src)
+	tempFile, err := os.CreateTemp("", "anyclaw-target-window-*.png")
+	if err != nil {
+		return "", 0, 0, nil, err
+	}
+	tempPath := tempFile.Name()
+	if err := png.Encode(tempFile, dst); err != nil {
+		_ = tempFile.Close()
+		_ = os.Remove(tempPath)
+		return "", 0, 0, nil, err
+	}
+	if err := tempFile.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return "", 0, 0, nil, err
+	}
+	return tempPath, cropRect.Min.X, cropRect.Min.Y, func() { _ = os.Remove(tempPath) }, nil
+}
+
+func focusDesktopTargetWindow(ctx context.Context, input map[string]any, window *desktopWindowInfo, opts BuiltinOptions) error {
+	if window == nil {
+		return nil
+	}
+	focusInput := map[string]any{}
+	if window.Handle > 0 {
+		focusInput["handle"] = window.Handle
+	}
+	if title := firstNonEmpty(window.Title, stringValue(input["title"])); title != "" {
+		focusInput["title"] = title
+	}
+	if processName := firstNonEmpty(window.ProcessName, stringValue(input["process_name"])); processName != "" {
+		focusInput["process_name"] = processName
+	}
+	if match := stringValue(input["match"]); match != "" {
+		focusInput["match"] = match
+	}
+	_, err := DesktopFocusWindowTool(ctx, focusInput, opts)
+	return err
+}
+
+func normalizeDesktopTargetAction(value string) (string, error) {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" {
+		return "auto", nil
+	}
+	switch value {
+	case "auto", "click", "double_click", "focus", "invoke", "select", "expand", "collapse", "toggle":
+		return value, nil
+	default:
+		return "", fmt.Errorf("action must be auto, click, double_click, focus, invoke, select, expand, collapse, or toggle")
+	}
+}
+
+func applyDesktopWindowBounds(result *desktopTargetResolution, window desktopWindowInfo) {
+	result.X = window.X
+	result.Y = window.Y
+	result.Width = window.Width
+	result.Height = window.Height
+	result.CenterX = window.CenterX
+	result.CenterY = window.CenterY
+}
+
+func applyDesktopElementBounds(result *desktopTargetResolution, element desktopAutomationElement) {
+	result.X = element.X
+	result.Y = element.Y
+	result.Width = element.Width
+	result.Height = element.Height
+	result.CenterX = element.CenterX
+	result.CenterY = element.CenterY
+}
+
+func applyDesktopTextBounds(result *desktopTargetResolution, match ocrTextMatchResult) {
+	result.X = match.X
+	result.Y = match.Y
+	result.Width = match.Width
+	result.Height = match.Height
+	result.CenterX = match.CenterX
+	result.CenterY = match.CenterY
+}
+
+func applyDesktopImageBounds(result *desktopTargetResolution, match imageMatchResult) {
+	result.X = match.X
+	result.Y = match.Y
+	result.Width = match.Width
+	result.Height = match.Height
+	result.CenterX = match.CenterX
+	result.CenterY = match.CenterY
+}
+
+func applyTextMatchOffset(result *ocrTextMatchResult, offsetX int, offsetY int) {
+	if result == nil || (offsetX == 0 && offsetY == 0) {
+		return
+	}
+	result.X += offsetX
+	result.Y += offsetY
+	result.CenterX += offsetX
+	result.CenterY += offsetY
+}
+
+func applyImageMatchOffset(result *imageMatchResult, offsetX int, offsetY int) {
+	if result == nil || (offsetX == 0 && offsetY == 0) {
+		return
+	}
+	result.X += offsetX
+	result.Y += offsetY
+	result.CenterX += offsetX
+	result.CenterY += offsetY
+}
+
+func desktopTargetNotFoundError(result desktopTargetResolution) error {
+	if result.Meta != nil {
+		if lastErr, ok := result.Meta["last_error"].(string); ok && strings.TrimSpace(lastErr) != "" {
+			return fmt.Errorf("target not found: %s", lastErr)
+		}
+	}
+	return fmt.Errorf("target not found")
+}
+
+func cloneInputMap(input map[string]any) map[string]any {
+	cloned := make(map[string]any, len(input))
+	for key, value := range input {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/pkg/capability/tools/desktop_target_test.go
+++ b/pkg/capability/tools/desktop_target_test.go
@@ -1,0 +1,76 @@
+package tools
+
+import "testing"
+
+func TestResolveDesktopTargetStrategiesAuto(t *testing.T) {
+	strategies, err := resolveDesktopTargetStrategies(map[string]any{
+		"title":         "QQ",
+		"name":          "发送",
+		"text":          "发送",
+		"template_path": "send-button.png",
+	})
+	if err != nil {
+		t.Fatalf("resolveDesktopTargetStrategies: %v", err)
+	}
+	expected := []string{"ui", "text", "image", "window"}
+	if len(strategies) != len(expected) {
+		t.Fatalf("expected %d strategies, got %d: %#v", len(expected), len(strategies), strategies)
+	}
+	for i, item := range expected {
+		if strategies[i] != item {
+			t.Fatalf("expected strategy %d to be %q, got %q", i, item, strategies[i])
+		}
+	}
+}
+
+func TestResolveDesktopTargetStrategiesExplicit(t *testing.T) {
+	strategies, err := resolveDesktopTargetStrategies(map[string]any{
+		"strategies": []any{"image", "text", "image"},
+	})
+	if err != nil {
+		t.Fatalf("resolveDesktopTargetStrategies: %v", err)
+	}
+	expected := []string{"image", "text"}
+	if len(strategies) != len(expected) {
+		t.Fatalf("expected %d strategies, got %d: %#v", len(expected), len(strategies), strategies)
+	}
+	for i, item := range expected {
+		if strategies[i] != item {
+			t.Fatalf("expected strategy %d to be %q, got %q", i, item, strategies[i])
+		}
+	}
+}
+
+func TestResolveDesktopTargetStrategiesRequireSelector(t *testing.T) {
+	_, err := resolveDesktopTargetStrategies(map[string]any{})
+	if err == nil {
+		t.Fatal("expected empty selector set to be rejected")
+	}
+}
+
+func TestShouldCropDesktopTargetToWindowDefaults(t *testing.T) {
+	window := &desktopWindowInfo{X: 10, Y: 20, Width: 400, Height: 300}
+	if !shouldCropDesktopTargetToWindow(map[string]any{}, window) {
+		t.Fatal("expected captured desktop source to crop to the target window by default")
+	}
+	if shouldCropDesktopTargetToWindow(map[string]any{"path": "shot.png"}, window) {
+		t.Fatal("expected explicit path source to skip implicit cropping")
+	}
+	if !shouldCropDesktopTargetToWindow(map[string]any{"path": "shot.png", "crop_to_window": true}, window) {
+		t.Fatal("expected crop_to_window override to force cropping")
+	}
+}
+
+func TestApplyDesktopTargetOffsets(t *testing.T) {
+	textMatch := ocrTextMatchResult{X: 5, Y: 6, CenterX: 15, CenterY: 16}
+	applyTextMatchOffset(&textMatch, 100, 200)
+	if textMatch.X != 105 || textMatch.Y != 206 || textMatch.CenterX != 115 || textMatch.CenterY != 216 {
+		t.Fatalf("unexpected text match offset result: %#v", textMatch)
+	}
+
+	imageMatch := imageMatchResult{X: 7, Y: 8, CenterX: 17, CenterY: 18}
+	applyImageMatchOffset(&imageMatch, 50, 70)
+	if imageMatch.X != 57 || imageMatch.Y != 78 || imageMatch.CenterX != 67 || imageMatch.CenterY != 88 {
+		t.Fatalf("unexpected image match offset result: %#v", imageMatch)
+	}
+}

--- a/pkg/capability/tools/memory_tools.go
+++ b/pkg/capability/tools/memory_tools.go
@@ -1,0 +1,217 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	appmemory "github.com/1024XEngineer/anyclaw/pkg/state/memory"
+)
+
+func MemorySearchToolWithCwd(ctx context.Context, input map[string]any, cwd string) (string, error) {
+	return MemorySearchToolWithBackend(ctx, input, cwd, nil)
+}
+
+func MemorySearchToolWithBackend(ctx context.Context, input map[string]any, cwd string, mem MemoryBackend) (string, error) {
+	query, ok := input["query"].(string)
+	if !ok || strings.TrimSpace(query) == "" {
+		return "", fmt.Errorf("query is required")
+	}
+
+	limit := 5
+	if value, ok := input["limit"].(float64); ok && value > 0 {
+		limit = int(value)
+	}
+
+	if mem != nil {
+		entries, err := mem.Search(query, limit)
+		if err != nil {
+			return "", err
+		}
+		if len(entries) == 0 {
+			return "No memory entries found in backend", nil
+		}
+
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("Found %d memory entries\n\n", len(entries)))
+		for _, entry := range entries {
+			sb.WriteString(fmt.Sprintf("## [%s] %s %s\n\n%s\n\n", entry.Type, entry.Timestamp.Format("2006-01-02 15:04"), entry.ID, entry.Content))
+		}
+		return strings.TrimSpace(sb.String()), nil
+	}
+
+	day, _ := input["date"].(string)
+	matches, err := appmemory.SearchDailyMarkdown(dailyMemoryDir(cwd), query, limit, day)
+	if err != nil {
+		return "", err
+	}
+	if len(matches) == 0 {
+		return "No daily memory matches found", nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d daily memory match(es)\n\n", len(matches)))
+	for _, match := range matches {
+		sb.WriteString(fmt.Sprintf("[%s] %s\n", match.Date, match.Path))
+		sb.WriteString(match.Snippet)
+		sb.WriteString("\n\n")
+	}
+	return strings.TrimSpace(sb.String()), nil
+}
+
+func MemoryVectorSearchTool(ctx context.Context, input map[string]any, mem MemoryBackend, vec appmemory.VectorBackend) (string, error) {
+	if mem == nil || vec == nil {
+		return "", fmt.Errorf("vector memory backend not available")
+	}
+
+	query, ok := input["query"].(string)
+	if !ok || strings.TrimSpace(query) == "" {
+		return "", fmt.Errorf("query is required")
+	}
+
+	limit := 5
+	if value, ok := input["limit"].(float64); ok && value > 0 {
+		limit = int(value)
+	}
+
+	threshold := 0.5
+	if value, ok := input["threshold"].(float64); ok && value > 0 {
+		threshold = value
+	}
+
+	var embedding []float64
+	if rawEmbedding, ok := input["embedding"].([]any); ok {
+		embedding = make([]float64, len(rawEmbedding))
+		for i, v := range rawEmbedding {
+			if f, ok := v.(float64); ok {
+				embedding[i] = f
+			}
+		}
+	}
+
+	if len(embedding) == 0 {
+		entries, err := mem.Search(query, limit)
+		if err != nil {
+			return "", err
+		}
+		if len(entries) == 0 {
+			return "No memory entries found", nil
+		}
+
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("Found %d memory entries (text search)\n\n", len(entries)))
+		for _, entry := range entries {
+			sb.WriteString(fmt.Sprintf("## [%s] %s %s\n\n%s\n\n", entry.Type, entry.Timestamp.Format("2006-01-02 15:04"), entry.ID, entry.Content))
+		}
+		return strings.TrimSpace(sb.String()), nil
+	}
+
+	results, err := vec.VectorSearch(embedding, limit, threshold)
+	if err != nil {
+		return "", err
+	}
+	if len(results) == 0 {
+		return "No vector memory matches found", nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d vector memory matches\n\n", len(results)))
+	for _, entry := range results {
+		sb.WriteString(fmt.Sprintf("## [%s] %s %s (score: %.4f)\n\n%s\n\n", entry.Type, entry.Timestamp.Format("2006-01-02 15:04"), entry.ID, entry.Score, entry.Content))
+	}
+	return strings.TrimSpace(sb.String()), nil
+}
+
+func MemoryHybridSearchTool(ctx context.Context, input map[string]any, mem MemoryBackend, vec appmemory.VectorBackend) (string, error) {
+	if mem == nil || vec == nil {
+		return "", fmt.Errorf("vector memory backend not available")
+	}
+
+	query, ok := input["query"].(string)
+	if !ok || strings.TrimSpace(query) == "" {
+		return "", fmt.Errorf("query is required")
+	}
+
+	limit := 5
+	if value, ok := input["limit"].(float64); ok && value > 0 {
+		limit = int(value)
+	}
+
+	vectorWeight := 0.5
+	if value, ok := input["vector_weight"].(float64); ok && value >= 0 && value <= 1 {
+		vectorWeight = value
+	}
+
+	var embedding []float64
+	if rawEmbedding, ok := input["embedding"].([]any); ok {
+		embedding = make([]float64, len(rawEmbedding))
+		for i, v := range rawEmbedding {
+			if f, ok := v.(float64); ok {
+				embedding[i] = f
+			}
+		}
+	}
+
+	if len(embedding) == 0 {
+		entries, err := mem.Search(query, limit)
+		if err != nil {
+			return "", err
+		}
+		if len(entries) == 0 {
+			return "No memory entries found", nil
+		}
+
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("Found %d memory entries (text search)\n\n", len(entries)))
+		for _, entry := range entries {
+			sb.WriteString(fmt.Sprintf("## [%s] %s %s\n\n%s\n\n", entry.Type, entry.Timestamp.Format("2006-01-02 15:04"), entry.ID, entry.Content))
+		}
+		return strings.TrimSpace(sb.String()), nil
+	}
+
+	results, err := vec.HybridSearch(query, embedding, limit, vectorWeight)
+	if err != nil {
+		return "", err
+	}
+	if len(results) == 0 {
+		return "No hybrid memory matches found", nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d hybrid memory matches\n\n", len(results)))
+	for _, result := range results {
+		sb.WriteString(fmt.Sprintf("## [%s] %s %s (fts: %.4f, vec: %.4f, final: %.4f)\n\n%s\n\n",
+			result.Entry.Type, result.Entry.Timestamp.Format("2006-01-02 15:04"), result.Entry.ID,
+			result.FTSScore, result.VectorScore, result.FinalScore,
+			result.Entry.Content))
+	}
+	return strings.TrimSpace(sb.String()), nil
+}
+
+func MemoryGetToolWithCwd(ctx context.Context, input map[string]any, cwd string) (string, error) {
+	day, ok := input["date"].(string)
+	if !ok || strings.TrimSpace(day) == "" {
+		return "", fmt.Errorf("date is required")
+	}
+
+	file, err := appmemory.GetDailyMarkdown(dailyMemoryDir(cwd), day)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("# Daily Memory %s\nPath: %s\n\n%s", file.Date, file.Path, file.Content), nil
+}
+
+func dailyMemoryDir(cwd string) string {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		cwd = "."
+	}
+	return filepath.Join(cwd, "memory")
+}
+
+func formatMemoryTimestamp(t time.Time) string {
+	return t.Format("2006-01-02 15:04")
+}

--- a/pkg/capability/tools/policy.go
+++ b/pkg/capability/tools/policy.go
@@ -1,0 +1,534 @@
+package tools
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	PrivacyScopePublic     = "public"
+	PrivacyScopeWork       = "work"
+	PrivacyScopePersonal   = "personal"
+	PrivacyScopeSystem     = "system"
+	PrivacyScopeRestricted = "restricted"
+)
+
+const (
+	DataScopeRead    = "read"
+	DataScopeWrite   = "write"
+	DataScopeDelete  = "delete"
+	DataScopeExecute = "execute"
+	DataScopeEgress  = "egress"
+)
+
+type PrivacyDomain int
+
+const (
+	PrivacyDomainNone PrivacyDomain = iota
+	PrivacyDomainBrowser
+	PrivacyDomainChat
+	PrivacyDomainCredentials
+	PrivacyDomainKeys
+	PrivacyDomainDocuments
+	PrivacyDomainMedia
+	PrivacyDomainSystem
+	PrivacyDomainNetwork
+)
+
+var privacyPathPatterns = map[PrivacyDomain][]string{
+	PrivacyDomainBrowser: {
+		`.*[\\/]Google[\\/]Chrome[\\/]Default[\\/]Login.*`,
+		`.*[\\/]Google[\\/]Chrome[\\/]Default[\\/]Network[\\/]Cookies.*`,
+		`.*[\\/]Microsoft[\\/]Edge[\\/]Default[\\/]Login.*`,
+		`.*[\\/]Microsoft[\\/]Edge[\\/]Default[\\/]Network[\\/]Cookies.*`,
+		`.*[\\/]Mozilla[\\/]Firefox[\\/]profiles[\\/].*[\\/]logins.json.*`,
+		`.*[\\/]Safari[\\/].*[\\/]Cookies.plist.*`,
+	},
+	PrivacyDomainChat: {
+		`.*[\\/]Tencent[\\/]Files[\\/].*[\\/]Msg.*`,
+		`.*[\\/]WeChat[\\/].*[\\/]Msg.*`,
+		`.*[\\/]QQ[\\/]Users[\\/].*[\\/]Msg.*`,
+		`.*[\\/]Telegram[\\/]tdata.*`,
+		`.*[\\/]Discord[\\/].*[\\/]messages.*`,
+		`.*[\\/]Slack[\\/].*[\\/]Cache.*`,
+	},
+	PrivacyDomainCredentials: {
+		`.*[\\/]\.netrc.*`,
+		`.*[\\/]git-credentials.*`,
+		`.*[\\/]\.aws[\\/]credentials.*`,
+		`.*[\\/]keychain.*`,
+		`.*[\\/]KeePass.*`,
+		`.*[\\/]1Password.*`,
+	},
+	PrivacyDomainKeys: {
+		`.*[\\/]\.ssh[\\/].*`,
+		`.*[\\/]gnupg[\\/].*`,
+		`.*[\\/]\.gnupg[\\/].*`,
+		`.*[\\/]id_rsa.*`,
+		`.*[\\/]id_ed25519.*`,
+		`.*[\\/]\.pem.*`,
+	},
+	PrivacyDomainDocuments: {
+		`.*[\\/]Documents[\\/]Personal.*`,
+		`.*[\\/]Desktop[\\/]Private.*`,
+		`.*[\\/]Downloads[\\/].*`,
+	},
+	PrivacyDomainMedia: {
+		`.*[\\/]Pictures[\\/]Camera Roll.*`,
+		`.*[\\/]Videos[\\/].*`,
+		`.*[\\/]Photos[\\/].*`,
+	},
+	PrivacyDomainSystem: {
+		`.*[\\/]Windows[\\/]System32[\\/].*`,
+		`.*[\\/]Windows[\\/]SysWOW64[\\/].*`,
+		`.*[\\/]Program Files[\\/].*`,
+		`.*[\\/]ProgramData[\\/].*`,
+		`.*[\\/]\.config[\\/]system.*`,
+	},
+}
+
+var dangerousCommandPatterns = []string{
+	`rm\s+-rf\s+`,
+	`del\s+/[fqs]\s+`,
+	`format\s+`,
+	`dd\s+if=`,
+	`mkfs\.`,
+	`fdisk\s+-`,
+	`shutdown`,
+	`reboot`,
+	`reg\s+(delete|add)`,
+	`sc\s+(delete|create|config)`,
+	`powershell\s+-Command\s+.*-Object\s+.*Start-Process`,
+	`curl\|sh`,
+	`wget\s+\|`,
+	`chmod\s+777`,
+	`chown\s+.*\s+root`,
+	`sudo\s+rm`,
+	`:\(){:|:&};:`,
+}
+
+type PolicyOptions struct {
+	WorkingDir           string
+	PermissionLevel      string
+	ProtectedPaths       []string
+	AllowedReadPaths     []string
+	AllowedWritePaths    []string
+	AllowedEgressDomains []string
+}
+
+type PolicyEngine struct {
+	workingDir           string
+	permissionLevel      string
+	protectedPaths       []string
+	allowedReadPaths     []string
+	allowedWritePaths    []string
+	allowedEgressDomains []string
+}
+
+type PrivacyEngine struct {
+	workingDir        string
+	allowedEgressDoms []string
+	blockedEgressDoms []string
+	privacyPathCache  map[string]PrivacyDomain
+	dangerousCmdRegex []*regexp.Regexp
+	privacyRegexCache map[PrivacyDomain][]*regexp.Regexp
+}
+
+type PrivacyCheckResult struct {
+	IsAllowed        bool
+	Domain           PrivacyDomain
+	DomainName       string
+	RequiresApproval bool
+	RiskLevel        string
+	Reason           string
+}
+
+type RiskLabel struct {
+	Name        string
+	Severity    string
+	Description string
+}
+
+func NewPolicyEngine(opts PolicyOptions) *PolicyEngine {
+	engine := &PolicyEngine{
+		permissionLevel: strings.TrimSpace(strings.ToLower(opts.PermissionLevel)),
+	}
+	engine.workingDir = normalizePolicyPath(resolvePath(opts.WorkingDir, ""))
+	engine.protectedPaths = normalizePolicyPaths(opts.ProtectedPaths, opts.WorkingDir)
+	engine.allowedReadPaths = normalizePolicyPaths(opts.AllowedReadPaths, opts.WorkingDir)
+	engine.allowedWritePaths = normalizePolicyPaths(opts.AllowedWritePaths, opts.WorkingDir)
+	engine.allowedEgressDomains = normalizePolicyDomains(opts.AllowedEgressDomains)
+	return engine
+}
+
+type PrivacyOptions struct {
+	WorkingDir           string
+	AllowedEgressDomains []string
+	BlockedEgressDomains []string
+}
+
+func NewPrivacyEngine(opts PrivacyOptions) *PrivacyEngine {
+	engine := &PrivacyEngine{
+		workingDir:        normalizePolicyPath(resolvePath(opts.WorkingDir, "")),
+		allowedEgressDoms: normalizePolicyDomains(opts.AllowedEgressDomains),
+		blockedEgressDoms: normalizePolicyDomains(opts.BlockedEgressDomains),
+		privacyPathCache:  make(map[string]PrivacyDomain),
+		dangerousCmdRegex: make([]*regexp.Regexp, 0, len(dangerousCommandPatterns)),
+		privacyRegexCache: make(map[PrivacyDomain][]*regexp.Regexp),
+	}
+	for _, pattern := range dangerousCommandPatterns {
+		if re, err := regexp.Compile("(?i)" + pattern); err == nil {
+			engine.dangerousCmdRegex = append(engine.dangerousCmdRegex, re)
+		}
+	}
+	return engine
+}
+
+func (pe *PrivacyEngine) ClassifyPath(path string) PrivacyDomain {
+	path = normalizePolicyPath(path)
+	if domain, ok := pe.privacyPathCache[path]; ok {
+		return domain
+	}
+	for domain := range privacyPathPatterns {
+		if pe.matchPathPatterns(path, domain) {
+			pe.privacyPathCache[path] = domain
+			return domain
+		}
+	}
+	return PrivacyDomainNone
+}
+
+func (pe *PrivacyEngine) matchPathPatterns(path string, domain PrivacyDomain) bool {
+	patterns, ok := privacyPathPatterns[domain]
+	if !ok {
+		return false
+	}
+	if regexes, ok := pe.privacyRegexCache[domain]; ok {
+		for _, re := range regexes {
+			if re.MatchString(path) {
+				return true
+			}
+		}
+		return false
+	}
+	var regexes []*regexp.Regexp
+	for _, pattern := range patterns {
+		if re, err := regexp.Compile("(?i)" + pattern); err == nil {
+			regexes = append(regexes, re)
+			if re.MatchString(path) {
+				pe.privacyRegexCache[domain] = regexes
+				return true
+			}
+		}
+	}
+	pe.privacyRegexCache[domain] = regexes
+	return false
+}
+
+func (pe *PrivacyEngine) CheckPath(path string) PrivacyCheckResult {
+	domain := pe.ClassifyPath(path)
+	return pe.evaluateDomain(domain, path)
+}
+
+func (pe *PrivacyEngine) evaluateDomain(domain PrivacyDomain, path string) PrivacyCheckResult {
+	result := PrivacyCheckResult{
+		Domain:     domain,
+		DomainName: domain.String(),
+	}
+	switch domain {
+	case PrivacyDomainNone:
+		result.IsAllowed = true
+		result.RiskLevel = "low"
+		result.RequiresApproval = false
+		result.Reason = "path is in public scope"
+	case PrivacyDomainBrowser, PrivacyDomainChat, PrivacyDomainCredentials, PrivacyDomainKeys:
+		result.IsAllowed = false
+		result.RiskLevel = "high"
+		result.RequiresApproval = true
+		result.Reason = fmt.Sprintf("accessing %s requires explicit approval", domain.String())
+	case PrivacyDomainDocuments, PrivacyDomainMedia:
+		result.IsAllowed = false
+		result.RiskLevel = "medium"
+		result.RequiresApproval = true
+		result.Reason = fmt.Sprintf("accessing %s may contain personal data", domain.String())
+	case PrivacyDomainSystem:
+		result.IsAllowed = false
+		result.RiskLevel = "high"
+		result.RequiresApproval = true
+		result.Reason = "modifying system files is restricted"
+	case PrivacyDomainNetwork:
+		result.IsAllowed = true
+		result.RiskLevel = "medium"
+		result.RequiresApproval = true
+		result.Reason = "network access requires approval"
+	}
+	return result
+}
+
+func (pe *PrivacyEngine) CheckCommand(command string) (bool, string) {
+	for _, re := range pe.dangerousCmdRegex {
+		if re.MatchString(command) {
+			return false, fmt.Sprintf("dangerous command pattern detected: %s", re.String())
+		}
+	}
+	return true, ""
+}
+
+func (pe *PrivacyEngine) CheckEgress(targetURL string) PrivacyCheckResult {
+	result := PrivacyCheckResult{
+		Domain:     PrivacyDomainNetwork,
+		DomainName: "network",
+	}
+	parsed, err := url.Parse(targetURL)
+	if err != nil {
+		result.IsAllowed = false
+		result.RiskLevel = "high"
+		result.Reason = fmt.Sprintf("invalid URL: %v", err)
+		return result
+	}
+	host := strings.TrimSpace(strings.ToLower(parsed.Hostname()))
+	if host == "" {
+		result.IsAllowed = false
+		result.RiskLevel = "high"
+		result.Reason = "empty hostname"
+		return result
+	}
+	for _, blocked := range pe.blockedEgressDoms {
+		if domainMatches(host, blocked) {
+			result.IsAllowed = false
+			result.RiskLevel = "high"
+			result.RequiresApproval = true
+			result.Reason = fmt.Sprintf("egress to %s is blocked", host)
+			return result
+		}
+	}
+	if isLocalEgressHost(host) {
+		result.IsAllowed = true
+		result.RiskLevel = "low"
+		result.Reason = "local network access"
+		return result
+	}
+	for _, allowed := range pe.allowedEgressDoms {
+		if domainMatches(host, allowed) {
+			result.IsAllowed = true
+			result.RiskLevel = "low"
+			result.RequiresApproval = false
+			result.Reason = fmt.Sprintf("egress to %s is allowed", host)
+			return result
+		}
+	}
+	result.IsAllowed = false
+	result.RiskLevel = "high"
+	result.RequiresApproval = true
+	result.Reason = fmt.Sprintf("egress to %s is not in allowed domains", host)
+	return result
+}
+
+func (d PrivacyDomain) String() string {
+	switch d {
+	case PrivacyDomainNone:
+		return "none"
+	case PrivacyDomainBrowser:
+		return "browser"
+	case PrivacyDomainChat:
+		return "chat"
+	case PrivacyDomainCredentials:
+		return "credentials"
+	case PrivacyDomainKeys:
+		return "keys"
+	case PrivacyDomainDocuments:
+		return "documents"
+	case PrivacyDomainMedia:
+		return "media"
+	case PrivacyDomainSystem:
+		return "system"
+	case PrivacyDomainNetwork:
+		return "network"
+	default:
+		return "unknown"
+	}
+}
+
+func (p *PolicyEngine) CheckReadPath(path string) error {
+	return p.checkPathAccess(path, p.allowedReadPaths, "read")
+}
+
+func (p *PolicyEngine) CheckWritePath(path string) error {
+	if strings.TrimSpace(strings.ToLower(p.permissionLevel)) == "read-only" {
+		return fmt.Errorf("permission denied: current agent is read-only")
+	}
+	return p.checkPathAccess(path, p.allowedWritePaths, "write")
+}
+
+func (p *PolicyEngine) CheckCommandCwd(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	if strings.TrimSpace(strings.ToLower(p.permissionLevel)) == "read-only" {
+		return fmt.Errorf("permission denied: current agent is read-only")
+	}
+	return p.checkPathAccess(path, p.allowedWritePaths, "execute")
+}
+
+func (p *PolicyEngine) CheckBrowserUpload(path string, targetURL string) error {
+	if err := p.CheckReadPath(path); err != nil {
+		return err
+	}
+	return p.CheckEgressURL(targetURL)
+}
+
+func (p *PolicyEngine) CheckEgressURL(targetURL string) error {
+	targetURL = strings.TrimSpace(targetURL)
+	if targetURL == "" {
+		return fmt.Errorf("browser upload denied: target page is unknown")
+	}
+	parsed, err := url.Parse(targetURL)
+	if err != nil {
+		return fmt.Errorf("browser upload denied: invalid target url: %w", err)
+	}
+	host := strings.TrimSpace(strings.ToLower(parsed.Hostname()))
+	if host == "" || parsed.Scheme == "file" || isLocalEgressHost(host) {
+		return nil
+	}
+	for _, allowed := range p.allowedEgressDomains {
+		if domainMatches(host, allowed) {
+			return nil
+		}
+	}
+	return fmt.Errorf("egress denied: %s is not in security.allowed_egress_domains", host)
+}
+
+func (p *PolicyEngine) ValidatePluginPermissions(pluginName string, permissions []string) error {
+	if len(permissions) == 0 {
+		return nil
+	}
+	for _, permission := range permissions {
+		if strings.EqualFold(strings.TrimSpace(permission), "net:out") && len(p.allowedEgressDomains) == 0 {
+			return fmt.Errorf("plugin %s requests net:out but no security.allowed_egress_domains are configured", strings.TrimSpace(pluginName))
+		}
+	}
+	return nil
+}
+
+func (p *PolicyEngine) checkPathAccess(path string, allowed []string, action string) error {
+	if p == nil {
+		return nil
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	target := normalizePolicyPath(path)
+	if target == "" {
+		return fmt.Errorf("failed to resolve %s path: %s", action, path)
+	}
+	if p.workingDir != "" && pathWithin(target, p.workingDir) {
+		return nil
+	}
+	for _, candidate := range allowed {
+		if candidate != "" && pathWithin(target, candidate) {
+			return nil
+		}
+	}
+	for _, protected := range p.protectedPaths {
+		if protected != "" && pathWithin(target, protected) {
+			return fmt.Errorf("%s denied: protected path %s", action, path)
+		}
+	}
+	return fmt.Errorf("%s denied outside working directory: %s", action, path)
+}
+
+func normalizePolicyPaths(paths []string, workingDir string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+	items := make([]string, 0, len(paths))
+	seen := map[string]bool{}
+	for _, item := range paths {
+		normalized := normalizePolicyPath(resolvePath(item, workingDir))
+		if normalized == "" || seen[normalized] {
+			continue
+		}
+		seen[normalized] = true
+		items = append(items, normalized)
+	}
+	return items
+}
+
+func normalizePolicyPath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	normalized, err := normalizePathForCompare(path)
+	if err != nil {
+		return ""
+	}
+	return normalized
+}
+
+func normalizePolicyDomains(domains []string) []string {
+	if len(domains) == 0 {
+		return nil
+	}
+	items := make([]string, 0, len(domains))
+	seen := map[string]bool{}
+	for _, item := range domains {
+		item = strings.TrimSpace(strings.ToLower(item))
+		item = strings.TrimPrefix(item, "https://")
+		item = strings.TrimPrefix(item, "http://")
+		item = strings.TrimSuffix(item, "/")
+		item = strings.TrimSpace(strings.Split(item, "/")[0])
+		item = strings.TrimSpace(strings.Split(item, ":")[0])
+		if item == "" || seen[item] {
+			continue
+		}
+		seen[item] = true
+		items = append(items, item)
+	}
+	return items
+}
+
+func domainMatches(host string, allowed string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	allowed = strings.TrimSpace(strings.ToLower(allowed))
+	if host == "" || allowed == "" {
+		return false
+	}
+	if host == allowed {
+		return true
+	}
+	if strings.HasPrefix(allowed, "*.") {
+		suffix := strings.TrimPrefix(allowed, "*.")
+		return host == suffix || strings.HasSuffix(host, "."+suffix)
+	}
+	return strings.HasSuffix(host, "."+allowed)
+}
+
+func isLocalEgressHost(host string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" {
+		return true
+	}
+	if host == "localhost" || strings.HasSuffix(host, ".local") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
+	}
+	return false
+}
+
+func normalizePolicyArtifactPath(path string, workingDir string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return resolvePath(path, workingDir)
+}

--- a/pkg/capability/tools/policy_test.go
+++ b/pkg/capability/tools/policy_test.go
@@ -1,0 +1,82 @@
+package tools
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPolicyEngineDeniesReadOutsideWorkingDir(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	policy := NewPolicyEngine(PolicyOptions{WorkingDir: workspace})
+
+	if err := policy.CheckReadPath(outside); err == nil {
+		t.Fatal("expected read outside working directory to be denied")
+	}
+}
+
+func TestPolicyEngineAllowsConfiguredReadPath(t *testing.T) {
+	workspace := t.TempDir()
+	allowed := t.TempDir()
+	policy := NewPolicyEngine(PolicyOptions{
+		WorkingDir:       workspace,
+		AllowedReadPaths: []string{allowed},
+	})
+
+	if err := policy.CheckReadPath(allowed); err != nil {
+		t.Fatalf("expected allowed read path, got %v", err)
+	}
+}
+
+func TestPolicyEngineAllowsConfiguredWritePathEvenIfProtected(t *testing.T) {
+	workspace := t.TempDir()
+	desktopRoot := t.TempDir()
+	target := filepath.Join(desktopRoot, "demo")
+	policy := NewPolicyEngine(PolicyOptions{
+		WorkingDir:        workspace,
+		ProtectedPaths:    []string{desktopRoot},
+		AllowedWritePaths: []string{desktopRoot},
+	})
+
+	if err := policy.CheckWritePath(target); err != nil {
+		t.Fatalf("expected explicit allowed write path to override protected path, got %v", err)
+	}
+}
+
+func TestPolicyEngineDeniesBrowserUploadWithoutAllowedDomain(t *testing.T) {
+	workspace := t.TempDir()
+	policy := NewPolicyEngine(PolicyOptions{WorkingDir: workspace})
+
+	if err := policy.CheckBrowserUpload(workspace, "https://example.com/upload"); err == nil {
+		t.Fatal("expected browser upload to non-allowed domain to be denied")
+	}
+}
+
+func TestPolicyEngineAllowsBrowserUploadToConfiguredDomain(t *testing.T) {
+	workspace := t.TempDir()
+	policy := NewPolicyEngine(PolicyOptions{
+		WorkingDir:           workspace,
+		AllowedEgressDomains: []string{"example.com"},
+	})
+
+	if err := policy.CheckBrowserUpload(workspace, "https://example.com/upload"); err != nil {
+		t.Fatalf("expected browser upload to allowed domain, got %v", err)
+	}
+}
+
+func TestPolicyEngineAllowsLocalBrowserUploadWithoutEgressAllowlist(t *testing.T) {
+	workspace := t.TempDir()
+	policy := NewPolicyEngine(PolicyOptions{WorkingDir: workspace})
+
+	if err := policy.CheckBrowserUpload(workspace, "http://127.0.0.1:3000/upload"); err != nil {
+		t.Fatalf("expected local browser upload to be allowed, got %v", err)
+	}
+}
+
+func TestPolicyEngineBlocksPluginNetOutWithoutAllowedDomain(t *testing.T) {
+	policy := NewPolicyEngine(PolicyOptions{WorkingDir: t.TempDir()})
+
+	if err := policy.ValidatePluginPermissions("demo-plugin", []string{"tool:exec", "net:out"}); err == nil {
+		t.Fatal("expected net:out plugin permission to be denied without egress allowlist")
+	}
+}

--- a/pkg/capability/tools/qmd_tools.go
+++ b/pkg/capability/tools/qmd_tools.go
@@ -1,0 +1,254 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func RegisterQMDTools(r *Registry, opts BuiltinOptions) {
+	if opts.QMDClient == nil {
+		return
+	}
+
+	r.RegisterTool(
+		"qmd",
+		"Query and manage structured data in the QMD in-memory data store. Supports: list_tables, list, get, query, insert, update, delete, count",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"action": map[string]string{"type": "string", "description": "Action: list_tables, list, get, query, insert, update, delete, count"},
+				"table":  map[string]string{"type": "string", "description": "Table name (required for all actions except list_tables)"},
+				"id":     map[string]string{"type": "string", "description": "Record ID (required for get, update, delete)"},
+				"field":  map[string]string{"type": "string", "description": "Field name to filter on (required for query)"},
+				"value":  map[string]string{"type": "string", "description": "Value to match (required for query)"},
+				"data":   map[string]string{"type": "object", "description": "Record data object (required for insert, update)"},
+				"limit":  map[string]string{"type": "number", "description": "Maximum number of records to return (default: 50)"},
+			},
+			"required": []string{"action"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return QMDTool(ctx, input, opts.QMDClient)
+		},
+	)
+}
+
+func QMDTool(ctx context.Context, input map[string]any, client QMDClient) (string, error) {
+	if client == nil {
+		return "", fmt.Errorf("QMD structured data store is not available")
+	}
+
+	action, _ := input["action"].(string)
+	action = strings.ToLower(strings.TrimSpace(action))
+	if action == "" {
+		return "", fmt.Errorf("action is required: list_tables, list, get, query, insert, update, delete, count")
+	}
+
+	table, _ := input["table"].(string)
+	table = strings.TrimSpace(table)
+
+	switch action {
+	case "list_tables":
+		return qmdListTables(ctx, client)
+	case "list":
+		return qmdList(ctx, client, table, input)
+	case "get":
+		return qmdGet(ctx, client, table, input)
+	case "query":
+		return qmdQuery(ctx, client, table, input)
+	case "insert":
+		return qmdInsert(ctx, client, table, input)
+	case "update":
+		return qmdUpdate(ctx, client, table, input)
+	case "delete":
+		return qmdDelete(ctx, client, table, input)
+	case "count":
+		return qmdCount(ctx, client, table)
+	default:
+		return "", fmt.Errorf("unknown action %q; use: list_tables, list, get, query, insert, update, delete, count", action)
+	}
+}
+
+func qmdListTables(ctx context.Context, client QMDClient) (string, error) {
+	tables, err := client.ListTables(ctx)
+	if err != nil {
+		return "", err
+	}
+	if len(tables) == 0 {
+		return "No QMD tables found", nil
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d QMD table(s)\n\n", len(tables)))
+	for _, t := range tables {
+		sb.WriteString(fmt.Sprintf("- %s (%d rows, %d columns)\n", t.Name, t.RowCount, t.Columns))
+	}
+	return sb.String(), nil
+}
+
+func qmdList(ctx context.Context, client QMDClient, table string, input map[string]any) (string, error) {
+	if table == "" {
+		return "", fmt.Errorf("table is required for list action")
+	}
+	limit := 50
+	if v, ok := input["limit"].(float64); ok && v > 0 {
+		limit = int(v)
+	}
+	records, err := client.List(ctx, table, limit)
+	if err != nil {
+		return "", err
+	}
+	if len(records) == 0 {
+		return fmt.Sprintf("No records in table %q", table), nil
+	}
+	return formatRecords(table, records), nil
+}
+
+func qmdGet(ctx context.Context, client QMDClient, table string, input map[string]any) (string, error) {
+	if table == "" {
+		return "", fmt.Errorf("table is required for get action")
+	}
+	id, _ := input["id"].(string)
+	if strings.TrimSpace(id) == "" {
+		return "", fmt.Errorf("id is required for get action")
+	}
+	record, err := client.Get(ctx, table, id)
+	if err != nil {
+		return "", err
+	}
+	return formatRecord(table, record), nil
+}
+
+func qmdQuery(ctx context.Context, client QMDClient, table string, input map[string]any) (string, error) {
+	if table == "" {
+		return "", fmt.Errorf("table is required for query action")
+	}
+	field, _ := input["field"].(string)
+	if strings.TrimSpace(field) == "" {
+		return "", fmt.Errorf("field is required for query action")
+	}
+	value := input["value"]
+	if value == nil {
+		return "", fmt.Errorf("value is required for query action")
+	}
+	limit := 50
+	if v, ok := input["limit"].(float64); ok && v > 0 {
+		limit = int(v)
+	}
+	records, err := client.Query(ctx, table, field, value, limit)
+	if err != nil {
+		return "", err
+	}
+	if len(records) == 0 {
+		return fmt.Sprintf("No records found in table %q where %s = %v", table, field, value), nil
+	}
+	return formatRecords(table, records), nil
+}
+
+func qmdInsert(ctx context.Context, client QMDClient, table string, input map[string]any) (string, error) {
+	if table == "" {
+		return "", fmt.Errorf("table is required for insert action")
+	}
+	data, ok := input["data"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("data (object) is required for insert action")
+	}
+	id, _ := input["id"].(string)
+	if strings.TrimSpace(id) == "" {
+		id = fmt.Sprintf("rec-%d", len(data))
+	}
+	record := map[string]any{"id": id}
+	for k, v := range data {
+		record[k] = v
+	}
+	if err := client.Insert(ctx, table, record); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Inserted record %q into table %q", id, table), nil
+}
+
+func qmdUpdate(ctx context.Context, client QMDClient, table string, input map[string]any) (string, error) {
+	if table == "" {
+		return "", fmt.Errorf("table is required for update action")
+	}
+	id, _ := input["id"].(string)
+	if strings.TrimSpace(id) == "" {
+		return "", fmt.Errorf("id is required for update action")
+	}
+	data, ok := input["data"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("data (object) is required for update action")
+	}
+	record := map[string]any{"id": id}
+	for k, v := range data {
+		record[k] = v
+	}
+	if err := client.Update(ctx, table, record); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Updated record %q in table %q", id, table), nil
+}
+
+func qmdDelete(ctx context.Context, client QMDClient, table string, input map[string]any) (string, error) {
+	if table == "" {
+		return "", fmt.Errorf("table is required for delete action")
+	}
+	id, _ := input["id"].(string)
+	if strings.TrimSpace(id) == "" {
+		return "", fmt.Errorf("id is required for delete action")
+	}
+	if err := client.Delete(ctx, table, id); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Deleted record %q from table %q", id, table), nil
+}
+
+func qmdCount(ctx context.Context, client QMDClient, table string) (string, error) {
+	if table == "" {
+		return "", fmt.Errorf("table is required for count action")
+	}
+	count, err := client.Count(ctx, table)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Table %q has %d record(s)", table, count), nil
+}
+
+func formatRecord(table string, record map[string]any) string {
+	data, _ := json.MarshalIndent(record, "", "  ")
+	return fmt.Sprintf("Table: %s\n\n%s", table, string(data))
+}
+
+func formatRecords(table string, records []map[string]any) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Table: %s (%d records)\n\n", table, len(records)))
+	for i, r := range records {
+		if i > 0 {
+			sb.WriteString("\n---\n\n")
+		}
+		sb.WriteString(formatRecord(table, r))
+	}
+	return sb.String()
+}
+
+func parseValue(v any) any {
+	switch s := v.(type) {
+	case string:
+		if strings.ToLower(s) == "true" {
+			return true
+		}
+		if strings.ToLower(s) == "false" {
+			return false
+		}
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return n
+		}
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			return f
+		}
+		return s
+	default:
+		return v
+	}
+}

--- a/pkg/capability/tools/registry.go
+++ b/pkg/capability/tools/registry.go
@@ -1,0 +1,502 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+	"github.com/1024XEngineer/anyclaw/pkg/state/memory"
+)
+
+// MemoryBackend is an alias for memory.MemoryBackend to avoid import cycles.
+type MemoryBackend = memory.MemoryBackend
+
+// VectorMemoryBackend is an alias for memory.VectorBackend to avoid import cycles.
+type VectorMemoryBackend = memory.VectorBackend
+
+// QMDClient is the interface for QMD structured data operations.
+type QMDClient interface {
+	CreateTable(ctx context.Context, name string, columns []string) error
+	Insert(ctx context.Context, table string, record map[string]any) error
+	Get(ctx context.Context, table, id string) (map[string]any, error)
+	Update(ctx context.Context, table string, record map[string]any) error
+	Delete(ctx context.Context, table, id string) error
+	List(ctx context.Context, table string, limit int) ([]map[string]any, error)
+	Query(ctx context.Context, table, field string, value any, limit int) ([]map[string]any, error)
+	ListTables(ctx context.Context) ([]TableStat, error)
+	Count(ctx context.Context, table string) (int, error)
+}
+
+// TableStat represents a QMD table summary.
+type TableStat struct {
+	Name     string `json:"name"`
+	RowCount int    `json:"row_count"`
+	Columns  int    `json:"columns"`
+}
+
+// AuditLogger 审计日志接口
+type AuditLogger interface {
+	LogTool(toolName string, input map[string]any, output string, err error)
+}
+
+// DangerousCommandConfirmer 危险命令确认器
+type DangerousCommandConfirmer func(command string) bool
+
+// BuiltinOptions 内置工具选项
+type BuiltinOptions struct {
+	WorkingDir              string
+	PermissionLevel         string
+	ExecutionMode           string
+	DangerousPatterns       []string
+	ProtectedPaths          []string
+	AllowedReadPaths        []string
+	AllowedWritePaths       []string
+	Policy                  *PolicyEngine
+	CommandTimeoutSeconds   int
+	ConfirmDangerousCommand DangerousCommandConfirmer
+	AuditLogger             AuditLogger
+	Sandbox                 *SandboxManager
+	MemoryBackend           MemoryBackend
+	QMDClient               QMDClient
+	LLMClient               llm.Client
+}
+
+// ToolFunc 工具函数
+type ToolFunc func(ctx context.Context, input map[string]any) (string, error)
+
+// ToolCategory 工具类别
+type ToolCategory string
+
+const (
+	ToolCategoryFile    ToolCategory = "file"
+	ToolCategoryCommand ToolCategory = "command"
+	ToolCategoryWeb     ToolCategory = "web"
+	ToolCategoryChannel ToolCategory = "channel"
+	ToolCategoryMemory  ToolCategory = "memory"
+	ToolCategoryBrowser ToolCategory = "browser"
+	ToolCategoryDesktop ToolCategory = "desktop"
+	ToolCategoryCustom  ToolCategory = "custom"
+)
+
+// ToolAccessLevel 工具访问级别
+type ToolAccessLevel string
+
+// ToolVisibility controls which agent roles can see a tool.
+type ToolVisibility string
+
+// ToolCachePolicy controls whether tool outputs may be cached.
+type ToolCachePolicy string
+
+const (
+	ToolAccessPublic  ToolAccessLevel = "public"
+	ToolAccessOwner   ToolAccessLevel = "owner"
+	ToolAccessAdmin   ToolAccessLevel = "admin"
+	ToolAccessPrivate ToolAccessLevel = "private"
+)
+
+const (
+	ToolVisibilityAll           ToolVisibility = "all"
+	ToolVisibilityMainAgentOnly ToolVisibility = "main_agent_only"
+)
+
+const (
+	ToolCachePolicyDefault ToolCachePolicy = "default"
+	ToolCachePolicyNever   ToolCachePolicy = "never"
+)
+
+// Tool 工具结构
+type Tool struct {
+	Name        string
+	Description string
+	InputSchema map[string]any
+	Handler     ToolFunc
+	Category    ToolCategory
+	AccessLevel ToolAccessLevel
+	Visibility  ToolVisibility
+	CachePolicy ToolCachePolicy
+	Timeout     time.Duration
+	Retryable   bool
+	MaxRetries  int
+}
+
+// Registry 工具注册表
+type Registry struct {
+	mu         sync.RWMutex
+	tools      map[string]*Tool
+	categories map[ToolCategory][]string
+	cache      map[string]interface{}
+	cacheTTL   time.Duration
+	cacheMu    sync.RWMutex
+}
+
+// NewRegistry 创建新的注册表
+func NewRegistry() *Registry {
+	return &Registry{
+		tools:      make(map[string]*Tool),
+		categories: make(map[ToolCategory][]string),
+		cache:      make(map[string]interface{}),
+		cacheTTL:   5 * time.Minute,
+	}
+}
+
+// RegisterTool 注册工具
+func (r *Registry) RegisterTool(name string, desc string, schema map[string]any, handler ToolFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.tools[name] = &Tool{
+		Name:        name,
+		Description: desc,
+		InputSchema: schema,
+		Handler:     handler,
+		Category:    ToolCategoryCustom,
+		AccessLevel: ToolAccessPublic,
+		Visibility:  ToolVisibilityAll,
+		CachePolicy: ToolCachePolicyDefault,
+	}
+}
+
+// Register 注册工具
+func (r *Registry) Register(t *Tool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if t.Visibility == "" {
+		t.Visibility = ToolVisibilityAll
+	}
+	if t.CachePolicy == "" {
+		t.CachePolicy = ToolCachePolicyDefault
+	}
+	r.tools[t.Name] = t
+	if t.Category != "" {
+		r.categories[t.Category] = append(r.categories[t.Category], t.Name)
+	}
+}
+
+// Get 获取工具
+func (r *Registry) Get(name string) (*Tool, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	t, ok := r.tools[name]
+	return t, ok
+}
+
+// ListTools 列出所有工具
+func (r *Registry) ListTools() []*Tool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var list []*Tool
+	for _, t := range r.tools {
+		list = append(list, t)
+	}
+	return list
+}
+
+// ListToolsForRole returns tool instances visible to the given agent role.
+func (r *Registry) ListToolsForRole(isSubAgent bool) []*Tool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var list []*Tool
+	for _, t := range r.tools {
+		if !toolVisibleForRole(t, isSubAgent) {
+			continue
+		}
+		list = append(list, t)
+	}
+	return list
+}
+
+// Call 调用工具
+func (r *Registry) Call(ctx context.Context, name string, input map[string]any) (string, error) {
+	r.mu.RLock()
+	t, ok := r.tools[name]
+	r.mu.RUnlock()
+
+	if !ok {
+		return "", fmt.Errorf("tool not found: %s", name)
+	}
+
+	if t.Handler == nil {
+		return "", fmt.Errorf("tool handler not implemented: %s", name)
+	}
+
+	if err := authorizeToolCall(ctx, t); err != nil {
+		return "", err
+	}
+
+	// 检查缓存
+	cacheEnabled := t.CachePolicy != ToolCachePolicyNever
+	cacheKey := ""
+	if cacheEnabled {
+		cacheKey = r.generateCacheKey(name, input)
+		if cached, found := r.getFromCache(cacheKey); found {
+			if str, ok := cached.(string); ok {
+				return str, nil
+			}
+		}
+	}
+
+	// 执行工具
+	startTime := time.Now()
+	result, err := t.Handler(ctx, input)
+	duration := time.Since(startTime)
+
+	if err != nil {
+		return "", err
+	}
+
+	// 保存到缓存
+	if cacheEnabled {
+		r.saveToCache(cacheKey, result)
+	}
+
+	_ = duration // 可以用于监控
+
+	return result, nil
+}
+
+// CallWithRetry 带重试调用工具
+func (r *Registry) CallWithRetry(ctx context.Context, name string, input map[string]any, maxRetries int) (string, error) {
+	r.mu.RLock()
+	t, ok := r.tools[name]
+	r.mu.RUnlock()
+
+	if !ok {
+		return "", fmt.Errorf("tool not found: %s", name)
+	}
+
+	if !t.Retryable {
+		return r.Call(ctx, name, input)
+	}
+
+	if maxRetries <= 0 {
+		maxRetries = t.MaxRetries
+	}
+	if maxRetries <= 0 {
+		maxRetries = 3
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		result, err := r.Call(ctx, name, input)
+		if err == nil {
+			return result, nil
+		}
+
+		lastErr = err
+
+		// 指数退避
+		if attempt < maxRetries {
+			backoff := time.Duration(1<<uint(attempt)) * 100 * time.Millisecond
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(backoff):
+				continue
+			}
+		}
+	}
+
+	return "", fmt.Errorf("tool %s failed after %d retries: %w", name, maxRetries, lastErr)
+}
+
+// GetToolsByCategory 按类别获取工具
+func (r *Registry) GetToolsByCategory(category ToolCategory) []*Tool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	names, exists := r.categories[category]
+	if !exists {
+		return nil
+	}
+
+	tools := make([]*Tool, 0, len(names))
+	for _, name := range names {
+		if tool, exists := r.tools[name]; exists {
+			tools = append(tools, tool)
+		}
+	}
+
+	return tools
+}
+
+// Unregister 注销工具
+func (r *Registry) Unregister(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tool, exists := r.tools[name]
+	if !exists {
+		return fmt.Errorf("tool %s not found", name)
+	}
+
+	// 从类别中移除
+	if tool.Category != "" {
+		if names, exists := r.categories[tool.Category]; exists {
+			for i, n := range names {
+				if n == name {
+					r.categories[tool.Category] = append(names[:i], names[i+1:]...)
+					break
+				}
+			}
+		}
+	}
+
+	delete(r.tools, name)
+	return nil
+}
+
+// ClearCache 清除缓存
+func (r *Registry) ClearCache() {
+	r.cacheMu.Lock()
+	defer r.cacheMu.Unlock()
+
+	r.cache = make(map[string]interface{})
+}
+
+// GetToolDefinitions 获取工具定义
+func (r *Registry) GetToolDefinitions() []map[string]any {
+	return r.GetToolDefinitionsForRole(false)
+}
+
+// GetToolDefinitionsJSON 获取工具定义的 JSON
+func (r *Registry) GetToolDefinitionsForRole(isSubAgent bool) []map[string]any {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	defs := make([]map[string]any, 0, len(r.tools))
+	for _, tool := range r.tools {
+		if !toolVisibleForRole(tool, isSubAgent) {
+			continue
+		}
+		defs = append(defs, map[string]any{
+			"name":         tool.Name,
+			"description":  tool.Description,
+			"category":     string(tool.Category),
+			"access_level": string(tool.AccessLevel),
+			"visibility":   string(tool.Visibility),
+			"cache_policy": string(tool.CachePolicy),
+			"input_schema": tool.InputSchema,
+		})
+	}
+
+	return defs
+}
+
+func (r *Registry) GetToolDefinitionsJSON() (string, error) {
+	defs := r.GetToolDefinitions()
+
+	data, err := json.MarshalIndent(defs, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal tool definitions: %w", err)
+	}
+
+	return string(data), nil
+}
+
+// ToolInfo 工具信息
+type ToolInfo struct {
+	Name        string
+	Description string
+	InputSchema map[string]any
+	Visibility  ToolVisibility
+	CachePolicy ToolCachePolicy
+}
+
+// List 列出工具信息
+func (r *Registry) List() []ToolInfo {
+	return r.ListForRole(false)
+}
+
+// generateCacheKey 生成缓存键
+func (r *Registry) ListForRole(isSubAgent bool) []ToolInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var list []ToolInfo
+	for _, t := range r.tools {
+		if !toolVisibleForRole(t, isSubAgent) {
+			continue
+		}
+		list = append(list, ToolInfo{
+			Name:        t.Name,
+			Description: t.Description,
+			InputSchema: t.InputSchema,
+			Visibility:  t.Visibility,
+			CachePolicy: t.CachePolicy,
+		})
+	}
+	return list
+}
+
+func toolVisibleForRole(tool *Tool, isSubAgent bool) bool {
+	if tool == nil {
+		return false
+	}
+	if tool.Visibility == "" || !isSubAgent {
+		return true
+	}
+	return tool.Visibility != ToolVisibilityMainAgentOnly
+}
+
+func authorizeToolCall(ctx context.Context, tool *Tool) error {
+	if tool == nil {
+		return fmt.Errorf("tool is nil")
+	}
+	caller := ToolCallerFromContext(ctx)
+	if toolVisibleForCaller(tool, caller.Role) {
+		return nil
+	}
+	role := string(caller.Role)
+	if role == "" {
+		role = "unknown"
+	}
+	return fmt.Errorf("tool %s is not available for caller role %s", tool.Name, role)
+}
+
+func toolVisibleForCaller(tool *Tool, role ToolCallerRole) bool {
+	switch role {
+	case ToolCallerRoleSubAgent:
+		return toolVisibleForRole(tool, true)
+	case ToolCallerRoleMainAgent, ToolCallerRoleSystem:
+		return true
+	default:
+		return tool.Visibility != ToolVisibilityMainAgentOnly
+	}
+}
+
+func (r *Registry) generateCacheKey(toolName string, input map[string]any) string {
+	data, _ := json.Marshal(input)
+	return fmt.Sprintf("%s:%x", toolName, data)
+}
+
+// getFromCache 从缓存获取
+func (r *Registry) getFromCache(key string) (interface{}, bool) {
+	r.cacheMu.RLock()
+	defer r.cacheMu.RUnlock()
+
+	item, exists := r.cache[key]
+	return item, exists
+}
+
+// saveToCache 保存到缓存
+func (r *Registry) saveToCache(key string, value interface{}) {
+	r.cacheMu.Lock()
+	defer r.cacheMu.Unlock()
+
+	r.cache[key] = value
+
+	// 定期清理缓存
+	go func() {
+		time.Sleep(r.cacheTTL)
+		r.cacheMu.Lock()
+		delete(r.cache, key)
+		r.cacheMu.Unlock()
+	}()
+}

--- a/pkg/capability/tools/sandbox.go
+++ b/pkg/capability/tools/sandbox.go
@@ -1,0 +1,143 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+type sandboxContextKey struct{}
+
+type SandboxScope struct {
+	SessionID string
+	Channel   string
+}
+
+func WithSandboxScope(ctx context.Context, scope SandboxScope) context.Context {
+	return context.WithValue(ctx, sandboxContextKey{}, scope)
+}
+
+func sandboxScopeFromContext(ctx context.Context) SandboxScope {
+	if ctx == nil {
+		return SandboxScope{}
+	}
+	if scope, ok := ctx.Value(sandboxContextKey{}).(SandboxScope); ok {
+		return scope
+	}
+	return SandboxScope{}
+}
+
+type SandboxManager struct {
+	config      config.SandboxConfig
+	workingDir  string
+	mu          sync.Mutex
+	dockerNames map[string]string
+}
+
+func NewSandboxManager(cfg config.SandboxConfig, workingDir string) *SandboxManager {
+	return &SandboxManager{config: cfg, workingDir: workingDir, dockerNames: map[string]string{}}
+}
+
+func (m *SandboxManager) Enabled() bool {
+	return m != nil && m.config.Enabled
+}
+
+func (m *SandboxManager) ResolveExecution(ctx context.Context, requestedCwd string) (string, func(context.Context, string) (*exec.Cmd, error), error) {
+	if m == nil || !m.config.Enabled {
+		cwd := strings.TrimSpace(requestedCwd)
+		if cwd == "" {
+			cwd = m.workingDir
+		}
+		return cwd, nil, nil
+	}
+	scope := sandboxScopeFromContext(ctx)
+	key := sanitizeSandboxKey(scope)
+	switch strings.ToLower(strings.TrimSpace(m.config.Backend)) {
+	case "docker":
+		container, err := m.ensureDockerContainer(key)
+		if err != nil {
+			return "", nil, err
+		}
+		cwd := "/workspace"
+		return cwd, func(cmdCtx context.Context, command string) (*exec.Cmd, error) {
+			return exec.CommandContext(cmdCtx, "docker", "exec", container, "sh", "-lc", "cd /workspace && "+command), nil
+		}, nil
+	case "local", "filesystem", "fs":
+		root, err := m.ensureLocalSandbox(key)
+		if err != nil {
+			return "", nil, err
+		}
+		return root, nil, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported sandbox backend: %s", m.config.Backend)
+	}
+}
+
+func (m *SandboxManager) ensureLocalSandbox(key string) (string, error) {
+	base := strings.TrimSpace(m.config.BaseDir)
+	if base == "" {
+		base = filepath.Join(m.workingDir, ".anyclaw", "sandboxes")
+	}
+	path := filepath.Join(base, key)
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func (m *SandboxManager) ensureDockerContainer(key string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, ok := m.dockerNames[key]; ok {
+		return existing, nil
+	}
+	image := strings.TrimSpace(m.config.DockerImage)
+	if image == "" {
+		image = "alpine:3.20"
+	}
+	name := "anyclaw-sbx-" + key
+	cmd := exec.Command("docker", "inspect", name)
+	if err := cmd.Run(); err != nil {
+		args := []string{"run", "-d", "--name", name}
+		if network := strings.TrimSpace(m.config.DockerNetwork); network != "" {
+			args = append(args, "--network", network)
+		}
+		args = append(args, image, "sh", "-lc", "mkdir -p /workspace && tail -f /dev/null")
+		out, runErr := exec.Command("docker", args...).CombinedOutput()
+		if runErr != nil {
+			return "", fmt.Errorf("failed to start docker sandbox: %w - %s", runErr, string(out))
+		}
+	}
+	m.dockerNames[key] = name
+	return name, nil
+}
+
+func sanitizeSandboxKey(scope SandboxScope) string {
+	parts := []string{}
+	if strings.TrimSpace(scope.Channel) != "" {
+		parts = append(parts, strings.TrimSpace(scope.Channel))
+	}
+	if strings.TrimSpace(scope.SessionID) != "" {
+		parts = append(parts, strings.TrimSpace(scope.SessionID))
+	}
+	if len(parts) == 0 {
+		parts = append(parts, "default")
+	}
+	joined := strings.ToLower(strings.Join(parts, "-"))
+	replacer := strings.NewReplacer("/", "-", "\\", "-", ":", "-", " ", "-")
+	joined = replacer.Replace(joined)
+	if len(joined) > 48 {
+		joined = joined[:48]
+	}
+	joined = strings.Trim(joined, "-.")
+	if joined == "" {
+		return "default"
+	}
+	return joined
+}

--- a/pkg/capability/tools/tools.go
+++ b/pkg/capability/tools/tools.go
@@ -1,0 +1,1321 @@
+package tools
+
+import (
+	"context"
+
+	"github.com/1024XEngineer/anyclaw/pkg/state/memory"
+)
+
+func RegisterBuiltins(r *Registry, opts BuiltinOptions) {
+	RegisterFileTools(r, opts)
+	RegisterMemoryTools(r, opts)
+	RegisterQMDTools(r, opts)
+	RegisterWebTools(r, opts)
+	RegisterDesktopTools(r, opts)
+	RegisterCLIHubTools(r, opts)
+	RegisterClawBridgeTools(r, opts)
+}
+
+func RegisterFileTools(r *Registry, opts BuiltinOptions) {
+	workingDir := opts.WorkingDir
+	r.RegisterTool(
+		"read_file",
+		"Read the contents of a file from the filesystem",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]string{"type": "string", "description": "Path to the file"},
+			},
+			"required": []string{"path"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "read_file", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return ReadFileToolWithPolicy(ctx, input, workingDir, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"write_file",
+		"Write content to a file",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path":    map[string]string{"type": "string", "description": "Path to the file"},
+				"content": map[string]string{"type": "string", "description": "Content to write"},
+			},
+			"required": []string{"path", "content"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "write_file", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return WriteFileToolWithPolicy(ctx, input, workingDir, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"list_directory",
+		"List files in a directory",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]string{"type": "string", "description": "Path to directory"},
+			},
+			"required": []string{"path"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "list_directory", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return ListDirectoryToolWithPolicy(ctx, input, workingDir, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"search_files",
+		"Search for files matching a pattern",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path":    map[string]string{"type": "string", "description": "Root path to search"},
+				"pattern": map[string]string{"type": "string", "description": "Search pattern"},
+			},
+			"required": []string{"path", "pattern"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "search_files", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return SearchFilesToolWithPolicy(ctx, input, workingDir, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"run_command",
+		"Execute a shell command within the working directory",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"command": map[string]string{"type": "string", "description": "Shell command to execute"},
+				"cwd":     map[string]string{"type": "string", "description": "Optional working directory override"},
+				"shell":   map[string]string{"type": "string", "description": "Optional shell: auto, cmd, powershell, pwsh, sh, or bash"},
+			},
+			"required": []string{"command"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "run_command", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return RunCommandToolWithPolicy(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+}
+
+func RegisterMemoryTools(r *Registry, opts BuiltinOptions) {
+	workingDir := opts.WorkingDir
+
+	r.RegisterTool(
+		"memory_search",
+		"Search memory entries. Uses the memory backend (SQLite/dual) when available, falls back to daily memory files.",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query": map[string]string{"type": "string", "description": "Text to search for in memory entries"},
+				"limit": map[string]string{"type": "number", "description": "Maximum number of matches to return"},
+				"date":  map[string]string{"type": "string", "description": "Optional day filter for daily files: YYYY-MM-DD, today, yesterday, or latest"},
+			},
+			"required": []string{"query"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "memory_search", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return MemorySearchToolWithBackend(ctx, input, workingDir, opts.MemoryBackend)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"memory_vector_search",
+		"Search memory entries using vector embeddings. Requires a vector-capable memory backend.",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query":     map[string]string{"type": "string", "description": "Text query (used as fallback if no embedding provided)"},
+				"limit":     map[string]string{"type": "number", "description": "Maximum number of matches to return"},
+				"threshold": map[string]string{"type": "number", "description": "Minimum cosine similarity threshold (default: 0.5)"},
+				"embedding": map[string]string{"type": "array", "description": "Query embedding vector (optional, falls back to text search)"},
+			},
+			"required": []string{"query"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "memory_vector_search", input, func(ctx context.Context, input map[string]any) (string, error) {
+				if vec, ok := opts.MemoryBackend.(memory.VectorBackend); ok {
+					return MemoryVectorSearchTool(ctx, input, opts.MemoryBackend, vec)
+				}
+				return MemorySearchToolWithBackend(ctx, input, workingDir, opts.MemoryBackend)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"memory_hybrid_search",
+		"Search memory entries using combined text + vector scoring. Requires a vector-capable memory backend.",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query":         map[string]string{"type": "string", "description": "Text query for hybrid search"},
+				"limit":         map[string]string{"type": "number", "description": "Maximum number of matches to return"},
+				"vector_weight": map[string]string{"type": "number", "description": "Weight for vector score vs text score (0.0-1.0, default: 0.5)"},
+				"embedding":     map[string]string{"type": "array", "description": "Query embedding vector (required for hybrid)"},
+			},
+			"required": []string{"query"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "memory_hybrid_search", input, func(ctx context.Context, input map[string]any) (string, error) {
+				if vec, ok := opts.MemoryBackend.(memory.VectorBackend); ok {
+					return MemoryHybridSearchTool(ctx, input, opts.MemoryBackend, vec)
+				}
+				return MemorySearchToolWithBackend(ctx, input, workingDir, opts.MemoryBackend)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"memory_get",
+		"Read a specific daily workspace memory file from memory/*.md",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"date": map[string]string{"type": "string", "description": "Target day: YYYY-MM-DD, today, yesterday, or latest"},
+			},
+			"required": []string{"date"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "memory_get", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return MemoryGetToolWithCwd(ctx, input, workingDir)
+			})(ctx, input)
+		},
+	)
+}
+
+func RegisterWebTools(r *Registry, opts BuiltinOptions) {
+	r.RegisterTool(
+		"web_search",
+		"Search the web for information using DuckDuckGo",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query":       map[string]string{"type": "string", "description": "Search query"},
+				"max_results": map[string]string{"type": "number", "description": "Maximum number of results (default: 5)"},
+			},
+			"required": []string{"query"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "web_search", input, WebSearchTool)(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"fetch_url",
+		"Fetch and extract text content from a URL",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"url": map[string]string{"type": "string", "description": "URL to fetch"},
+			},
+			"required": []string{"url"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "fetch_url", input, FetchURLTool)(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"browser_navigate",
+		"Open a page in a headless browser automation session (not a visible desktop browser window)",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional tab id"},
+				"url":        map[string]string{"type": "string", "description": "URL to open"},
+			},
+			"required": []string{"url"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return BrowserNavigateTool(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"browser_click",
+		"Click an element on the current page",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional tab id"},
+				"selector":   map[string]string{"type": "string", "description": "CSS selector to click"},
+			},
+			"required": []string{"selector"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) { return BrowserClickTool(ctx, input) },
+	)
+
+	r.RegisterTool(
+		"browser_type",
+		"Type text into an element",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional tab id"},
+				"selector":   map[string]string{"type": "string", "description": "CSS selector to type into"},
+				"text":       map[string]string{"type": "string", "description": "Text to type"},
+			},
+			"required": []string{"selector", "text"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) { return BrowserTypeTool(ctx, input) },
+	)
+
+	r.RegisterTool(
+		"browser_screenshot",
+		"Take a screenshot of the current page or element",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional tab id"},
+				"path":       map[string]string{"type": "string", "description": "File path to save screenshot"},
+				"selector":   map[string]string{"type": "string", "description": "Optional CSS selector for element screenshot"},
+			},
+			"required": []string{"path"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return BrowserScreenshotToolWithPolicy(ctx, input, opts)
+		},
+	)
+
+	r.RegisterTool(
+		"browser_upload",
+		"Upload a file via input element",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional tab id"},
+				"selector":   map[string]string{"type": "string", "description": "File input CSS selector"},
+				"path":       map[string]string{"type": "string", "description": "Local path to upload"},
+			},
+			"required": []string{"selector", "path"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return BrowserUploadToolWithPolicy(ctx, input, opts)
+		},
+	)
+
+	r.RegisterTool(
+		"browser_wait",
+		"Wait for an element or page state",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional tab id"},
+				"selector":   map[string]string{"type": "string", "description": "Optional CSS selector"},
+				"state":      map[string]string{"type": "string", "description": "ready, visible, or enabled"},
+				"timeout_ms": map[string]string{"type": "number", "description": "Timeout in milliseconds"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) { return BrowserWaitTool(ctx, input) },
+	)
+
+	r.RegisterTool(
+		"browser_select",
+		"Select a value in a form control",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional tab id"},
+				"selector":   map[string]string{"type": "string", "description": "CSS selector"},
+				"value":      map[string]string{"type": "string", "description": "Value to set"},
+			},
+			"required": []string{"selector", "value"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) { return BrowserSelectTool(ctx, input) },
+	)
+
+	r.RegisterTool(
+		"browser_press",
+		"Press a keyboard key in the page",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional tab id"},
+				"selector":   map[string]string{"type": "string", "description": "Optional CSS selector to focus"},
+				"key":        map[string]string{"type": "string", "description": "Key to press, e.g. Enter, Tab, ArrowDown"},
+			},
+			"required": []string{"key"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) { return BrowserPressTool(ctx, input) },
+	)
+
+	r.RegisterTool(
+		"browser_scroll",
+		"Scroll the page or an element",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional tab id"},
+				"selector":   map[string]string{"type": "string", "description": "Optional CSS selector to scroll inside"},
+				"direction":  map[string]string{"type": "string", "description": "up or down"},
+				"pixels":     map[string]string{"type": "number", "description": "Scroll distance in pixels"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) { return BrowserScrollTool(ctx, input) },
+	)
+
+	r.RegisterTool(
+		"browser_download",
+		"Download a linked resource to disk",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional tab id"},
+				"selector":   map[string]string{"type": "string", "description": "Optional selector whose href/src should be downloaded"},
+				"url":        map[string]string{"type": "string", "description": "Optional absolute URL to download"},
+				"path":       map[string]string{"type": "string", "description": "Destination file path"},
+			},
+			"required": []string{"path"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return BrowserDownloadToolWithPolicy(ctx, input, opts)
+		},
+	)
+
+	r.RegisterTool(
+		"browser_snapshot",
+		"Capture the current page HTML and title",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional tab id"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return BrowserSnapshotTool(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"browser_eval",
+		"Evaluate JavaScript in the page context",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional tab id"},
+				"expression": map[string]string{"type": "string", "description": "JavaScript expression"},
+			},
+			"required": []string{"expression"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return BrowserEvaluateTool(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"browser_pdf",
+		"Export the current page to PDF",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional tab id"},
+				"path":       map[string]string{"type": "string", "description": "File path to save PDF"},
+			},
+			"required": []string{"path"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return BrowserPDFToolWithPolicy(ctx, input, opts)
+		},
+	)
+
+	r.RegisterTool(
+		"browser_close",
+		"Close a browser automation session",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) { return BrowserCloseTool(ctx, input) },
+	)
+
+	r.RegisterTool(
+		"browser_tab_new",
+		"Create a new browser tab in the session",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Optional desired tab id"},
+				"url":        map[string]string{"type": "string", "description": "Optional URL to open immediately"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) { return BrowserTabNewTool(ctx, input) },
+	)
+
+	r.RegisterTool(
+		"browser_tab_list",
+		"List all tabs in the browser session",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) { return BrowserTabListTool(ctx, input) },
+	)
+
+	r.RegisterTool(
+		"browser_tab_switch",
+		"Switch the active browser tab",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Tab id to activate"},
+			},
+			"required": []string{"tab_id"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return BrowserTabSwitchTool(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"browser_tab_close",
+		"Close a specific browser tab",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session_id": map[string]string{"type": "string", "description": "Browser session id"},
+				"tab_id":     map[string]string{"type": "string", "description": "Tab id to close"},
+			},
+			"required": []string{"tab_id"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return BrowserTabCloseTool(ctx, input)
+		},
+	)
+}
+
+func RegisterDesktopTools(r *Registry, opts BuiltinOptions) {
+	r.RegisterTool(
+		"desktop_open",
+		"Open a visible application, URL, or file on the desktop host",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"target": map[string]string{"type": "string", "description": "Application path/name, URL, or file path. Use this to open a real browser window."},
+				"kind":   map[string]string{"type": "string", "description": "Optional kind: app, url, or file"},
+			},
+			"required": []string{"target"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_open", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopOpenTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_type",
+		"Type text into the active desktop window",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"text": map[string]string{"type": "string", "description": "Text to send to the active window"},
+			},
+			"required": []string{"text"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_type", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopTypeTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_type_human",
+		"Type text into the active desktop window with small delays to resemble human input",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"text":        map[string]string{"type": "string", "description": "Text to send to the active window"},
+				"delay_ms":    map[string]string{"type": "number", "description": "Base delay between characters"},
+				"jitter_ms":   map[string]string{"type": "number", "description": "Additional random per-character delay"},
+				"pause_every": map[string]string{"type": "number", "description": "Insert a longer pause after this many characters"},
+				"pause_ms":    map[string]string{"type": "number", "description": "Duration of the longer pause"},
+				"submit":      map[string]string{"type": "boolean", "description": "Whether to press Enter after typing"},
+			},
+			"required": []string{"text"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_type_human", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopTypeHumanTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_hotkey",
+		"Send a desktop hotkey chord to the active window",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"keys": map[string]any{
+					"type":        "array",
+					"description": "List of keys, e.g. [\"ctrl\", \"s\"]",
+					"items":       map[string]string{"type": "string"},
+				},
+			},
+			"required": []string{"keys"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_hotkey", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopHotkeyTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_clipboard_set",
+		"Set text into the Windows clipboard",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"text": map[string]string{"type": "string", "description": "Text to place on the clipboard"},
+			},
+			"required": []string{"text"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_clipboard_set", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopClipboardSetTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_clipboard_get",
+		"Read text from the Windows clipboard",
+		map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_clipboard_get", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopClipboardGetTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_paste",
+		"Paste the current clipboard text, or set clipboard text and paste it into the active window",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"text":    map[string]string{"type": "string", "description": "Optional text to place on the clipboard before pasting"},
+				"wait_ms": map[string]string{"type": "number", "description": "Optional pause before sending Ctrl+V"},
+				"submit":  map[string]string{"type": "boolean", "description": "Whether to press Enter after pasting"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_paste", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopPasteTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_click",
+		"Click a desktop screen coordinate on the host",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"x":      map[string]string{"type": "number", "description": "Screen X coordinate"},
+				"y":      map[string]string{"type": "number", "description": "Screen Y coordinate"},
+				"button": map[string]string{"type": "string", "description": "Optional mouse button: left, right, middle"},
+			},
+			"required": []string{"x", "y"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_click", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopClickTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_move",
+		"Move the mouse cursor to a desktop screen coordinate",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"x": map[string]string{"type": "number", "description": "Screen X coordinate"},
+				"y": map[string]string{"type": "number", "description": "Screen Y coordinate"},
+			},
+			"required": []string{"x", "y"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_move", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopMoveTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_double_click",
+		"Double click a desktop screen coordinate on the host",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"x":           map[string]string{"type": "number", "description": "Screen X coordinate"},
+				"y":           map[string]string{"type": "number", "description": "Screen Y coordinate"},
+				"button":      map[string]string{"type": "string", "description": "Optional mouse button: left, right, middle"},
+				"interval_ms": map[string]string{"type": "number", "description": "Delay between clicks in milliseconds"},
+			},
+			"required": []string{"x", "y"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_double_click", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopDoubleClickTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_scroll",
+		"Scroll the mouse wheel on the desktop host",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"x":         map[string]string{"type": "number", "description": "Optional screen X coordinate"},
+				"y":         map[string]string{"type": "number", "description": "Optional screen Y coordinate"},
+				"direction": map[string]string{"type": "string", "description": "Optional direction: up or down"},
+				"clicks":    map[string]string{"type": "number", "description": "Optional wheel clicks when direction is used"},
+				"delta":     map[string]string{"type": "number", "description": "Optional raw wheel delta override"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_scroll", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopScrollTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_drag",
+		"Drag the mouse from one desktop coordinate to another",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"x1":          map[string]string{"type": "number", "description": "Starting screen X coordinate"},
+				"y1":          map[string]string{"type": "number", "description": "Starting screen Y coordinate"},
+				"x2":          map[string]string{"type": "number", "description": "Ending screen X coordinate"},
+				"y2":          map[string]string{"type": "number", "description": "Ending screen Y coordinate"},
+				"button":      map[string]string{"type": "string", "description": "Optional mouse button: left, right, middle"},
+				"steps":       map[string]string{"type": "number", "description": "Optional number of interpolation steps"},
+				"duration_ms": map[string]string{"type": "number", "description": "Optional drag duration in milliseconds"},
+			},
+			"required": []string{"x1", "y1", "x2", "y2"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_drag", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopDragTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_wait",
+		"Pause desktop execution for a fixed number of milliseconds",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"wait_ms": map[string]string{"type": "number", "description": "Milliseconds to wait"},
+			},
+			"required": []string{"wait_ms"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_wait", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopWaitTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_list_windows",
+		"List desktop application windows on the local host",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"title":        map[string]string{"type": "string", "description": "Optional window title filter"},
+				"process_name": map[string]string{"type": "string", "description": "Optional process name filter, without .exe"},
+				"handle":       map[string]string{"type": "number", "description": "Optional native window handle filter"},
+				"match":        map[string]string{"type": "string", "description": "Optional title match mode: contains or exact"},
+				"active_only":  map[string]string{"type": "boolean", "description": "Whether to return only the focused window"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_list_windows", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopListWindowsTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_wait_window",
+		"Wait until a desktop application window appears on the local host",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"title":        map[string]string{"type": "string", "description": "Optional window title filter"},
+				"process_name": map[string]string{"type": "string", "description": "Optional process name filter, without .exe"},
+				"handle":       map[string]string{"type": "number", "description": "Optional native window handle filter"},
+				"match":        map[string]string{"type": "string", "description": "Optional title match mode: contains or exact"},
+				"active_only":  map[string]string{"type": "boolean", "description": "Whether to wait for a focused window"},
+				"timeout_ms":   map[string]string{"type": "number", "description": "Optional timeout in milliseconds"},
+				"interval_ms":  map[string]string{"type": "number", "description": "Optional poll interval in milliseconds"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_wait_window", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopWaitWindowTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_focus_window",
+		"Bring a desktop window to the foreground by title or process name",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"title":        map[string]string{"type": "string", "description": "Window title to match"},
+				"process_name": map[string]string{"type": "string", "description": "Process name to match, without .exe"},
+				"match":        map[string]string{"type": "string", "description": "Optional title match mode: contains or exact"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_focus_window", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopFocusWindowTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_inspect_ui",
+		"Inspect UI automation elements inside a desktop application window",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"title":             map[string]string{"type": "string", "description": "Window title to match"},
+				"process_name":      map[string]string{"type": "string", "description": "Process name to match, without .exe"},
+				"handle":            map[string]string{"type": "number", "description": "Optional native window handle"},
+				"match":             map[string]string{"type": "string", "description": "Optional match mode for title/name/class filters: contains or exact"},
+				"scope":             map[string]string{"type": "string", "description": "children or descendants"},
+				"name":              map[string]string{"type": "string", "description": "Optional visible control name filter"},
+				"automation_id":     map[string]string{"type": "string", "description": "Optional automation id filter"},
+				"class_name":        map[string]string{"type": "string", "description": "Optional class name filter"},
+				"control_type":      map[string]string{"type": "string", "description": "Optional control type filter, e.g. button or edit"},
+				"max_elements":      map[string]string{"type": "number", "description": "Optional maximum number of matching elements"},
+				"include_offscreen": map[string]string{"type": "boolean", "description": "Whether to include offscreen controls"},
+				"include_disabled":  map[string]string{"type": "boolean", "description": "Whether to include disabled controls"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_inspect_ui", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopInspectUITool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_invoke_ui",
+		"Invoke or click a UI automation control inside a desktop application window",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"title":             map[string]string{"type": "string", "description": "Window title to match"},
+				"process_name":      map[string]string{"type": "string", "description": "Process name to match, without .exe"},
+				"handle":            map[string]string{"type": "number", "description": "Optional native window handle"},
+				"match":             map[string]string{"type": "string", "description": "Optional match mode for title/name/class filters: contains or exact"},
+				"scope":             map[string]string{"type": "string", "description": "children or descendants"},
+				"name":              map[string]string{"type": "string", "description": "Optional visible control name filter"},
+				"automation_id":     map[string]string{"type": "string", "description": "Optional automation id filter"},
+				"class_name":        map[string]string{"type": "string", "description": "Optional class name filter"},
+				"control_type":      map[string]string{"type": "string", "description": "Optional control type filter, e.g. button or edit"},
+				"index":             map[string]string{"type": "number", "description": "Optional 1-based match index"},
+				"action":            map[string]string{"type": "string", "description": "auto, invoke, click, focus, select, expand, collapse, or toggle"},
+				"include_offscreen": map[string]string{"type": "boolean", "description": "Whether to include offscreen controls"},
+				"include_disabled":  map[string]string{"type": "boolean", "description": "Whether to include disabled controls"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_invoke_ui", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopInvokeUITool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_set_value_ui",
+		"Set the value of a UI automation input control inside a desktop application window",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"title":             map[string]string{"type": "string", "description": "Window title to match"},
+				"process_name":      map[string]string{"type": "string", "description": "Process name to match, without .exe"},
+				"handle":            map[string]string{"type": "number", "description": "Optional native window handle"},
+				"match":             map[string]string{"type": "string", "description": "Optional match mode for title/name/class filters: contains or exact"},
+				"scope":             map[string]string{"type": "string", "description": "children or descendants"},
+				"name":              map[string]string{"type": "string", "description": "Optional visible control name filter"},
+				"automation_id":     map[string]string{"type": "string", "description": "Optional automation id filter"},
+				"class_name":        map[string]string{"type": "string", "description": "Optional class name filter"},
+				"control_type":      map[string]string{"type": "string", "description": "Optional control type filter, e.g. edit or document"},
+				"index":             map[string]string{"type": "number", "description": "Optional 1-based match index"},
+				"value":             map[string]string{"type": "string", "description": "Text value to enter"},
+				"append":            map[string]string{"type": "boolean", "description": "Whether to append instead of replace"},
+				"submit":            map[string]string{"type": "boolean", "description": "Whether to press Enter after setting the value"},
+				"include_offscreen": map[string]string{"type": "boolean", "description": "Whether to include offscreen controls"},
+				"include_disabled":  map[string]string{"type": "boolean", "description": "Whether to include disabled controls"},
+			},
+			"required": []string{"value"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_set_value_ui", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopSetValueUITool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_resolve_target",
+		"Resolve a local desktop target by combining window, UI automation, OCR text, and image matching",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"strategy":          map[string]string{"type": "string", "description": "Optional single strategy: auto, window, ui, text, or image"},
+				"strategies":        map[string]string{"type": "array", "description": "Optional ordered strategy list: window, ui, text, image"},
+				"title":             map[string]string{"type": "string", "description": "Optional window title to match"},
+				"process_name":      map[string]string{"type": "string", "description": "Optional process name to match, without .exe"},
+				"handle":            map[string]string{"type": "number", "description": "Optional native window handle"},
+				"match":             map[string]string{"type": "string", "description": "Optional title/name/class match mode: contains or exact"},
+				"scope":             map[string]string{"type": "string", "description": "Optional UI automation scope: children or descendants"},
+				"name":              map[string]string{"type": "string", "description": "Optional UI automation control name"},
+				"automation_id":     map[string]string{"type": "string", "description": "Optional UI automation AutomationId"},
+				"class_name":        map[string]string{"type": "string", "description": "Optional UI automation class name"},
+				"control_type":      map[string]string{"type": "string", "description": "Optional UI automation control type"},
+				"index":             map[string]string{"type": "number", "description": "Optional 1-based UI match index"},
+				"include_offscreen": map[string]string{"type": "boolean", "description": "Whether to include offscreen UI controls"},
+				"include_disabled":  map[string]string{"type": "boolean", "description": "Whether to include disabled UI controls"},
+				"text":              map[string]string{"type": "string", "description": "Optional OCR text to find"},
+				"mode":              map[string]string{"type": "string", "description": "Optional OCR match mode: contains, exact, or regex"},
+				"ignore_case":       map[string]string{"type": "boolean", "description": "Whether OCR matching ignores case"},
+				"occurrence":        map[string]string{"type": "number", "description": "Optional 1-based OCR match occurrence"},
+				"min_confidence":    map[string]string{"type": "number", "description": "Optional minimum OCR confidence"},
+				"lang":              map[string]string{"type": "string", "description": "Optional Tesseract language code"},
+				"psm":               map[string]string{"type": "number", "description": "Optional Tesseract page segmentation mode"},
+				"oem":               map[string]string{"type": "number", "description": "Optional Tesseract OCR engine mode"},
+				"template_path":     map[string]string{"type": "string", "description": "Optional template image path"},
+				"threshold":         map[string]string{"type": "number", "description": "Optional image similarity threshold between 0 and 1"},
+				"path":              map[string]string{"type": "string", "description": "Optional screenshot path; omit to capture the current desktop"},
+				"require_found":     map[string]string{"type": "boolean", "description": "Whether to return an error when the target cannot be resolved"},
+				"crop_to_window":    map[string]string{"type": "boolean", "description": "Whether to crop vision matching to the selected window"},
+				"search_x":          map[string]string{"type": "number", "description": "Optional search area X coordinate for image matching"},
+				"search_y":          map[string]string{"type": "number", "description": "Optional search area Y coordinate for image matching"},
+				"search_width":      map[string]string{"type": "number", "description": "Optional search area width for image matching"},
+				"search_height":     map[string]string{"type": "number", "description": "Optional search area height for image matching"},
+				"step":              map[string]string{"type": "number", "description": "Optional coarse image search step in pixels"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_resolve_target", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopResolveTargetTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_activate_target",
+		"Activate a resolved desktop target by invoking a UI control or clicking the matched text, image, or window",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"strategy":          map[string]string{"type": "string", "description": "Optional single strategy: auto, window, ui, text, or image"},
+				"strategies":        map[string]string{"type": "array", "description": "Optional ordered strategy list: window, ui, text, image"},
+				"action":            map[string]string{"type": "string", "description": "Optional action: auto, click, double_click, focus, invoke, select, expand, collapse, or toggle"},
+				"button":            map[string]string{"type": "string", "description": "Optional mouse button for click-based fallback: left, right, middle"},
+				"interval_ms":       map[string]string{"type": "number", "description": "Optional double click interval in milliseconds"},
+				"title":             map[string]string{"type": "string", "description": "Optional window title to match"},
+				"process_name":      map[string]string{"type": "string", "description": "Optional process name to match, without .exe"},
+				"handle":            map[string]string{"type": "number", "description": "Optional native window handle"},
+				"match":             map[string]string{"type": "string", "description": "Optional title/name/class match mode: contains or exact"},
+				"scope":             map[string]string{"type": "string", "description": "Optional UI automation scope: children or descendants"},
+				"name":              map[string]string{"type": "string", "description": "Optional UI automation control name"},
+				"automation_id":     map[string]string{"type": "string", "description": "Optional UI automation AutomationId"},
+				"class_name":        map[string]string{"type": "string", "description": "Optional UI automation class name"},
+				"control_type":      map[string]string{"type": "string", "description": "Optional UI automation control type"},
+				"index":             map[string]string{"type": "number", "description": "Optional 1-based UI match index"},
+				"include_offscreen": map[string]string{"type": "boolean", "description": "Whether to include offscreen UI controls"},
+				"include_disabled":  map[string]string{"type": "boolean", "description": "Whether to include disabled UI controls"},
+				"text":              map[string]string{"type": "string", "description": "Optional OCR text to find"},
+				"mode":              map[string]string{"type": "string", "description": "Optional OCR match mode: contains, exact, or regex"},
+				"ignore_case":       map[string]string{"type": "boolean", "description": "Whether OCR matching ignores case"},
+				"occurrence":        map[string]string{"type": "number", "description": "Optional 1-based OCR match occurrence"},
+				"min_confidence":    map[string]string{"type": "number", "description": "Optional minimum OCR confidence"},
+				"lang":              map[string]string{"type": "string", "description": "Optional Tesseract language code"},
+				"psm":               map[string]string{"type": "number", "description": "Optional Tesseract page segmentation mode"},
+				"oem":               map[string]string{"type": "number", "description": "Optional Tesseract OCR engine mode"},
+				"template_path":     map[string]string{"type": "string", "description": "Optional template image path"},
+				"threshold":         map[string]string{"type": "number", "description": "Optional image similarity threshold between 0 and 1"},
+				"path":              map[string]string{"type": "string", "description": "Optional screenshot path; omit to capture the current desktop"},
+				"crop_to_window":    map[string]string{"type": "boolean", "description": "Whether to crop vision matching to the selected window"},
+				"search_x":          map[string]string{"type": "number", "description": "Optional search area X coordinate for image matching"},
+				"search_y":          map[string]string{"type": "number", "description": "Optional search area Y coordinate for image matching"},
+				"search_width":      map[string]string{"type": "number", "description": "Optional search area width for image matching"},
+				"search_height":     map[string]string{"type": "number", "description": "Optional search area height for image matching"},
+				"step":              map[string]string{"type": "number", "description": "Optional coarse image search step in pixels"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_activate_target", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopActivateTargetTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_set_target_value",
+		"Set text into a resolved desktop target, preferring UI automation and falling back to click-and-type",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"strategy":          map[string]string{"type": "string", "description": "Optional single strategy: auto, window, ui, text, or image"},
+				"strategies":        map[string]string{"type": "array", "description": "Optional ordered strategy list: window, ui, text, image"},
+				"title":             map[string]string{"type": "string", "description": "Optional window title to match"},
+				"process_name":      map[string]string{"type": "string", "description": "Optional process name to match, without .exe"},
+				"handle":            map[string]string{"type": "number", "description": "Optional native window handle"},
+				"match":             map[string]string{"type": "string", "description": "Optional title/name/class match mode: contains or exact"},
+				"scope":             map[string]string{"type": "string", "description": "Optional UI automation scope: children or descendants"},
+				"name":              map[string]string{"type": "string", "description": "Optional UI automation control name"},
+				"automation_id":     map[string]string{"type": "string", "description": "Optional UI automation AutomationId"},
+				"class_name":        map[string]string{"type": "string", "description": "Optional UI automation class name"},
+				"control_type":      map[string]string{"type": "string", "description": "Optional UI automation control type"},
+				"index":             map[string]string{"type": "number", "description": "Optional 1-based UI match index"},
+				"include_offscreen": map[string]string{"type": "boolean", "description": "Whether to include offscreen UI controls"},
+				"include_disabled":  map[string]string{"type": "boolean", "description": "Whether to include disabled UI controls"},
+				"text":              map[string]string{"type": "string", "description": "Optional OCR text to find"},
+				"mode":              map[string]string{"type": "string", "description": "Optional OCR match mode: contains, exact, or regex"},
+				"ignore_case":       map[string]string{"type": "boolean", "description": "Whether OCR matching ignores case"},
+				"occurrence":        map[string]string{"type": "number", "description": "Optional 1-based OCR match occurrence"},
+				"min_confidence":    map[string]string{"type": "number", "description": "Optional minimum OCR confidence"},
+				"lang":              map[string]string{"type": "string", "description": "Optional Tesseract language code"},
+				"psm":               map[string]string{"type": "number", "description": "Optional Tesseract page segmentation mode"},
+				"oem":               map[string]string{"type": "number", "description": "Optional Tesseract OCR engine mode"},
+				"template_path":     map[string]string{"type": "string", "description": "Optional template image path"},
+				"threshold":         map[string]string{"type": "number", "description": "Optional image similarity threshold between 0 and 1"},
+				"path":              map[string]string{"type": "string", "description": "Optional screenshot path; omit to capture the current desktop"},
+				"crop_to_window":    map[string]string{"type": "boolean", "description": "Whether to crop vision matching to the selected window"},
+				"search_x":          map[string]string{"type": "number", "description": "Optional search area X coordinate for image matching"},
+				"search_y":          map[string]string{"type": "number", "description": "Optional search area Y coordinate for image matching"},
+				"search_width":      map[string]string{"type": "number", "description": "Optional search area width for image matching"},
+				"search_height":     map[string]string{"type": "number", "description": "Optional search area height for image matching"},
+				"step":              map[string]string{"type": "number", "description": "Optional coarse image search step in pixels"},
+				"value":             map[string]string{"type": "string", "description": "Text value to enter"},
+				"append":            map[string]string{"type": "boolean", "description": "Whether to append instead of replacing the current value"},
+				"submit":            map[string]string{"type": "boolean", "description": "Whether to press Enter after entering the value"},
+			},
+			"required": []string{"value"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_set_target_value", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopSetTargetValueTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_screenshot",
+		"Capture a screenshot of the desktop and save it to a file",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]string{"type": "string", "description": "Destination PNG path inside the working directory"},
+			},
+			"required": []string{"path"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_screenshot", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopScreenshotTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_screenshot_window",
+		"Capture a screenshot of a desktop window and save it to a file",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path":         map[string]string{"type": "string", "description": "Destination PNG path inside the working directory"},
+				"title":        map[string]string{"type": "string", "description": "Optional window title to match"},
+				"process_name": map[string]string{"type": "string", "description": "Optional process name to match, without .exe"},
+				"handle":       map[string]string{"type": "number", "description": "Optional native window handle"},
+				"match":        map[string]string{"type": "string", "description": "Optional title match mode: contains or exact"},
+				"active_only":  map[string]string{"type": "boolean", "description": "Whether to capture only a focused window match"},
+			},
+			"required": []string{"path"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_screenshot_window", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopScreenshotWindowTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_match_image",
+		"Find a template image on the desktop or in a screenshot",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path":          map[string]string{"type": "string", "description": "Optional screenshot path; omit to capture the current desktop"},
+				"template_path": map[string]string{"type": "string", "description": "Template image path to locate"},
+				"threshold":     map[string]string{"type": "number", "description": "Optional similarity threshold between 0 and 1"},
+				"search_x":      map[string]string{"type": "number", "description": "Optional search area X coordinate"},
+				"search_y":      map[string]string{"type": "number", "description": "Optional search area Y coordinate"},
+				"search_width":  map[string]string{"type": "number", "description": "Optional search area width"},
+				"search_height": map[string]string{"type": "number", "description": "Optional search area height"},
+				"step":          map[string]string{"type": "number", "description": "Optional coarse search step in pixels"},
+			},
+			"required": []string{"template_path"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_match_image", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopMatchImageTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_click_image",
+		"Find a template image on the desktop and click its center",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path":          map[string]string{"type": "string", "description": "Optional screenshot path; omit to capture the current desktop"},
+				"template_path": map[string]string{"type": "string", "description": "Template image path to locate"},
+				"threshold":     map[string]string{"type": "number", "description": "Optional similarity threshold between 0 and 1"},
+				"search_x":      map[string]string{"type": "number", "description": "Optional search area X coordinate"},
+				"search_y":      map[string]string{"type": "number", "description": "Optional search area Y coordinate"},
+				"search_width":  map[string]string{"type": "number", "description": "Optional search area width"},
+				"search_height": map[string]string{"type": "number", "description": "Optional search area height"},
+				"step":          map[string]string{"type": "number", "description": "Optional coarse search step in pixels"},
+				"button":        map[string]string{"type": "string", "description": "Optional mouse button: left, right, middle"},
+				"offset_x":      map[string]string{"type": "number", "description": "Optional X offset from the matched center"},
+				"offset_y":      map[string]string{"type": "number", "description": "Optional Y offset from the matched center"},
+				"double":        map[string]string{"type": "boolean", "description": "Optional double click toggle"},
+				"interval_ms":   map[string]string{"type": "number", "description": "Optional double click interval in milliseconds"},
+			},
+			"required": []string{"template_path"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_click_image", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopClickImageTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_wait_image",
+		"Wait until a template image appears on the desktop",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"template_path": map[string]string{"type": "string", "description": "Template image path to locate"},
+				"threshold":     map[string]string{"type": "number", "description": "Optional similarity threshold between 0 and 1"},
+				"search_x":      map[string]string{"type": "number", "description": "Optional search area X coordinate"},
+				"search_y":      map[string]string{"type": "number", "description": "Optional search area Y coordinate"},
+				"search_width":  map[string]string{"type": "number", "description": "Optional search area width"},
+				"search_height": map[string]string{"type": "number", "description": "Optional search area height"},
+				"step":          map[string]string{"type": "number", "description": "Optional coarse search step in pixels"},
+				"timeout_ms":    map[string]string{"type": "number", "description": "Optional timeout in milliseconds"},
+				"interval_ms":   map[string]string{"type": "number", "description": "Optional poll interval in milliseconds"},
+			},
+			"required": []string{"template_path"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_wait_image", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopWaitImageTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_ocr",
+		"Run OCR on the desktop or a screenshot image using the local OCR engine",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]string{"type": "string", "description": "Optional screenshot path; omit to capture the current desktop"},
+				"lang": map[string]string{"type": "string", "description": "Optional Tesseract language code, e.g. eng or chi_sim"},
+				"psm":  map[string]string{"type": "number", "description": "Optional Tesseract page segmentation mode"},
+				"oem":  map[string]string{"type": "number", "description": "Optional Tesseract OCR engine mode"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_ocr", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopOCRTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_verify_text",
+		"Verify that OCR output contains expected text on the desktop",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path":        map[string]string{"type": "string", "description": "Optional screenshot path; omit to capture the current desktop"},
+				"expected":    map[string]string{"type": "string", "description": "Expected OCR text"},
+				"mode":        map[string]string{"type": "string", "description": "contains, exact, or regex"},
+				"ignore_case": map[string]string{"type": "boolean", "description": "Whether to ignore case during matching"},
+				"lang":        map[string]string{"type": "string", "description": "Optional Tesseract language code"},
+				"psm":         map[string]string{"type": "number", "description": "Optional Tesseract page segmentation mode"},
+				"oem":         map[string]string{"type": "number", "description": "Optional Tesseract OCR engine mode"},
+			},
+			"required": []string{"expected"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_verify_text", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopVerifyTextTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_find_text",
+		"Find visible text on the desktop via OCR and return its screen bounds",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path":           map[string]string{"type": "string", "description": "Optional screenshot path; omit to capture the current desktop"},
+				"text":           map[string]string{"type": "string", "description": "Visible text to locate"},
+				"mode":           map[string]string{"type": "string", "description": "contains, exact, or regex"},
+				"ignore_case":    map[string]string{"type": "boolean", "description": "Whether to ignore case during matching"},
+				"occurrence":     map[string]string{"type": "number", "description": "Optional 1-based match occurrence to return"},
+				"min_confidence": map[string]string{"type": "number", "description": "Optional minimum OCR confidence threshold"},
+				"lang":           map[string]string{"type": "string", "description": "Optional Tesseract language code"},
+				"psm":            map[string]string{"type": "number", "description": "Optional Tesseract page segmentation mode"},
+				"oem":            map[string]string{"type": "number", "description": "Optional Tesseract OCR engine mode"},
+			},
+			"required": []string{"text"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_find_text", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopFindTextTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_click_text",
+		"Find visible text on the desktop via OCR and click it",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path":           map[string]string{"type": "string", "description": "Optional screenshot path; omit to capture the current desktop"},
+				"text":           map[string]string{"type": "string", "description": "Visible text to locate"},
+				"mode":           map[string]string{"type": "string", "description": "contains, exact, or regex"},
+				"ignore_case":    map[string]string{"type": "boolean", "description": "Whether to ignore case during matching"},
+				"occurrence":     map[string]string{"type": "number", "description": "Optional 1-based match occurrence to return"},
+				"min_confidence": map[string]string{"type": "number", "description": "Optional minimum OCR confidence threshold"},
+				"lang":           map[string]string{"type": "string", "description": "Optional Tesseract language code"},
+				"psm":            map[string]string{"type": "number", "description": "Optional Tesseract page segmentation mode"},
+				"oem":            map[string]string{"type": "number", "description": "Optional Tesseract OCR engine mode"},
+				"button":         map[string]string{"type": "string", "description": "Optional mouse button: left, right, middle"},
+				"offset_x":       map[string]string{"type": "number", "description": "Optional X offset from the matched center"},
+				"offset_y":       map[string]string{"type": "number", "description": "Optional Y offset from the matched center"},
+				"double":         map[string]string{"type": "boolean", "description": "Optional double click toggle"},
+				"interval_ms":    map[string]string{"type": "number", "description": "Optional double click interval in milliseconds"},
+			},
+			"required": []string{"text"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_click_text", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopClickTextTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"desktop_wait_text",
+		"Wait until visible text appears on the desktop via OCR",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"text":           map[string]string{"type": "string", "description": "Visible text to wait for"},
+				"path":           map[string]string{"type": "string", "description": "Optional screenshot path; omit to capture the current desktop"},
+				"mode":           map[string]string{"type": "string", "description": "contains, exact, or regex"},
+				"ignore_case":    map[string]string{"type": "boolean", "description": "Whether to ignore case during matching"},
+				"occurrence":     map[string]string{"type": "number", "description": "Optional 1-based match occurrence to return"},
+				"min_confidence": map[string]string{"type": "number", "description": "Optional minimum OCR confidence threshold"},
+				"timeout_ms":     map[string]string{"type": "number", "description": "Optional timeout in milliseconds"},
+				"interval_ms":    map[string]string{"type": "number", "description": "Optional poll interval in milliseconds"},
+				"lang":           map[string]string{"type": "string", "description": "Optional Tesseract language code"},
+				"psm":            map[string]string{"type": "number", "description": "Optional Tesseract page segmentation mode"},
+				"oem":            map[string]string{"type": "number", "description": "Optional Tesseract OCR engine mode"},
+			},
+			"required": []string{"text"},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "desktop_wait_text", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return DesktopWaitTextTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+
+	r.RegisterTool(
+		"image_analyze",
+		"Analyze an image using a multimodal LLM (GPT-4V, Claude Vision, etc.). Describe objects, text, scenes, and visual content.",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path":   map[string]string{"type": "string", "description": "Local image file path"},
+				"url":    map[string]string{"type": "string", "description": "Image URL to analyze"},
+				"prompt": map[string]string{"type": "string", "description": "Custom analysis prompt (optional)"},
+			},
+		},
+		func(ctx context.Context, input map[string]any) (string, error) {
+			return auditCall(opts, "image_analyze", input, func(ctx context.Context, input map[string]any) (string, error) {
+				return ImageAnalyzeTool(ctx, input, opts)
+			})(ctx, input)
+		},
+	)
+}
+
+func auditCall(opts BuiltinOptions, toolName string, input map[string]any, next ToolFunc) ToolFunc {
+	return func(ctx context.Context, _ map[string]any) (string, error) {
+		output, err := next(ctx, input)
+		if opts.AuditLogger != nil {
+			opts.AuditLogger.LogTool(toolName, input, output, err)
+		}
+		return output, err
+	}
+}

--- a/pkg/capability/tools/ui_automation.go
+++ b/pkg/capability/tools/ui_automation.go
@@ -1,0 +1,742 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type desktopWindowInfo struct {
+	Title       string `json:"title,omitempty"`
+	ProcessName string `json:"process_name,omitempty"`
+	ProcessID   int    `json:"process_id,omitempty"`
+	Handle      int    `json:"handle,omitempty"`
+	X           int    `json:"x,omitempty"`
+	Y           int    `json:"y,omitempty"`
+	Width       int    `json:"width,omitempty"`
+	Height      int    `json:"height,omitempty"`
+	CenterX     int    `json:"center_x,omitempty"`
+	CenterY     int    `json:"center_y,omitempty"`
+	IsFocused   bool   `json:"is_focused,omitempty"`
+}
+
+type desktopAutomationElement struct {
+	Name             string `json:"name,omitempty"`
+	AutomationID     string `json:"automation_id,omitempty"`
+	ClassName        string `json:"class_name,omitempty"`
+	ControlType      string `json:"control_type,omitempty"`
+	ProcessID        int    `json:"process_id,omitempty"`
+	Handle           int    `json:"handle,omitempty"`
+	IsEnabled        bool   `json:"is_enabled,omitempty"`
+	HasKeyboardFocus bool   `json:"has_keyboard_focus,omitempty"`
+	IsOffscreen      bool   `json:"is_offscreen,omitempty"`
+	X                int    `json:"x,omitempty"`
+	Y                int    `json:"y,omitempty"`
+	Width            int    `json:"width,omitempty"`
+	Height           int    `json:"height,omitempty"`
+	CenterX          int    `json:"center_x,omitempty"`
+	CenterY          int    `json:"center_y,omitempty"`
+}
+
+type desktopAutomationActionResult struct {
+	Action  string                    `json:"action,omitempty"`
+	Element *desktopAutomationElement `json:"element,omitempty"`
+	Value   string                    `json:"value,omitempty"`
+	Submit  bool                      `json:"submit,omitempty"`
+}
+
+type desktopAutomationSelector struct {
+	WindowTitle      string
+	ProcessName      string
+	Handle           int
+	Match            string
+	Scope            string
+	Index            int
+	MaxElements      int
+	Name             string
+	AutomationID     string
+	ClassName        string
+	ControlType      string
+	IncludeOffscreen bool
+	IncludeDisabled  bool
+}
+
+const desktopAutomationPSScriptPrelude = `
+Add-Type -AssemblyName UIAutomationClient;
+Add-Type -AssemblyName UIAutomationTypes;
+
+function Get-WindowProcessName([int]$ProcessId) {
+  if ($ProcessId -le 0) {
+    return ""
+  }
+  $proc = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($proc) {
+    return [string]$proc.ProcessName
+  }
+  return ""
+}
+
+function Match-DesktopValue([string]$Candidate, [string]$Needle, [string]$MatchMode) {
+  if ([string]::IsNullOrWhiteSpace($Needle)) {
+    return $true
+  }
+  if ($null -eq $Candidate) {
+    $Candidate = ""
+  }
+  if ($MatchMode -eq "exact") {
+    return $Candidate -eq $Needle
+  }
+  return $Candidate -like ("*" + $Needle + "*")
+}
+
+function Get-ControlTypeName($ControlType) {
+  if ($null -eq $ControlType) {
+    return ""
+  }
+  return ([string]$ControlType.ProgrammaticName) -replace '^ControlType\.', ''
+}
+
+function Get-BoundsObject($Rect) {
+  $width = [int]($Rect.Right - $Rect.Left)
+  $height = [int]($Rect.Bottom - $Rect.Top)
+  [pscustomobject]@{
+    x = [int]$Rect.Left
+    y = [int]$Rect.Top
+    width = $width
+    height = $height
+    center_x = [int]($Rect.Left + ($width / 2))
+    center_y = [int]($Rect.Top + ($height / 2))
+  }
+}
+
+function Find-DesktopWindow([string]$WindowTitle, [string]$ProcessName, [int]$WindowHandle, [string]$MatchMode) {
+  $windows = [System.Windows.Automation.AutomationElement]::RootElement.FindAll([System.Windows.Automation.TreeScope]::Children, [System.Windows.Automation.Condition]::TrueCondition)
+  foreach ($candidate in $windows) {
+    try {
+      $current = $candidate.Current
+      $handle = [int]$current.NativeWindowHandle
+      if ($handle -eq 0) {
+        continue
+      }
+      $title = [string]$current.Name
+      $procName = Get-WindowProcessName([int]$current.ProcessId)
+      if ($WindowHandle -gt 0 -and $handle -ne $WindowHandle) {
+        continue
+      }
+      if (-not (Match-DesktopValue $title $WindowTitle $MatchMode)) {
+        continue
+      }
+      if (-not (Match-DesktopValue $procName $ProcessName "exact")) {
+        continue
+      }
+      return $candidate
+    } catch {
+    }
+  }
+  return $null
+}
+
+function Get-ElementSnapshot($Element) {
+  $current = $Element.Current
+  $rect = $current.BoundingRectangle
+  $bounds = Get-BoundsObject $rect
+  [pscustomobject]@{
+    name = [string]$current.Name
+    automation_id = [string]$current.AutomationId
+    class_name = [string]$current.ClassName
+    control_type = (Get-ControlTypeName $current.ControlType)
+    process_id = [int]$current.ProcessId
+    handle = [int]$current.NativeWindowHandle
+    is_enabled = [bool]$current.IsEnabled
+    has_keyboard_focus = [bool]$current.HasKeyboardFocus
+    is_offscreen = [bool]$current.IsOffscreen
+    x = $bounds.x
+    y = $bounds.y
+    width = $bounds.width
+    height = $bounds.height
+    center_x = $bounds.center_x
+    center_y = $bounds.center_y
+  }
+}
+
+function Match-AutomationElement($Element, [string]$ElementName, [string]$AutomationId, [string]$ClassName, [string]$ControlType, [string]$MatchMode, [bool]$IncludeOffscreen, [bool]$IncludeDisabled) {
+  $snapshot = Get-ElementSnapshot $Element
+  if (-not $IncludeOffscreen -and ($snapshot.width -le 0 -or $snapshot.height -le 0 -or $snapshot.is_offscreen)) {
+    return $false
+  }
+  if (-not $IncludeDisabled -and -not $snapshot.is_enabled) {
+    return $false
+  }
+  if (-not (Match-DesktopValue $snapshot.name $ElementName $MatchMode)) {
+    return $false
+  }
+  if (-not (Match-DesktopValue $snapshot.automation_id $AutomationId "exact")) {
+    return $false
+  }
+  if (-not (Match-DesktopValue $snapshot.class_name $ClassName $MatchMode)) {
+    return $false
+  }
+  if (-not (Match-DesktopValue $snapshot.control_type $ControlType "exact")) {
+    return $false
+  }
+  return $true
+}
+`
+
+func DesktopListWindowsTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_list_windows", opts, true); err != nil {
+		return "", err
+	}
+	windows, err := runDesktopWindowQuery(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(windows)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func DesktopWaitWindowTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_wait_window", opts, true); err != nil {
+		return "", err
+	}
+	timeoutMS, ok := numberInput(input["timeout_ms"])
+	if !ok || timeoutMS <= 0 {
+		timeoutMS = 10000
+	}
+	intervalMS, ok := numberInput(input["interval_ms"])
+	if !ok || intervalMS <= 0 {
+		intervalMS = 500
+	}
+	deadline := time.Now().Add(time.Duration(timeoutMS) * time.Millisecond)
+	attempts := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+		}
+		attempts++
+		windows, err := runDesktopWindowQuery(ctx, input)
+		if err != nil {
+			return "", err
+		}
+		if len(windows) > 0 {
+			payload, err := json.Marshal(map[string]any{
+				"attempts": attempts,
+				"window":   windows[0],
+			})
+			if err != nil {
+				return "", err
+			}
+			return string(payload), nil
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("window did not appear within %dms", timeoutMS)
+		}
+		timer := time.NewTimer(time.Duration(intervalMS) * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return "", ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func DesktopInspectUITool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_inspect_ui", opts, true); err != nil {
+		return "", err
+	}
+	selector, err := resolveDesktopAutomationSelector(input, true)
+	if err != nil {
+		return "", err
+	}
+	script := desktopAutomationPSScriptPrelude + fmt.Sprintf(`
+$windowTitle = %s;
+$processName = %s;
+$windowHandle = %d;
+$matchMode = %s;
+$scopeName = %s;
+$elementName = %s;
+$automationId = %s;
+$className = %s;
+$controlType = %s;
+$maxElements = %d;
+$includeOffscreen = %s;
+$includeDisabled = %s;
+
+$targetWindow = Find-DesktopWindow $windowTitle $processName $windowHandle $matchMode
+if (-not $targetWindow) {
+  throw "window not found"
+}
+$scope = if ($scopeName -eq "children") { [System.Windows.Automation.TreeScope]::Children } else { [System.Windows.Automation.TreeScope]::Descendants }
+$elements = $targetWindow.FindAll($scope, [System.Windows.Automation.Condition]::TrueCondition)
+$items = @()
+foreach ($candidate in $elements) {
+  try {
+    if (-not (Match-AutomationElement $candidate $elementName $automationId $className $controlType $matchMode $includeOffscreen $includeDisabled)) {
+      continue
+    }
+    $items += Get-ElementSnapshot $candidate
+    if ($items.Count -ge $maxElements) {
+      break
+    }
+  } catch {
+  }
+}
+$items | ConvertTo-Json -Depth 6 -Compress
+`,
+		powerShellString(selector.WindowTitle),
+		powerShellString(selector.ProcessName),
+		selector.Handle,
+		powerShellString(selector.Match),
+		powerShellString(selector.Scope),
+		powerShellString(selector.Name),
+		powerShellString(selector.AutomationID),
+		powerShellString(selector.ClassName),
+		powerShellString(selector.ControlType),
+		selector.MaxElements,
+		powerShellBool(selector.IncludeOffscreen),
+		powerShellBool(selector.IncludeDisabled),
+	)
+	output, err := runDesktopPowerShell(ctx, script)
+	if err != nil {
+		return "", err
+	}
+	elements, err := unmarshalJSONObjectOrArray[desktopAutomationElement](output)
+	if err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(elements)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func DesktopInvokeUITool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_invoke_ui", opts, false); err != nil {
+		return "", err
+	}
+	selector, err := resolveDesktopAutomationSelector(input, true)
+	if err != nil {
+		return "", err
+	}
+	action := strings.TrimSpace(strings.ToLower(stringValue(input["action"])))
+	if action == "" {
+		action = "auto"
+	}
+	switch action {
+	case "auto", "invoke", "click", "focus", "select", "expand", "collapse", "toggle":
+	default:
+		return "", fmt.Errorf("action must be auto, invoke, click, focus, select, expand, collapse, or toggle")
+	}
+	script := desktopAutomationPSScriptPrelude + fmt.Sprintf(`
+$windowTitle = %s;
+$processName = %s;
+$windowHandle = %d;
+$matchMode = %s;
+$scopeName = %s;
+$elementName = %s;
+$automationId = %s;
+$className = %s;
+$controlType = %s;
+$elementIndex = %d;
+$requestedAction = %s;
+$includeOffscreen = %s;
+$includeDisabled = %s;
+
+$targetWindow = Find-DesktopWindow $windowTitle $processName $windowHandle $matchMode
+if (-not $targetWindow) {
+  throw "window not found"
+}
+$scope = if ($scopeName -eq "children") { [System.Windows.Automation.TreeScope]::Children } else { [System.Windows.Automation.TreeScope]::Descendants }
+$elements = $targetWindow.FindAll($scope, [System.Windows.Automation.Condition]::TrueCondition)
+$matches = New-Object System.Collections.ArrayList
+foreach ($candidate in $elements) {
+  try {
+    if (-not (Match-AutomationElement $candidate $elementName $automationId $className $controlType $matchMode $includeOffscreen $includeDisabled)) {
+      continue
+    }
+    [void]$matches.Add($candidate)
+  } catch {
+  }
+}
+if ($matches.Count -lt $elementIndex) {
+  throw "automation element not found"
+}
+$target = $matches[$elementIndex - 1]
+$performedAction = ""
+$target.SetFocus()
+Start-Sleep -Milliseconds 50
+$pattern = $null
+if (($requestedAction -eq "invoke" -or $requestedAction -eq "auto") -and $target.TryGetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern, [ref]$pattern)) {
+  $pattern.Invoke()
+  $performedAction = "invoke"
+}
+if (-not $performedAction -and ($requestedAction -eq "select" -or $requestedAction -eq "auto") -and $target.TryGetCurrentPattern([System.Windows.Automation.SelectionItemPattern]::Pattern, [ref]$pattern)) {
+  $pattern.Select()
+  $performedAction = "select"
+}
+if (-not $performedAction -and ($requestedAction -eq "expand" -or $requestedAction -eq "auto") -and $target.TryGetCurrentPattern([System.Windows.Automation.ExpandCollapsePattern]::Pattern, [ref]$pattern)) {
+  $pattern.Expand()
+  $performedAction = "expand"
+}
+if (-not $performedAction -and $requestedAction -eq "collapse" -and $target.TryGetCurrentPattern([System.Windows.Automation.ExpandCollapsePattern]::Pattern, [ref]$pattern)) {
+  $pattern.Collapse()
+  $performedAction = "collapse"
+}
+if (-not $performedAction -and ($requestedAction -eq "toggle" -or $requestedAction -eq "auto") -and $target.TryGetCurrentPattern([System.Windows.Automation.TogglePattern]::Pattern, [ref]$pattern)) {
+  $pattern.Toggle()
+  $performedAction = "toggle"
+}
+if (-not $performedAction -and $requestedAction -eq "focus") {
+  $performedAction = "focus"
+}
+if (-not $performedAction -and ($requestedAction -eq "click" -or $requestedAction -eq "auto")) {
+  Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class DesktopNative {
+  [DllImport("user32.dll")] public static extern bool SetCursorPos(int X, int Y);
+  [DllImport("user32.dll")] public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, UIntPtr dwExtraInfo);
+}
+"@;
+  $snapshot = Get-ElementSnapshot $target
+  if ($snapshot.width -le 0 -or $snapshot.height -le 0) {
+    throw "automation element has no clickable bounds"
+  }
+  [DesktopNative]::SetCursorPos($snapshot.center_x, $snapshot.center_y) | Out-Null
+  [DesktopNative]::mouse_event(0x0002, 0, 0, 0, [UIntPtr]::Zero)
+  [DesktopNative]::mouse_event(0x0004, 0, 0, 0, [UIntPtr]::Zero)
+  $performedAction = "click"
+}
+if (-not $performedAction) {
+  throw "unable to invoke automation element"
+}
+[pscustomobject]@{
+  action = $performedAction
+  element = Get-ElementSnapshot $target
+} | ConvertTo-Json -Depth 6 -Compress
+`,
+		powerShellString(selector.WindowTitle),
+		powerShellString(selector.ProcessName),
+		selector.Handle,
+		powerShellString(selector.Match),
+		powerShellString(selector.Scope),
+		powerShellString(selector.Name),
+		powerShellString(selector.AutomationID),
+		powerShellString(selector.ClassName),
+		powerShellString(selector.ControlType),
+		selector.Index,
+		powerShellString(action),
+		powerShellBool(selector.IncludeOffscreen),
+		powerShellBool(selector.IncludeDisabled),
+	)
+	output, err := runDesktopPowerShell(ctx, script)
+	if err != nil {
+		return "", err
+	}
+	result := desktopAutomationActionResult{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &result); err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func DesktopSetValueUITool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_set_value_ui", opts, false); err != nil {
+		return "", err
+	}
+	selector, err := resolveDesktopAutomationSelector(input, true)
+	if err != nil {
+		return "", err
+	}
+	value := stringValue(input["value"])
+	if value == "" {
+		return "", fmt.Errorf("value is required")
+	}
+	appendValue, _ := input["append"].(bool)
+	submit, _ := input["submit"].(bool)
+	script := desktopAutomationPSScriptPrelude + fmt.Sprintf(`
+$windowTitle = %s;
+$processName = %s;
+$windowHandle = %d;
+$matchMode = %s;
+$scopeName = %s;
+$elementName = %s;
+$automationId = %s;
+$className = %s;
+$controlType = %s;
+$elementIndex = %d;
+$valueText = %s;
+$appendValue = %s;
+$submit = %s;
+$includeOffscreen = %s;
+$includeDisabled = %s;
+
+$targetWindow = Find-DesktopWindow $windowTitle $processName $windowHandle $matchMode
+if (-not $targetWindow) {
+  throw "window not found"
+}
+$scope = if ($scopeName -eq "children") { [System.Windows.Automation.TreeScope]::Children } else { [System.Windows.Automation.TreeScope]::Descendants }
+$elements = $targetWindow.FindAll($scope, [System.Windows.Automation.Condition]::TrueCondition)
+$matches = New-Object System.Collections.ArrayList
+foreach ($candidate in $elements) {
+  try {
+    if (-not (Match-AutomationElement $candidate $elementName $automationId $className $controlType $matchMode $includeOffscreen $includeDisabled)) {
+      continue
+    }
+    [void]$matches.Add($candidate)
+  } catch {
+  }
+}
+if ($matches.Count -lt $elementIndex) {
+  throw "automation element not found"
+}
+$target = $matches[$elementIndex - 1]
+$target.SetFocus()
+Start-Sleep -Milliseconds 50
+$performedAction = ""
+$pattern = $null
+if ($target.TryGetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern, [ref]$pattern)) {
+  if ($appendValue) {
+    $pattern.SetValue(([string]$pattern.Current.Value) + $valueText)
+  } else {
+    $pattern.SetValue($valueText)
+  }
+  $performedAction = "value_pattern"
+} else {
+  Add-Type -AssemblyName System.Windows.Forms
+  if (-not $appendValue) {
+    [System.Windows.Forms.SendKeys]::SendWait("^a")
+    Start-Sleep -Milliseconds 50
+    [System.Windows.Forms.SendKeys]::SendWait("{BACKSPACE}")
+    Start-Sleep -Milliseconds 50
+  }
+  [System.Windows.Forms.SendKeys]::SendWait(%s)
+  $performedAction = "send_keys"
+}
+if ($submit) {
+  Add-Type -AssemblyName System.Windows.Forms
+  Start-Sleep -Milliseconds 50
+  [System.Windows.Forms.SendKeys]::SendWait("{ENTER}")
+}
+[pscustomobject]@{
+  action = $performedAction
+  value = $valueText
+  submit = $submit
+  element = Get-ElementSnapshot $target
+} | ConvertTo-Json -Depth 6 -Compress
+`,
+		powerShellString(selector.WindowTitle),
+		powerShellString(selector.ProcessName),
+		selector.Handle,
+		powerShellString(selector.Match),
+		powerShellString(selector.Scope),
+		powerShellString(selector.Name),
+		powerShellString(selector.AutomationID),
+		powerShellString(selector.ClassName),
+		powerShellString(selector.ControlType),
+		selector.Index,
+		powerShellString(value),
+		powerShellBool(appendValue),
+		powerShellBool(submit),
+		powerShellBool(selector.IncludeOffscreen),
+		powerShellBool(selector.IncludeDisabled),
+		powerShellString(sendKeysEscape(value)),
+	)
+	output, err := runDesktopPowerShell(ctx, script)
+	if err != nil {
+		return "", err
+	}
+	result := desktopAutomationActionResult{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &result); err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func runDesktopWindowQuery(ctx context.Context, input map[string]any) ([]desktopWindowInfo, error) {
+	title := strings.TrimSpace(stringValue(input["title"]))
+	processName := strings.TrimSpace(stringValue(input["process_name"]))
+	handle, _ := numberInput(input["handle"])
+	match := normalizeDesktopMatchMode(stringValue(input["match"]))
+	activeOnly, _ := input["active_only"].(bool)
+	script := desktopAutomationPSScriptPrelude + fmt.Sprintf(`
+$windowTitle = %s;
+$processName = %s;
+$windowHandle = %d;
+$matchMode = %s;
+$activeOnly = %s;
+
+$windows = [System.Windows.Automation.AutomationElement]::RootElement.FindAll([System.Windows.Automation.TreeScope]::Children, [System.Windows.Automation.Condition]::TrueCondition)
+$items = @()
+foreach ($candidate in $windows) {
+  try {
+    $current = $candidate.Current
+    $handle = [int]$current.NativeWindowHandle
+    if ($handle -eq 0) {
+      continue
+    }
+    $title = [string]$current.Name
+    $procName = Get-WindowProcessName([int]$current.ProcessId)
+    $focused = [bool]$current.HasKeyboardFocus
+    if ($windowHandle -gt 0 -and $handle -ne $windowHandle) {
+      continue
+    }
+    if (-not (Match-DesktopValue $title $windowTitle $matchMode)) {
+      continue
+    }
+    if (-not (Match-DesktopValue $procName $processName "exact")) {
+      continue
+    }
+    if ($activeOnly -and -not $focused) {
+      continue
+    }
+    $rect = $current.BoundingRectangle
+    $bounds = Get-BoundsObject $rect
+    $items += [pscustomobject]@{
+      title = $title
+      process_name = $procName
+      process_id = [int]$current.ProcessId
+      handle = $handle
+      x = $bounds.x
+      y = $bounds.y
+      width = $bounds.width
+      height = $bounds.height
+      center_x = $bounds.center_x
+      center_y = $bounds.center_y
+      is_focused = $focused
+    }
+  } catch {
+  }
+}
+$items | ConvertTo-Json -Depth 5 -Compress
+`,
+		powerShellString(title),
+		powerShellString(processName),
+		handle,
+		powerShellString(match),
+		powerShellBool(activeOnly),
+	)
+	output, err := runDesktopPowerShell(ctx, script)
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalJSONObjectOrArray[desktopWindowInfo](output)
+}
+
+func resolveDesktopAutomationSelector(input map[string]any, requireWindow bool) (desktopAutomationSelector, error) {
+	selector := desktopAutomationSelector{
+		WindowTitle:      strings.TrimSpace(stringValue(input["title"])),
+		ProcessName:      strings.TrimSpace(stringValue(input["process_name"])),
+		Match:            normalizeDesktopMatchMode(stringValue(input["match"])),
+		Scope:            normalizeDesktopScope(stringValue(input["scope"])),
+		Name:             strings.TrimSpace(stringValue(input["name"])),
+		AutomationID:     strings.TrimSpace(stringValue(input["automation_id"])),
+		ClassName:        strings.TrimSpace(stringValue(input["class_name"])),
+		ControlType:      normalizeDesktopControlType(stringValue(input["control_type"])),
+		IncludeOffscreen: boolValue(input["include_offscreen"]),
+		IncludeDisabled:  boolValue(input["include_disabled"]),
+	}
+	handle, _ := numberInput(input["handle"])
+	selector.Handle = handle
+	index, ok := numberInput(input["index"])
+	if !ok || index <= 0 {
+		index = 1
+	}
+	selector.Index = index
+	maxElements, ok := numberInput(input["max_elements"])
+	if !ok || maxElements <= 0 {
+		maxElements = 50
+	}
+	if maxElements > 200 {
+		maxElements = 200
+	}
+	selector.MaxElements = maxElements
+	if requireWindow && !desktopWindowSelectionProvided(selector) {
+		return selector, fmt.Errorf("title, process_name, or handle is required")
+	}
+	if selector.Name == "" && selector.AutomationID == "" && selector.ClassName == "" && selector.ControlType == "" {
+		if requireWindow {
+			selector.MaxElements = maxElements
+		}
+	}
+	return selector, nil
+}
+
+func desktopWindowSelectionProvided(selector desktopAutomationSelector) bool {
+	return strings.TrimSpace(selector.WindowTitle) != "" || strings.TrimSpace(selector.ProcessName) != "" || selector.Handle > 0
+}
+
+func normalizeDesktopMatchMode(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	switch value {
+	case "exact":
+		return "exact"
+	default:
+		return "contains"
+	}
+}
+
+func normalizeDesktopScope(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	switch value {
+	case "children":
+		return "children"
+	default:
+		return "descendants"
+	}
+}
+
+func normalizeDesktopControlType(value string) string {
+	return strings.TrimSpace(strings.ToLower(value))
+}
+
+func powerShellBool(value bool) string {
+	if value {
+		return "$true"
+	}
+	return "$false"
+}
+
+func boolValue(value any) bool {
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		return strings.EqualFold(strings.TrimSpace(v), "true")
+	default:
+		return false
+	}
+}
+
+func unmarshalJSONObjectOrArray[T any](raw string) ([]T, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" {
+		return nil, nil
+	}
+	var items []T
+	if err := json.Unmarshal([]byte(raw), &items); err == nil {
+		return items, nil
+	}
+	var item T
+	if err := json.Unmarshal([]byte(raw), &item); err == nil {
+		return []T{item}, nil
+	}
+	return nil, fmt.Errorf("failed to parse JSON output: %s", raw)
+}

--- a/pkg/capability/tools/ui_automation_test.go
+++ b/pkg/capability/tools/ui_automation_test.go
@@ -1,0 +1,69 @@
+package tools
+
+import (
+	"testing"
+)
+
+func TestResolveDesktopAutomationSelectorDefaults(t *testing.T) {
+	selector, err := resolveDesktopAutomationSelector(map[string]any{
+		"title": "Notepad",
+		"name":  "Save",
+	}, true)
+	if err != nil {
+		t.Fatalf("resolveDesktopAutomationSelector: %v", err)
+	}
+	if selector.Match != "contains" {
+		t.Fatalf("expected contains match default, got %q", selector.Match)
+	}
+	if selector.Scope != "descendants" {
+		t.Fatalf("expected descendants scope default, got %q", selector.Scope)
+	}
+	if selector.Index != 1 {
+		t.Fatalf("expected index 1 default, got %d", selector.Index)
+	}
+	if selector.MaxElements != 50 {
+		t.Fatalf("expected maxElements 50 default, got %d", selector.MaxElements)
+	}
+}
+
+func TestResolveDesktopAutomationSelectorRequiresWindowTarget(t *testing.T) {
+	_, err := resolveDesktopAutomationSelector(map[string]any{
+		"name": "Save",
+	}, true)
+	if err == nil {
+		t.Fatal("expected missing window selection to be rejected")
+	}
+}
+
+func TestUnmarshalJSONObjectOrArrayHandlesArrayAndObject(t *testing.T) {
+	items, err := unmarshalJSONObjectOrArray[desktopWindowInfo](`[{"title":"Notepad"},{"title":"Calculator"}]`)
+	if err != nil {
+		t.Fatalf("unmarshal array: %v", err)
+	}
+	if len(items) != 2 || items[1].Title != "Calculator" {
+		t.Fatalf("unexpected array items: %#v", items)
+	}
+
+	items, err = unmarshalJSONObjectOrArray[desktopWindowInfo](`{"title":"Single"}`)
+	if err != nil {
+		t.Fatalf("unmarshal object: %v", err)
+	}
+	if len(items) != 1 || items[0].Title != "Single" {
+		t.Fatalf("unexpected object items: %#v", items)
+	}
+}
+
+func TestNormalizeDesktopScopeAndMatch(t *testing.T) {
+	if normalizeDesktopMatchMode("exact") != "exact" {
+		t.Fatal("expected exact match mode")
+	}
+	if normalizeDesktopMatchMode("weird") != "contains" {
+		t.Fatal("expected unknown match mode to fall back to contains")
+	}
+	if normalizeDesktopScope("children") != "children" {
+		t.Fatal("expected children scope")
+	}
+	if normalizeDesktopScope("weird") != "descendants" {
+		t.Fatal("expected unknown scope to fall back to descendants")
+	}
+}

--- a/pkg/capability/tools/vision.go
+++ b/pkg/capability/tools/vision.go
@@ -1,0 +1,1186 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+)
+
+type imageMatchResult struct {
+	Found        bool             `json:"found"`
+	Score        float64          `json:"score"`
+	Threshold    float64          `json:"threshold"`
+	X            int              `json:"x,omitempty"`
+	Y            int              `json:"y,omitempty"`
+	Width        int              `json:"width,omitempty"`
+	Height       int              `json:"height,omitempty"`
+	CenterX      int              `json:"center_x,omitempty"`
+	CenterY      int              `json:"center_y,omitempty"`
+	SourcePath   string           `json:"source_path,omitempty"`
+	TemplatePath string           `json:"template_path,omitempty"`
+	SearchArea   *imageSearchArea `json:"search_area,omitempty"`
+	Meta         map[string]any   `json:"meta,omitempty"`
+}
+
+type imageSearchArea struct {
+	X      int `json:"x"`
+	Y      int `json:"y"`
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+type grayImage struct {
+	Width  int
+	Height int
+	Pix    []uint8
+}
+
+type templateMatch struct {
+	X     int
+	Y     int
+	Score float64
+}
+
+type ocrResult struct {
+	Text       string   `json:"text"`
+	Lines      []string `json:"lines,omitempty"`
+	SourcePath string   `json:"source_path,omitempty"`
+	Engine     string   `json:"engine,omitempty"`
+	Lang       string   `json:"lang,omitempty"`
+}
+
+type ocrWordBox struct {
+	Text       string
+	Normalized string
+	Confidence float64
+	X          int
+	Y          int
+	Width      int
+	Height     int
+	CenterX    int
+	CenterY    int
+	Key        string
+	WordNum    int
+}
+
+type ocrLineBox struct {
+	Text       string
+	Normalized string
+	Confidence float64
+	X          int
+	Y          int
+	Width      int
+	Height     int
+	CenterX    int
+	CenterY    int
+	Words      []ocrWordBox
+}
+
+type ocrTextMatchResult struct {
+	Found      bool           `json:"found"`
+	Query      string         `json:"query"`
+	Mode       string         `json:"mode"`
+	IgnoreCase bool           `json:"ignore_case"`
+	Scope      string         `json:"scope,omitempty"`
+	Text       string         `json:"text,omitempty"`
+	Confidence float64        `json:"confidence,omitempty"`
+	X          int            `json:"x,omitempty"`
+	Y          int            `json:"y,omitempty"`
+	Width      int            `json:"width,omitempty"`
+	Height     int            `json:"height,omitempty"`
+	CenterX    int            `json:"center_x,omitempty"`
+	CenterY    int            `json:"center_y,omitempty"`
+	SourcePath string         `json:"source_path,omitempty"`
+	Engine     string         `json:"engine,omitempty"`
+	Lang       string         `json:"lang,omitempty"`
+	Meta       map[string]any `json:"meta,omitempty"`
+}
+
+func DesktopMatchImageTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_match_image", opts, true); err != nil {
+		return "", err
+	}
+	result, err := runDesktopImageMatch(ctx, input, opts)
+	if err != nil {
+		return "", err
+	}
+	return marshalImageMatchResult(result)
+}
+
+func DesktopClickImageTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_click_image", opts, false); err != nil {
+		return "", err
+	}
+	result, err := runDesktopImageMatch(ctx, input, opts)
+	if err != nil {
+		return "", err
+	}
+	if !result.Found {
+		return "", fmt.Errorf("image not found (score %.4f below threshold %.4f)", result.Score, result.Threshold)
+	}
+	clickInput := map[string]any{
+		"x": result.CenterX + intNumberValue(input["offset_x"]),
+		"y": result.CenterY + intNumberValue(input["offset_y"]),
+	}
+	if button, _ := input["button"].(string); strings.TrimSpace(button) != "" {
+		clickInput["button"] = strings.TrimSpace(button)
+	}
+	doubleClick, _ := input["double"].(bool)
+	if doubleClick {
+		if intervalMS, ok := numberInput(input["interval_ms"]); ok && intervalMS > 0 {
+			clickInput["interval_ms"] = intervalMS
+		}
+		if _, err := DesktopDoubleClickTool(ctx, clickInput, opts); err != nil {
+			return "", err
+		}
+		result.Meta = mergeMeta(result.Meta, map[string]any{"action": "double_click"})
+	} else {
+		if _, err := DesktopClickTool(ctx, clickInput, opts); err != nil {
+			return "", err
+		}
+		result.Meta = mergeMeta(result.Meta, map[string]any{"action": "click"})
+	}
+	result.Meta = mergeMeta(result.Meta, map[string]any{
+		"clicked_x": clickInput["x"],
+		"clicked_y": clickInput["y"],
+	})
+	return marshalImageMatchResult(result)
+}
+
+func DesktopWaitImageTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_wait_image", opts, true); err != nil {
+		return "", err
+	}
+	timeoutMS, ok := numberInput(input["timeout_ms"])
+	if !ok || timeoutMS <= 0 {
+		timeoutMS = 10000
+	}
+	intervalMS, ok := numberInput(input["interval_ms"])
+	if !ok || intervalMS <= 0 {
+		intervalMS = 500
+	}
+	deadline := time.Now().Add(time.Duration(timeoutMS) * time.Millisecond)
+	attempts := 0
+	var last imageMatchResult
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+		}
+		attempts++
+		result, err := runDesktopImageMatch(ctx, input, opts)
+		if err != nil {
+			return "", err
+		}
+		last = result
+		if result.Found {
+			result.Meta = mergeMeta(result.Meta, map[string]any{
+				"attempts":   attempts,
+				"timeout_ms": timeoutMS,
+			})
+			return marshalImageMatchResult(result)
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("image did not appear within %dms (best score %.4f below threshold %.4f)", timeoutMS, last.Score, last.Threshold)
+		}
+		timer := time.NewTimer(time.Duration(intervalMS) * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return "", ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func DesktopOCRTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_ocr", opts, true); err != nil {
+		return "", err
+	}
+	result, err := runDesktopOCR(ctx, input, opts)
+	if err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func DesktopVerifyTextTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_verify_text", opts, true); err != nil {
+		return "", err
+	}
+	expected, _ := input["expected"].(string)
+	if strings.TrimSpace(expected) == "" {
+		return "", fmt.Errorf("expected is required")
+	}
+	mode, _ := input["mode"].(string)
+	mode = strings.TrimSpace(strings.ToLower(mode))
+	if mode == "" {
+		mode = "contains"
+	}
+	if mode != "contains" && mode != "exact" && mode != "regex" {
+		return "", fmt.Errorf("mode must be contains, exact, or regex")
+	}
+	ignoreCase := true
+	if value, ok := input["ignore_case"].(bool); ok {
+		ignoreCase = value
+	}
+	result, err := runDesktopOCR(ctx, input, opts)
+	if err != nil {
+		return "", err
+	}
+	if !verifyOCRText(result.Text, expected, mode, ignoreCase) {
+		snippet := result.Text
+		if len(snippet) > 240 {
+			snippet = snippet[:240] + "..."
+		}
+		return "", fmt.Errorf("expected text not found via OCR (mode=%s): %s", mode, snippet)
+	}
+	response := map[string]any{
+		"matched":     true,
+		"mode":        mode,
+		"expected":    expected,
+		"ignore_case": ignoreCase,
+		"ocr":         result,
+	}
+	payload, err := json.Marshal(response)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func DesktopFindTextTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_find_text", opts, true); err != nil {
+		return "", err
+	}
+	query := strings.TrimSpace(stringValue(input["text"]))
+	if query == "" {
+		return "", fmt.Errorf("text is required")
+	}
+	result, err := runDesktopTextMatch(ctx, input, opts)
+	if err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func DesktopClickTextTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_click_text", opts, false); err != nil {
+		return "", err
+	}
+	result, err := runDesktopTextMatch(ctx, input, opts)
+	if err != nil {
+		return "", err
+	}
+	if !result.Found {
+		return "", fmt.Errorf("text not found: %s", strings.TrimSpace(result.Query))
+	}
+	clickInput := map[string]any{
+		"x": result.CenterX + intNumberValue(input["offset_x"]),
+		"y": result.CenterY + intNumberValue(input["offset_y"]),
+	}
+	if button, _ := input["button"].(string); strings.TrimSpace(button) != "" {
+		clickInput["button"] = strings.TrimSpace(button)
+	}
+	doubleClick, _ := input["double"].(bool)
+	if doubleClick {
+		if intervalMS, ok := numberInput(input["interval_ms"]); ok && intervalMS > 0 {
+			clickInput["interval_ms"] = intervalMS
+		}
+		if _, err := DesktopDoubleClickTool(ctx, clickInput, opts); err != nil {
+			return "", err
+		}
+		result.Meta = mergeMeta(result.Meta, map[string]any{"action": "double_click"})
+	} else {
+		if _, err := DesktopClickTool(ctx, clickInput, opts); err != nil {
+			return "", err
+		}
+		result.Meta = mergeMeta(result.Meta, map[string]any{"action": "click"})
+	}
+	result.Meta = mergeMeta(result.Meta, map[string]any{
+		"clicked_x": clickInput["x"],
+		"clicked_y": clickInput["y"],
+	})
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func DesktopWaitTextTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	if err := ensureDesktopAllowed("desktop_wait_text", opts, true); err != nil {
+		return "", err
+	}
+	query := strings.TrimSpace(stringValue(input["text"]))
+	if query == "" {
+		return "", fmt.Errorf("text is required")
+	}
+	timeoutMS, ok := numberInput(input["timeout_ms"])
+	if !ok || timeoutMS <= 0 {
+		timeoutMS = 10000
+	}
+	intervalMS, ok := numberInput(input["interval_ms"])
+	if !ok || intervalMS <= 0 {
+		intervalMS = 500
+	}
+	deadline := time.Now().Add(time.Duration(timeoutMS) * time.Millisecond)
+	attempts := 0
+	var last ocrTextMatchResult
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+		}
+		attempts++
+		result, err := runDesktopTextMatch(ctx, input, opts)
+		if err != nil {
+			return "", err
+		}
+		last = result
+		if result.Found {
+			result.Meta = mergeMeta(result.Meta, map[string]any{
+				"attempts":   attempts,
+				"timeout_ms": timeoutMS,
+			})
+			payload, err := json.Marshal(result)
+			if err != nil {
+				return "", err
+			}
+			return string(payload), nil
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("text did not appear within %dms: %s", timeoutMS, strings.TrimSpace(last.Query))
+		}
+		timer := time.NewTimer(time.Duration(intervalMS) * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return "", ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func runDesktopImageMatch(ctx context.Context, input map[string]any, opts BuiltinOptions) (imageMatchResult, error) {
+	sourcePath, cleanup, err := resolveDesktopVisionSource(ctx, input, opts)
+	if err != nil {
+		return imageMatchResult{}, err
+	}
+	defer cleanup()
+
+	templatePath, err := resolveDesktopVisionTemplate(input, opts)
+	if err != nil {
+		return imageMatchResult{}, err
+	}
+
+	sourceImage, err := loadImageFile(sourcePath)
+	if err != nil {
+		return imageMatchResult{}, err
+	}
+	templateImage, err := loadImageFile(templatePath)
+	if err != nil {
+		return imageMatchResult{}, err
+	}
+
+	sourceBounds := normalizeBounds(sourceImage.Bounds())
+	templateBounds := normalizeBounds(templateImage.Bounds())
+	searchRect, err := resolveSearchRect(input, sourceBounds, templateBounds)
+	if err != nil {
+		return imageMatchResult{}, err
+	}
+	step := resolveSearchStep(input, searchRect, templateBounds)
+	match, err := locateTemplate(sourceImage, templateImage, searchRect, step)
+	if err != nil {
+		return imageMatchResult{}, err
+	}
+
+	threshold := numberInputFloat(input["threshold"], 0.92)
+	found := match.Score >= threshold
+	return imageMatchResult{
+		Found:        found,
+		Score:        round4(match.Score),
+		Threshold:    round4(threshold),
+		X:            match.X,
+		Y:            match.Y,
+		Width:        templateBounds.Dx(),
+		Height:       templateBounds.Dy(),
+		CenterX:      match.X + templateBounds.Dx()/2,
+		CenterY:      match.Y + templateBounds.Dy()/2,
+		SourcePath:   sourcePath,
+		TemplatePath: templatePath,
+		SearchArea: &imageSearchArea{
+			X:      searchRect.Min.X,
+			Y:      searchRect.Min.Y,
+			Width:  searchRect.Dx(),
+			Height: searchRect.Dy(),
+		},
+		Meta: map[string]any{
+			"step": step,
+		},
+	}, nil
+}
+
+func runDesktopOCR(ctx context.Context, input map[string]any, opts BuiltinOptions) (ocrResult, error) {
+	sourcePath, cleanup, err := resolveDesktopVisionSource(ctx, input, opts)
+	if err != nil {
+		return ocrResult{}, err
+	}
+	defer cleanup()
+
+	lang := strings.TrimSpace(stringValue(input["lang"]))
+	text, err := runTesseractOCR(ctx, sourcePath, lang, intNumberValue(input["psm"]), intNumberValue(input["oem"]))
+	if err != nil {
+		return ocrResult{}, err
+	}
+	result := ocrResult{
+		Text:       normalizeOCRText(text),
+		SourcePath: sourcePath,
+		Engine:     "tesseract",
+		Lang:       lang,
+	}
+	result.Lines = splitOCRLines(result.Text)
+	return result, nil
+}
+
+func runDesktopTextMatch(ctx context.Context, input map[string]any, opts BuiltinOptions) (ocrTextMatchResult, error) {
+	sourcePath, cleanup, err := resolveDesktopVisionSource(ctx, input, opts)
+	if err != nil {
+		return ocrTextMatchResult{}, err
+	}
+	defer cleanup()
+
+	query := strings.TrimSpace(stringValue(input["text"]))
+	mode := strings.TrimSpace(strings.ToLower(stringValue(input["mode"])))
+	if mode == "" {
+		mode = "contains"
+	}
+	if mode != "contains" && mode != "exact" && mode != "regex" {
+		return ocrTextMatchResult{}, fmt.Errorf("mode must be contains, exact, or regex")
+	}
+	ignoreCase := true
+	if value, ok := input["ignore_case"].(bool); ok {
+		ignoreCase = value
+	}
+	occurrence := intNumberValue(input["occurrence"])
+	if occurrence <= 0 {
+		occurrence = 1
+	}
+	minConfidence := numberInputFloat(input["min_confidence"], 30)
+	lang := strings.TrimSpace(stringValue(input["lang"]))
+
+	tsv, err := runTesseractOCRTSV(ctx, sourcePath, lang, intNumberValue(input["psm"]), intNumberValue(input["oem"]))
+	if err != nil {
+		return ocrTextMatchResult{}, err
+	}
+	words, err := parseTesseractTSV(tsv)
+	if err != nil {
+		return ocrTextMatchResult{}, err
+	}
+	lines := buildOCRLineBoxes(words, minConfidence)
+	result := findOCRTextMatch(lines, words, query, mode, ignoreCase, occurrence, minConfidence)
+	result.Query = query
+	result.Mode = mode
+	result.IgnoreCase = ignoreCase
+	result.SourcePath = sourcePath
+	result.Engine = "tesseract"
+	result.Lang = lang
+	result.Meta = mergeMeta(result.Meta, map[string]any{
+		"occurrence":     occurrence,
+		"min_confidence": round4(minConfidence),
+		"line_count":     len(lines),
+		"word_count":     len(words),
+	})
+	return result, nil
+}
+
+func resolveDesktopVisionSource(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, func(), error) {
+	if path, _ := input["path"].(string); strings.TrimSpace(path) != "" {
+		resolved := resolvePath(strings.TrimSpace(path), opts.WorkingDir)
+		if err := validateProtectedPath(resolved, opts.ProtectedPaths); err != nil {
+			return "", nil, err
+		}
+		return resolved, func() {}, nil
+	}
+	tempFile, err := os.CreateTemp("", "anyclaw-desktop-*.png")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temp screenshot file: %w", err)
+	}
+	tempPath := tempFile.Name()
+	_ = tempFile.Close()
+	if _, err := captureDesktopScreenshotToPath(ctx, tempPath); err != nil {
+		_ = os.Remove(tempPath)
+		return "", nil, err
+	}
+	return tempPath, func() { _ = os.Remove(tempPath) }, nil
+}
+
+func resolveDesktopVisionTemplate(input map[string]any, opts BuiltinOptions) (string, error) {
+	path, _ := input["template_path"].(string)
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("template_path is required")
+	}
+	resolved := resolvePath(strings.TrimSpace(path), opts.WorkingDir)
+	if err := validateProtectedPath(resolved, opts.ProtectedPaths); err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+func loadImageFile(path string) (image.Image, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open image %s: %w", path, err)
+	}
+	defer file.Close()
+	img, _, err := image.Decode(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode image %s: %w", path, err)
+	}
+	return img, nil
+}
+
+func resolveSearchRect(input map[string]any, source image.Rectangle, template image.Rectangle) (image.Rectangle, error) {
+	x, hasX := numberInput(input["search_x"])
+	y, hasY := numberInput(input["search_y"])
+	width, hasWidth := numberInput(input["search_width"])
+	height, hasHeight := numberInput(input["search_height"])
+
+	rect := source
+	if hasX || hasY || hasWidth || hasHeight {
+		if !hasWidth || !hasHeight {
+			return image.Rectangle{}, fmt.Errorf("search_width and search_height are required when using search bounds")
+		}
+		if !hasX {
+			x = 0
+		}
+		if !hasY {
+			y = 0
+		}
+		if width <= 0 || height <= 0 {
+			return image.Rectangle{}, fmt.Errorf("search_width and search_height must be positive")
+		}
+		rect = image.Rect(x, y, x+width, y+height).Intersect(source)
+	}
+	if rect.Dx() < template.Dx() || rect.Dy() < template.Dy() {
+		return image.Rectangle{}, fmt.Errorf("search area is smaller than template")
+	}
+	return rect, nil
+}
+
+func resolveSearchStep(input map[string]any, searchRect image.Rectangle, template image.Rectangle) int {
+	if step, ok := numberInput(input["step"]); ok && step > 0 {
+		return step
+	}
+	positions := (searchRect.Dx() - template.Dx() + 1) * (searchRect.Dy() - template.Dy() + 1)
+	switch {
+	case positions > 2_000_000:
+		return 4
+	case positions > 600_000:
+		return 2
+	default:
+		return 1
+	}
+}
+
+func locateTemplate(source image.Image, template image.Image, searchRect image.Rectangle, step int) (templateMatch, error) {
+	srcGray := toGrayImage(source)
+	tplGray := toGrayImage(template)
+	if tplGray.Width <= 0 || tplGray.Height <= 0 {
+		return templateMatch{}, fmt.Errorf("template image is empty")
+	}
+	maxX := searchRect.Max.X - tplGray.Width
+	maxY := searchRect.Max.Y - tplGray.Height
+	if maxX < searchRect.Min.X || maxY < searchRect.Min.Y {
+		return templateMatch{}, fmt.Errorf("template does not fit inside search area")
+	}
+
+	coarseSamples := samplePointsForSize(tplGray.Width, tplGray.Height, 6)
+	best := templateMatch{Score: -1}
+	for y := searchRect.Min.Y; y <= maxY; y += step {
+		for x := searchRect.Min.X; x <= maxX; x += step {
+			score := similarityScore(srcGray, tplGray, x, y, coarseSamples)
+			if score > best.Score {
+				best = templateMatch{X: x, Y: y, Score: score}
+			}
+		}
+	}
+	if best.Score < 0 {
+		return templateMatch{}, fmt.Errorf("no search positions available")
+	}
+
+	refineMinX := maxInt(searchRect.Min.X, best.X-step)
+	refineMaxX := minInt(maxX, best.X+step)
+	refineMinY := maxInt(searchRect.Min.Y, best.Y-step)
+	refineMaxY := minInt(maxY, best.Y+step)
+	fineSamples := samplePointsForSize(tplGray.Width, tplGray.Height, 14)
+	for y := refineMinY; y <= refineMaxY; y++ {
+		for x := refineMinX; x <= refineMaxX; x++ {
+			score := similarityScore(srcGray, tplGray, x, y, fineSamples)
+			if score > best.Score {
+				best = templateMatch{X: x, Y: y, Score: score}
+			}
+		}
+	}
+	return best, nil
+}
+
+func toGrayImage(img image.Image) grayImage {
+	bounds := normalizeBounds(img.Bounds())
+	width := bounds.Dx()
+	height := bounds.Dy()
+	pix := make([]uint8, width*height)
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			r, g, b, _ := img.At(bounds.Min.X+x, bounds.Min.Y+y).RGBA()
+			luma := ((299*r + 587*g + 114*b + 500) / 1000) >> 8
+			pix[y*width+x] = uint8(luma)
+		}
+	}
+	return grayImage{Width: width, Height: height, Pix: pix}
+}
+
+func samplePointsForSize(width int, height int, grid int) []image.Point {
+	if width <= 0 || height <= 0 {
+		return nil
+	}
+	if grid <= 1 {
+		return []image.Point{{0, 0}}
+	}
+	points := make([]image.Point, 0, grid*grid)
+	seen := map[image.Point]bool{}
+	for gy := 0; gy < grid; gy++ {
+		y := scalePoint(gy, grid, height)
+		for gx := 0; gx < grid; gx++ {
+			x := scalePoint(gx, grid, width)
+			point := image.Pt(x, y)
+			if !seen[point] {
+				seen[point] = true
+				points = append(points, point)
+			}
+		}
+	}
+	return points
+}
+
+func scalePoint(index int, grid int, size int) int {
+	if size <= 1 || grid <= 1 {
+		return 0
+	}
+	if index >= grid-1 {
+		return size - 1
+	}
+	value := int(math.Round(float64(index) * float64(size-1) / float64(grid-1)))
+	if value < 0 {
+		return 0
+	}
+	if value >= size {
+		return size - 1
+	}
+	return value
+}
+
+func similarityScore(source grayImage, template grayImage, offsetX int, offsetY int, samples []image.Point) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	var total float64
+	for _, point := range samples {
+		srcValue := source.Pix[(offsetY+point.Y)*source.Width+(offsetX+point.X)]
+		tplValue := template.Pix[point.Y*template.Width+point.X]
+		diff := math.Abs(float64(srcValue) - float64(tplValue))
+		total += diff / 255.0
+	}
+	score := 1 - total/float64(len(samples))
+	if score < 0 {
+		return 0
+	}
+	return score
+}
+
+func normalizeBounds(bounds image.Rectangle) image.Rectangle {
+	return image.Rect(0, 0, bounds.Dx(), bounds.Dy())
+}
+
+func marshalImageMatchResult(result imageMatchResult) (string, error) {
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func numberInputFloat(value any, fallback float64) float64 {
+	switch v := value.(type) {
+	case float64:
+		if v > 0 {
+			return v
+		}
+	case float32:
+		if v > 0 {
+			return float64(v)
+		}
+	case int:
+		if v > 0 {
+			return float64(v)
+		}
+	case int64:
+		if v > 0 {
+			return float64(v)
+		}
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return fallback
+		}
+		if parsed, err := strconv.ParseFloat(strings.TrimSpace(v), 64); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func intNumberValue(value any) int {
+	n, ok := numberInput(value)
+	if !ok {
+		return 0
+	}
+	return n
+}
+
+func round4(value float64) float64 {
+	return math.Round(value*10000) / 10000
+}
+
+func minInt(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt(a int, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func mergeMeta(dst map[string]any, src map[string]any) map[string]any {
+	if dst == nil && src == nil {
+		return nil
+	}
+	if dst == nil {
+		dst = map[string]any{}
+	}
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}
+
+func runTesseractOCR(ctx context.Context, path string, lang string, psm int, oem int) (string, error) {
+	return runTesseractOutput(ctx, path, lang, psm, oem, "")
+}
+
+func runTesseractOCRTSV(ctx context.Context, path string, lang string, psm int, oem int) (string, error) {
+	return runTesseractOutput(ctx, path, lang, psm, oem, "tsv")
+}
+
+func runTesseractOutput(ctx context.Context, path string, lang string, psm int, oem int, format string) (string, error) {
+	exe, err := exec.LookPath("tesseract")
+	if err != nil {
+		return "", fmt.Errorf("desktop_ocr requires Tesseract OCR in PATH")
+	}
+	args := []string{path, "stdout"}
+	if psm <= 0 {
+		psm = 6
+	}
+	args = append(args, "--psm", strconv.Itoa(psm))
+	if oem > 0 {
+		args = append(args, "--oem", strconv.Itoa(oem))
+	}
+	if strings.TrimSpace(lang) != "" {
+		args = append(args, "-l", strings.TrimSpace(lang))
+	}
+	if strings.TrimSpace(format) != "" {
+		args = append(args, strings.TrimSpace(format))
+	}
+	cmd := exec.CommandContext(ctx, exe, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("tesseract OCR failed: %w - %s", err, strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
+}
+
+func normalizeOCRText(text string) string {
+	text = strings.ReplaceAll(text, "\u000c", "")
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	lines := splitOCRLines(text)
+	return strings.Join(lines, "\n")
+}
+
+func normalizeOCRSearchText(text string) string {
+	text = strings.TrimSpace(strings.ToLower(normalizeOCRText(text)))
+	if text == "" {
+		return ""
+	}
+	return strings.Join(strings.Fields(text), " ")
+}
+
+func splitOCRLines(text string) []string {
+	rawLines := strings.Split(strings.TrimSpace(text), "\n")
+	lines := make([]string, 0, len(rawLines))
+	for _, line := range rawLines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+func verifyOCRText(actual string, expected string, mode string, ignoreCase bool) bool {
+	actual = normalizeOCRText(actual)
+	expected = normalizeOCRText(expected)
+	if ignoreCase {
+		actual = strings.ToLower(actual)
+		expected = strings.ToLower(expected)
+	}
+	switch mode {
+	case "exact":
+		return actual == expected
+	case "regex":
+		pattern := expected
+		if ignoreCase {
+			pattern = "(?i)" + pattern
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return false
+		}
+		return re.MatchString(actual)
+	default:
+		return strings.Contains(actual, expected)
+	}
+}
+
+func stringValue(value any) string {
+	if value == nil {
+		return ""
+	}
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	default:
+		return strings.TrimSpace(fmt.Sprint(value))
+	}
+}
+
+func parseTesseractTSV(tsv string) ([]ocrWordBox, error) {
+	lines := strings.Split(strings.ReplaceAll(tsv, "\r\n", "\n"), "\n")
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("empty tesseract TSV output")
+	}
+	header := strings.Split(lines[0], "\t")
+	indexes := map[string]int{}
+	for i, item := range header {
+		indexes[strings.TrimSpace(strings.ToLower(item))] = i
+	}
+	required := []string{"level", "block_num", "par_num", "line_num", "word_num", "left", "top", "width", "height", "conf", "text"}
+	for _, key := range required {
+		if _, ok := indexes[key]; !ok {
+			return nil, fmt.Errorf("invalid tesseract TSV header: missing %s", key)
+		}
+	}
+	words := make([]ocrWordBox, 0)
+	for _, line := range lines[1:] {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < len(header) {
+			continue
+		}
+		if fieldValue(fields, indexes, "level") != "5" {
+			continue
+		}
+		text := strings.TrimSpace(fieldValue(fields, indexes, "text"))
+		if text == "" {
+			continue
+		}
+		x, okX := numberInput(fieldValue(fields, indexes, "left"))
+		y, okY := numberInput(fieldValue(fields, indexes, "top"))
+		width, okW := numberInput(fieldValue(fields, indexes, "width"))
+		height, okH := numberInput(fieldValue(fields, indexes, "height"))
+		wordNum, _ := numberInput(fieldValue(fields, indexes, "word_num"))
+		if !okX || !okY || !okW || !okH || width <= 0 || height <= 0 {
+			continue
+		}
+		words = append(words, ocrWordBox{
+			Text:       text,
+			Normalized: normalizeOCRSearchText(text),
+			Confidence: numberInputFloat(fieldValue(fields, indexes, "conf"), 0),
+			X:          x,
+			Y:          y,
+			Width:      width,
+			Height:     height,
+			CenterX:    x + width/2,
+			CenterY:    y + height/2,
+			Key: strings.Join([]string{
+				fieldValue(fields, indexes, "block_num"),
+				fieldValue(fields, indexes, "par_num"),
+				fieldValue(fields, indexes, "line_num"),
+			}, ":"),
+			WordNum: wordNum,
+		})
+	}
+	return words, nil
+}
+
+func fieldValue(fields []string, indexes map[string]int, key string) string {
+	idx, ok := indexes[key]
+	if !ok || idx < 0 || idx >= len(fields) {
+		return ""
+	}
+	return fields[idx]
+}
+
+func buildOCRLineBoxes(words []ocrWordBox, minConfidence float64) []ocrLineBox {
+	grouped := map[string][]ocrWordBox{}
+	for _, word := range words {
+		if word.Confidence < minConfidence {
+			continue
+		}
+		grouped[word.Key] = append(grouped[word.Key], word)
+	}
+	keys := make([]string, 0, len(grouped))
+	for key := range grouped {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	lines := make([]ocrLineBox, 0, len(keys))
+	for _, key := range keys {
+		items := append([]ocrWordBox(nil), grouped[key]...)
+		sort.Slice(items, func(i, j int) bool {
+			if items[i].Y == items[j].Y {
+				return items[i].WordNum < items[j].WordNum
+			}
+			return items[i].Y < items[j].Y
+		})
+		texts := make([]string, 0, len(items))
+		minX, minY := 0, 0
+		maxX, maxY := 0, 0
+		var totalConfidence float64
+		for i, word := range items {
+			texts = append(texts, word.Text)
+			totalConfidence += word.Confidence
+			if i == 0 || word.X < minX {
+				minX = word.X
+			}
+			if i == 0 || word.Y < minY {
+				minY = word.Y
+			}
+			if i == 0 || word.X+word.Width > maxX {
+				maxX = word.X + word.Width
+			}
+			if i == 0 || word.Y+word.Height > maxY {
+				maxY = word.Y + word.Height
+			}
+		}
+		text := strings.Join(texts, " ")
+		lines = append(lines, ocrLineBox{
+			Text:       text,
+			Normalized: normalizeOCRSearchText(text),
+			Confidence: round4(totalConfidence / float64(len(items))),
+			X:          minX,
+			Y:          minY,
+			Width:      maxX - minX,
+			Height:     maxY - minY,
+			CenterX:    minX + (maxX-minX)/2,
+			CenterY:    minY + (maxY-minY)/2,
+			Words:      items,
+		})
+	}
+	return lines
+}
+
+func findOCRTextMatch(lines []ocrLineBox, words []ocrWordBox, query string, mode string, ignoreCase bool, occurrence int, minConfidence float64) ocrTextMatchResult {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return ocrTextMatchResult{}
+	}
+	matchCount := 0
+	for _, line := range lines {
+		if matchesOCRText(line.Text, query, mode, ignoreCase) {
+			matchCount++
+			if matchCount == occurrence {
+				return ocrTextMatchResult{
+					Found:      true,
+					Query:      query,
+					Mode:       mode,
+					IgnoreCase: ignoreCase,
+					Scope:      "line",
+					Text:       line.Text,
+					Confidence: line.Confidence,
+					X:          line.X,
+					Y:          line.Y,
+					Width:      line.Width,
+					Height:     line.Height,
+					CenterX:    line.CenterX,
+					CenterY:    line.CenterY,
+				}
+			}
+		}
+	}
+	for _, word := range words {
+		if word.Confidence < minConfidence {
+			continue
+		}
+		if matchesOCRText(word.Text, query, mode, ignoreCase) {
+			matchCount++
+			if matchCount == occurrence {
+				return ocrTextMatchResult{
+					Found:      true,
+					Query:      query,
+					Mode:       mode,
+					IgnoreCase: ignoreCase,
+					Scope:      "word",
+					Text:       word.Text,
+					Confidence: round4(word.Confidence),
+					X:          word.X,
+					Y:          word.Y,
+					Width:      word.Width,
+					Height:     word.Height,
+					CenterX:    word.CenterX,
+					CenterY:    word.CenterY,
+				}
+			}
+		}
+	}
+	return ocrTextMatchResult{
+		Found:      false,
+		Query:      query,
+		Mode:       mode,
+		IgnoreCase: ignoreCase,
+	}
+}
+
+func matchesOCRText(actual string, expected string, mode string, ignoreCase bool) bool {
+	return verifyOCRText(actual, expected, mode, ignoreCase)
+}
+
+func ImageAnalyzeTool(ctx context.Context, input map[string]any, opts BuiltinOptions) (string, error) {
+	path, _ := input["path"].(string)
+	url, _ := input["url"].(string)
+	prompt, _ := input["prompt"].(string)
+	if strings.TrimSpace(path) == "" && strings.TrimSpace(url) == "" {
+		return "", fmt.Errorf("image_analyze requires either path or url")
+	}
+
+	var imageData []byte
+	var mimeType string
+	var err error
+
+	if strings.TrimSpace(path) != "" {
+		imageData, err = os.ReadFile(strings.TrimSpace(path))
+		if err != nil {
+			return "", fmt.Errorf("read image: %w", err)
+		}
+		mimeType = mimeTypeFromPath(path)
+		if mimeType == "" {
+			mimeType = "image/jpeg"
+		}
+	} else {
+		resp, err := http.Get(strings.TrimSpace(url))
+		if err != nil {
+			return "", fmt.Errorf("fetch image: %w", err)
+		}
+		defer resp.Body.Close()
+		imageData, err = io.ReadAll(io.LimitReader(resp.Body, 20*1024*1024))
+		if err != nil {
+			return "", fmt.Errorf("read image: %w", err)
+		}
+		mimeType = resp.Header.Get("Content-Type")
+		if mimeType == "" {
+			mimeType = "image/jpeg"
+		}
+	}
+
+	if prompt == "" {
+		prompt = "Describe this image in detail. Include objects, text, people, actions, colors, and overall scene."
+	}
+
+	client := opts.LLMClient
+	if client == nil {
+		return "", fmt.Errorf("image_analyze requires an LLM client with vision capabilities (use gpt-4o, claude-3, etc.)")
+	}
+
+	msg := llm.NewUserMessage(
+		llm.TextBlock(prompt),
+		llm.ImageBlockFromBase64(imageData, mimeType),
+	)
+
+	resp, err := client.Chat(ctx, []llm.Message{msg}, nil)
+	if err != nil {
+		return "", fmt.Errorf("image analysis: %w", err)
+	}
+
+	result := map[string]any{
+		"description": resp.Content,
+		"source":      path,
+		"prompt":      prompt,
+		"usage": map[string]int{
+			"input_tokens":  resp.Usage.InputTokens,
+			"output_tokens": resp.Usage.OutputTokens,
+		},
+	}
+	payload, _ := json.Marshal(result)
+	return string(payload), nil
+}
+
+func mimeTypeFromPath(path string) string {
+	ext := strings.ToLower(path)
+	switch {
+	case strings.HasSuffix(ext, ".jpg"), strings.HasSuffix(ext, ".jpeg"):
+		return "image/jpeg"
+	case strings.HasSuffix(ext, ".png"):
+		return "image/png"
+	case strings.HasSuffix(ext, ".gif"):
+		return "image/gif"
+	case strings.HasSuffix(ext, ".webp"):
+		return "image/webp"
+	case strings.HasSuffix(ext, ".bmp"):
+		return "image/bmp"
+	default:
+		return "image/jpeg"
+	}
+}

--- a/pkg/capability/tools/vision_test.go
+++ b/pkg/capability/tools/vision_test.go
@@ -1,0 +1,146 @@
+package tools
+
+import (
+	"image"
+	"image/color"
+	"strings"
+	"testing"
+)
+
+func TestLocateTemplateFindsInsertedTemplate(t *testing.T) {
+	source := image.NewNRGBA(image.Rect(0, 0, 96, 72))
+	fillRect(source, source.Bounds(), color.NRGBA{R: 24, G: 28, B: 34, A: 255})
+
+	template := image.NewNRGBA(image.Rect(0, 0, 14, 10))
+	for y := 0; y < template.Bounds().Dy(); y++ {
+		for x := 0; x < template.Bounds().Dx(); x++ {
+			template.Set(x, y, color.NRGBA{
+				R: uint8(20 + x*11),
+				G: uint8(40 + y*13),
+				B: uint8(120 + (x+y)*3),
+				A: 255,
+			})
+		}
+	}
+
+	targetX, targetY := 31, 22
+	drawInto(source, template, targetX, targetY)
+
+	match, err := locateTemplate(source, template, image.Rect(0, 0, 96, 72), 2)
+	if err != nil {
+		t.Fatalf("locateTemplate: %v", err)
+	}
+	if match.X != targetX || match.Y != targetY {
+		t.Fatalf("expected match at %d,%d got %d,%d", targetX, targetY, match.X, match.Y)
+	}
+	if match.Score < 0.99 {
+		t.Fatalf("expected strong score, got %.4f", match.Score)
+	}
+}
+
+func TestResolveSearchRectRejectsSmallArea(t *testing.T) {
+	_, err := resolveSearchRect(map[string]any{
+		"search_x":      0,
+		"search_y":      0,
+		"search_width":  8,
+		"search_height": 8,
+	}, image.Rect(0, 0, 100, 100), image.Rect(0, 0, 12, 12))
+	if err == nil {
+		t.Fatal("expected search area size validation error")
+	}
+}
+
+func TestVerifyOCRTextModes(t *testing.T) {
+	actual := "Task Completed\nExport finished"
+
+	if !verifyOCRText(actual, "completed", "contains", true) {
+		t.Fatal("expected contains match to succeed")
+	}
+	if !verifyOCRText(actual, "Task Completed\nExport finished", "exact", false) {
+		t.Fatal("expected exact match to succeed")
+	}
+	if !verifyOCRText(actual, "export\\s+finished", "regex", true) {
+		t.Fatal("expected regex match to succeed")
+	}
+	if verifyOCRText(actual, "failed", "contains", true) {
+		t.Fatal("expected missing text check to fail")
+	}
+}
+
+func TestNormalizeOCRTextRemovesNoise(t *testing.T) {
+	actual := " Hello \r\n\r\nWorld \u000c"
+	if normalized := normalizeOCRText(actual); normalized != "Hello\nWorld" {
+		t.Fatalf("unexpected normalized OCR text: %q", normalized)
+	}
+}
+
+func TestParseTesseractTSVAndFindTextMatch(t *testing.T) {
+	tsv := strings.Join([]string{
+		"level\tpage_num\tblock_num\tpar_num\tline_num\tword_num\tleft\ttop\twidth\theight\tconf\ttext",
+		"5\t1\t1\t1\t1\t1\t100\t200\t50\t20\t96\tExport",
+		"5\t1\t1\t1\t1\t2\t156\t200\t62\t20\t93\tPNG",
+		"5\t1\t1\t1\t2\t1\t100\t240\t80\t20\t88\tCancel",
+	}, "\n")
+
+	words, err := parseTesseractTSV(tsv)
+	if err != nil {
+		t.Fatalf("parseTesseractTSV: %v", err)
+	}
+	if len(words) != 3 {
+		t.Fatalf("expected 3 OCR words, got %d", len(words))
+	}
+
+	lines := buildOCRLineBoxes(words, 30)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 OCR lines, got %d", len(lines))
+	}
+
+	match := findOCRTextMatch(lines, words, "Export PNG", "contains", true, 1, 30)
+	if !match.Found {
+		t.Fatal("expected Export PNG line match")
+	}
+	if match.Scope != "line" {
+		t.Fatalf("expected line scope, got %q", match.Scope)
+	}
+	if match.X != 100 || match.Y != 200 {
+		t.Fatalf("unexpected line bounds: %#v", match)
+	}
+	if match.CenterX <= 0 || match.CenterY <= 0 {
+		t.Fatalf("expected valid click center: %#v", match)
+	}
+}
+
+func TestFindOCRTextMatchFallsBackToWord(t *testing.T) {
+	words := []ocrWordBox{
+		{Text: "Open", Confidence: 92, X: 10, Y: 10, Width: 40, Height: 18, CenterX: 30, CenterY: 19, Key: "1:1:1", WordNum: 1},
+		{Text: "File", Confidence: 95, X: 60, Y: 10, Width: 30, Height: 18, CenterX: 75, CenterY: 19, Key: "1:1:1", WordNum: 2},
+	}
+	lines := buildOCRLineBoxes(words, 30)
+
+	match := findOCRTextMatch(lines, words, "^File$", "regex", true, 1, 30)
+	if !match.Found {
+		t.Fatal("expected regex word match")
+	}
+	if match.Scope != "word" {
+		t.Fatalf("expected word scope, got %q", match.Scope)
+	}
+	if match.X != 60 || match.Y != 10 {
+		t.Fatalf("unexpected word bounds: %#v", match)
+	}
+}
+
+func fillRect(img *image.NRGBA, rect image.Rectangle, c color.NRGBA) {
+	for y := rect.Min.Y; y < rect.Max.Y; y++ {
+		for x := rect.Min.X; x < rect.Max.X; x++ {
+			img.Set(x, y, c)
+		}
+	}
+}
+
+func drawInto(dst *image.NRGBA, src *image.NRGBA, offsetX int, offsetY int) {
+	for y := 0; y < src.Bounds().Dy(); y++ {
+		for x := 0; x < src.Bounds().Dx(); x++ {
+			dst.Set(offsetX+x, offsetY+y, src.At(x, y))
+		}
+	}
+}

--- a/pkg/capability/tools/web/web.go
+++ b/pkg/capability/tools/web/web.go
@@ -1,0 +1,85 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+type SearchResult struct {
+	Title       string
+	URL         string
+	Description string
+}
+
+func Search(ctx context.Context, query string, maxResults int) ([]SearchResult, error) {
+	if maxResults <= 0 {
+		maxResults = 5
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://ddg-api.vercel.app/search?q="+query, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []struct {
+		Title       string `json:"title"`
+		URL         string `json:"url"`
+		Description string `json:"body"`
+	}
+
+	if err := json.Unmarshal(body, &results); err != nil {
+		return nil, err
+	}
+
+	output := make([]SearchResult, 0, len(results))
+	for i, r := range results {
+		if i >= maxResults {
+			break
+		}
+		output = append(output, SearchResult{
+			Title:       r.Title,
+			URL:         r.URL,
+			Description: r.Description,
+		})
+	}
+
+	return output, nil
+}
+
+func Fetch(ctx context.Context, urlStr string) (string, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", urlStr, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}


### PR DESCRIPTION
## 🚀 功能说明
新增 capability 层 tools 模块，实现工具注册、调用及相关能力封装。

## 📦 主要改动
- 新增工具注册机制（registry）
- 新增内置工具（builtins）
- 新增浏览器、桌面、UI 自动化等工具支持
- 新增 policy / sandbox 等安全控制逻辑
- 新增 memory / vision / web 等工具能力
- 补充 tools 模块单元测试

## 🎯 目的
为系统提供统一的工具调用层，使 Agent 能够调用不同类型的工具完成任务。

## 🧪 测试方式
go test ./pkg/capability/tools/...

## ⚠️ 说明
- 依赖 agents / skills 模块
- 不涉及破坏性变更