### PR TITLE
feat(input): add discord and slack adapters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17k
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/pkg/input/channels/channels_flow_test.go
+++ b/pkg/input/channels/channels_flow_test.go
@@ -570,9 +570,13 @@ func TestDiscordAdapterStreamingFallback(t *testing.T) {
 	}, nil)
 	adapter.client = server.Client()
 
-	err := adapter.sendStreamingMessage(context.Background(), "chan-1", "", func(onChunk func(chunk string)) error {
-		onChunk("hello")
-		onChunk(" discord")
+	err := adapter.sendStreamingMessage(context.Background(), "chan-1", "", func(onChunk func(chunk string) error) error {
+		if err := onChunk("hello"); err != nil {
+			return err
+		}
+		if err := onChunk(" discord"); err != nil {
+			return err
+		}
 		return nil
 	})
 	if err != nil {
@@ -599,6 +603,15 @@ func TestSlackHelpersAndMetadata(t *testing.T) {
 	}
 	if got := boolString(false); got != "false" {
 		t.Fatalf("expected false string, got %q", got)
+	}
+	if !slackTSLessOrEqual("1710000000.000100", "1710000000.000100") {
+		t.Fatal("expected equal slack timestamps to compare as less-or-equal")
+	}
+	if !slackTSLessOrEqual("1710000000.000099", "1710000000.000100") {
+		t.Fatal("expected older slack timestamp to compare as less-or-equal")
+	}
+	if slackTSLessOrEqual("1710000000.000101", "1710000000.000100") {
+		t.Fatal("expected newer slack timestamp to compare as greater")
 	}
 }
 
@@ -659,6 +672,7 @@ func TestSlackAdapterPollOnceAndStream(t *testing.T) {
 		Enabled:        true,
 		BotToken:       "token",
 		DefaultChannel: "C123",
+		StreamInterval: 1,
 	}, func(eventType string, sessionID string, payload map[string]any) {})
 
 	var historyCalls int
@@ -763,6 +777,66 @@ func TestSlackAdapterPollOnceAndStream(t *testing.T) {
 	}
 }
 
