### PR TITLE
feat(adapters): add extension registry and execution core

### DIFF
--- a/pkg/extensions/adapters/builtins.go
+++ b/pkg/extensions/adapters/builtins.go
@@ -1,0 +1,28 @@
+package extension
+
+func builtinExtensionManifests() []Manifest {
+	return []Manifest{
+		{ID: "email", Name: "Email", Version: "1.0.0", Description: "Inbound and outbound email automation hooks", Kind: "channel", Builtin: true, Channels: []string{"email"}},
+		{ID: "sms", Name: "SMS", Version: "1.0.0", Description: "SMS notifications and reply workflows", Kind: "channel", Builtin: true, Channels: []string{"sms"}},
+		{ID: "webhook", Name: "Webhook", Version: "1.0.0", Description: "Generic webhook ingestion and dispatch", Kind: "hook", Builtin: true},
+		{ID: "rss", Name: "RSS Watcher", Version: "1.0.0", Description: "RSS feed ingestion and summarization", Kind: "hook", Builtin: true},
+		{ID: "github-webhook", Name: "GitHub Webhook", Version: "1.0.0", Description: "GitHub issue and PR event adapter", Kind: "hook", Builtin: true, Skills: []string{"github", "github-issues"}},
+		{ID: "gitlab", Name: "GitLab", Version: "1.0.0", Description: "GitLab notifications and merge event routing", Kind: "channel", Builtin: true, Channels: []string{"gitlab"}},
+		{ID: "jira", Name: "Jira", Version: "1.0.0", Description: "Jira issue stream and workflow hooks", Kind: "tool", Builtin: true},
+		{ID: "confluence", Name: "Confluence", Version: "1.0.0", Description: "Confluence page sync and note surfaces", Kind: "tool", Builtin: true},
+		{ID: "notion", Name: "Notion", Version: "1.0.0", Description: "Notion knowledge capture and publishing", Kind: "tool", Builtin: true},
+		{ID: "linear", Name: "Linear", Version: "1.0.0", Description: "Linear issue routing and sprint actions", Kind: "tool", Builtin: true},
+		{ID: "reddit", Name: "Reddit", Version: "1.0.0", Description: "Reddit thread ingestion and moderation hooks", Kind: "channel", Builtin: true, Channels: []string{"reddit"}},
+		{ID: "x", Name: "X", Version: "1.0.0", Description: "X posting and mention handling surface", Kind: "channel", Builtin: true, Channels: []string{"x"}},
+		{ID: "mastodon", Name: "Mastodon", Version: "1.0.0", Description: "Mastodon timeline and social publishing support", Kind: "channel", Builtin: true, Channels: []string{"mastodon"}},
+		{ID: "linkedin", Name: "LinkedIn", Version: "1.0.0", Description: "LinkedIn publishing and outreach automation", Kind: "channel", Builtin: true, Channels: []string{"linkedin"}},
+		{ID: "youtube", Name: "YouTube", Version: "1.0.0", Description: "YouTube publishing and comment triage", Kind: "channel", Builtin: true, Channels: []string{"youtube"}},
+		{ID: "outlook", Name: "Outlook", Version: "1.0.0", Description: "Outlook calendar and mailbox integration", Kind: "channel", Builtin: true, Channels: []string{"outlook"}},
+		{ID: "zoom", Name: "Zoom", Version: "1.0.0", Description: "Zoom meeting event hooks and summaries", Kind: "hook", Builtin: true},
+		{ID: "webex", Name: "Webex", Version: "1.0.0", Description: "Webex meetings and chat event adapter", Kind: "channel", Builtin: true, Channels: []string{"webex"}},
+		{ID: "basecamp", Name: "Basecamp", Version: "1.0.0", Description: "Basecamp project update integration", Kind: "tool", Builtin: true},
+		{ID: "asana", Name: "Asana", Version: "1.0.0", Description: "Asana project and task synchronization", Kind: "tool", Builtin: true},
+		{ID: "clickup", Name: "ClickUp", Version: "1.0.0", Description: "ClickUp task and workflow hooks", Kind: "tool", Builtin: true},
+		{ID: "webhook-relay", Name: "Webhook Relay", Version: "1.0.0", Description: "Shared webhook relay and routing helper", Kind: "hook", Builtin: true},
+	}
+}