+func TestSlackAdapterPollOnceSkipsOlderMessages(t *testing.T) {
+	var calls []string
+
+	adapter := NewSlackAdapter(config.SlackChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "C123",
+	}, nil)
+
+	historyCalls := 0
+	adapter.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case "/api/conversations.history":
+				historyCalls++
+				if historyCalls == 1 {
+					return jsonResponse(http.StatusOK, map[string]any{
+						"ok": true,
+						"messages": []map[string]any{
+							{"text": "second", "ts": "1710000000.000200", "user": "U2"},
+							{"text": "first", "ts": "1710000000.000100", "user": "U1"},
+						},
+					}), nil
+				}
+				return jsonResponse(http.StatusOK, map[string]any{
+					"ok": true,
+					"messages": []map[string]any{
+						{"text": "third", "ts": "1710000000.000300", "user": "U3"},
+						{"text": "second", "ts": "1710000000.000200", "user": "U2"},
+						{"text": "first", "ts": "1710000000.000100", "user": "U1"},
+					},
+				}), nil
+			case "/api/chat.postMessage":
+				return jsonResponse(http.StatusOK, map[string]any{"ok": true, "ts": "reply-ts"}), nil
+			default:
+				return nil, fmt.Errorf("unexpected request path: %s", req.URL.Path)
+			}
+		}),
+	}
+
+	handle := func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		calls = append(calls, message)
+		return "session", "ok", nil
+	}
+
+	if err := adapter.pollOnce(context.Background(), handle); err != nil {
+		t.Fatalf("first pollOnce returned error: %v", err)
+	}
+	if err := adapter.pollOnce(context.Background(), handle); err != nil {
+		t.Fatalf("second pollOnce returned error: %v", err)
+	}
+
+	if len(calls) != 3 {
+		t.Fatalf("expected only new slack message to be processed on second poll, got %v", calls)
+	}
+	if calls[2] != "third" {
+		t.Fatalf("expected final processed message to be third, got %v", calls)
+	}
+}
+
 func TestSlackAdapterErrorBranchesAndFallback(t *testing.T) {
 	adapter := NewSlackAdapter(config.SlackChannelConfig{
 		Enabled:        true,
@@ -796,8 +870,10 @@ func TestSlackAdapterErrorBranchesAndFallback(t *testing.T) {
 		t.Fatalf("expected slack history error, got %v", err)
 	}
 
-	if err := adapter.sendStreamingMessage(context.Background(), "thread-1", func(onChunk func(chunk string)) error {
-		onChunk("fallback")
+	if err := adapter.sendStreamingMessage(context.Background(), "thread-1", func(onChunk func(chunk string) error) error {
+		if err := onChunk("fallback"); err != nil {
+			return err
+		}
 		return nil
 	}); err != nil {
 		t.Fatalf("expected slack streaming fallback to succeed, got %v", err)
@@ -805,6 +881,37 @@ func TestSlackAdapterErrorBranchesAndFallback(t *testing.T) {
 
 	if err := adapter.editMessage(context.Background(), "ts-1", "hello"); err == nil || !strings.Contains(err.Error(), "edit_failed") {
 		t.Fatalf("expected slack update failure, got %v", err)
+	}
+}
+
+func TestSlackAdapterSendStreamingMessageReturnsEditError(t *testing.T) {
+	adapter := NewSlackAdapter(config.SlackChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "C123",
+		StreamInterval: 1,
+	}, nil)
+
+	postCalls := 0
+	adapter.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case "/api/chat.postMessage":
+				postCalls++
+				return jsonResponse(http.StatusOK, map[string]any{"ok": true, "ts": fmt.Sprintf("ts-%d", postCalls)}), nil
+			case "/api/chat.update":
+				return jsonResponse(http.StatusOK, map[string]any{"ok": false, "error": "edit_failed"}), nil
+			default:
+				return nil, fmt.Errorf("unexpected request path: %s", req.URL.Path)
+			}
+		}),
+	}
+
+	err := adapter.sendStreamingMessage(context.Background(), "thread-1", func(onChunk func(chunk string) error) error {
+		return onChunk("hello")
+	})
+	if err == nil || !strings.Contains(err.Error(), "edit_failed") {
+		t.Fatalf("expected slack streaming edit failure, got %v", err)
 	}
 }
 

--- a/pkg/input/channels/channels_flow_test.go
+++ b/pkg/input/channels/channels_flow_test.go
@@ -1,0 +1,955 @@
+package channels
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	"github.com/gorilla/websocket"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func jsonResponse(status int, payload any) *http.Response {
+	body, _ := json.Marshal(payload)
+	return &http.Response{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+}
+
+func readJSONBody(t *testing.T, req *http.Request) map[string]any {
+	t.Helper()
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	if len(data) == 0 {
+		return map[string]any{}
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	return payload
+}
+
+func TestReadBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/body", strings.NewReader("payload"))
+	body, err := ReadBody(req)
+	if err != nil {
+		t.Fatalf("ReadBody returned error: %v", err)
+	}
+	if string(body) != "payload" {
+		t.Fatalf("expected payload body, got %q", string(body))
+	}
+}
+
+func TestDiscordAdapterHelpers(t *testing.T) {
+	adapter := NewDiscordAdapter(config.DiscordChannelConfig{
+		Enabled:   true,
+		BotToken:  "token",
+		GuildID:   "guild",
+		PublicKey: "not-hex",
+	}, nil)
+
+	if adapter.Name() != "discord" {
+		t.Fatalf("expected adapter name discord, got %q", adapter.Name())
+	}
+	if adapter.Enabled() {
+		t.Fatal("expected adapter without default channel to be disabled")
+	}
+	if adapter.apiBaseURL != "https://discord.com/api/v10" {
+		t.Fatalf("expected default api base url, got %q", adapter.apiBaseURL)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/interactions", nil)
+	if adapter.VerifyInteraction(req, []byte(`{}`)) {
+		t.Fatal("expected invalid public key config to fail verification")
+	}
+
+	audioURL, audioMIME := adapter.findAudioAttachment([]struct {
+		ID          string "json:\"id\""
+		URL         string "json:\"url\""
+		ProxyURL    string "json:\"proxy_url\""
+		Filename    string "json:\"filename\""
+		ContentType string "json:\"content_type\""
+		Size        int    "json:\"size\""
+	}{
+		{Filename: "voice.ogg", ProxyURL: "https://audio.example/voice"},
+	})
+	if audioURL != "https://audio.example/voice" || audioMIME != "audio/ogg" {
+		t.Fatalf("unexpected filename-based audio detection: %q %q", audioURL, audioMIME)
+	}
+
+	adapter.processed["stale"] = time.Now().UTC().Add(-31 * time.Minute)
+	if adapter.seen("fresh") {
+		t.Fatal("expected first message id to be unseen")
+	}
+	if _, ok := adapter.processed["stale"]; ok {
+		t.Fatal("expected stale processed entry to be cleaned up")
+	}
+	if !adapter.seen("fresh") {
+		t.Fatal("expected repeated message id to be marked as seen")
+	}
+}
+
+func TestDiscordAdapterHandleInteractionPingAndError(t *testing.T) {
+	adapter := NewDiscordAdapter(config.DiscordChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "123",
+	}, nil)
+
+	resp, err := adapter.HandleInteraction(context.Background(), []byte(`{"type":1}`), func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		t.Fatal("ping interaction should not invoke handler")
+		return "", "", nil
+	})
+	if err != nil {
+		t.Fatalf("ping interaction returned error: %v", err)
+	}
+	if resp["type"] != 1 {
+		t.Fatalf("expected ping response type 1, got %#v", resp["type"])
+	}
+
+	if _, err := adapter.HandleInteraction(context.Background(), []byte(`{bad json}`), nil); err == nil {
+		t.Fatal("expected invalid interaction payload to fail")
+	}
+}
+
+func TestDiscordAdapterSendMethods(t *testing.T) {
+	var (
+		postBodies  []map[string]any
+		patchBodies []map[string]any
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			postBodies = append(postBodies, readJSONBody(t, r))
+			_, _ = w.Write([]byte(`{"id":"sent-1"}`))
+		case http.MethodPatch:
+			patchBodies = append(patchBodies, readJSONBody(t, r))
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	adapter := NewDiscordAdapter(config.DiscordChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "default-chan",
+		APIBaseURL:     server.URL,
+	}, nil)
+	adapter.client = server.Client()
+
+	if err := adapter.sendMessage(context.Background(), "", "reply-1", "hello"); err != nil {
+		t.Fatalf("sendMessage returned error: %v", err)
+	}
+	messageID, err := adapter.sendMessageWithResult(context.Background(), "chan-2", "", "hello 2")
+	if err != nil {
+		t.Fatalf("sendMessageWithResult returned error: %v", err)
+	}
+	if messageID != "sent-1" {
+		t.Fatalf("expected sent message id, got %q", messageID)
+	}
+
+	longText := strings.Repeat("x", 2105)
+	if err := adapter.editMessage(context.Background(), "", "msg-1", longText); err != nil {
+		t.Fatalf("editMessage returned error: %v", err)
+	}
+
+	if len(postBodies) != 2 {
+		t.Fatalf("expected 2 post requests, got %d", len(postBodies))
+	}
+	if postBodies[0]["content"] != "hello" {
+		t.Fatalf("unexpected first post body: %+v", postBodies[0])
+	}
+	if _, ok := postBodies[0]["message_reference"]; !ok {
+		t.Fatalf("expected reply message reference in first post body: %+v", postBodies[0])
+	}
+	if postBodies[1]["content"] != "hello 2" {
+		t.Fatalf("unexpected second post body: %+v", postBodies[1])
+	}
+
+	if len(patchBodies) != 1 {
+		t.Fatalf("expected 1 patch request, got %d", len(patchBodies))
+	}
+	patched := patchBodies[0]["content"].(string)
+	if len([]rune(patched)) != 2000 || !strings.HasSuffix(patched, "...") {
+		t.Fatalf("expected truncated patch body, got len=%d content suffix=%q", len([]rune(patched)), patched[len(patched)-3:])
+	}
+}
+
+func TestDiscordAdapterPollOnceProcessesMessages(t *testing.T) {
+	var (
+		sentBodies []map[string]any
+		events     []string
+		calls      []map[string]string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/messages"):
+			_, _ = w.Write([]byte(`[
+				{
+					"id":"2",
+					"channel_id":"chan-1",
+					"content":"hello discord",
+					"guild_id":"guild-1",
+					"author":{"id":"user-1","username":"alice","bot":false},
+					"message_reference":{"message_id":"reply-1"}
+				},
+				{
+					"id":"1",
+					"channel_id":"chan-1",
+					"content":"voice caption",
+					"guild_id":"guild-1",
+					"author":{"id":"user-2","username":"bob","bot":false},
+					"attachments":[{"filename":"voice.ogg","proxy_url":"https://audio.example/1"}]
+				}
+			]`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/messages"):
+			sentBodies = append(sentBodies, readJSONBody(t, r))
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	adapter := NewDiscordAdapter(config.DiscordChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "default-chan",
+		APIBaseURL:     server.URL,
+	}, func(eventType string, sessionID string, payload map[string]any) {
+		events = append(events, eventType)
+	})
+	adapter.client = server.Client()
+
+	err := adapter.pollOnce(context.Background(), func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		calls = append(calls, map[string]string{
+			"message":      message,
+			"message_type": meta["message_type"],
+			"audio_url":    meta["audio_url"],
+			"channel_type": meta["channel_type"],
+			"is_group":     meta["is_group"],
+		})
+		if meta["message_type"] == "voice_note" {
+			return "session-voice", "voice response", nil
+		}
+		return "session-text", "text response", nil
+	})
+	if err != nil {
+		t.Fatalf("pollOnce returned error: %v", err)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 handler calls, got %d", len(calls))
+	}
+	if calls[0]["message_type"] != "voice_note" || calls[0]["audio_url"] != "https://audio.example/1" {
+		t.Fatalf("unexpected voice call: %+v", calls[0])
+	}
+	if calls[1]["message"] != "hello discord" {
+		t.Fatalf("unexpected text call: %+v", calls[1])
+	}
+	if calls[1]["channel_type"] != "guild" || calls[1]["is_group"] != "true" {
+		t.Fatalf("unexpected channel metadata: %+v", calls[1])
+	}
+	if len(sentBodies) != 2 {
+		t.Fatalf("expected 2 outbound sends, got %d", len(sentBodies))
+	}
+	if sentBodies[0]["content"] != "voice response" || sentBodies[1]["content"] != "text response" {
+		t.Fatalf("unexpected outbound messages: %+v", sentBodies)
+	}
+	if adapter.Status().LastActivity.IsZero() {
+		t.Fatal("expected pollOnce to mark adapter activity")
+	}
+	if len(events) < 2 {
+		t.Fatalf("expected append event callbacks, got %v", events)
+	}
+}
+
+func TestDiscordAdapterPollOnceStream(t *testing.T) {
+	var (
+		postBodies  []map[string]any
+		patchBodies []map[string]any
+		events      []string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/messages"):
+			_, _ = w.Write([]byte(`[
+				{
+					"id":"1",
+					"channel_id":"chan-1",
+					"content":"stream hello",
+					"guild_id":"guild-1",
+					"author":{"id":"user-1","username":"alice","bot":false}
+				}
+			]`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/messages"):
+			postBodies = append(postBodies, readJSONBody(t, r))
+			_, _ = w.Write([]byte(`{"id":"out-1"}`))
+		case r.Method == http.MethodPatch:
+			patchBodies = append(patchBodies, readJSONBody(t, r))
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	adapter := NewDiscordAdapter(config.DiscordChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "default-chan",
+		APIBaseURL:     server.URL,
+	}, func(eventType string, sessionID string, payload map[string]any) {
+		events = append(events, eventType)
+	})
+	adapter.client = server.Client()
+
+	err := adapter.pollOnceStream(context.Background(), func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+		if message != "stream hello" {
+			t.Fatalf("unexpected stream message: %q", message)
+		}
+		if err := onChunk("part-1"); err != nil {
+			return "", err
+		}
+		if err := onChunk("part-2"); err != nil {
+			return "", err
+		}
+		return "session-stream", nil
+	})
+	if err != nil {
+		t.Fatalf("pollOnceStream returned error: %v", err)
+	}
+
+	if len(postBodies) != 1 || postBodies[0]["content"] != "\u200b" {
+		t.Fatalf("expected placeholder message to be posted first, got %+v", postBodies)
+	}
+	if len(patchBodies) == 0 || patchBodies[len(patchBodies)-1]["content"] != "part-1part-2" {
+		t.Fatalf("expected final patch content, got %+v", patchBodies)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected streaming poll to append events")
+	}
+}
+
+func TestDiscordAdapterRunGatewayWS(t *testing.T) {
+	var upgrader websocket.Upgrader
+	var receivedMessages []map[string]string
+
+	var cancel context.CancelFunc
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/messages") {
+			t.Fatalf("unexpected discord api request: %s %s", r.Method, r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{}`))
+		if cancel != nil {
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				cancel()
+			}()
+		}
+	}))
+	defer apiServer.Close()
+
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade websocket: %v", err)
+		}
+		defer conn.Close()
+
+		if err := conn.WriteJSON(map[string]any{
+			"op": 10,
+			"d":  map[string]any{"heartbeat_interval": 10},
+		}); err != nil {
+			t.Fatalf("write hello packet: %v", err)
+		}
+
+		for i := 0; i < 2; i++ {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				t.Fatalf("read client packet: %v", err)
+			}
+		}
+
+		messagePayload := map[string]any{
+			"id":         "1",
+			"content":    "gateway hello",
+			"channel_id": "chan-1",
+			"guild_id":   "guild-1",
+			"author": map[string]any{
+				"id":       "user-1",
+				"username": "alice",
+				"bot":      false,
+			},
+		}
+		raw, _ := json.Marshal(messagePayload)
+		if err := conn.WriteJSON(map[string]any{
+			"op": 0,
+			"t":  "MESSAGE_CREATE",
+			"d":  json.RawMessage(raw),
+		}); err != nil {
+			t.Fatalf("write gateway event: %v", err)
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}))
+	defer wsServer.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+	adapter := NewDiscordAdapter(config.DiscordChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "default-chan",
+		APIBaseURL:     apiServer.URL,
+	}, nil)
+	adapter.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() == "https://discord.com/api/gateway/bot" {
+				return jsonResponse(http.StatusOK, map[string]any{"url": wsURL}), nil
+			}
+			return apiServer.Client().Transport.RoundTrip(req)
+		}),
+	}
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	cancel = cancelFn
+	err := adapter.runGatewayWS(ctx, func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		receivedMessages = append(receivedMessages, map[string]string{
+			"message": message,
+			"user":    meta["username"],
+		})
+		return "session-1", "ok", nil
+	})
+	if err != nil && len(receivedMessages) == 0 {
+		t.Fatalf("runGatewayWS returned error: %v", err)
+	}
+	if len(receivedMessages) != 1 || receivedMessages[0]["message"] != "gateway hello" || receivedMessages[0]["user"] != "alice" {
+		t.Fatalf("unexpected gateway handler calls: %+v", receivedMessages)
+	}
+}
+
+func TestDiscordAdapterRunGatewayWSStream(t *testing.T) {
+	var upgrader websocket.Upgrader
+	var cancel context.CancelFunc
+	var patchBodies []map[string]any
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			_, _ = w.Write([]byte(`{"id":"stream-msg"}`))
+		case http.MethodPatch:
+			patchBodies = append(patchBodies, readJSONBody(t, r))
+			_, _ = w.Write([]byte(`{}`))
+			if cancel != nil {
+				go func() {
+					time.Sleep(20 * time.Millisecond)
+					cancel()
+				}()
+			}
+		default:
+			t.Fatalf("unexpected discord api request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer apiServer.Close()
+
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade websocket: %v", err)
+		}
+		defer conn.Close()
+
+		if err := conn.WriteJSON(map[string]any{"op": 10, "d": map[string]any{"heartbeat_interval": 10}}); err != nil {
+			t.Fatalf("write hello packet: %v", err)
+		}
+		for i := 0; i < 2; i++ {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				t.Fatalf("read client packet: %v", err)
+			}
+		}
+
+		messagePayload := map[string]any{
+			"id":         "1",
+			"content":    "gateway stream",
+			"channel_id": "chan-1",
+			"guild_id":   "guild-1",
+			"author": map[string]any{
+				"id":       "user-1",
+				"username": "alice",
+				"bot":      false,
+			},
+		}
+		raw, _ := json.Marshal(messagePayload)
+		if err := conn.WriteJSON(map[string]any{"op": 0, "t": "MESSAGE_CREATE", "d": json.RawMessage(raw)}); err != nil {
+			t.Fatalf("write gateway event: %v", err)
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}))
+	defer wsServer.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+	adapter := NewDiscordAdapter(config.DiscordChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "default-chan",
+		APIBaseURL:     apiServer.URL,
+	}, nil)
+	adapter.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() == "https://discord.com/api/gateway/bot" {
+				return jsonResponse(http.StatusOK, map[string]any{"url": wsURL}), nil
+			}
+			return apiServer.Client().Transport.RoundTrip(req)
+		}),
+	}
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	cancel = cancelFn
+	err := adapter.runGatewayWSStream(ctx, func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+		if message != "gateway stream" {
+			t.Fatalf("unexpected gateway stream message: %q", message)
+		}
+		_ = onChunk("chunk-1")
+		_ = onChunk("chunk-2")
+		return "session-stream", nil
+	})
+	if err != nil && len(patchBodies) == 0 {
+		t.Fatalf("runGatewayWSStream returned error: %v", err)
+	}
+	if len(patchBodies) == 0 || patchBodies[len(patchBodies)-1]["content"] != "chunk-1chunk-2" {
+		t.Fatalf("unexpected gateway stream patches: %+v", patchBodies)
+	}
+}
+
+func TestDiscordAdapterStreamingFallback(t *testing.T) {
+	var postBodies []map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/messages") {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		postBodies = append(postBodies, readJSONBody(t, r))
+		if len(postBodies) == 1 {
+			_, _ = w.Write([]byte(`{"id":""}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	adapter := NewDiscordAdapter(config.DiscordChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "default-chan",
+		APIBaseURL:     server.URL,
+	}, nil)
+	adapter.client = server.Client()
+
+	err := adapter.sendStreamingMessage(context.Background(), "chan-1", "", func(onChunk func(chunk string)) error {
+		onChunk("hello")
+		onChunk(" discord")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sendStreamingMessage returned error: %v", err)
+	}
+
+	if len(postBodies) != 2 {
+		t.Fatalf("expected placeholder and fallback send, got %d", len(postBodies))
+	}
+	if postBodies[1]["content"] != "hello discord" {
+		t.Fatalf("unexpected fallback final message: %+v", postBodies[1])
+	}
+}
+
+func TestSlackHelpersAndMetadata(t *testing.T) {
+	if got, isGroup := slackConversationMetadata("D123"); got != "dm" || isGroup {
+		t.Fatalf("expected dm metadata, got %q %v", got, isGroup)
+	}
+	if got, isGroup := slackConversationMetadata("C123"); got != "group" || !isGroup {
+		t.Fatalf("expected group metadata, got %q %v", got, isGroup)
+	}
+	if got := boolString(true); got != "true" {
+		t.Fatalf("expected true string, got %q", got)
+	}
+	if got := boolString(false); got != "false" {
+		t.Fatalf("expected false string, got %q", got)
+	}
+}
+
+func TestSlackAdapterSendMethods(t *testing.T) {
+	var bodies []map[string]any
+	adapter := NewSlackAdapter(config.SlackChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "C123",
+	}, nil)
+	adapter.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			bodies = append(bodies, readJSONBody(t, req))
+			switch req.URL.Path {
+			case "/api/chat.postMessage":
+				return jsonResponse(http.StatusOK, map[string]any{"ok": true, "ts": "ts-1"}), nil
+			case "/api/chat.update":
+				return jsonResponse(http.StatusOK, map[string]any{"ok": true}), nil
+			default:
+				return nil, fmt.Errorf("unexpected request path: %s", req.URL.Path)
+			}
+		}),
+	}
+
+	if err := adapter.sendMessage(context.Background(), "hello", "thread-1"); err != nil {
+		t.Fatalf("sendMessage returned error: %v", err)
+	}
+	ts, err := adapter.sendMessageWithResult(context.Background(), "hello again", "")
+	if err != nil {
+		t.Fatalf("sendMessageWithResult returned error: %v", err)
+	}
+	if ts != "ts-1" {
+		t.Fatalf("expected sent ts, got %q", ts)
+	}
+	if err := adapter.editMessage(context.Background(), "ts-1", "edited"); err != nil {
+		t.Fatalf("editMessage returned error: %v", err)
+	}
+
+	if len(bodies) != 3 {
+		t.Fatalf("expected 3 outbound requests, got %d", len(bodies))
+	}
+	if bodies[0]["thread_ts"] != "thread-1" {
+		t.Fatalf("expected thread ts in sendMessage body, got %+v", bodies[0])
+	}
+	if bodies[2]["text"] != "edited" {
+		t.Fatalf("expected edit payload, got %+v", bodies[2])
+	}
+}
+
+func TestSlackAdapterPollOnceAndStream(t *testing.T) {
+	var (
+		mu         sync.Mutex
+		postBodies []map[string]any
+		calls      []map[string]string
+	)
+
+	adapter := NewSlackAdapter(config.SlackChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "C123",
+	}, func(eventType string, sessionID string, payload map[string]any) {})
+
+	var historyCalls int
+	adapter.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case "/api/conversations.history":
+				historyCalls++
+				if historyCalls == 1 {
+					return jsonResponse(http.StatusOK, map[string]any{
+						"ok": true,
+						"messages": []map[string]any{
+							{"text": "text message", "ts": "2", "thread_ts": "thread-2", "user": "U2"},
+							{
+								"text": "voice caption",
+								"ts":   "1",
+								"user": "U1",
+								"files": []map[string]any{
+									{"mimetype": "audio/mpeg", "url_private": "https://audio.example/slack.mp3", "title": "voice"},
+								},
+							},
+						},
+					}), nil
+				}
+				return jsonResponse(http.StatusOK, map[string]any{
+					"ok": true,
+					"messages": []map[string]any{
+						{"text": "stream text", "ts": "3", "thread_ts": "thread-3", "user": "U3"},
+					},
+				}), nil
+			case "/api/chat.postMessage":
+				mu.Lock()
+				postBodies = append(postBodies, readJSONBody(t, req))
+				current := len(postBodies)
+				mu.Unlock()
+				if current == 3 {
+					return jsonResponse(http.StatusOK, map[string]any{"ok": true, "ts": "stream-ts"}), nil
+				}
+				return jsonResponse(http.StatusOK, map[string]any{"ok": true, "ts": fmt.Sprintf("ts-%d", current)}), nil
+			case "/api/chat.update":
+				mu.Lock()
+				postBodies = append(postBodies, readJSONBody(t, req))
+				mu.Unlock()
+				return jsonResponse(http.StatusOK, map[string]any{"ok": true}), nil
+			default:
+				return nil, fmt.Errorf("unexpected request path: %s", req.URL.Path)
+			}
+		}),
+	}
+
+	err := adapter.pollOnce(context.Background(), func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		calls = append(calls, map[string]string{
+			"message":      message,
+			"message_type": meta["message_type"],
+			"audio_url":    meta["audio_url"],
+			"channel_type": meta["channel_type"],
+			"is_group":     meta["is_group"],
+		})
+		if meta["message_type"] == "voice_note" {
+			return "session-voice", "voice reply", nil
+		}
+		return "session-text", "text reply", nil
+	})
+	if err != nil {
+		t.Fatalf("pollOnce returned error: %v", err)
+	}
+
+	err = adapter.pollOnceStream(context.Background(), func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+		if err := onChunk("chunk-a"); err != nil {
+			return "", err
+		}
+		if err := onChunk("chunk-b"); err != nil {
+			return "", err
+		}
+		return "session-stream", nil
+	})
+	if err != nil {
+		t.Fatalf("pollOnceStream returned error: %v", err)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 pollOnce handler calls, got %d", len(calls))
+	}
+	if calls[0]["message_type"] != "voice_note" || calls[0]["audio_url"] != "https://audio.example/slack.mp3" {
+		t.Fatalf("unexpected slack voice call: %+v", calls[0])
+	}
+	if calls[1]["message"] != "text message" || calls[1]["channel_type"] != "group" || calls[1]["is_group"] != "true" {
+		t.Fatalf("unexpected slack text call: %+v", calls[1])
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(postBodies) < 4 {
+		t.Fatalf("expected outbound slack messages and updates, got %d", len(postBodies))
+	}
+	if postBodies[0]["text"] != "voice reply" || postBodies[1]["text"] != "text reply" {
+		t.Fatalf("unexpected first slack outbound bodies: %+v", postBodies[:2])
+	}
+	last := postBodies[len(postBodies)-1]
+	if last["text"] != "chunk-achunk-b" {
+		t.Fatalf("unexpected final slack streamed body: %+v", last)
+	}
+}
+
+func TestSlackAdapterErrorBranchesAndFallback(t *testing.T) {
+	adapter := NewSlackAdapter(config.SlackChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "D123",
+	}, nil)
+
+	postCalls := 0
+	adapter.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case "/api/conversations.history":
+				return jsonResponse(http.StatusOK, map[string]any{"ok": false, "error": "denied"}), nil
+			case "/api/chat.postMessage":
+				postCalls++
+				if postCalls == 1 {
+					return jsonResponse(http.StatusOK, map[string]any{"ok": true, "ts": ""}), nil
+				}
+				return jsonResponse(http.StatusOK, map[string]any{"ok": true, "ts": "ts-2"}), nil
+			case "/api/chat.update":
+				return jsonResponse(http.StatusOK, map[string]any{"ok": false, "error": "edit_failed"}), nil
+			default:
+				return nil, fmt.Errorf("unexpected request path: %s", req.URL.Path)
+			}
+		}),
+	}
+
+	if err := adapter.pollOnce(context.Background(), func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		return "", "", nil
+	}); err == nil || !strings.Contains(err.Error(), "denied") {
+		t.Fatalf("expected slack history error, got %v", err)
+	}
+
+	if err := adapter.sendStreamingMessage(context.Background(), "thread-1", func(onChunk func(chunk string)) error {
+		onChunk("fallback")
+		return nil
+	}); err != nil {
+		t.Fatalf("expected slack streaming fallback to succeed, got %v", err)
+	}
+
+	if err := adapter.editMessage(context.Background(), "ts-1", "hello"); err == nil || !strings.Contains(err.Error(), "edit_failed") {
+		t.Fatalf("expected slack update failure, got %v", err)
+	}
+}
+
+func TestAdaptersRunAndRunStream(t *testing.T) {
+	t.Run("discord run", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/messages"):
+				_, _ = w.Write([]byte(`[
+					{"id":"1","channel_id":"chan-1","content":"hello","author":{"id":"user-1","username":"alice","bot":false}}
+				]`))
+			case r.Method == http.MethodPost:
+				_, _ = w.Write([]byte(`{}`))
+			default:
+				t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+		}))
+		defer server.Close()
+
+		adapter := NewDiscordAdapter(config.DiscordChannelConfig{
+			Enabled:        true,
+			BotToken:       "token",
+			DefaultChannel: "default-chan",
+			APIBaseURL:     server.URL,
+			PollEvery:      1,
+		}, nil)
+		adapter.client = server.Client()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err := adapter.Run(ctx, func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+			cancel()
+			return "session-1", "ok", nil
+		})
+		if err != nil {
+			t.Fatalf("discord Run returned error: %v", err)
+		}
+	})
+
+	t.Run("discord run stream", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/messages"):
+				_, _ = w.Write([]byte(`[
+					{"id":"1","channel_id":"chan-1","content":"hello","author":{"id":"user-1","username":"alice","bot":false}}
+				]`))
+			case r.Method == http.MethodPost:
+				_, _ = w.Write([]byte(`{"id":"stream-1"}`))
+			case r.Method == http.MethodPatch:
+				_, _ = w.Write([]byte(`{}`))
+			default:
+				t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+		}))
+		defer server.Close()
+
+		adapter := NewDiscordAdapter(config.DiscordChannelConfig{
+			Enabled:        true,
+			BotToken:       "token",
+			DefaultChannel: "default-chan",
+			APIBaseURL:     server.URL,
+			PollEvery:      1,
+		}, nil)
+		adapter.client = server.Client()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err := adapter.RunStream(ctx, func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+			cancel()
+			_ = onChunk("ok")
+			return "session-1", nil
+		})
+		if err != nil {
+			t.Fatalf("discord RunStream returned error: %v", err)
+		}
+	})
+
+	t.Run("slack run", func(t *testing.T) {
+		adapter := NewSlackAdapter(config.SlackChannelConfig{
+			Enabled:        true,
+			BotToken:       "token",
+			DefaultChannel: "C123",
+			PollEvery:      1,
+		}, nil)
+		adapter.client = &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.Path {
+				case "/api/conversations.history":
+					return jsonResponse(http.StatusOK, map[string]any{
+						"ok": true,
+						"messages": []map[string]any{
+							{"text": "hello", "ts": "1", "user": "U1"},
+						},
+					}), nil
+				case "/api/chat.postMessage":
+					return jsonResponse(http.StatusOK, map[string]any{"ok": true, "ts": "1"}), nil
+				default:
+					return nil, fmt.Errorf("unexpected request path: %s", req.URL.Path)
+				}
+			}),
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err := adapter.Run(ctx, func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+			cancel()
+			return "session-1", "ok", nil
+		})
+		if err != nil {
+			t.Fatalf("slack Run returned error: %v", err)
+		}
+	})
+
+	t.Run("slack run stream", func(t *testing.T) {
+		adapter := NewSlackAdapter(config.SlackChannelConfig{
+			Enabled:        true,
+			BotToken:       "token",
+			DefaultChannel: "C123",
+			PollEvery:      1,
+		}, nil)
+		adapter.client = &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.Path {
+				case "/api/conversations.history":
+					return jsonResponse(http.StatusOK, map[string]any{
+						"ok": true,
+						"messages": []map[string]any{
+							{"text": "hello", "ts": "1", "thread_ts": "thread-1", "user": "U1"},
+						},
+					}), nil
+				case "/api/chat.postMessage":
+					return jsonResponse(http.StatusOK, map[string]any{"ok": true, "ts": "tmp-1"}), nil
+				case "/api/chat.update":
+					return jsonResponse(http.StatusOK, map[string]any{"ok": true}), nil
+				default:
+					return nil, fmt.Errorf("unexpected request path: %s", req.URL.Path)
+				}
+			}),
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err := adapter.RunStream(ctx, func(ctx context.Context, sessionID string, message string, meta map[string]string, onChunk func(chunk string) error) (string, error) {
+			cancel()
+			_ = onChunk("ok")
+			return "session-1", nil
+		})
+		if err != nil {
+			t.Fatalf("slack RunStream returned error: %v", err)
+		}
+	})
+}

--- a/pkg/input/channels/channels_test.go
+++ b/pkg/input/channels/channels_test.go
@@ -1,0 +1,154 @@
+package channels
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+func TestStreamWithMessageFallback(t *testing.T) {
+	var sent []string
+	err := streamWithMessageFallback(func(onChunk func(chunk string)) error {
+		onChunk("hello")
+		onChunk(" world")
+		return nil
+	}, func(text string) error {
+		sent = append(sent, text)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected fallback stream to succeed, got %v", err)
+	}
+	if len(sent) != 1 || sent[0] != "hello world" {
+		t.Fatalf("unexpected sent messages: %v", sent)
+	}
+
+	sent = nil
+	wantErr := errors.New("boom")
+	err = streamWithMessageFallback(func(onChunk func(chunk string)) error {
+		onChunk("partial")
+		return wantErr
+	}, func(text string) error {
+		sent = append(sent, text)
+		return nil
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected original error, got %v", err)
+	}
+	if len(sent) != 1 || !strings.Contains(sent[0], "partial") || !strings.Contains(sent[0], "boom") {
+		t.Fatalf("unexpected fallback error message: %v", sent)
+	}
+}
+
+func TestDiscordChannelType(t *testing.T) {
+	if got := discordChannelType("guild-1"); got != "guild" {
+		t.Fatalf("expected guild channel type, got %q", got)
+	}
+	if got := discordChannelType("   "); got != "private" {
+		t.Fatalf("expected private channel type, got %q", got)
+	}
+}
+
+func TestDiscordAdapterVerifyInteraction(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	body := []byte(`{"type":1}`)
+	timestamp := "1710000000"
+	signature := ed25519.Sign(privateKey, append([]byte(timestamp), body...))
+
+	adapter := NewDiscordAdapter(config.DiscordChannelConfig{
+		Enabled:   true,
+		BotToken:  "token",
+		PublicKey: hex.EncodeToString(publicKey),
+	}, nil)
+
+	req := httptest.NewRequest("POST", "/interactions", strings.NewReader(string(body)))
+	req.Header.Set("X-Signature-Ed25519", hex.EncodeToString(signature))
+	req.Header.Set("X-Signature-Timestamp", timestamp)
+
+	if !adapter.VerifyInteraction(req, body) {
+		t.Fatal("expected valid discord interaction signature to verify")
+	}
+
+	req.Header.Set("X-Signature-Ed25519", strings.Repeat("0", len(signature)*2))
+	if adapter.VerifyInteraction(req, body) {
+		t.Fatal("expected invalid discord interaction signature to fail verification")
+	}
+}
+
+func TestDiscordAdapterHandleInteraction(t *testing.T) {
+	adapter := NewDiscordAdapter(config.DiscordChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "123",
+	}, nil)
+
+	body := []byte(`{
+		"type": 2,
+		"data": {
+			"name": "ask",
+			"options": [{"name":"message","value":"hello"}]
+		},
+		"channel_id": "chan-1",
+		"guild_id": "guild-1",
+		"member": {"user": {"id":"user-1","username":"alice"}}
+	}`)
+
+	called := false
+	resp, err := adapter.HandleInteraction(context.Background(), body, func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		called = true
+		if message != "hello" {
+			t.Fatalf("expected interaction message hello, got %q", message)
+		}
+		if meta["channel"] != "discord" || meta["channel_id"] != "chan-1" || meta["guild_id"] != "guild-1" {
+			t.Fatalf("unexpected interaction meta: %+v", meta)
+		}
+		return "session-1", "ok", nil
+	})
+	if err != nil {
+		t.Fatalf("handle interaction returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected interaction handler to be called")
+	}
+	if resp["type"] != 4 {
+		t.Fatalf("expected response type 4, got %#v", resp["type"])
+	}
+}
+
+func TestSlackAdapterHelpers(t *testing.T) {
+	adapter := NewSlackAdapter(config.SlackChannelConfig{
+		Enabled:        true,
+		BotToken:       "token",
+		DefaultChannel: "C123",
+	}, nil)
+
+	if !adapter.Enabled() {
+		t.Fatal("expected slack adapter to be enabled with valid config")
+	}
+	status := adapter.Status()
+	if !status.Enabled || status.Name != "slack" {
+		t.Fatalf("unexpected slack adapter status: %+v", status)
+	}
+
+	audioURL, audioMIME := adapter.findAudioFile([]struct {
+		Mimetype string `json:"mimetype"`
+		URL      string `json:"url_private"`
+		Title    string `json:"title"`
+	}{
+		{Mimetype: "image/png", URL: "https://example.com/image"},
+		{Mimetype: "audio/mpeg", URL: "https://example.com/audio", Title: "voice"},
+	})
+	if audioURL != "https://example.com/audio" || audioMIME != "audio/mpeg" {
+		t.Fatalf("unexpected audio file detection result: %q %q", audioURL, audioMIME)
+	}
+}