--- a/pkg/extensions/adapters/cli/exec/exec.go
+++ b/pkg/extensions/adapters/cli/exec/exec.go
@@ -1,0 +1,156 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	cr "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/registry"
+)
+
+type Executor struct {
+	mu       sync.RWMutex
+	reg      *cr.Registry
+	handlers map[string]CommandHandler
+}
+
+type CommandHandler func(ctx context.Context, args []string) (string, error)
+
+type ExecResult struct {
+	Name      string   `json:"name"`
+	Args      []string `json:"args"`
+	Output    string   `json:"output"`
+	Error     string   `json:"error,omitempty"`
+	ExitCode  int      `json:"exit_code"`
+	Installed bool     `json:"installed"`
+}
+
+func NewExecutor(reg *cr.Registry) *Executor {
+	return &Executor{
+		reg:      reg,
+		handlers: make(map[string]CommandHandler),
+	}
+}
+
+func (e *Executor) RegisterHandler(name string, handler CommandHandler) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.handlers[name] = handler
+}
+
+func (e *Executor) Exec(ctx context.Context, name string, args []string) *ExecResult {
+	result := &ExecResult{
+		Name: name,
+		Args: args,
+	}
+
+	entry, ok := e.reg.Find(name)
+	if !ok {
+		result.Error = fmt.Sprintf("CLI not found: %s", name)
+		return result
+	}
+
+	e.mu.RLock()
+	if handler, exists := e.handlers[name]; exists {
+		e.mu.RUnlock()
+		output, err := handler(ctx, args)
+		result.Output = output
+		if err != nil {
+			result.Error = err.Error()
+			result.ExitCode = 1
+		} else {
+			result.ExitCode = 0
+		}
+		result.Installed = true
+		return result
+	}
+	e.mu.RUnlock()
+
+	if entry.Installed && entry.ExecutablePath != "" {
+		return e.execBinary(ctx, entry.ExecutablePath, args, result)
+	}
+
+	result.Error = fmt.Sprintf("CLI not installed: %s (install with: %s)", name, entry.InstallCmd)
+	result.Installed = false
+	return result
+}
+
+func (e *Executor) execBinary(ctx context.Context, path string, args []string, result *ExecResult) *ExecResult {
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	output, err := cmd.CombinedOutput()
+	result.Output = string(output)
+	result.Installed = true
+
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			result.ExitCode = exitErr.ExitCode()
+		} else {
+			result.ExitCode = 1
+		}
+		result.Error = err.Error()
+	} else {
+		result.ExitCode = 0
+	}
+
+	return result
+}
+
+func (e *Executor) AutoInstall(ctx context.Context, name string) *ExecResult {
+	result := &ExecResult{Name: name}
+
+	entry, ok := e.reg.Get(name)
+	if !ok {
+		result.Error = "CLI not found in registry"
+		return result
+	}
+
+	if entry.InstallCmd == "" {
+		result.Error = "No install command available"
+		return result
+	}
+
+	parts := strings.Fields(entry.InstallCmd)
+	if len(parts) < 2 {
+		result.Error = "Invalid install command"
+		return result
+	}
+
+	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		result.Error = fmt.Sprintf("Install failed: %v", err)
+		result.ExitCode = 1
+		return result
+	}
+
+	result.Output = "Installation completed"
+	result.ExitCode = 0
+	result.Installed = true
+	e.reg.MarkInstalled(name, entry.EntryPoint)
+
+	return result
+}
+
+func (e *Executor) List() []*cr.EntryStatus {
+	return e.reg.List()
+}
+
+func (e *Executor) Search(query, category string, limit int) []*cr.EntryStatus {
+	return e.reg.Search(query, category, limit)
+}
+
+func (e *Executor) Categories() map[string]int {
+	return e.reg.Categories()
+}
+
+func (e *Executor) JSON() (string, error) {
+	return e.reg.JSON()
+}