--- a/pkg/input/channels/channels_test.go
+++ b/pkg/input/channels/channels_test.go
@@ -5,9 +5,11 @@ import (
 	"crypto/ed25519"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/1024XEngineer/anyclaw/pkg/config"
 )
@@ -62,7 +64,7 @@ func TestDiscordAdapterVerifyInteraction(t *testing.T) {
 	}
 
 	body := []byte(`{"type":1}`)
-	timestamp := "1710000000"
+	timestamp := fmt.Sprintf("%d", time.Now().Unix())
 	signature := ed25519.Sign(privateKey, append([]byte(timestamp), body...))
 
 	adapter := NewDiscordAdapter(config.DiscordChannelConfig{
@@ -82,6 +84,14 @@ func TestDiscordAdapterVerifyInteraction(t *testing.T) {
 	req.Header.Set("X-Signature-Ed25519", strings.Repeat("0", len(signature)*2))
 	if adapter.VerifyInteraction(req, body) {
 		t.Fatal("expected invalid discord interaction signature to fail verification")
+	}
+
+	staleTimestamp := fmt.Sprintf("%d", time.Now().Add(-10*time.Minute).Unix())
+	staleSignature := ed25519.Sign(privateKey, append([]byte(staleTimestamp), body...))
+	req.Header.Set("X-Signature-Timestamp", staleTimestamp)
+	req.Header.Set("X-Signature-Ed25519", hex.EncodeToString(staleSignature))
+	if adapter.VerifyInteraction(req, body) {
+		t.Fatal("expected stale discord interaction timestamp to fail verification")
 	}
 }
 

--- a/pkg/input/channels/discord.go
+++ b/pkg/input/channels/discord.go
@@ -1,0 +1,905 @@
+package channels
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	inputlayer "github.com/1024XEngineer/anyclaw/pkg/input"
+	"github.com/gorilla/websocket"
+)
+
+type DiscordAdapter struct {
+	base        inputlayer.BaseAdapter
+	config      config.DiscordChannelConfig
+	client      *http.Client
+	appendEvent func(eventType string, sessionID string, payload map[string]any)
+	latestID    string
+	apiBaseURL  string
+	processed   map[string]time.Time
+}
+
+type discordGatewayPacket struct {
+	Op int             `json:"op"`
+	T  string          `json:"t"`
+	S  *int            `json:"s"`
+	D  json.RawMessage `json:"d"`
+}
+
+func (a *DiscordAdapter) VerifyInteraction(r *http.Request, body []byte) bool {
+	publicKeyHex := strings.TrimSpace(a.config.PublicKey)
+	if publicKeyHex == "" {
+		return false
+	}
+	publicKey, err := hex.DecodeString(publicKeyHex)
+	if err != nil || len(publicKey) != ed25519.PublicKeySize {
+		return false
+	}
+	sigHex := strings.TrimSpace(r.Header.Get("X-Signature-Ed25519"))
+	ts := strings.TrimSpace(r.Header.Get("X-Signature-Timestamp"))
+	if sigHex == "" || ts == "" {
+		return false
+	}
+	sig, err := hex.DecodeString(sigHex)
+	if err != nil {
+		return false
+	}
+	message := append([]byte(ts), body...)
+	return ed25519.Verify(ed25519.PublicKey(publicKey), message, sig)
+}
+
+func (a *DiscordAdapter) HandleInteraction(ctx context.Context, body []byte, handle inputlayer.InboundHandler) (map[string]any, error) {
+	var payload struct {
+		Type int `json:"type"`
+		Data struct {
+			Name    string `json:"name"`
+			Options []struct {
+				Name  string `json:"name"`
+				Value any    `json:"value"`
+			} `json:"options"`
+		} `json:"data"`
+		ChannelID string `json:"channel_id"`
+		GuildID   string `json:"guild_id"`
+		Member    struct {
+			User struct {
+				ID       string `json:"id"`
+				Username string `json:"username"`
+			} `json:"user"`
+		} `json:"member"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	if payload.Type == 1 {
+		return map[string]any{"type": 1}, nil
+	}
+	message := payload.Data.Name
+	for _, opt := range payload.Data.Options {
+		if strings.EqualFold(opt.Name, "message") {
+			message = fmt.Sprintf("%v", opt.Value)
+		}
+	}
+	respSession, response, err := handle(ctx, "", message, map[string]string{
+		"channel":      "discord",
+		"channel_id":   payload.ChannelID,
+		"guild_id":     payload.GuildID,
+		"user_id":      payload.Member.User.ID,
+		"username":     payload.Member.User.Username,
+		"reply_target": payload.ChannelID,
+		"message_id":   fmt.Sprintf("interaction:%d", time.Now().UnixNano()),
+		"channel_type": discordChannelType(payload.GuildID),
+		"is_group":     boolString(strings.TrimSpace(payload.GuildID) != ""),
+	})
+	if err != nil {
+		return nil, err
+	}
+	_ = respSession
+	return map[string]any{"type": 4, "data": map[string]any{"content": response}}, nil
+}
+
+func ReadBody(r *http.Request) ([]byte, error) {
+	defer r.Body.Close()
+	return io.ReadAll(r.Body)
+}
+
+func NewDiscordAdapter(cfg config.DiscordChannelConfig, appendEvent func(eventType string, sessionID string, payload map[string]any)) *DiscordAdapter {
+	apiBaseURL := strings.TrimRight(strings.TrimSpace(cfg.APIBaseURL), "/")
+	if apiBaseURL == "" {
+		apiBaseURL = "https://discord.com/api/v10"
+	}
+	return &DiscordAdapter{
+		base:        inputlayer.NewBaseAdapter("discord", cfg.Enabled && cfg.BotToken != ""),
+		config:      cfg,
+		client:      &http.Client{Timeout: 20 * time.Second},
+		appendEvent: appendEvent,
+		apiBaseURL:  apiBaseURL,
+		processed:   make(map[string]time.Time),
+	}
+}
+
+func (a *DiscordAdapter) Name() string {
+	return "discord"
+}
+
+func (a *DiscordAdapter) Enabled() bool {
+	return a.config.Enabled && strings.TrimSpace(a.config.BotToken) != "" && strings.TrimSpace(a.config.DefaultChannel) != ""
+}
+
+func (a *DiscordAdapter) Status() inputlayer.Status {
+	status := a.base.Status()
+	status.Enabled = a.Enabled()
+	return status
+}
+
+func (a *DiscordAdapter) Run(ctx context.Context, handle inputlayer.InboundHandler) error {
+	a.base.SetRunning(true)
+	defer a.base.SetRunning(false)
+	if a.config.UseGatewayWS {
+		if err := a.runGatewayWS(ctx, handle); err == nil {
+			return nil
+		} else {
+			a.append("channel.discord.gateway.error", "", map[string]any{"error": err.Error()})
+		}
+	}
+	interval := time.Duration(a.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := a.pollOnce(ctx, handle); err != nil {
+			a.base.SetError(err)
+			a.append("channel.discord.error", "", map[string]any{"error": err.Error()})
+		} else {
+			a.base.SetError(nil)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *DiscordAdapter) runGatewayWS(ctx context.Context, handle inputlayer.InboundHandler) error {
+	return a.runGateway(ctx, func(ctx context.Context, packet discordGatewayPacket) error {
+		if packet.T == "MESSAGE_CREATE" || packet.T == "THREAD_CREATE" || packet.T == "TYPING_START" || packet.T == "PRESENCE_UPDATE" || packet.T == "INTERACTION_CREATE" {
+			return a.handleGatewayEvent(ctx, packet.T, packet.D, handle)
+		}
+		return nil
+	})
+}
+
+func (a *DiscordAdapter) runGateway(ctx context.Context, handlePacket func(context.Context, discordGatewayPacket) error) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://discord.com/api/gateway/bot", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var gateway struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&gateway); err != nil {
+		return err
+	}
+	if strings.TrimSpace(gateway.URL) == "" {
+		return fmt.Errorf("discord gateway URL missing")
+	}
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, gateway.URL+"?v=10&encoding=json", nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
+
+	var writeMu sync.Mutex
+	send := func(payload map[string]any) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return conn.WriteJSON(payload)
+	}
+
+	var (
+		identified    bool
+		heartbeatStop chan struct{}
+		seqMu         sync.RWMutex
+		lastSeq       int
+		hasSeq        bool
+	)
+	defer func() {
+		if heartbeatStop != nil {
+			close(heartbeatStop)
+		}
+	}()
+
+	currentSeq := func() any {
+		seqMu.RLock()
+		defer seqMu.RUnlock()
+		if !hasSeq {
+			return nil
+		}
+		return lastSeq
+	}
+
+	for {
+		var packet discordGatewayPacket
+		if err := conn.ReadJSON(&packet); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+		if packet.S != nil {
+			seqMu.Lock()
+			lastSeq = *packet.S
+			hasSeq = true
+			seqMu.Unlock()
+		}
+		if packet.Op == 10 {
+			var hello struct {
+				HeartbeatInterval int `json:"heartbeat_interval"`
+			}
+			if err := json.Unmarshal(packet.D, &hello); err != nil {
+				return err
+			}
+			if hello.HeartbeatInterval <= 0 {
+				return fmt.Errorf("discord heartbeat interval missing")
+			}
+			if heartbeatStop != nil {
+				close(heartbeatStop)
+			}
+			heartbeatStop = make(chan struct{})
+			go func(interval time.Duration, stop <-chan struct{}) {
+				ticker := time.NewTicker(interval)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-stop:
+						return
+					case <-ticker.C:
+						_ = send(map[string]any{"op": 1, "d": currentSeq()})
+					}
+				}
+			}(time.Duration(hello.HeartbeatInterval)*time.Millisecond, heartbeatStop)
+			if err := send(map[string]any{"op": 1, "d": currentSeq()}); err != nil {
+				return err
+			}
+			if !identified {
+				if err := send(map[string]any{
+					"op": 2,
+					"d": map[string]any{
+						"token":   a.config.BotToken,
+						"intents": 4609,
+						"properties": map[string]string{
+							"$os":      "windows",
+							"$browser": "anyclaw",
+							"$device":  "anyclaw",
+						},
+					},
+				}); err != nil {
+					return err
+				}
+				identified = true
+			}
+			continue
+		}
+		if packet.Op == 11 {
+			continue
+		}
+		if packet.Op == 7 {
+			return fmt.Errorf("discord requested reconnect")
+		}
+		if handlePacket != nil {
+			if err := handlePacket(ctx, packet); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (a *DiscordAdapter) handleGatewayEvent(ctx context.Context, eventType string, raw json.RawMessage, handle inputlayer.InboundHandler) error {
+	a.append("channel.discord.gateway.event", "", map[string]any{"event": eventType})
+	if eventType == "MESSAGE_CREATE" {
+		var msg struct {
+			ID        string `json:"id"`
+			Content   string `json:"content"`
+			ChannelID string `json:"channel_id"`
+			GuildID   string `json:"guild_id"`
+			Author    struct {
+				ID       string `json:"id"`
+				Username string `json:"username"`
+				Bot      bool   `json:"bot"`
+			} `json:"author"`
+			Attachments []struct {
+				ID          string `json:"id"`
+				URL         string `json:"url"`
+				ProxyURL    string `json:"proxy_url"`
+				Filename    string `json:"filename"`
+				ContentType string `json:"content_type"`
+				Size        int    `json:"size"`
+			} `json:"attachments"`
+			MessageReference struct {
+				MessageID string `json:"message_id"`
+				ChannelID string `json:"channel_id"`
+			} `json:"message_reference"`
+		}
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			return err
+		}
+		if msg.Author.Bot || a.seen(msg.ID) {
+			return nil
+		}
+
+		meta := map[string]string{
+			"channel":      "discord",
+			"channel_id":   msg.ChannelID,
+			"guild_id":     msg.GuildID,
+			"user_id":      msg.Author.ID,
+			"username":     msg.Author.Username,
+			"reply_target": msg.ChannelID,
+			"message_id":   msg.ID,
+			"sender":       msg.Author.Username,
+			"channel_type": discordChannelType(msg.GuildID),
+			"is_group":     boolString(strings.TrimSpace(msg.GuildID) != ""),
+		}
+
+		audioURL, audioMIME := a.findAudioAttachment(msg.Attachments)
+		if audioURL != "" {
+			meta["message_type"] = "voice_note"
+			meta["audio_url"] = audioURL
+			meta["audio_mime"] = audioMIME
+			if strings.TrimSpace(msg.Content) != "" {
+				meta["caption"] = strings.TrimSpace(msg.Content)
+			}
+
+			respSession, response, err := handle(ctx, "", audioURL, meta)
+			if err != nil {
+				return err
+			}
+			_ = respSession
+			return a.sendMessage(ctx, msg.ChannelID, strings.TrimSpace(msg.MessageReference.MessageID), response)
+		}
+
+		if strings.TrimSpace(msg.Content) == "" {
+			return nil
+		}
+
+		respSession, response, err := handle(ctx, "", msg.Content, meta)
+		if err != nil {
+			return err
+		}
+		_ = respSession
+		return a.sendMessage(ctx, msg.ChannelID, strings.TrimSpace(msg.MessageReference.MessageID), response)
+	}
+	return nil
+}
+
+func (a *DiscordAdapter) findAudioAttachment(attachments []struct {
+	ID          string `json:"id"`
+	URL         string `json:"url"`
+	ProxyURL    string `json:"proxy_url"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type"`
+	Size        int    `json:"size"`
+}) (string, string) {
+	for _, att := range attachments {
+		ct := strings.ToLower(att.ContentType)
+		fn := strings.ToLower(att.Filename)
+		if strings.HasPrefix(ct, "audio/") {
+			url := att.URL
+			if url == "" {
+				url = att.ProxyURL
+			}
+			return url, att.ContentType
+		}
+		if strings.HasSuffix(fn, ".ogg") || strings.HasSuffix(fn, ".mp3") || strings.HasSuffix(fn, ".wav") || strings.HasSuffix(fn, ".flac") || strings.HasSuffix(fn, ".m4a") || strings.HasSuffix(fn, ".webm") {
+			url := att.URL
+			if url == "" {
+				url = att.ProxyURL
+			}
+			mime := "audio/unknown"
+			switch {
+			case strings.HasSuffix(fn, ".ogg"):
+				mime = "audio/ogg"
+			case strings.HasSuffix(fn, ".mp3"):
+				mime = "audio/mpeg"
+			case strings.HasSuffix(fn, ".wav"):
+				mime = "audio/wav"
+			case strings.HasSuffix(fn, ".flac"):
+				mime = "audio/flac"
+			case strings.HasSuffix(fn, ".m4a"):
+				mime = "audio/mp4"
+			case strings.HasSuffix(fn, ".webm"):
+				mime = "audio/webm"
+			}
+			return url, mime
+		}
+	}
+	return "", ""
+}
+
+type discordMessageReference struct {
+	MessageID string `json:"message_id"`
+	ChannelID string `json:"channel_id"`
+}
+
+type discordPolledMessage struct {
+	ID        string `json:"id"`
+	ChannelID string `json:"channel_id"`
+	Content   string `json:"content"`
+	GuildID   string `json:"guild_id"`
+	Author    struct {
+		ID       string `json:"id"`
+		Username string `json:"username"`
+		Bot      bool   `json:"bot"`
+	} `json:"author"`
+	MessageReference discordMessageReference `json:"message_reference"`
+	Attachments      []struct {
+		ID          string `json:"id"`
+		URL         string `json:"url"`
+		ProxyURL    string `json:"proxy_url"`
+		Filename    string `json:"filename"`
+		ContentType string `json:"content_type"`
+		Size        int    `json:"size"`
+	} `json:"attachments"`
+}
+
+func (a *DiscordAdapter) pollOnce(ctx context.Context, handle inputlayer.InboundHandler) error {
+	url := fmt.Sprintf("%s/channels/%s/messages?limit=20", a.apiBaseURL, a.config.DefaultChannel)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("discord fetch failed: %s", resp.Status)
+	}
+
+	var messages []discordPolledMessage
+	if err := json.NewDecoder(resp.Body).Decode(&messages); err != nil {
+		return err
+	}
+
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.ID == "" || msg.ID == a.latestID || msg.Author.Bot || a.seen(msg.ID) {
+			continue
+		}
+		a.latestID = msg.ID
+		targetChannel := strings.TrimSpace(msg.ChannelID)
+		if targetChannel == "" {
+			targetChannel = strings.TrimSpace(a.config.DefaultChannel)
+		}
+		replyMessageID := strings.TrimSpace(msg.MessageReference.MessageID)
+
+		meta := map[string]string{
+			"channel":      "discord",
+			"channel_id":   targetChannel,
+			"guild_id":     msg.GuildID,
+			"user_id":      msg.Author.ID,
+			"username":     msg.Author.Username,
+			"reply_target": targetChannel,
+			"message_id":   msg.ID,
+			"sender":       msg.Author.Username,
+			"channel_type": discordChannelType(msg.GuildID),
+			"is_group":     boolString(strings.TrimSpace(msg.GuildID) != ""),
+		}
+
+		audioURL, audioMIME := a.findAudioAttachment(msg.Attachments)
+		if audioURL != "" {
+			meta["message_type"] = "voice_note"
+			meta["audio_url"] = audioURL
+			meta["audio_mime"] = audioMIME
+			if strings.TrimSpace(msg.Content) != "" {
+				meta["caption"] = strings.TrimSpace(msg.Content)
+			}
+
+			sessionID, response, err := handle(ctx, "", audioURL, meta)
+			if err != nil {
+				return err
+			}
+			if err := a.sendMessage(ctx, targetChannel, replyMessageID, response); err != nil {
+				return err
+			}
+			a.base.MarkActivity()
+			a.append("channel.discord.voice", sessionID, map[string]any{
+				"channel":      a.config.DefaultChannel,
+				"user":         msg.Author.Username,
+				"user_id":      msg.Author.ID,
+				"message_type": "voice_note",
+				"audio_url":    audioURL,
+				"audio_mime":   audioMIME,
+			})
+			continue
+		}
+
+		if strings.TrimSpace(msg.Content) == "" {
+			continue
+		}
+
+		sessionID, response, err := handle(ctx, "", msg.Content, meta)
+		if err != nil {
+			return err
+		}
+		if err := a.sendMessage(ctx, targetChannel, replyMessageID, response); err != nil {
+			return err
+		}
+		a.base.MarkActivity()
+		a.append("channel.discord.message", sessionID, map[string]any{
+			"channel": a.config.DefaultChannel,
+			"user":    msg.Author.Username,
+			"user_id": msg.Author.ID,
+			"text":    msg.Content,
+		})
+	}
+	return nil
+}
+
+func (a *DiscordAdapter) sendMessage(ctx context.Context, target string, replyMessageID string, text string) error {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		target = strings.TrimSpace(a.config.DefaultChannel)
+	}
+	bodyMap := map[string]any{"content": text}
+	if strings.TrimSpace(replyMessageID) != "" {
+		bodyMap["message_reference"] = map[string]any{"message_id": replyMessageID}
+	}
+	body, _ := json.Marshal(bodyMap)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/channels/%s/messages", a.apiBaseURL, target), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("discord send failed: %s", resp.Status)
+	}
+	return nil
+}
+
+func (a *DiscordAdapter) append(eventType string, sessionID string, payload map[string]any) {
+	if a.appendEvent != nil {
+		a.appendEvent(eventType, sessionID, payload)
+	}
+}
+
+func (a *DiscordAdapter) seen(id string) bool {
+	for key, ts := range a.processed {
+		if time.Since(ts) > 30*time.Minute {
+			delete(a.processed, key)
+		}
+	}
+	if _, ok := a.processed[id]; ok {
+		return true
+	}
+	a.processed[id] = time.Now().UTC()
+	return false
+}
+
+func (a *DiscordAdapter) sendStreamingMessage(ctx context.Context, target string, replyMessageID string, streamFn func(onChunk func(chunk string)) error) error {
+	streamInterval := time.Duration(a.config.StreamInterval) * time.Millisecond
+	if streamInterval <= 0 {
+		streamInterval = 500 * time.Millisecond
+	}
+
+	initialMsgID, err := a.sendMessageWithResult(ctx, target, replyMessageID, "\u200B")
+	if err != nil {
+		return err
+	}
+	if initialMsgID == "" {
+		return streamWithMessageFallback(streamFn, func(final string) error {
+			return a.sendMessage(ctx, target, replyMessageID, final)
+		})
+	}
+
+	var accumulated strings.Builder
+	var mu sync.Mutex
+	lastEdit := time.Now()
+
+	onChunk := func(chunk string) {
+		mu.Lock()
+		accumulated.WriteString(chunk)
+		shouldEdit := time.Since(lastEdit) >= streamInterval
+		if shouldEdit {
+			lastEdit = time.Now()
+		}
+		mu.Unlock()
+
+		if shouldEdit {
+			mu.Lock()
+			text := accumulated.String()
+			mu.Unlock()
+			a.editMessage(ctx, target, initialMsgID, text)
+		}
+	}
+
+	if err := streamFn(onChunk); err != nil {
+		mu.Lock()
+		final := accumulated.String()
+		mu.Unlock()
+		a.editMessage(ctx, target, initialMsgID, final+"\n\n[Error: "+err.Error()+"]")
+		return err
+	}
+
+	mu.Lock()
+	final := accumulated.String()
+	mu.Unlock()
+	a.editMessage(ctx, target, initialMsgID, final)
+	return nil
+}
+
+func (a *DiscordAdapter) sendMessageWithResult(ctx context.Context, target string, replyMessageID string, text string) (string, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		target = strings.TrimSpace(a.config.DefaultChannel)
+	}
+	bodyMap := map[string]any{"content": text}
+	if strings.TrimSpace(replyMessageID) != "" {
+		bodyMap["message_reference"] = map[string]any{"message_id": replyMessageID}
+	}
+	body, _ := json.Marshal(bodyMap)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/channels/%s/messages", a.apiBaseURL, target), bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("discord send failed: %s", resp.Status)
+	}
+
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	return result.ID, nil
+}
+
+func (a *DiscordAdapter) editMessage(ctx context.Context, target string, messageID string, text string) error {
+	if messageID == "" {
+		return nil
+	}
+	target = strings.TrimSpace(target)
+	if target == "" {
+		target = strings.TrimSpace(a.config.DefaultChannel)
+	}
+	truncated := text
+	if len([]rune(truncated)) > 2000 {
+		truncated = string([]rune(truncated)[:1997]) + "..."
+	}
+	body := map[string]any{"content": truncated}
+	payload, _ := json.Marshal(body)
+	url := fmt.Sprintf("%s/channels/%s/messages/%s", a.apiBaseURL, target, messageID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func (a *DiscordAdapter) RunStream(ctx context.Context, handle inputlayer.StreamChunkHandler) error {
+	a.base.SetRunning(true)
+	defer a.base.SetRunning(false)
+	if a.config.UseGatewayWS {
+		if err := a.runGatewayWSStream(ctx, handle); err == nil {
+			return nil
+		} else {
+			a.append("channel.discord.gateway.error", "", map[string]any{"error": err.Error()})
+		}
+	}
+	interval := time.Duration(a.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := a.pollOnceStream(ctx, handle); err != nil {
+			a.base.SetError(err)
+			a.append("channel.discord.error", "", map[string]any{"error": err.Error()})
+		} else {
+			a.base.SetError(nil)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *DiscordAdapter) runGatewayWSStream(ctx context.Context, handle inputlayer.StreamChunkHandler) error {
+	return a.runGateway(ctx, func(ctx context.Context, packet discordGatewayPacket) error {
+		if packet.T == "MESSAGE_CREATE" || packet.T == "THREAD_CREATE" {
+			return a.handleGatewayEventStream(ctx, packet.T, packet.D, handle)
+		}
+		return nil
+	})
+}
+
+func (a *DiscordAdapter) handleGatewayEventStream(ctx context.Context, eventType string, raw json.RawMessage, handle inputlayer.StreamChunkHandler) error {
+	if eventType == "MESSAGE_CREATE" {
+		var msg struct {
+			ID        string `json:"id"`
+			Content   string `json:"content"`
+			ChannelID string `json:"channel_id"`
+			GuildID   string `json:"guild_id"`
+			Author    struct {
+				ID       string `json:"id"`
+				Username string `json:"username"`
+				Bot      bool   `json:"bot"`
+			} `json:"author"`
+			MessageReference struct {
+				MessageID string `json:"message_id"`
+				ChannelID string `json:"channel_id"`
+			} `json:"message_reference"`
+		}
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			return err
+		}
+		if msg.Author.Bot || a.seen(msg.ID) {
+			return nil
+		}
+		if strings.TrimSpace(msg.Content) == "" {
+			return nil
+		}
+
+		meta := map[string]string{
+			"channel":      "discord",
+			"channel_id":   msg.ChannelID,
+			"guild_id":     msg.GuildID,
+			"user_id":      msg.Author.ID,
+			"username":     msg.Author.Username,
+			"reply_target": msg.ChannelID,
+			"message_id":   msg.ID,
+			"sender":       msg.Author.Username,
+			"channel_type": discordChannelType(msg.GuildID),
+			"is_group":     boolString(strings.TrimSpace(msg.GuildID) != ""),
+		}
+		replyMessageID := strings.TrimSpace(msg.MessageReference.MessageID)
+
+		sessionID := ""
+		err := a.sendStreamingMessage(ctx, msg.ChannelID, replyMessageID, func(onChunk func(chunk string)) error {
+			var err error
+			sessionID, err = handle(ctx, sessionID, msg.Content, meta, func(chunk string) error {
+				onChunk(chunk)
+				return nil
+			})
+			return err
+		})
+		if err != nil {
+			return err
+		}
+		a.base.MarkActivity()
+		return nil
+	}
+	return nil
+}
+
+func (a *DiscordAdapter) pollOnceStream(ctx context.Context, handle inputlayer.StreamChunkHandler) error {
+	url := fmt.Sprintf("%s/channels/%s/messages?limit=20", a.apiBaseURL, a.config.DefaultChannel)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bot "+a.config.BotToken)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("discord fetch failed: %s", resp.Status)
+	}
+
+	var messages []discordPolledMessage
+	if err := json.NewDecoder(resp.Body).Decode(&messages); err != nil {
+		return err
+	}
+
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.ID == "" || msg.ID == a.latestID || msg.Author.Bot || a.seen(msg.ID) {
+			continue
+		}
+		a.latestID = msg.ID
+		targetChannel := strings.TrimSpace(msg.ChannelID)
+		if targetChannel == "" {
+			targetChannel = strings.TrimSpace(a.config.DefaultChannel)
+		}
+		replyMessageID := strings.TrimSpace(msg.MessageReference.MessageID)
+
+		if strings.TrimSpace(msg.Content) == "" {
+			continue
+		}
+
+		meta := map[string]string{
+			"channel":      "discord",
+			"channel_id":   targetChannel,
+			"guild_id":     msg.GuildID,
+			"user_id":      msg.Author.ID,
+			"username":     msg.Author.Username,
+			"reply_target": targetChannel,
+			"message_id":   msg.ID,
+			"sender":       msg.Author.Username,
+			"channel_type": discordChannelType(msg.GuildID),
+			"is_group":     boolString(strings.TrimSpace(msg.GuildID) != ""),
+		}
+
+		sessionID := ""
+
+		err := a.sendStreamingMessage(ctx, targetChannel, replyMessageID, func(onChunk func(chunk string)) error {
+			var err error
+			sessionID, err = handle(ctx, sessionID, msg.Content, meta, func(chunk string) error {
+				onChunk(chunk)
+				return nil
+			})
+			return err
+		})
+		if err != nil {
+			return err
+		}
+		a.base.MarkActivity()
+		a.append("channel.discord.message", sessionID, map[string]any{
+			"channel":   a.config.DefaultChannel,
+			"user":      msg.Author.Username,
+			"user_id":   msg.Author.ID,
+			"text":      msg.Content,
+			"streaming": true,
+		})
+	}
+	return nil
+}
+
+func discordChannelType(guildID string) string {
+	if strings.TrimSpace(guildID) != "" {
+		return "guild"
+	}
+	return "private"
+}

--- a/pkg/input/channels/discord.go
+++ b/pkg/input/channels/discord.go
@@ -6,9 +6,11 @@ import (
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -35,6 +37,8 @@ type discordGatewayPacket struct {
 	D  json.RawMessage `json:"d"`
 }
 
+const discordInteractionTimestampSkew = 5 * time.Minute
+
 func (a *DiscordAdapter) VerifyInteraction(r *http.Request, body []byte) bool {
 	publicKeyHex := strings.TrimSpace(a.config.PublicKey)
 	if publicKeyHex == "" {
@@ -47,6 +51,17 @@ func (a *DiscordAdapter) VerifyInteraction(r *http.Request, body []byte) bool {
 	sigHex := strings.TrimSpace(r.Header.Get("X-Signature-Ed25519"))
 	ts := strings.TrimSpace(r.Header.Get("X-Signature-Timestamp"))
 	if sigHex == "" || ts == "" {
+		return false
+	}
+	timestamp, err := strconv.ParseInt(ts, 10, 64)
+	if err != nil {
+		return false
+	}
+	skew := time.Since(time.Unix(timestamp, 0))
+	if skew < 0 {
+		skew = -skew
+	}
+	if skew > discordInteractionTimestampSkew {
 		return false
 	}
 	sig, err := hex.DecodeString(sigHex)
@@ -347,7 +362,7 @@ func (a *DiscordAdapter) handleGatewayEvent(ctx context.Context, eventType strin
 		if err := json.Unmarshal(raw, &msg); err != nil {
 			return err
 		}
-		if msg.Author.Bot || a.seen(msg.ID) {
+		if msg.Author.Bot || a.hasSeen(msg.ID) {
 			return nil
 		}
 
@@ -378,10 +393,15 @@ func (a *DiscordAdapter) handleGatewayEvent(ctx context.Context, eventType strin
 				return err
 			}
 			_ = respSession
-			return a.sendMessage(ctx, msg.ChannelID, strings.TrimSpace(msg.MessageReference.MessageID), response)
+			if err := a.sendMessage(ctx, msg.ChannelID, strings.TrimSpace(msg.MessageReference.MessageID), response); err != nil {
+				return err
+			}
+			a.markSeen(msg.ID)
+			return nil
 		}
 
 		if strings.TrimSpace(msg.Content) == "" {
+			a.markSeen(msg.ID)
 			return nil
 		}
 
@@ -390,7 +410,11 @@ func (a *DiscordAdapter) handleGatewayEvent(ctx context.Context, eventType strin
 			return err
 		}
 		_ = respSession
-		return a.sendMessage(ctx, msg.ChannelID, strings.TrimSpace(msg.MessageReference.MessageID), response)
+		if err := a.sendMessage(ctx, msg.ChannelID, strings.TrimSpace(msg.MessageReference.MessageID), response); err != nil {
+			return err
+		}
+		a.markSeen(msg.ID)
+		return nil
 	}
 	return nil
 }
@@ -488,10 +512,9 @@ func (a *DiscordAdapter) pollOnce(ctx context.Context, handle inputlayer.Inbound
 
 	for i := len(messages) - 1; i >= 0; i-- {
 		msg := messages[i]
-		if msg.ID == "" || msg.ID == a.latestID || msg.Author.Bot || a.seen(msg.ID) {
+		if msg.ID == "" || msg.ID == a.latestID || msg.Author.Bot || a.hasSeen(msg.ID) {
 			continue
 		}
-		a.latestID = msg.ID
 		targetChannel := strings.TrimSpace(msg.ChannelID)
 		if targetChannel == "" {
 			targetChannel = strings.TrimSpace(a.config.DefaultChannel)
@@ -527,6 +550,8 @@ func (a *DiscordAdapter) pollOnce(ctx context.Context, handle inputlayer.Inbound
 			if err := a.sendMessage(ctx, targetChannel, replyMessageID, response); err != nil {
 				return err
 			}
+			a.latestID = msg.ID
+			a.markSeen(msg.ID)
 			a.base.MarkActivity()
 			a.append("channel.discord.voice", sessionID, map[string]any{
 				"channel":      a.config.DefaultChannel,
@@ -540,6 +565,8 @@ func (a *DiscordAdapter) pollOnce(ctx context.Context, handle inputlayer.Inbound
 		}
 
 		if strings.TrimSpace(msg.Content) == "" {
+			a.latestID = msg.ID
+			a.markSeen(msg.ID)
 			continue
 		}
 
@@ -550,6 +577,8 @@ func (a *DiscordAdapter) pollOnce(ctx context.Context, handle inputlayer.Inbound
 		if err := a.sendMessage(ctx, targetChannel, replyMessageID, response); err != nil {
 			return err
 		}
+		a.latestID = msg.ID
+		a.markSeen(msg.ID)
 		a.base.MarkActivity()
 		a.append("channel.discord.message", sessionID, map[string]any{
 			"channel": a.config.DefaultChannel,
@@ -594,20 +623,37 @@ func (a *DiscordAdapter) append(eventType string, sessionID string, payload map[
 	}
 }
 
-func (a *DiscordAdapter) seen(id string) bool {
+func (a *DiscordAdapter) pruneSeen() {
 	for key, ts := range a.processed {
 		if time.Since(ts) > 30*time.Minute {
 			delete(a.processed, key)
 		}
 	}
-	if _, ok := a.processed[id]; ok {
+}
+
+func (a *DiscordAdapter) hasSeen(id string) bool {
+	a.pruneSeen()
+	_, ok := a.processed[id]
+	return ok
+}
+
+func (a *DiscordAdapter) markSeen(id string) {
+	if strings.TrimSpace(id) == "" {
+		return
+	}
+	a.pruneSeen()
+	a.processed[id] = time.Now().UTC()
+}
+
+func (a *DiscordAdapter) seen(id string) bool {
+	if a.hasSeen(id) {
 		return true
 	}
-	a.processed[id] = time.Now().UTC()
+	a.markSeen(id)
 	return false
 }
 
-func (a *DiscordAdapter) sendStreamingMessage(ctx context.Context, target string, replyMessageID string, streamFn func(onChunk func(chunk string)) error) error {
+func (a *DiscordAdapter) sendStreamingMessage(ctx context.Context, target string, replyMessageID string, streamFn func(onChunk func(chunk string) error) error) error {
 	streamInterval := time.Duration(a.config.StreamInterval) * time.Millisecond
 	if streamInterval <= 0 {
 		streamInterval = 500 * time.Millisecond
@@ -618,7 +664,12 @@ func (a *DiscordAdapter) sendStreamingMessage(ctx context.Context, target string
 		return err
 	}
 	if initialMsgID == "" {
-		return streamWithMessageFallback(streamFn, func(final string) error {
+		return streamWithMessageFallback(func(onChunk func(chunk string)) error {
+			return streamFn(func(chunk string) error {
+				onChunk(chunk)
+				return nil
+			})
+		}, func(final string) error {
 			return a.sendMessage(ctx, target, replyMessageID, final)
 		})
 	}
@@ -627,7 +678,7 @@ func (a *DiscordAdapter) sendStreamingMessage(ctx context.Context, target string
 	var mu sync.Mutex
 	lastEdit := time.Now()
 
-	onChunk := func(chunk string) {
+	onChunk := func(chunk string) error {
 		mu.Lock()
 		accumulated.WriteString(chunk)
 		shouldEdit := time.Since(lastEdit) >= streamInterval
@@ -640,23 +691,27 @@ func (a *DiscordAdapter) sendStreamingMessage(ctx context.Context, target string
 			mu.Lock()
 			text := accumulated.String()
 			mu.Unlock()
-			a.editMessage(ctx, target, initialMsgID, text)
+			if err := a.editMessage(ctx, target, initialMsgID, text); err != nil {
+				return err
+			}
 		}
+		return nil
 	}
 
 	if err := streamFn(onChunk); err != nil {
 		mu.Lock()
 		final := accumulated.String()
 		mu.Unlock()
-		a.editMessage(ctx, target, initialMsgID, final+"\n\n[Error: "+err.Error()+"]")
+		if editErr := a.editMessage(ctx, target, initialMsgID, final+"\n\n[Error: "+err.Error()+"]"); editErr != nil {
+			return errors.Join(err, editErr)
+		}
 		return err
 	}
 
 	mu.Lock()
 	final := accumulated.String()
 	mu.Unlock()
-	a.editMessage(ctx, target, initialMsgID, final)
-	return nil
+	return a.editMessage(ctx, target, initialMsgID, final)
 }
 
 func (a *DiscordAdapter) sendMessageWithResult(ctx context.Context, target string, replyMessageID string, text string) (string, error) {
@@ -716,9 +771,12 @@ func (a *DiscordAdapter) editMessage(ctx context.Context, target string, message
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := a.client.Do(req)
 	if err != nil {
-		return nil
+		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("discord update failed: %s", resp.Status)
+	}
 	return nil
 }
 
@@ -783,10 +841,11 @@ func (a *DiscordAdapter) handleGatewayEventStream(ctx context.Context, eventType
 		if err := json.Unmarshal(raw, &msg); err != nil {
 			return err
 		}
-		if msg.Author.Bot || a.seen(msg.ID) {
+		if msg.Author.Bot || a.hasSeen(msg.ID) {
 			return nil
 		}
 		if strings.TrimSpace(msg.Content) == "" {
+			a.markSeen(msg.ID)
 			return nil
 		}
 
@@ -805,17 +864,17 @@ func (a *DiscordAdapter) handleGatewayEventStream(ctx context.Context, eventType
 		replyMessageID := strings.TrimSpace(msg.MessageReference.MessageID)
 
 		sessionID := ""
-		err := a.sendStreamingMessage(ctx, msg.ChannelID, replyMessageID, func(onChunk func(chunk string)) error {
+		err := a.sendStreamingMessage(ctx, msg.ChannelID, replyMessageID, func(onChunk func(chunk string) error) error {
 			var err error
 			sessionID, err = handle(ctx, sessionID, msg.Content, meta, func(chunk string) error {
-				onChunk(chunk)
-				return nil
+				return onChunk(chunk)
 			})
 			return err
 		})
 		if err != nil {
 			return err
 		}
+		a.markSeen(msg.ID)
 		a.base.MarkActivity()
 		return nil
 	}
@@ -845,10 +904,9 @@ func (a *DiscordAdapter) pollOnceStream(ctx context.Context, handle inputlayer.S
 
 	for i := len(messages) - 1; i >= 0; i-- {
 		msg := messages[i]
-		if msg.ID == "" || msg.ID == a.latestID || msg.Author.Bot || a.seen(msg.ID) {
+		if msg.ID == "" || msg.ID == a.latestID || msg.Author.Bot || a.hasSeen(msg.ID) {
 			continue
 		}
-		a.latestID = msg.ID
 		targetChannel := strings.TrimSpace(msg.ChannelID)
 		if targetChannel == "" {
 			targetChannel = strings.TrimSpace(a.config.DefaultChannel)
@@ -856,6 +914,8 @@ func (a *DiscordAdapter) pollOnceStream(ctx context.Context, handle inputlayer.S
 		replyMessageID := strings.TrimSpace(msg.MessageReference.MessageID)
 
 		if strings.TrimSpace(msg.Content) == "" {
+			a.latestID = msg.ID
+			a.markSeen(msg.ID)
 			continue
 		}
 
@@ -874,17 +934,18 @@ func (a *DiscordAdapter) pollOnceStream(ctx context.Context, handle inputlayer.S
 
 		sessionID := ""
 
-		err := a.sendStreamingMessage(ctx, targetChannel, replyMessageID, func(onChunk func(chunk string)) error {
+		err := a.sendStreamingMessage(ctx, targetChannel, replyMessageID, func(onChunk func(chunk string) error) error {
 			var err error
 			sessionID, err = handle(ctx, sessionID, msg.Content, meta, func(chunk string) error {
-				onChunk(chunk)
-				return nil
+				return onChunk(chunk)
 			})
 			return err
 		})
 		if err != nil {
 			return err
 		}
+		a.latestID = msg.ID
+		a.markSeen(msg.ID)
 		a.base.MarkActivity()
 		a.append("channel.discord.message", sessionID, map[string]any{
 			"channel":   a.config.DefaultChannel,

--- a/pkg/input/channels/helpers.go
+++ b/pkg/input/channels/helpers.go
@@ -1,0 +1,22 @@
+package channels
+
+import "strings"
+
+func streamWithMessageFallback(streamFn func(onChunk func(chunk string)) error, sendFinal func(text string) error) error {
+	var accumulated strings.Builder
+	err := streamFn(func(chunk string) {
+		accumulated.WriteString(chunk)
+	})
+
+	final := accumulated.String()
+	if err != nil {
+		if strings.TrimSpace(final) != "" {
+			_ = sendFinal(final + "\n\n[Error: " + err.Error() + "]")
+		}
+		return err
+	}
+	if strings.TrimSpace(final) == "" {
+		return nil
+	}
+	return sendFinal(final)
+}

--- a/pkg/input/channels/helpers.go
+++ b/pkg/input/channels/helpers.go
@@ -20,3 +20,58 @@ func streamWithMessageFallback(streamFn func(onChunk func(chunk string)) error, 
 	}
 	return sendFinal(final)
 }
+
+func slackTSLessOrEqual(left string, right string) bool {
+	if strings.TrimSpace(right) == "" {
+		return false
+	}
+	return slackTSCompare(left, right) <= 0
+}
+
+func slackTSCompare(left string, right string) int {
+	leftWhole, leftFrac := splitSlackTS(left)
+	rightWhole, rightFrac := splitSlackTS(right)
+
+	if cmp := compareNumericStrings(leftWhole, rightWhole); cmp != 0 {
+		return cmp
+	}
+
+	width := len(leftFrac)
+	if len(rightFrac) > width {
+		width = len(rightFrac)
+	}
+	leftFrac += strings.Repeat("0", width-len(leftFrac))
+	rightFrac += strings.Repeat("0", width-len(rightFrac))
+
+	return compareNumericStrings(leftFrac, rightFrac)
+}
+
+func splitSlackTS(ts string) (string, string) {
+	parts := strings.SplitN(strings.TrimSpace(ts), ".", 2)
+	if len(parts) == 1 {
+		return parts[0], ""
+	}
+	return parts[0], parts[1]
+}
+
+func compareNumericStrings(left string, right string) int {
+	left = normalizeNumericString(left)
+	right = normalizeNumericString(right)
+
+	switch {
+	case len(left) < len(right):
+		return -1
+	case len(left) > len(right):
+		return 1
+	default:
+		return strings.Compare(left, right)
+	}
+}
+
+func normalizeNumericString(value string) string {
+	value = strings.TrimLeft(strings.TrimSpace(value), "0")
+	if value == "" {
+		return "0"
+	}
+	return value
+}

--- a/pkg/input/channels/slack.go
+++ b/pkg/input/channels/slack.go
@@ -1,0 +1,480 @@
+package channels
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	inputlayer "github.com/1024XEngineer/anyclaw/pkg/input"
+)
+
+type SlackAdapter struct {
+	base        inputlayer.BaseAdapter
+	config      config.SlackChannelConfig
+	client      *http.Client
+	appendEvent func(eventType string, sessionID string, payload map[string]any)
+	latestTS    string
+}
+
+func NewSlackAdapter(cfg config.SlackChannelConfig, appendEvent func(eventType string, sessionID string, payload map[string]any)) *SlackAdapter {
+	return &SlackAdapter{
+		base:        inputlayer.NewBaseAdapter("slack", cfg.Enabled && cfg.BotToken != ""),
+		config:      cfg,
+		client:      &http.Client{Timeout: 20 * time.Second},
+		appendEvent: appendEvent,
+	}
+}
+
+func (a *SlackAdapter) Name() string {
+	return "slack"
+}
+
+func (a *SlackAdapter) Enabled() bool {
+	return a.config.Enabled && strings.TrimSpace(a.config.BotToken) != "" && strings.TrimSpace(a.config.DefaultChannel) != ""
+}
+
+func (a *SlackAdapter) Status() inputlayer.Status {
+	status := a.base.Status()
+	status.Enabled = a.Enabled()
+	return status
+}
+
+func (a *SlackAdapter) Run(ctx context.Context, handle inputlayer.InboundHandler) error {
+	a.base.SetRunning(true)
+	defer a.base.SetRunning(false)
+	interval := time.Duration(a.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := a.pollOnce(ctx, handle); err != nil {
+			a.base.SetError(err)
+			a.append("channel.slack.error", "", map[string]any{"error": err.Error()})
+		} else {
+			a.base.SetError(nil)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *SlackAdapter) pollOnce(ctx context.Context, handle inputlayer.InboundHandler) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://slack.com/api/conversations.history?channel="+a.config.DefaultChannel+"&limit=10", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.config.BotToken)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var payload struct {
+		OK       bool   `json:"ok"`
+		Error    string `json:"error"`
+		Messages []struct {
+			Text     string `json:"text"`
+			Ts       string `json:"ts"`
+			ThreadTS string `json:"thread_ts"`
+			User     string `json:"user"`
+			BotID    string `json:"bot_id"`
+			Files    []struct {
+				Mimetype string `json:"mimetype"`
+				URL      string `json:"url_private"`
+				Title    string `json:"title"`
+			} `json:"files"`
+		} `json:"messages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return err
+	}
+	if !payload.OK {
+		if strings.TrimSpace(payload.Error) == "" {
+			return fmt.Errorf("slack history failed: api returned ok=false")
+		}
+		return fmt.Errorf("slack history failed: %s", payload.Error)
+	}
+
+	for i := len(payload.Messages) - 1; i >= 0; i-- {
+		msg := payload.Messages[i]
+		if msg.Ts == "" || msg.Ts == a.latestTS || msg.BotID != "" {
+			continue
+		}
+		a.latestTS = msg.Ts
+		channelType, isGroup := slackConversationMetadata(a.config.DefaultChannel)
+
+		meta := map[string]string{
+			"channel":      "slack",
+			"channel_id":   a.config.DefaultChannel,
+			"user_id":      msg.User,
+			"reply_target": a.config.DefaultChannel,
+			"message_id":   msg.Ts,
+			"sender":       msg.User,
+			"thread_id":    msg.ThreadTS,
+			"channel_type": channelType,
+			"is_group":     boolString(isGroup),
+		}
+
+		audioURL, audioMIME := a.findAudioFile(msg.Files)
+		if audioURL != "" {
+			meta["message_type"] = "voice_note"
+			meta["audio_url"] = audioURL
+			meta["audio_mime"] = audioMIME
+			if strings.TrimSpace(msg.Text) != "" {
+				meta["caption"] = strings.TrimSpace(msg.Text)
+			}
+
+			sessionID, response, err := handle(ctx, "", audioURL, meta)
+			if err != nil {
+				return err
+			}
+			if err := a.sendMessage(ctx, response, msg.ThreadTS); err != nil {
+				return err
+			}
+			a.base.MarkActivity()
+			a.append("channel.slack.voice", sessionID, map[string]any{
+				"channel":      a.config.DefaultChannel,
+				"user":         msg.User,
+				"message_type": "voice_note",
+				"audio_url":    audioURL,
+				"audio_mime":   audioMIME,
+			})
+			continue
+		}
+
+		if strings.TrimSpace(msg.Text) == "" {
+			continue
+		}
+
+		sessionID, response, err := handle(ctx, "", msg.Text, meta)
+		if err != nil {
+			return err
+		}
+		if err := a.sendMessage(ctx, response, msg.ThreadTS); err != nil {
+			return err
+		}
+		a.base.MarkActivity()
+		a.append("channel.slack.message", sessionID, map[string]any{
+			"channel": a.config.DefaultChannel,
+			"user":    msg.User,
+			"text":    msg.Text,
+		})
+	}
+	return nil
+}
+
+func (a *SlackAdapter) sendMessage(ctx context.Context, text string, threadTS string) error {
+	bodyMap := map[string]any{"channel": a.config.DefaultChannel, "text": text}
+	if strings.TrimSpace(threadTS) != "" {
+		bodyMap["thread_ts"] = threadTS
+	}
+	body, _ := json.Marshal(bodyMap)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://slack.com/api/chat.postMessage", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("slack send failed: %s", resp.Status)
+	}
+
+	var result struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+	if !result.OK {
+		if strings.TrimSpace(result.Error) == "" {
+			return fmt.Errorf("slack send failed: api returned ok=false")
+		}
+		return fmt.Errorf("slack send failed: %s", result.Error)
+	}
+	return nil
+}
+
+func (a *SlackAdapter) append(eventType string, sessionID string, payload map[string]any) {
+	if a.appendEvent != nil {
+		a.appendEvent(eventType, sessionID, payload)
+	}
+}
+
+func (a *SlackAdapter) findAudioFile(files []struct {
+	Mimetype string `json:"mimetype"`
+	URL      string `json:"url_private"`
+	Title    string `json:"title"`
+}) (string, string) {
+	for _, f := range files {
+		mime := strings.ToLower(f.Mimetype)
+		if strings.HasPrefix(mime, "audio/") {
+			return f.URL, f.Mimetype
+		}
+	}
+	return "", ""
+}
+
+func (a *SlackAdapter) sendMessageWithResult(ctx context.Context, text string, threadTS string) (string, error) {
+	bodyMap := map[string]any{"channel": a.config.DefaultChannel, "text": text}
+	if strings.TrimSpace(threadTS) != "" {
+		bodyMap["thread_ts"] = threadTS
+	}
+	body, _ := json.Marshal(bodyMap)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://slack.com/api/chat.postMessage", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("slack send failed: %s", resp.Status)
+	}
+
+	var result struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+		Ts    string `json:"ts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	if !result.OK {
+		if strings.TrimSpace(result.Error) == "" {
+			return "", fmt.Errorf("slack send failed: api returned ok=false")
+		}
+		return "", fmt.Errorf("slack send failed: %s", result.Error)
+	}
+	return result.Ts, nil
+}
+
+func (a *SlackAdapter) editMessage(ctx context.Context, ts string, text string) error {
+	if ts == "" {
+		return nil
+	}
+	body, _ := json.Marshal(map[string]any{"channel": a.config.DefaultChannel, "ts": ts, "text": text})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://slack.com/api/chat.update", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	var result struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+	if !result.OK {
+		if strings.TrimSpace(result.Error) == "" {
+			return fmt.Errorf("slack update failed: api returned ok=false")
+		}
+		return fmt.Errorf("slack update failed: %s", result.Error)
+	}
+	return nil
+}
+
+func (a *SlackAdapter) sendStreamingMessage(ctx context.Context, threadTS string, streamFn func(onChunk func(chunk string)) error) error {
+	streamInterval := time.Duration(a.config.StreamInterval) * time.Millisecond
+	if streamInterval <= 0 {
+		streamInterval = 500 * time.Millisecond
+	}
+
+	initialTs, err := a.sendMessageWithResult(ctx, "\u200B", threadTS)
+	if err != nil {
+		return err
+	}
+	if initialTs == "" {
+		return streamWithMessageFallback(streamFn, func(final string) error {
+			return a.sendMessage(ctx, final, threadTS)
+		})
+	}
+
+	var accumulated strings.Builder
+	var mu sync.Mutex
+	lastEdit := time.Now()
+
+	onChunk := func(chunk string) {
+		mu.Lock()
+		accumulated.WriteString(chunk)
+		shouldEdit := time.Since(lastEdit) >= streamInterval
+		if shouldEdit {
+			lastEdit = time.Now()
+		}
+		mu.Unlock()
+
+		if shouldEdit {
+			mu.Lock()
+			text := accumulated.String()
+			mu.Unlock()
+			a.editMessage(ctx, initialTs, text)
+		}
+	}
+
+	if err := streamFn(onChunk); err != nil {
+		mu.Lock()
+		final := accumulated.String()
+		mu.Unlock()
+		a.editMessage(ctx, initialTs, final+"\n\n[Error: "+err.Error()+"]")
+		return err
+	}
+
+	mu.Lock()
+	final := accumulated.String()
+	mu.Unlock()
+	a.editMessage(ctx, initialTs, final)
+	return nil
+}
+
+func (a *SlackAdapter) RunStream(ctx context.Context, handle inputlayer.StreamChunkHandler) error {
+	a.base.SetRunning(true)
+	defer a.base.SetRunning(false)
+	interval := time.Duration(a.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := a.pollOnceStream(ctx, handle); err != nil {
+			a.base.SetError(err)
+			a.append("channel.slack.error", "", map[string]any{"error": err.Error()})
+		} else {
+			a.base.SetError(nil)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *SlackAdapter) pollOnceStream(ctx context.Context, handle inputlayer.StreamChunkHandler) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://slack.com/api/conversations.history?channel="+a.config.DefaultChannel+"&limit=10", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.config.BotToken)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var payload struct {
+		OK       bool   `json:"ok"`
+		Error    string `json:"error"`
+		Messages []struct {
+			Text     string `json:"text"`
+			Ts       string `json:"ts"`
+			ThreadTS string `json:"thread_ts"`
+			User     string `json:"user"`
+			BotID    string `json:"bot_id"`
+		} `json:"messages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return err
+	}
+	if !payload.OK {
+		if strings.TrimSpace(payload.Error) == "" {
+			return fmt.Errorf("slack history failed: api returned ok=false")
+		}
+		return fmt.Errorf("slack history failed: %s", payload.Error)
+	}
+
+	for i := len(payload.Messages) - 1; i >= 0; i-- {
+		msg := payload.Messages[i]
+		if msg.Ts == "" || msg.Ts == a.latestTS || msg.BotID != "" {
+			continue
+		}
+		a.latestTS = msg.Ts
+
+		if strings.TrimSpace(msg.Text) == "" {
+			continue
+		}
+		channelType, isGroup := slackConversationMetadata(a.config.DefaultChannel)
+
+		meta := map[string]string{
+			"channel":      "slack",
+			"channel_id":   a.config.DefaultChannel,
+			"user_id":      msg.User,
+			"reply_target": a.config.DefaultChannel,
+			"message_id":   msg.Ts,
+			"sender":       msg.User,
+			"thread_id":    msg.ThreadTS,
+			"channel_type": channelType,
+			"is_group":     boolString(isGroup),
+		}
+
+		sessionID := ""
+		err := a.sendStreamingMessage(ctx, msg.ThreadTS, func(onChunk func(chunk string)) error {
+			var err error
+			sessionID, err = handle(ctx, sessionID, msg.Text, meta, func(chunk string) error {
+				onChunk(chunk)
+				return nil
+			})
+			return err
+		})
+		if err != nil {
+			return err
+		}
+		a.base.MarkActivity()
+		a.append("channel.slack.message", sessionID, map[string]any{
+			"channel":   a.config.DefaultChannel,
+			"user":      msg.User,
+			"text":      msg.Text,
+			"streaming": true,
+		})
+	}
+	return nil
+}
+
+func slackConversationMetadata(channelID string) (string, bool) {
+	channelID = strings.ToUpper(strings.TrimSpace(channelID))
+	switch {
+	case strings.HasPrefix(channelID, "D"):
+		return "dm", false
+	case channelID != "":
+		return "group", true
+	default:
+		return "", false
+	}
+}
+
+func boolString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}

--- a/pkg/input/channels/slack.go
+++ b/pkg/input/channels/slack.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -110,10 +111,9 @@ func (a *SlackAdapter) pollOnce(ctx context.Context, handle inputlayer.InboundHa
 
 	for i := len(payload.Messages) - 1; i >= 0; i-- {
 		msg := payload.Messages[i]
-		if msg.Ts == "" || msg.Ts == a.latestTS || msg.BotID != "" {
+		if msg.Ts == "" || slackTSLessOrEqual(msg.Ts, a.latestTS) || msg.BotID != "" {
 			continue
 		}
-		a.latestTS = msg.Ts
 		channelType, isGroup := slackConversationMetadata(a.config.DefaultChannel)
 
 		meta := map[string]string{
@@ -144,6 +144,7 @@ func (a *SlackAdapter) pollOnce(ctx context.Context, handle inputlayer.InboundHa
 			if err := a.sendMessage(ctx, response, msg.ThreadTS); err != nil {
 				return err
 			}
+			a.latestTS = msg.Ts
 			a.base.MarkActivity()
 			a.append("channel.slack.voice", sessionID, map[string]any{
 				"channel":      a.config.DefaultChannel,
@@ -156,6 +157,7 @@ func (a *SlackAdapter) pollOnce(ctx context.Context, handle inputlayer.InboundHa
 		}
 
 		if strings.TrimSpace(msg.Text) == "" {
+			a.latestTS = msg.Ts
 			continue
 		}
 
@@ -166,6 +168,7 @@ func (a *SlackAdapter) pollOnce(ctx context.Context, handle inputlayer.InboundHa
 		if err := a.sendMessage(ctx, response, msg.ThreadTS); err != nil {
 			return err
 		}
+		a.latestTS = msg.Ts
 		a.base.MarkActivity()
 		a.append("channel.slack.message", sessionID, map[string]any{
 			"channel": a.config.DefaultChannel,
@@ -284,9 +287,12 @@ func (a *SlackAdapter) editMessage(ctx context.Context, ts string, text string) 
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := a.client.Do(req)
 	if err != nil {
-		return nil
+		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("slack update failed: %s", resp.Status)
+	}
 	var result struct {
 		OK    bool   `json:"ok"`
 		Error string `json:"error"`
@@ -303,7 +309,7 @@ func (a *SlackAdapter) editMessage(ctx context.Context, ts string, text string) 
 	return nil
 }
 
-func (a *SlackAdapter) sendStreamingMessage(ctx context.Context, threadTS string, streamFn func(onChunk func(chunk string)) error) error {
+func (a *SlackAdapter) sendStreamingMessage(ctx context.Context, threadTS string, streamFn func(onChunk func(chunk string) error) error) error {
 	streamInterval := time.Duration(a.config.StreamInterval) * time.Millisecond
 	if streamInterval <= 0 {
 		streamInterval = 500 * time.Millisecond
@@ -314,7 +320,12 @@ func (a *SlackAdapter) sendStreamingMessage(ctx context.Context, threadTS string
 		return err
 	}
 	if initialTs == "" {
-		return streamWithMessageFallback(streamFn, func(final string) error {
+		return streamWithMessageFallback(func(onChunk func(chunk string)) error {
+			return streamFn(func(chunk string) error {
+				onChunk(chunk)
+				return nil
+			})
+		}, func(final string) error {
 			return a.sendMessage(ctx, final, threadTS)
 		})
 	}
@@ -323,7 +334,7 @@ func (a *SlackAdapter) sendStreamingMessage(ctx context.Context, threadTS string
 	var mu sync.Mutex
 	lastEdit := time.Now()
 
-	onChunk := func(chunk string) {
+	onChunk := func(chunk string) error {
 		mu.Lock()
 		accumulated.WriteString(chunk)
 		shouldEdit := time.Since(lastEdit) >= streamInterval
@@ -336,23 +347,27 @@ func (a *SlackAdapter) sendStreamingMessage(ctx context.Context, threadTS string
 			mu.Lock()
 			text := accumulated.String()
 			mu.Unlock()
-			a.editMessage(ctx, initialTs, text)
+			if err := a.editMessage(ctx, initialTs, text); err != nil {
+				return err
+			}
 		}
+		return nil
 	}
 
 	if err := streamFn(onChunk); err != nil {
 		mu.Lock()
 		final := accumulated.String()
 		mu.Unlock()
-		a.editMessage(ctx, initialTs, final+"\n\n[Error: "+err.Error()+"]")
+		if editErr := a.editMessage(ctx, initialTs, final+"\n\n[Error: "+err.Error()+"]"); editErr != nil {
+			return errors.Join(err, editErr)
+		}
 		return err
 	}
 
 	mu.Lock()
 	final := accumulated.String()
 	mu.Unlock()
-	a.editMessage(ctx, initialTs, final)
-	return nil
+	return a.editMessage(ctx, initialTs, final)
 }
 
 func (a *SlackAdapter) RunStream(ctx context.Context, handle inputlayer.StreamChunkHandler) error {
@@ -415,12 +430,12 @@ func (a *SlackAdapter) pollOnceStream(ctx context.Context, handle inputlayer.Str
 
 	for i := len(payload.Messages) - 1; i >= 0; i-- {
 		msg := payload.Messages[i]
-		if msg.Ts == "" || msg.Ts == a.latestTS || msg.BotID != "" {
+		if msg.Ts == "" || slackTSLessOrEqual(msg.Ts, a.latestTS) || msg.BotID != "" {
 			continue
 		}
-		a.latestTS = msg.Ts
 
 		if strings.TrimSpace(msg.Text) == "" {
+			a.latestTS = msg.Ts
 			continue
 		}
 		channelType, isGroup := slackConversationMetadata(a.config.DefaultChannel)
@@ -438,17 +453,17 @@ func (a *SlackAdapter) pollOnceStream(ctx context.Context, handle inputlayer.Str
 		}
 
 		sessionID := ""
-		err := a.sendStreamingMessage(ctx, msg.ThreadTS, func(onChunk func(chunk string)) error {
+		err := a.sendStreamingMessage(ctx, msg.ThreadTS, func(onChunk func(chunk string) error) error {
 			var err error
 			sessionID, err = handle(ctx, sessionID, msg.Text, meta, func(chunk string) error {
-				onChunk(chunk)
-				return nil
+				return onChunk(chunk)
 			})
 			return err
 		})
 		if err != nil {
 			return err
 		}
+		a.latestTS = msg.Ts
 		a.base.MarkActivity()
 		a.append("channel.slack.message", sessionID, map[string]any{
 			"channel":   a.config.DefaultChannel,


### PR DESCRIPTION
## 内容
- 新增 Discord 输入适配器
- 新增 Slack 输入适配器
- 补充流式消息回退 helper
- 补充适配器相关单元测试
- 补充 Discord 网关需要的 websocket 依赖

## 测试
- go test ./...