--- a/pkg/extensions/adapters/cli/registry/registry.go
+++ b/pkg/extensions/adapters/cli/registry/registry.go
@@ -1,0 +1,243 @@
+package cliadapter
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type Entry struct {
+	Name           string `json:"name"`
+	DisplayName    string `json:"display_name"`
+	Version        string `json:"version"`
+	Description    string `json:"description"`
+	Requires       string `json:"requires"`
+	Homepage       string `json:"homepage"`
+	InstallCmd     string `json:"install_cmd"`
+	EntryPoint     string `json:"entry_point"`
+	SkillMD        string `json:"skill_md"`
+	Category       string `json:"category"`
+	Contributor    string `json:"contributor"`
+	ContributorURL string `json:"contributor_url"`
+}
+
+type EntryStatus struct {
+	Entry
+	Installed      bool   `json:"installed"`
+	ExecutablePath string `json:"executable_path,omitempty"`
+}
+
+type Registry struct {
+	mu         sync.RWMutex
+	root       string
+	entries    map[string]*EntryStatus
+	categories map[string]int
+}
+
+func NewRegistry(root string) (*Registry, error) {
+	r := &Registry{
+		root:       root,
+		entries:    make(map[string]*EntryStatus),
+		categories: make(map[string]int),
+	}
+
+	if err := r.load(); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (r *Registry) load() error {
+	data, err := os.ReadFile(filepath.Join(r.root, "registry.json"))
+	if err != nil {
+		return err
+	}
+
+	var file struct {
+		Meta struct {
+			Repo        string `json:"repo"`
+			Description string `json:"description"`
+			Updated     string `json:"updated"`
+		} `json:"meta"`
+		CLIs []Entry `json:"clis"`
+	}
+
+	if err := json.Unmarshal(data, &file); err != nil {
+		return err
+	}
+
+	for _, e := range file.CLIs {
+		entry := e
+		r.entries[e.Name] = &EntryStatus{
+			Entry:     entry,
+			Installed: false,
+		}
+		r.categories[e.Category]++
+	}
+
+	return nil
+}
+
+func (r *Registry) Get(name string) (*EntryStatus, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, ok := r.entries[name]
+	return entry, ok
+}
+
+func (r *Registry) List() []*EntryStatus {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]*EntryStatus, 0, len(r.entries))
+	for _, e := range r.entries {
+		result = append(result, e)
+	}
+	return result
+}
+
+func (r *Registry) Search(query string, category string, limit int) []*EntryStatus {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var results []*EntryStatus
+	query = strings.ToLower(query)
+	category = strings.ToLower(category)
+
+	for _, e := range r.entries {
+		if category != "" && strings.ToLower(e.Category) != category {
+			continue
+		}
+
+		if query == "" {
+			results = append(results, e)
+			continue
+		}
+
+		if strings.Contains(strings.ToLower(e.Name), query) ||
+			strings.Contains(strings.ToLower(e.DisplayName), query) ||
+			strings.Contains(strings.ToLower(e.Description), query) {
+			results = append(results, e)
+		}
+
+		if limit > 0 && len(results) >= limit {
+			break
+		}
+	}
+
+	return results
+}
+
+func (r *Registry) Categories() map[string]int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make(map[string]int)
+	for k, v := range r.categories {
+		result[k] = v
+	}
+	return result
+}
+
+func (r *Registry) Root() string {
+	return r.root
+}
+
+func (r *Registry) EntriesCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.entries)
+}
+
+type builtinAdapter struct {
+	Name        string
+	Description string
+	Category    string
+	Handler     func(args []string) (string, error)
+}
+
+var builtinAdapters = map[string]*builtinAdapter{}
+
+func RegisterBuiltinAdapter(name, desc, category string, handler func(args []string) (string, error)) {
+	builtinAdapters[name] = &builtinAdapter{
+		Name:        name,
+		Description: desc,
+		Category:    category,
+		Handler:     handler,
+	}
+}
+
+func GetBuiltinAdapter(name string) (*builtinAdapter, bool) {
+	a, ok := builtinAdapters[name]
+	return a, ok
+}
+
+func ListBuiltinAdapters() []*builtinAdapter {
+	result := make([]*builtinAdapter, 0, len(builtinAdapters))
+	for _, a := range builtinAdapters {
+		result = append(result, a)
+	}
+	return result
+}
+
+func (r *Registry) Find(name string) (*EntryStatus, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	name = strings.ToLower(name)
+
+	if entry, ok := r.entries[name]; ok {
+		return entry, true
+	}
+
+	for _, e := range r.entries {
+		if strings.ToLower(e.EntryPoint) == name ||
+			strings.ToLower(e.DisplayName) == name {
+			return e, true
+		}
+	}
+
+	if adapter, ok := builtinAdapters[name]; ok {
+		return &EntryStatus{
+			Entry: Entry{
+				Name:        adapter.Name,
+				DisplayName: adapter.Name,
+				Description: adapter.Description,
+				Category:    adapter.Category,
+			},
+			Installed: true,
+		}, true
+	}
+
+	return nil, false
+}
+
+func (r *Registry) MarkInstalled(name string, path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if e, ok := r.entries[name]; ok {
+		e.Installed = true
+		e.ExecutablePath = path
+	}
+}
+
+func (r *Registry) JSON() (string, error) {
+	data := map[string]any{
+		"root":          r.root,
+		"entries_count": r.EntriesCount(),
+		"categories":    r.Categories(),
+		"entries":       r.List(),
+		"builtin_count": len(builtinAdapters),
+	}
+
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}

--- a/pkg/extensions/adapters/extension.go
+++ b/pkg/extensions/adapters/extension.go
@@ -1,0 +1,198 @@
+// Package extension provides the extension loading and management system.
+// Extensions are self-contained modules that add channels, tools, providers,
+// and other capabilities to AnyClaw, similar to OpenClaw's extensions/ architecture.
+package extension
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Manifest defines the extension metadata (anyclaw.extension.json).
+type Manifest struct {
+	ID           string         `json:"id"`
+	Name         string         `json:"name"`
+	Version      string         `json:"version"`
+	Description  string         `json:"description"`
+	Kind         string         `json:"kind"` // "channel", "tool", "provider", "memory", "hook"
+	Builtin      bool           `json:"builtin,omitempty"`
+	Channels     []string       `json:"channels,omitempty"`      // Channel IDs this extension provides
+	Providers    []string       `json:"providers,omitempty"`     // LLM provider IDs
+	Skills       []string       `json:"skills,omitempty"`        // Skill IDs bundled
+	Entrypoint   string         `json:"entrypoint"`              // Main executable/script
+	Permissions  []string       `json:"permissions,omitempty"`   // Required permissions
+	ConfigSchema map[string]any `json:"config_schema,omitempty"` // JSON Schema for config
+}
+
+// Extension represents a loaded extension with runtime state.
+type Extension struct {
+	Manifest Manifest
+	Path     string
+	Enabled  bool
+	Config   map[string]any
+}
+
+// Registry manages all loaded extensions.
+type Registry struct {
+	mu            sync.RWMutex
+	extensions    map[string]*Extension
+	extensionsDir string
+}
+
+// NewRegistry creates a new extension registry.
+func NewRegistry(extensionsDir string) *Registry {
+	return &Registry{
+		extensions:    make(map[string]*Extension),
+		extensionsDir: extensionsDir,
+	}
+}
+
+// Discover scans the extensions directory for available extensions.
+func (r *Registry) Discover() ([]Manifest, error) {
+	manifests := append([]Manifest(nil), builtinExtensionManifests()...)
+
+	entries, err := os.ReadDir(r.extensionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return manifests, nil
+		}
+		return nil, fmt.Errorf("failed to read extensions dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		manifestPath := filepath.Join(r.extensionsDir, entry.Name(), "anyclaw.extension.json")
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read manifest %s: %w", manifestPath, err)
+		}
+
+		var m Manifest
+		if err := json.Unmarshal(data, &m); err != nil {
+			return nil, fmt.Errorf("invalid manifest %s: %w", manifestPath, err)
+		}
+
+		manifests = append(manifests, m)
+	}
+
+	return manifests, nil
+}
+
+// Register adds an extension to the registry.
+func (r *Registry) Register(ext *Extension) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.extensions[ext.Manifest.ID] = ext
+}
+
+// Get returns an extension by ID.
+func (r *Registry) Get(id string) (*Extension, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ext, ok := r.extensions[id]
+	return ext, ok
+}
+
+// List returns all registered extensions.
+func (r *Registry) List() []*Extension {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]*Extension, 0, len(r.extensions))
+	for _, ext := range r.extensions {
+		result = append(result, ext)
+	}
+	return result
+}
+
+// ListByKind returns extensions filtered by kind.
+func (r *Registry) ListByKind(kind string) []*Extension {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var result []*Extension
+	for _, ext := range r.extensions {
+		if ext.Manifest.Kind == kind && ext.Enabled {
+			result = append(result, ext)
+		}
+	}
+	return result
+}
+
+// Enable marks an extension as enabled.
+func (r *Registry) Enable(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ext, ok := r.extensions[id]
+	if !ok {
+		return fmt.Errorf("extension %q not found", id)
+	}
+	ext.Enabled = true
+	return nil
+}
+
+// Disable marks an extension as disabled.
+func (r *Registry) Disable(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ext, ok := r.extensions[id]
+	if !ok {
+		return fmt.Errorf("extension %q not found", id)
+	}
+	ext.Enabled = false
+	return nil
+}
+
+// LoadExtension loads a single extension from its directory.
+func LoadExtension(dir string) (*Extension, error) {
+	manifestPath := filepath.Join(dir, "anyclaw.extension.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read manifest: %w", err)
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("invalid manifest: %w", err)
+	}
+
+	return &Extension{
+		Manifest: m,
+		Path:     dir,
+		Enabled:  true,
+	}, nil
+}
+
+// LoadAll discovers and loads all extensions from the registry's directory.
+func (r *Registry) LoadAll() error {
+	manifests, err := r.Discover()
+	if err != nil {
+		return err
+	}
+
+	for _, m := range manifests {
+		if m.Builtin {
+			r.Register(&Extension{
+				Manifest: m,
+				Path:     "builtin://extensions/" + m.ID,
+				Enabled:  true,
+			})
+			continue
+		}
+		extPath := filepath.Join(r.extensionsDir, m.ID)
+		ext, err := LoadExtension(extPath)
+		if err != nil {
+			return fmt.Errorf("failed to load extension %s: %w", m.ID, err)
+		}
+		r.Register(ext)
+	}
+
+	return nil
+}

--- a/pkg/extensions/adapters/extension_test.go
+++ b/pkg/extensions/adapters/extension_test.go
@@ -1,0 +1,37 @@
+package extension
+
+import "testing"
+
+func TestBuiltinExtensionCatalogHasRecommendedCount(t *testing.T) {
+	if got := len(builtinExtensionManifests()); got != 22 {
+		t.Fatalf("expected 22 builtin extensions, got %d", got)
+	}
+}
+
+func TestDiscoverIncludesBuiltinExtensionsWithoutDirectory(t *testing.T) {
+	registry := NewRegistry("missing-dir")
+	items, err := registry.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(items) != 22 {
+		t.Fatalf("expected 22 builtin extensions from discover, got %d", len(items))
+	}
+}
+
+func TestLoadAllRegistersBuiltinExtensionsWithoutDirectory(t *testing.T) {
+	registry := NewRegistry("missing-dir")
+	if err := registry.LoadAll(); err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if got := len(registry.List()); got != 22 {
+		t.Fatalf("expected 22 loaded builtin extensions, got %d", got)
+	}
+	ext, ok := registry.Get("zoom")
+	if !ok {
+		t.Fatal("expected zoom builtin extension")
+	}
+	if !ext.Manifest.Builtin {
+		t.Fatal("expected builtin flag on zoom manifest")
+	}
+}

--- a/pkg/extensions/adapters/webhook/handler.go
+++ b/pkg/extensions/adapters/webhook/handler.go
@@ -1,0 +1,200 @@
+package webhook
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Handler manages incoming webhooks from external services.
+type Handler struct {
+	mu      sync.RWMutex
+	hooks   map[string]*Webhook
+	history []Event
+	maxHist int
+}
+
+type Webhook struct {
+	ID           string            `json:"id"`
+	Name         string            `json:"name"`
+	Path         string            `json:"path"`
+	Secret       string            `json:"secret,omitempty"`
+	Agent        string            `json:"agent,omitempty"`
+	Template     string            `json:"template,omitempty"`
+	Headers      map[string]string `json:"headers,omitempty"`
+	Enabled      bool              `json:"enabled"`
+	CreatedAt    time.Time         `json:"created_at"`
+	LastTrigger  *time.Time        `json:"last_trigger,omitempty"`
+	TriggerCount int               `json:"trigger_count"`
+}
+
+type Event struct {
+	ID        string            `json:"id"`
+	WebhookID string            `json:"webhook_id"`
+	Timestamp time.Time         `json:"timestamp"`
+	Headers   map[string]string `json:"headers,omitempty"`
+	Body      string            `json:"body,omitempty"`
+	Response  string            `json:"response,omitempty"`
+	Status    string            `json:"status"`
+	Error     string            `json:"error,omitempty"`
+	Duration  time.Duration     `json:"duration"`
+}
+
+func NewHandler() *Handler {
+	return &Handler{
+		hooks:   make(map[string]*Webhook),
+		maxHist: 100,
+	}
+}
+
+func (h *Handler) Register(webhook *Webhook) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if webhook.ID == "" {
+		webhook.ID = fmt.Sprintf("wh-%d", time.Now().UnixNano())
+	}
+	if webhook.Path == "" {
+		webhook.Path = fmt.Sprintf("/webhooks/%s", webhook.ID)
+	}
+	webhook.CreatedAt = time.Now()
+	webhook.Enabled = true
+
+	h.hooks[webhook.ID] = webhook
+	return nil
+}
+
+func (h *Handler) Unregister(id string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.hooks[id]; !ok {
+		return fmt.Errorf("webhook not found: %s", id)
+	}
+	delete(h.hooks, id)
+	return nil
+}
+
+func (h *Handler) Get(id string) (*Webhook, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	hook, ok := h.hooks[id]
+	return hook, ok
+}
+
+func (h *Handler) List() []*Webhook {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	list := make([]*Webhook, 0, len(h.hooks))
+	for _, hook := range h.hooks {
+		list = append(list, hook)
+	}
+	return list
+}
+
+func (h *Handler) GetHistory(limit int) []Event {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if limit <= 0 || limit > len(h.history) {
+		limit = len(h.history)
+	}
+	return h.history[len(h.history)-limit:]
+}
+
+func (h *Handler) HandleRequest(ctx context.Context, r *http.Request, processFn func(context.Context, *Webhook, []byte) (string, error)) (int, []byte) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	path := r.URL.Path
+
+	var matched *Webhook
+	for _, hook := range h.hooks {
+		if hook.Enabled && strings.HasPrefix(path, hook.Path) {
+			matched = hook
+			break
+		}
+	}
+
+	if matched == nil {
+		return http.StatusNotFound, []byte(`{"error":"webhook not found"}`)
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return http.StatusBadRequest, []byte(fmt.Sprintf(`{"error":"%s"}`, err.Error()))
+	}
+
+	if matched.Secret != "" {
+		signature := r.Header.Get("X-Hub-Signature-256")
+		if signature == "" {
+			signature = r.Header.Get("X-Signature-256")
+		}
+		if !verifySignature(matched.Secret, body, signature) {
+			return http.StatusUnauthorized, []byte(`{"error":"invalid signature"}`)
+		}
+	}
+
+	event := Event{
+		ID:        fmt.Sprintf("evt-%d", time.Now().UnixNano()),
+		WebhookID: matched.ID,
+		Timestamp: time.Now(),
+		Body:      string(body),
+		Status:    "processing",
+		Headers:   map[string]string{},
+	}
+	for key, values := range r.Header {
+		if len(values) > 0 {
+			event.Headers[key] = values[0]
+		}
+	}
+
+	start := time.Now()
+	response, err := processFn(ctx, matched, body)
+	event.Duration = time.Since(start)
+
+	if err != nil {
+		event.Status = "failed"
+		event.Error = err.Error()
+	} else {
+		event.Status = "success"
+		event.Response = response
+	}
+
+	now := time.Now()
+	matched.LastTrigger = &now
+	matched.TriggerCount++
+
+	h.history = append(h.history, event)
+	if len(h.history) > h.maxHist {
+		h.history = h.history[len(h.history)-h.maxHist:]
+	}
+
+	if err != nil {
+		return http.StatusInternalServerError, []byte(fmt.Sprintf(`{"error":"%s"}`, err.Error()))
+	}
+
+	return http.StatusOK, []byte(response)
+}
+
+func verifySignature(secret string, body []byte, signature string) bool {
+	if signature == "" {
+		return false
+	}
+
+	signature = strings.TrimPrefix(signature, "sha256=")
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+
+	return hmac.Equal([]byte(signature), []byte(expected))
+}


### PR DESCRIPTION
This is a file-scoped split PR for the pkg/extensions/adapters area.

Source branch: $(@{branch=split/extensions-adapters-core; title=feat(adapters): add extension registry and execution core; commit=feat(adapters): add extension registry and execution core; source=pr/pkg-extensions-adapters; scope=pkg/extensions/adapters; files=System.Object[]}.source)
Changed lines: 862
Reason: split the original larger PR into reviewable chunks under 3000 changed lines.