### PR TITLE
feat(ui): add shell state and settings overlays

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Bot, Cable, Cloud, LayoutDashboard, Sparkles } from "lucide-react";
+import { Bot, Cable, Cloud, LayoutDashboard, Settings2, Sparkles } from "lucide-react";
 import { useState } from "react";
 
 import { BackendDetailSection } from "@/features/backend-ui/BackendDetailSection";
@@ -11,6 +11,8 @@ import { BackendSummaryStrip } from "@/features/backend-ui/BackendSummaryStrip";
 import { StatusBadge } from "@/features/backend-ui/StatusBadge";
 import { BackendToolbar } from "@/features/backend-ui/BackendToolbar";
 import { getStatusTone } from "@/features/backend-ui/getStatusTone";
+import { ShellOverlays } from "@/features/shell/ShellOverlays";
+import { useShellStore } from "@/features/shell/useShellStore";
 import { type AgentRecord, type ChannelRecord, type SkillRecord, useWorkspaceOverview } from "@/features/workspace/useWorkspaceOverview";
 
 const queryClient = new QueryClient({
@@ -166,6 +168,9 @@ function ChannelList({ items }: { items: ChannelRecord[] }) {
 
 function WorkspaceOverviewApp() {
   const { data } = useWorkspaceOverview();
+  const openAgentDrawer = useShellStore((state) => state.openAgentDrawer);
+  const openModelSettings = useShellStore((state) => state.openModelSettings);
+  const openSettings = useShellStore((state) => state.openSettings);
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<OverviewFilter>("all");
 
@@ -219,6 +224,33 @@ function WorkspaceOverviewApp() {
             ]}
           />
         </div>
+
+        <section className="mt-4 grid gap-3 sm:grid-cols-3">
+          <button
+            className="shell-button h-12 justify-center px-5 text-sm font-medium"
+            onClick={openAgentDrawer}
+            type="button"
+          >
+            <Bot size={16} strokeWidth={2.1} />
+            <span>查看 Agent 抽屉</span>
+          </button>
+          <button
+            className="shell-button h-12 justify-center px-5 text-sm font-medium"
+            onClick={openModelSettings}
+            type="button"
+          >
+            <Sparkles size={16} strokeWidth={2.1} />
+            <span>打开模型设置</span>
+          </button>
+          <button
+            className="chip-button h-12 justify-center px-5 text-sm"
+            onClick={() => openSettings("general")}
+            type="button"
+          >
+            <Settings2 size={16} strokeWidth={2.1} />
+            <span>打开工作区设置</span>
+          </button>
+        </section>
 
         <BackendToolbar
           groups={[
@@ -363,6 +395,7 @@ function WorkspaceOverviewApp() {
           </BackendDetailSection>
         </section>
       </div>
+      <ShellOverlays />
     </div>
   );
 }

--- a/ui/src/features/agent-drawer/AgentDrawer.tsx
+++ b/ui/src/features/agent-drawer/AgentDrawer.tsx
@@ -1,0 +1,194 @@
+import { Bot, FolderKanban, ShieldCheck, Sparkles, Waypoints, X } from "lucide-react";
+
+import { useShellStore } from "@/features/shell/useShellStore";
+import { useWorkspaceOverview } from "@/features/workspace/useWorkspaceOverview";
+
+type AgentDrawerProps = {
+  onClose: () => void;
+};
+
+export function AgentDrawer({ onClose }: AgentDrawerProps) {
+  const { data } = useWorkspaceOverview();
+  const openSettings = useShellStore((state) => state.openSettings);
+  const runtimeProfile = data.runtimeProfile;
+  const activeAgent = data.localAgents.find((agent) => agent.active) ?? data.localAgents[0];
+  const highlights = [
+    { label: "模型", value: runtimeProfile.model, icon: Sparkles },
+    { label: "权限", value: runtimeProfile.permission, icon: ShieldCheck },
+    { label: "工作空间", value: runtimeProfile.workspace, icon: FolderKanban },
+  ];
+
+  return (
+    <section
+      aria-labelledby="agent-drawer-title"
+      aria-modal="true"
+      className="shell-panel pointer-events-auto flex h-full w-full max-w-[560px] flex-col border-l border-white/80 shadow-[0_28px_90px_rgba(27,24,20,0.24)]"
+      role="dialog"
+    >
+      <header className="flex items-start justify-between gap-4 border-b border-skin px-5 py-5 sm:px-6">
+        <div className="space-y-2">
+          <div className="inline-flex items-center gap-2 rounded-full bg-[#f3f6fb] px-3 py-1.5 text-sm text-[#5f7597]">
+            <Bot size={15} strokeWidth={2.1} />
+            Round 3 · Agent 实时摘要
+          </div>
+          <div>
+            <h2
+              className="text-[30px] font-semibold tracking-[-0.04em] text-ink"
+              id="agent-drawer-title"
+            >
+              当前 Agent
+            </h2>
+            <p className="mt-2 text-sm leading-7 text-mute">
+              这里已经开始读取运行配置、Provider 摘要和网关状态。后续如果继续做第四轮，可以把这里扩展成真正的 Agent 管理面板。
+            </p>
+          </div>
+        </div>
+
+        <button
+          aria-label="关闭 Agent 抽屉"
+          className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-white/80 text-[#556274] shadow-soft transition-transform duration-150 hover:-translate-y-0.5"
+          onClick={onClose}
+          type="button"
+        >
+          <X size={18} strokeWidth={2.2} />
+        </button>
+      </header>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-5 sm:px-6">
+        <section className="rounded-[30px] border border-white/80 bg-white/74 p-5 shadow-soft">
+          <div className="flex items-start gap-4">
+            <span className="flex h-16 w-16 shrink-0 items-center justify-center rounded-[24px] bg-[radial-gradient(circle_at_30%_28%,#ffe3a5,transparent_28%),linear-gradient(140deg,#ffb36f,#ff6c3c)] text-white shadow-[0_16px_30px_rgba(255,123,67,0.22)]">
+              <Bot size={28} strokeWidth={2.1} />
+            </span>
+            <div className="min-w-0">
+              <div className="inline-flex rounded-full bg-[#f5f7fb] px-3 py-1 text-xs font-medium text-[#5b6f8b]">
+                {runtimeProfile.title}
+              </div>
+              <h3 className="mt-3 text-[30px] font-semibold tracking-[-0.04em] text-ink">
+                {runtimeProfile.name}
+              </h3>
+              <p className="mt-3 text-sm leading-7 text-mute">{runtimeProfile.description}</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-5 grid gap-4">
+          {highlights.map(({ label, value, icon: Icon }) => (
+            <article
+              key={label}
+              className="rounded-[26px] border border-white/75 bg-white/72 p-5 shadow-soft"
+            >
+              <div className="flex items-center gap-3">
+                <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#f3f6fb] text-[#607699]">
+                  <Icon size={19} strokeWidth={2.1} />
+                </span>
+                <div>
+                  <div className="text-sm text-mute">{label}</div>
+                  <div className="text-[24px] font-semibold tracking-[-0.04em] text-ink">{value}</div>
+                </div>
+              </div>
+            </article>
+          ))}
+        </section>
+
+        <section className="mt-5 rounded-[30px] border border-white/75 bg-white/72 p-5 shadow-soft">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <h3 className="text-[24px] font-semibold tracking-[-0.04em] text-ink">运行时摘要</h3>
+              <p className="mt-2 text-sm leading-7 text-mute">这里汇总当前网关、会话、工具和运行时缓存的状态。</p>
+            </div>
+            <div className="rounded-full bg-[#f5f7fb] px-3 py-1 text-xs text-[#5b6f8b]">
+              {runtimeProfile.orchestrator}
+            </div>
+          </div>
+
+          <div className="mt-4 space-y-3 text-sm">
+            <div className="flex items-center justify-between gap-4 rounded-[20px] bg-[#f8fafc] px-4 py-3">
+              <span className="text-mute">Provider</span>
+              <span className="font-medium text-ink">
+                {runtimeProfile.providerLabel} · {runtimeProfile.provider}
+              </span>
+            </div>
+            <div className="flex items-center justify-between gap-4 rounded-[20px] bg-[#f8fafc] px-4 py-3">
+              <span className="text-mute">网关</span>
+              <span className="font-medium text-ink">
+                {runtimeProfile.gatewayOnline ? "在线" : "离线"} · {runtimeProfile.address}
+              </span>
+            </div>
+            <div className="flex items-center justify-between gap-4 rounded-[20px] bg-[#f8fafc] px-4 py-3">
+              <span className="text-mute">会话 / 运行时</span>
+              <span className="font-medium text-ink">
+                {runtimeProfile.sessions} / {runtimeProfile.runtimes}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-5 rounded-[30px] border border-white/75 bg-white/72 p-5 shadow-soft">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <h3 className="text-[24px] font-semibold tracking-[-0.04em] text-ink">已挂接能力</h3>
+              <p className="mt-2 text-sm leading-7 text-mute">这里优先展示当前 Agent 对应的技能与主要渠道入口。</p>
+            </div>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            {data.localSkills.slice(0, 6).map((skill) => (
+              <span
+                key={skill.name}
+                className="rounded-full border border-white/80 bg-white/88 px-3 py-1.5 text-xs text-[#5d5344]"
+              >
+                {skill.name}
+              </span>
+            ))}
+          </div>
+
+          <div className="mt-5 flex flex-wrap gap-2">
+            {data.priorityChannels.slice(0, 4).map((channel) => (
+              <span
+                key={channel.slug}
+                className="inline-flex items-center gap-2 rounded-full bg-[#edf2fa] px-3 py-1.5 text-xs text-[#577098]"
+              >
+                <Waypoints size={12} strokeWidth={2.2} />
+                {channel.name}
+              </span>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-5 rounded-[30px] border border-white/75 bg-white/72 p-5 shadow-soft">
+          <div className="text-sm font-medium uppercase tracking-[0.16em] text-[#64748b]">当前配置角色</div>
+          <div className="mt-3 text-[24px] font-semibold tracking-[-0.04em] text-ink">
+            {activeAgent?.role || runtimeProfile.title}
+          </div>
+          <p className="mt-3 text-sm leading-7 text-mute">
+            {activeAgent?.summary || "当前 Agent 的描述会在这里展示。"}
+          </p>
+        </section>
+
+        <footer className="mt-5 flex flex-col gap-3 sm:flex-row">
+          <button
+            className="shell-button h-12 justify-center px-5 text-base font-medium"
+            onClick={() => {
+              onClose();
+              openSettings("skills");
+            }}
+            type="button"
+          >
+            查看 Skill
+          </button>
+          <button
+            className="chip-button justify-center px-5"
+            onClick={() => {
+              onClose();
+              openSettings("channels");
+            }}
+            type="button"
+          >
+            查看渠道
+          </button>
+        </footer>
+      </div>
+    </section>
+  );
+}

--- a/ui/src/features/model-settings/ModelSettingsModal.test.tsx
+++ b/ui/src/features/model-settings/ModelSettingsModal.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ModelSettingsModal } from "@/features/model-settings/ModelSettingsModal";
+
+function jsonResponse(payload: unknown) {
+  return new Response(JSON.stringify(payload), {
+    headers: { "Content-Type": "application/json" },
+    status: 200,
+  });
+}
+
+function renderWithClient(node: React.ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+
+  return render(<QueryClientProvider client={client}>{node}</QueryClientProvider>);
+}
+
+describe("ModelSettingsModal", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps provider selection separate from setting the default provider", async () => {
+    const providers = [
+      {
+        default_model: "gpt-5.4",
+        enabled: true,
+        has_api_key: true,
+        id: "provider-a",
+        is_default: true,
+        name: "Primary Provider",
+        provider: "compatible",
+      },
+      {
+        default_model: "claude-sonnet",
+        enabled: true,
+        has_api_key: true,
+        id: "provider-b",
+        is_default: false,
+        name: "Secondary Provider",
+        provider: "compatible",
+      },
+    ];
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+
+      if (url === "/providers" && method === "GET") {
+        return jsonResponse(providers);
+      }
+
+      if (url === "/providers" && method === "POST") {
+        return jsonResponse(providers[1]);
+      }
+
+      if (url === "/providers/default" && method === "POST") {
+        return jsonResponse({
+          ...providers[1],
+          is_default: true,
+        });
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithClient(<ModelSettingsModal onClose={vi.fn()} />);
+
+    await screen.findByDisplayValue("Primary Provider");
+
+    fireEvent.click(screen.getByRole("button", { name: /Secondary Provider/i }));
+
+    expect(screen.getByDisplayValue("Secondary Provider")).toBeInTheDocument();
+    expect(
+      fetchMock.mock.calls.some(
+        ([input]) => String(input) === "/providers/default",
+      ),
+    ).toBe(false);
+
+    fireEvent.click(screen.getByRole("button", { name: /设为默认模型/i }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(
+          ([input, init]) =>
+            String(input) === "/providers/default" &&
+            init?.method === "POST" &&
+            init.body === JSON.stringify({ provider_ref: "provider-b" }),
+        ),
+      ).toBe(true);
+    });
+  });
+});

--- a/ui/src/features/model-settings/ModelSettingsModal.tsx
+++ b/ui/src/features/model-settings/ModelSettingsModal.tsx
@@ -1,0 +1,739 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  CheckCircle2,
+  Eye,
+  EyeOff,
+  LoaderCircle,
+  Plus,
+  ServerCog,
+  Sparkles,
+  X,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+type ModelSettingsModalProps = {
+  onClose: () => void;
+};
+
+type ProviderRuntime = "compatible" | "ollama" | "qwen";
+
+type ProviderHealth = {
+  http_status?: number;
+  message?: string;
+  ok?: boolean;
+  status?: string;
+};
+
+type ProviderView = {
+  api_key_preview?: string;
+  base_url?: string;
+  capabilities?: string[];
+  default_model?: string;
+  enabled: boolean;
+  has_api_key?: boolean;
+  health?: ProviderHealth;
+  id: string;
+  is_default?: boolean;
+  name: string;
+  provider: string;
+  type?: string;
+};
+
+type ProviderDraft = {
+  apiKey: string;
+  apiKeyPreview: string;
+  baseUrl: string;
+  capabilities: string[];
+  enabled: boolean;
+  hasStoredApiKey: boolean;
+  id: string;
+  model: string;
+  name: string;
+  runtime: ProviderRuntime;
+  type: string;
+};
+
+type NoticeState =
+  | {
+      kind: "error" | "success";
+      message: string;
+    }
+  | null;
+
+const NEW_PROVIDER_ID = "__new_provider__";
+
+function safeJsonParse(value: string) {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+async function requestJSON<T>(input: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, {
+    ...init,
+    headers: {
+      Accept: "application/json",
+      ...(init?.body ? { "Content-Type": "application/json" } : null),
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  const raw = await response.text();
+  const payload = raw ? safeJsonParse(raw) : null;
+
+  if (!response.ok) {
+    const message =
+      payload && typeof payload === "object" && "error" in payload && typeof payload.error === "string"
+        ? payload.error
+        : `请求失败 (${response.status})`;
+    throw new Error(message);
+  }
+
+  return payload as T;
+}
+
+function normalizeRuntime(value?: string): ProviderRuntime {
+  const runtime = value?.trim().toLowerCase();
+  if (runtime === "ollama") return "ollama";
+  if (runtime === "qwen") return "qwen";
+  return "compatible";
+}
+
+function runtimeLabel(runtime: ProviderRuntime) {
+  switch (runtime) {
+    case "ollama":
+      return "Ollama";
+    case "qwen":
+      return "通义千问";
+    default:
+      return "兼容接口";
+  }
+}
+
+function runtimeModelPlaceholder(runtime: ProviderRuntime) {
+  switch (runtime) {
+    case "ollama":
+      return "例如 llama3.2";
+    case "qwen":
+      return "例如 qwen-max";
+    default:
+      return "例如 gpt-5.4";
+  }
+}
+
+function runtimeBaseUrlPlaceholder(runtime: ProviderRuntime) {
+  switch (runtime) {
+    case "ollama":
+      return "例如 http://127.0.0.1:11434";
+    case "qwen":
+      return "例如 https://dashscope.aliyuncs.com/compatible-mode/v1";
+    default:
+      return "例如 https://api.openai.com/v1";
+  }
+}
+
+function runtimeDescription(runtime: ProviderRuntime) {
+  switch (runtime) {
+    case "ollama":
+      return "适合本地模型，通常不需要 API Key。";
+    case "qwen":
+      return "适合阿里云百炼兼容模式接入。";
+    default:
+      return "适合 OpenAI、OpenRouter、火山方舟等兼容接口。";
+  }
+}
+
+function runtimeToType(runtime: ProviderRuntime) {
+  switch (runtime) {
+    case "ollama":
+      return "ollama";
+    case "qwen":
+      return "qwen";
+    default:
+      return "openai-compatible";
+  }
+}
+
+function createEmptyDraft(): ProviderDraft {
+  return {
+    apiKey: "",
+    apiKeyPreview: "",
+    baseUrl: "",
+    capabilities: [],
+    enabled: true,
+    hasStoredApiKey: false,
+    id: "",
+    model: "",
+    name: "",
+    runtime: "compatible",
+    type: runtimeToType("compatible"),
+  };
+}
+
+function providerToDraft(provider: ProviderView): ProviderDraft {
+  const runtime = normalizeRuntime(provider.provider);
+
+  return {
+    apiKey: "",
+    apiKeyPreview: provider.api_key_preview ?? "",
+    baseUrl: provider.base_url ?? "",
+    capabilities: provider.capabilities ?? [],
+    enabled: provider.enabled,
+    hasStoredApiKey: provider.has_api_key ?? false,
+    id: provider.id,
+    model: provider.default_model ?? "",
+    name: provider.name,
+    runtime,
+    type: provider.type ?? runtimeToType(runtime),
+  };
+}
+
+function buildPayload(draft: ProviderDraft) {
+  return {
+    api_key: draft.apiKey.trim(),
+    base_url: draft.baseUrl.trim(),
+    capabilities: draft.capabilities,
+    default_model: draft.model.trim(),
+    enabled: draft.enabled,
+    id: draft.id.trim(),
+    name: draft.name.trim(),
+    provider: draft.runtime,
+    type: runtimeToType(draft.runtime),
+  };
+}
+
+function validateDraft(draft: ProviderDraft) {
+  if (draft.name.trim() === "") return "请填写配置名称";
+  if (draft.model.trim() === "") return "请填写模型名称";
+  if (draft.runtime !== "ollama" && draft.apiKey.trim() === "" && !draft.hasStoredApiKey) {
+    return "请填写 API Key";
+  }
+  return null;
+}
+
+function StatusPill({ provider }: { provider: ProviderView | null }) {
+  if (!provider) return null;
+
+  const status = provider.health?.status ?? (provider.enabled ? "ready" : "disabled");
+  const label =
+    status === "ready"
+      ? "可用"
+      : status === "reachable"
+        ? "已连通"
+        : status === "missing_key"
+          ? "缺少密钥"
+          : status === "disabled"
+            ? "已停用"
+            : "待检查";
+
+  return (
+    <span
+      className={[
+        "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium",
+        status === "ready" || status === "reachable"
+          ? "bg-[#eefbf2] text-[#166534]"
+          : "bg-[#f4f5f7] text-[#667085]",
+      ].join(" ")}
+    >
+      {label}
+    </span>
+  );
+}
+
+function resolveTestFeedback(result: ProviderHealth | null) {
+  if (!result) {
+    return null;
+  }
+
+  const httpStatus = result.http_status;
+  const isHealthyHttp = httpStatus === undefined || (httpStatus >= 200 && httpStatus < 300);
+
+  if (result.ok && isHealthyHttp) {
+    return {
+      message: result.message || "连接测试已完成",
+      tone: "success" as const,
+    };
+  }
+
+  if (result.ok && httpStatus !== undefined) {
+    return {
+      message:
+        result.message ||
+        `服务可达，但返回了 HTTP ${httpStatus}。请确认 Base URL 和接口路径是否正确。`,
+      tone: "warning" as const,
+    };
+  }
+
+  return {
+    message: result.message || "连接测试失败",
+    tone: "error" as const,
+  };
+}
+
+function FieldLabel({ hint, label }: { hint?: string; label: string }) {
+  return (
+    <div className="mb-2 flex items-center justify-between gap-3">
+      <label className="text-sm font-medium text-[#344054]">{label}</label>
+      {hint ? <span className="text-xs text-[#98a2b3]">{hint}</span> : null}
+    </div>
+  );
+}
+
+export function ModelSettingsModal({ onClose }: ModelSettingsModalProps) {
+  const queryClient = useQueryClient();
+  const [draft, setDraft] = useState<ProviderDraft>(createEmptyDraft());
+  const [notice, setNotice] = useState<NoticeState>(null);
+  const [secretVisible, setSecretVisible] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<ProviderHealth | null>(null);
+
+  const providersQuery = useQuery({
+    queryKey: ["provider-profiles"],
+    queryFn: () => requestJSON<ProviderView[]>("/providers"),
+    staleTime: 5_000,
+  });
+
+  const saveProviderMutation = useMutation({
+    mutationFn: (payload: ReturnType<typeof buildPayload>) =>
+      requestJSON<ProviderView>("/providers", {
+        body: JSON.stringify(payload),
+        method: "POST",
+      }),
+  });
+
+  const setDefaultMutation = useMutation({
+    mutationFn: (providerRef: string) =>
+      requestJSON<ProviderView>("/providers/default", {
+        body: JSON.stringify({ provider_ref: providerRef }),
+        method: "POST",
+      }),
+  });
+
+  const testProviderMutation = useMutation({
+    mutationFn: (payload: ReturnType<typeof buildPayload>) =>
+      requestJSON<ProviderHealth>("/providers/test", {
+        body: JSON.stringify(payload),
+        method: "POST",
+      }),
+  });
+
+  const providers = providersQuery.data ?? [];
+
+  const selectedProvider = useMemo(
+    () => providers.find((provider) => provider.id === selectedId) ?? null,
+    [providers, selectedId],
+  );
+  const currentDefaultId = providers.find((provider) => provider.is_default)?.id ?? null;
+
+  const isCreating = selectedId === NEW_PROVIDER_ID;
+  const requiresApiKey = draft.runtime !== "ollama";
+  const isBusy =
+    saveProviderMutation.isPending || setDefaultMutation.isPending || testProviderMutation.isPending;
+  const testFeedback = resolveTestFeedback(testResult);
+
+  useEffect(() => {
+    if (selectedId !== null) return;
+
+    if (providers.length > 0) {
+      const currentDefault = providers.find((provider) => provider.is_default) ?? providers[0];
+      setSelectedId(currentDefault.id);
+      setDraft(providerToDraft(currentDefault));
+      return;
+    }
+
+    if (providersQuery.isFetched || providersQuery.isError) {
+      setSelectedId(NEW_PROVIDER_ID);
+      setDraft(createEmptyDraft());
+    }
+  }, [providers, providersQuery.isError, providersQuery.isFetched, selectedId]);
+
+  function resetFeedback() {
+    setNotice(null);
+    setTestResult(null);
+  }
+
+  async function handleSelectProvider(provider: ProviderView) {
+    setSelectedId(provider.id);
+    setDraft(providerToDraft(provider));
+    setSecretVisible(false);
+    resetFeedback();
+
+    if (provider.id === currentDefaultId) {
+      return;
+    }
+
+    try {
+      const defaultProvider = await setDefaultMutation.mutateAsync(provider.id);
+      setSelectedId(defaultProvider.id);
+      setDraft(providerToDraft(defaultProvider));
+      await refreshQueries();
+      setNotice({
+        kind: "success",
+        message: `已切换到 ${defaultProvider.default_model || defaultProvider.name}`,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "切换默认模型失败";
+      setNotice({ kind: "error", message });
+    }
+  }
+
+  function handleCreateProvider() {
+    setSelectedId(NEW_PROVIDER_ID);
+    setDraft(createEmptyDraft());
+    setSecretVisible(false);
+    resetFeedback();
+  }
+
+  function updateDraft<K extends keyof ProviderDraft>(key: K, value: ProviderDraft[K]) {
+    setDraft((current) => {
+      const next = { ...current, [key]: value };
+      if (key === "runtime") {
+        next.type = runtimeToType(value as ProviderRuntime);
+      }
+      return next;
+    });
+    setNotice(null);
+    setTestResult(null);
+  }
+
+  async function refreshQueries() {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["provider-profiles"] }),
+      queryClient.invalidateQueries({ queryKey: ["workspace-overview"] }),
+    ]);
+  }
+
+  async function handleSave(makeDefault: boolean) {
+    const validationMessage = validateDraft(draft);
+    if (validationMessage) {
+      setNotice({ kind: "error", message: validationMessage });
+      return;
+    }
+
+    setNotice(null);
+
+    try {
+      const savedProvider = await saveProviderMutation.mutateAsync(buildPayload(draft));
+      setSelectedId(savedProvider.id);
+      setDraft(providerToDraft(savedProvider));
+
+      if (makeDefault) {
+        const defaultProvider = await setDefaultMutation.mutateAsync(savedProvider.id);
+        setDraft(providerToDraft(defaultProvider));
+        await refreshQueries();
+        onClose();
+        return;
+      }
+
+      await refreshQueries();
+      setNotice({
+        kind: "success",
+        message: `已保存 ${savedProvider.name}`,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "保存失败";
+      setNotice({ kind: "error", message });
+    }
+  }
+
+  async function handleTest() {
+    const validationMessage = validateDraft({
+      ...draft,
+      model: draft.model.trim() || "placeholder-model",
+    });
+
+    if (validationMessage === "请填写模型名称") {
+      setNotice({ kind: "error", message: "测试前请先填写模型名称" });
+      return;
+    }
+
+    if (validationMessage === "请填写 API Key") {
+      setNotice({ kind: "error", message: validationMessage });
+      return;
+    }
+
+    try {
+      setNotice(null);
+      const result = await testProviderMutation.mutateAsync(buildPayload(draft));
+      setTestResult(result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "测试失败";
+      setNotice({ kind: "error", message });
+      setTestResult(null);
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby="model-settings-dialog-title"
+      aria-modal="true"
+      className="pointer-events-auto mx-4 flex h-[88vh] w-full max-w-[1180px] flex-col overflow-hidden rounded-[32px] border border-white/80 bg-white shadow-[0_36px_90px_rgba(15,23,42,0.18)] sm:mx-6 lg:h-[82vh]"
+      role="dialog"
+    >
+      <header className="flex items-center justify-between gap-4 border-b border-[#eceff3] px-6 py-5">
+        <div>
+          <div className="text-sm font-medium text-[#667085]">模型设置</div>
+          <h2 className="mt-1 text-[24px] font-semibold tracking-[-0.03em] text-[#111827]" id="model-settings-dialog-title">
+            默认大模型
+          </h2>
+        </div>
+
+        <button
+          aria-label="关闭模型设置"
+          className="flex h-11 w-11 items-center justify-center rounded-full text-[#667085] transition-colors duration-150 hover:bg-[#f3f4f6] hover:text-[#111827]"
+          onClick={onClose}
+          type="button"
+        >
+          <X size={22} strokeWidth={2.1} />
+        </button>
+      </header>
+
+      <div className="grid min-h-0 flex-1 lg:grid-cols-[320px_minmax(0,1fr)]">
+        <aside className="flex min-h-0 flex-col border-b border-[#eceff3] bg-[#fbfcfe] lg:border-b-0 lg:border-r">
+          <div className="border-b border-[#eceff3] px-5 py-5">
+            <button
+              className="flex h-11 w-full items-center justify-center gap-2 rounded-[16px] bg-[#1f2430] px-4 text-sm font-medium text-white transition-transform duration-150 hover:-translate-y-0.5"
+              onClick={handleCreateProvider}
+              type="button"
+            >
+              <Plus size={16} strokeWidth={2.1} />
+              <span>新建自定义配置</span>
+            </button>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+            {providersQuery.isLoading ? (
+              <div className="flex items-center gap-2 px-3 py-4 text-sm text-[#667085]">
+                <LoaderCircle className="animate-spin" size={16} strokeWidth={2.1} />
+                <span>正在读取模型配置...</span>
+              </div>
+            ) : null}
+
+            {providersQuery.isError ? (
+              <div className="px-3 py-4 text-sm leading-6 text-[#667085]">已有配置读取失败，但你仍然可以新建配置。</div>
+            ) : null}
+
+            {providers.map((provider) => {
+              const active = provider.id === selectedId;
+
+              return (
+                <button
+                  aria-pressed={active}
+                  className={[
+                    "mb-2 flex w-full items-start gap-3 rounded-[20px] px-4 py-3 text-left transition-colors duration-150",
+                    active ? "bg-white text-[#111827] shadow-[0_10px_24px_rgba(15,23,42,0.06)]" : "text-[#475467] hover:bg-white",
+                    isBusy ? "cursor-wait opacity-70" : "",
+                  ].join(" ")}
+                  disabled={isBusy}
+                  key={provider.id}
+                  onClick={() => void handleSelectProvider(provider)}
+                  type="button"
+                >
+                  <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-[14px] bg-[#f4f6fb] text-[#1f2430]">
+                    {provider.is_default ? <CheckCircle2 size={18} strokeWidth={2.1} /> : <ServerCog size={18} strokeWidth={2.1} />}
+                  </span>
+
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-2">
+                      <span className="truncate text-sm font-semibold text-[#111827]">{provider.name}</span>
+                      {provider.is_default ? (
+                        <span className="rounded-full bg-[#eef2ff] px-2.5 py-1 text-[11px] font-medium text-[#3b5bcc]">
+                          默认
+                        </span>
+                      ) : null}
+                    </span>
+                    <span className="mt-1 block text-sm text-[#667085]">
+                      {runtimeLabel(normalizeRuntime(provider.provider))}
+                      {provider.default_model ? ` · ${provider.default_model}` : ""}
+                    </span>
+                    {provider.base_url ? (
+                      <span className="mt-1 block truncate text-xs text-[#98a2b3]">{provider.base_url}</span>
+                    ) : null}
+                  </span>
+                </button>
+              );
+            })}
+
+            {!providersQuery.isLoading && providers.length === 0 ? (
+              <div className="px-3 py-4 text-sm leading-6 text-[#667085]">还没有可用配置，先新建一个模型接入。</div>
+            ) : null}
+          </div>
+        </aside>
+
+        <div className="flex min-h-0 flex-col">
+          <div className="border-b border-[#eceff3] px-6 py-5 lg:px-8">
+            <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+              <div>
+                <div className="flex items-center gap-2">
+                  <div className="text-[22px] font-semibold tracking-[-0.03em] text-[#111827]">
+                    {isCreating ? "新建模型配置" : draft.name || "模型配置"}
+                  </div>
+                  {!isCreating && selectedProvider?.is_default ? (
+                    <span className="rounded-full bg-[#eef2ff] px-3 py-1 text-xs font-medium text-[#3b5bcc]">
+                      当前默认
+                    </span>
+                  ) : null}
+                  <StatusPill provider={selectedProvider} />
+                </div>
+                <div className="mt-2 text-sm text-[#667085]">{runtimeDescription(draft.runtime)}</div>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <button
+                  className="chip-button px-4 py-2 text-sm text-[#475467]"
+                  disabled={isBusy}
+                  onClick={handleTest}
+                  type="button"
+                >
+                  {testProviderMutation.isPending ? (
+                    <LoaderCircle className="animate-spin" size={15} strokeWidth={2.1} />
+                  ) : (
+                    <Sparkles size={15} strokeWidth={2.1} />
+                  )}
+                  <span>测试连接</span>
+                </button>
+              </div>
+            </div>
+
+            {testFeedback ? (
+              <div
+                className={[
+                  "mt-4 rounded-[16px] px-4 py-3 text-sm",
+                  testFeedback.tone === "success"
+                    ? "bg-[#eefbf2] text-[#166534]"
+                    : testFeedback.tone === "warning"
+                      ? "bg-[#fff7ed] text-[#b45309]"
+                      : "bg-[#fff7ed] text-[#c2410c]",
+                ].join(" ")}
+              >
+                {testFeedback.message}
+              </div>
+            ) : null}
+
+            {notice ? (
+              <div
+                className={[
+                  "mt-4 rounded-[16px] px-4 py-3 text-sm",
+                  notice.kind === "success" ? "bg-[#eefbf2] text-[#166534]" : "bg-[#fff7ed] text-[#c2410c]",
+                ].join(" ")}
+              >
+                {notice.message}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 lg:px-8 lg:py-7">
+            <div className="grid gap-6 xl:grid-cols-2">
+              <div>
+                <FieldLabel label="配置名称" />
+                <input
+                  className="h-12 w-full rounded-[16px] border border-[#dbe1ea] bg-white px-4 text-sm text-[#111827] outline-none transition-colors duration-150 placeholder:text-[#98a2b3] focus:border-[#98a2b3]"
+                  onChange={(event) => updateDraft("name", event.target.value)}
+                  placeholder="例如 我的 OpenAI 接口"
+                  value={draft.name}
+                />
+              </div>
+
+              <div>
+                <FieldLabel label="运行时" />
+                <select
+                  className="h-12 w-full rounded-[16px] border border-[#dbe1ea] bg-white px-4 text-sm text-[#111827] outline-none transition-colors duration-150 focus:border-[#98a2b3]"
+                  onChange={(event) => updateDraft("runtime", event.target.value as ProviderRuntime)}
+                  value={draft.runtime}
+                >
+                  <option value="compatible">兼容接口</option>
+                  <option value="qwen">通义千问</option>
+                  <option value="ollama">Ollama</option>
+                </select>
+              </div>
+
+              <div>
+                <FieldLabel label="模型名称" />
+                <input
+                  className="h-12 w-full rounded-[16px] border border-[#dbe1ea] bg-white px-4 text-sm text-[#111827] outline-none transition-colors duration-150 placeholder:text-[#98a2b3] focus:border-[#98a2b3]"
+                  onChange={(event) => updateDraft("model", event.target.value)}
+                  placeholder={runtimeModelPlaceholder(draft.runtime)}
+                  value={draft.model}
+                />
+              </div>
+
+              <div>
+                <FieldLabel hint="可留空" label="Base URL" />
+                <input
+                  className="h-12 w-full rounded-[16px] border border-[#dbe1ea] bg-white px-4 text-sm text-[#111827] outline-none transition-colors duration-150 placeholder:text-[#98a2b3] focus:border-[#98a2b3]"
+                  onChange={(event) => updateDraft("baseUrl", event.target.value)}
+                  placeholder={runtimeBaseUrlPlaceholder(draft.runtime)}
+                  value={draft.baseUrl}
+                />
+              </div>
+
+              <div className="xl:col-span-2">
+                <FieldLabel hint={requiresApiKey ? "必填" : "本地模型通常不需要"} label="API Key" />
+                <div className="relative">
+                  <input
+                    className="h-12 w-full rounded-[16px] border border-[#dbe1ea] bg-white px-4 pr-12 text-sm text-[#111827] outline-none transition-colors duration-150 placeholder:text-[#98a2b3] focus:border-[#98a2b3]"
+                    onChange={(event) => updateDraft("apiKey", event.target.value)}
+                    placeholder={requiresApiKey ? "输入你的 API Key" : "如有需要可填写"}
+                    type={secretVisible ? "text" : "password"}
+                    value={draft.apiKey}
+                  />
+                  <button
+                    aria-label={secretVisible ? "隐藏 API Key" : "显示 API Key"}
+                    className="absolute right-2 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full text-[#98a2b3] transition-colors duration-150 hover:bg-[#f4f5f7] hover:text-[#344054]"
+                    onClick={() => setSecretVisible((current) => !current)}
+                    type="button"
+                  >
+                    {secretVisible ? <EyeOff size={16} strokeWidth={2.1} /> : <Eye size={16} strokeWidth={2.1} />}
+                  </button>
+                </div>
+
+                {draft.hasStoredApiKey && draft.apiKeyPreview && draft.apiKey.trim() === "" ? (
+                  <div className="mt-2 text-xs text-[#667085]">已保存密钥：{draft.apiKeyPreview}</div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <footer className="flex flex-col gap-3 border-t border-[#eceff3] px-6 py-5 sm:flex-row sm:items-center sm:justify-end lg:px-8">
+            <button
+              className="chip-button justify-center px-5 py-3 text-sm text-[#475467]"
+              disabled={isBusy}
+              onClick={onClose}
+              type="button"
+            >
+              取消
+            </button>
+
+            <button
+              className="chip-button justify-center px-5 py-3 text-sm text-[#475467] disabled:opacity-60"
+              disabled={isBusy}
+              onClick={() => void handleSave(false)}
+              type="button"
+            >
+              {saveProviderMutation.isPending && !setDefaultMutation.isPending ? (
+                <LoaderCircle className="animate-spin" size={15} strokeWidth={2.1} />
+              ) : null}
+              <span>保存配置</span>
+            </button>
+
+            <button
+              className="flex items-center justify-center gap-2 rounded-full bg-[#1f2430] px-5 py-3 text-sm font-medium text-white transition-transform duration-150 hover:-translate-y-0.5 disabled:opacity-60"
+              disabled={isBusy}
+              onClick={() => void handleSave(true)}
+              type="button"
+            >
+              {setDefaultMutation.isPending ? (
+                <LoaderCircle className="animate-spin" size={15} strokeWidth={2.1} />
+              ) : (
+                <CheckCircle2 size={16} strokeWidth={2.1} />
+              )}
+              <span>{isCreating ? "保存并设为默认" : "设为默认模型"}</span>
+            </button>
+          </footer>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/ui/src/features/model-settings/ModelSettingsModal.tsx
+++ b/ui/src/features/model-settings/ModelSettingsModal.tsx
@@ -325,7 +325,6 @@ export function ModelSettingsModal({ onClose }: ModelSettingsModalProps) {
     () => providers.find((provider) => provider.id === selectedId) ?? null,
     [providers, selectedId],
   );
-  const currentDefaultId = providers.find((provider) => provider.is_default)?.id ?? null;
 
   const isCreating = selectedId === NEW_PROVIDER_ID;
   const requiresApiKey = draft.runtime !== "ollama";
@@ -359,24 +358,6 @@ export function ModelSettingsModal({ onClose }: ModelSettingsModalProps) {
     setDraft(providerToDraft(provider));
     setSecretVisible(false);
     resetFeedback();
-
-    if (provider.id === currentDefaultId) {
-      return;
-    }
-
-    try {
-      const defaultProvider = await setDefaultMutation.mutateAsync(provider.id);
-      setSelectedId(defaultProvider.id);
-      setDraft(providerToDraft(defaultProvider));
-      await refreshQueries();
-      setNotice({
-        kind: "success",
-        message: `已切换到 ${defaultProvider.default_model || defaultProvider.name}`,
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "切换默认模型失败";
-      setNotice({ kind: "error", message });
-    }
   }
 
   function handleCreateProvider() {

--- a/ui/src/features/settings/SettingsModal.test.tsx
+++ b/ui/src/features/settings/SettingsModal.test.tsx
@@ -1,0 +1,197 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SettingsModal } from "@/features/settings/SettingsModal";
+import { useShellStore } from "@/features/shell/useShellStore";
+import { useWorkspaceOverview, type WorkspaceOverview } from "@/features/workspace/useWorkspaceOverview";
+
+vi.mock("@/features/workspace/useWorkspaceOverview", () => ({
+  useWorkspaceOverview: vi.fn(),
+}));
+
+function createOverview(): WorkspaceOverview {
+  return {
+    appearanceSettings: [],
+    channelSettings: [],
+    cloudRoadmap: [],
+    extensionAdapters: [],
+    localAgents: [],
+    localSkills: [],
+    meta: {
+      generatedAt: "2026-04-22T08:00:00.000Z",
+      liveConnected: true,
+      sourceLabel: "live",
+    },
+    priorityChannels: [],
+    providers: [],
+    runtimeProfile: {
+      address: "http://127.0.0.1:18789",
+      description: "workspace",
+      events: 0,
+      gatewayOnline: true,
+      gatewaySource: "live",
+      language: "zh-CN",
+      model: "gpt-5.4",
+      name: "workspace",
+      orchestrator: "default",
+      permission: "workspace-write",
+      provider: "openai",
+      providerLabel: "OpenAI",
+      providersCount: 1,
+      runtimes: 1,
+      secured: true,
+      sessions: 0,
+      skills: 0,
+      startedAt: "2026-04-22T08:00:00.000Z",
+      title: "workspace",
+      tools: 0,
+      workDir: "D:/anyclaw",
+      workspace: "D:/anyclaw",
+    },
+    runtimeSettings: [],
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, reject, resolve };
+}
+
+function jsonResponse(payload: unknown) {
+  return new Response(JSON.stringify(payload), {
+    headers: { "Content-Type": "application/json" },
+    status: 200,
+  });
+}
+
+function renderWithClient(node: React.ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+
+  return render(<QueryClientProvider client={client}>{node}</QueryClientProvider>);
+}
+
+function mockWorkspaceOverview(data: WorkspaceOverview) {
+  vi.mocked(useWorkspaceOverview).mockReturnValue({
+    data,
+  } as ReturnType<typeof useWorkspaceOverview>);
+}
+
+describe("SettingsModal", () => {
+  const mockedUseWorkspaceOverview = vi.mocked(useWorkspaceOverview);
+
+  beforeEach(() => {
+    useShellStore.setState({
+      agentDrawerOpen: false,
+      modelSettingsOpen: false,
+      settingsOpen: true,
+      settingsSection: "general",
+    });
+    mockedUseWorkspaceOverview.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("disables skill toggles while a skill update is in flight", async () => {
+    const deferred = createDeferred<Response>();
+    const fetchMock = vi.fn(() => deferred.promise);
+    vi.stubGlobal("fetch", fetchMock);
+
+    mockWorkspaceOverview({
+      ...createOverview(),
+      localSkills: [
+        {
+          description: "first skill",
+          enabled: true,
+          installCommand: "",
+          loaded: true,
+          name: "skill-one",
+          registry: "local",
+          source: "local",
+          version: "1.0.0",
+        },
+        {
+          description: "second skill",
+          enabled: false,
+          installCommand: "",
+          loaded: false,
+          name: "skill-two",
+          registry: "local",
+          source: "local",
+          version: "1.0.0",
+        },
+      ],
+    });
+
+    useShellStore.setState({ settingsSection: "skills" });
+
+    renderWithClient(<SettingsModal onClose={vi.fn()} />);
+
+    const firstSwitch = screen.getByRole("button", { name: "skill-one 状态" });
+    const secondSwitch = screen.getByRole("button", { name: "skill-two 状态" });
+
+    fireEvent.click(firstSwitch);
+
+    await waitFor(() => {
+      expect(firstSwitch).toBeDisabled();
+      expect(secondSwitch).toBeDisabled();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    deferred.resolve(
+      jsonResponse({
+        enabled: false,
+        loaded: false,
+        name: "skill-one",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(firstSwitch).not.toBeDisabled();
+      expect(secondSwitch).not.toBeDisabled();
+    });
+  });
+
+  it("shows agent status as read-only instead of an interactive toggle", () => {
+    mockWorkspaceOverview({
+      ...createOverview(),
+      localAgents: [
+        {
+          active: true,
+          model: "gpt-5.4",
+          name: "Agent One",
+          permissionLevel: "workspace-write",
+          providerName: "OpenAI",
+          role: "assistant",
+          skillsCount: 2,
+          status: "运行中",
+          summary: "agent summary",
+          tags: [],
+          workingDir: "D:/anyclaw",
+        },
+      ],
+    });
+
+    useShellStore.setState({ settingsSection: "agents" });
+
+    renderWithClient(<SettingsModal onClose={vi.fn()} />);
+
+    expect(screen.getByText("当前仅展示状态")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Agent One 状态" })).not.toBeInTheDocument();
+    expect(screen.getByText("后端已启用")).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/settings/SettingsModal.tsx
+++ b/ui/src/features/settings/SettingsModal.tsx
@@ -1,0 +1,672 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  BarChart3,
+  Bot,
+  Cable,
+  CheckCircle2,
+  FolderKanban,
+  Info,
+  Search,
+  SlidersHorizontal,
+  Sparkles,
+  X,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { BackendPropertyList } from "@/features/backend-ui/BackendPropertyList";
+import { useShellStore, type SettingsSection } from "@/features/shell/useShellStore";
+import { useWorkspaceOverview } from "@/features/workspace/useWorkspaceOverview";
+
+type SettingsModalProps = {
+  onClose: () => void;
+};
+
+type SkillFilter = "all" | "loaded" | "local" | "registry";
+type AgentFilter = "active" | "all" | "configured";
+
+const sections: Array<{ id: SettingsSection; icon: typeof Sparkles; label: string }> = [
+  { id: "general", icon: SlidersHorizontal, label: "通用设置" },
+  { id: "usage", icon: BarChart3, label: "用量统计" },
+  { id: "skills", icon: Sparkles, label: "Skill 管理" },
+  { id: "agents", icon: Bot, label: "Agent 管理" },
+  { id: "channels", icon: Cable, label: "渠道接入" },
+  { id: "about", icon: Info, label: "工作区" },
+];
+
+function formatDateTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString("zh-CN", {
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "2-digit",
+  });
+}
+
+async function requestJSON<T>(input: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, {
+    ...init,
+    headers: {
+      Accept: "application/json",
+      ...(init?.body ? { "Content-Type": "application/json" } : null),
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  const raw = await response.text();
+  const payload = raw ? (JSON.parse(raw) as T | { error?: string }) : null;
+
+  if (!response.ok) {
+    const message =
+      payload && typeof payload === "object" && "error" in payload && typeof payload.error === "string"
+        ? payload.error
+        : `Request failed (${response.status})`;
+    throw new Error(message);
+  }
+
+  return payload as T;
+}
+
+function MenuButton({
+  active,
+  icon: Icon,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  icon: typeof Sparkles;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      className={[
+        "flex w-full items-center gap-3 rounded-[20px] px-4 py-3 text-left text-[15px] font-medium transition-colors duration-150",
+        active ? "bg-[#f3f4f6] text-[#111827]" : "text-[#667085] hover:bg-[#f7f7f8] hover:text-[#111827]",
+      ].join(" ")}
+      onClick={onClick}
+      type="button"
+    >
+      <Icon size={18} strokeWidth={2.1} />
+      <span>{label}</span>
+    </button>
+  );
+}
+
+function FilterChip({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      className={[
+        "rounded-full px-4 py-2 text-sm font-medium transition-colors duration-150",
+        active ? "bg-[#111827] text-white" : "bg-[#f4f5f7] text-[#667085] hover:bg-[#eceef1] hover:text-[#111827]",
+      ].join(" ")}
+      onClick={onClick}
+      type="button"
+    >
+      {label}
+    </button>
+  );
+}
+
+function StatusSwitch({
+  active,
+  disabled = false,
+  label,
+  onToggle,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  label: string;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      aria-label={label}
+      aria-pressed={active}
+      disabled={disabled}
+      className={[
+        "relative flex h-8 w-14 shrink-0 items-center overflow-hidden rounded-full p-1 transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-60",
+        active ? "bg-[#111827]" : "bg-[#d7dbe3]",
+      ].join(" ")}
+      onClick={onToggle}
+      type="button"
+    >
+      <span
+        className={[
+          "block h-6 w-6 rounded-full bg-white shadow-[0_3px_10px_rgba(15,23,42,0.18)] transition-transform duration-150",
+          active ? "translate-x-6" : "translate-x-0",
+        ].join(" ")}
+      />
+    </button>
+  );
+}
+
+export function SettingsModal({ onClose }: SettingsModalProps) {
+  const queryClient = useQueryClient();
+  const { data } = useWorkspaceOverview();
+  const settingsSection = useShellStore((state) => state.settingsSection);
+  const setSettingsSection = useShellStore((state) => state.setSettingsSection);
+  const [search, setSearch] = useState("");
+  const [skillFilter, setSkillFilter] = useState<SkillFilter>("all");
+  const [agentFilter, setAgentFilter] = useState<AgentFilter>("all");
+  const [skillEnabled, setSkillEnabled] = useState<Record<string, boolean>>({});
+  const [agentEnabled, setAgentEnabled] = useState<Record<string, boolean>>({});
+  const [pendingSkillName, setPendingSkillName] = useState<string | null>(null);
+
+  const toggleSkillMutation = useMutation({
+    mutationFn: ({ enabled, name }: { enabled: boolean; name: string }) =>
+      requestJSON<{ enabled: boolean; loaded: boolean; name: string }>("/skills", {
+        body: JSON.stringify({ enabled, name }),
+        method: "POST",
+      }),
+  });
+
+  useEffect(() => {
+    setSkillEnabled(Object.fromEntries(data.localSkills.map((skill) => [skill.name, skill.enabled])));
+  }, [data.localSkills]);
+
+  useEffect(() => {
+    setAgentEnabled(
+      Object.fromEntries(
+        data.localAgents.map((agent) => [agent.name, agent.active || agent.status !== "已停用"]),
+      ),
+    );
+  }, [data.localAgents]);
+
+  useEffect(() => {
+    setSearch("");
+    setSkillFilter("all");
+    setAgentFilter("all");
+  }, [settingsSection]);
+
+  const visibleSkills = useMemo(() => {
+    const keyword = search.trim().toLowerCase();
+    return data.localSkills.filter((skill) => {
+      const matchesKeyword =
+        keyword === "" ||
+        [skill.name, skill.description, skill.registry, skill.source].join(" ").toLowerCase().includes(keyword);
+      const sourceLabel = (skill.registry || skill.source || "local").toLowerCase();
+      const loaded = skillEnabled[skill.name] ?? skill.enabled;
+      const matchesFilter =
+        skillFilter === "all"
+          ? true
+          : skillFilter === "loaded"
+            ? loaded
+            : skillFilter === "local"
+              ? sourceLabel.includes("local")
+              : !sourceLabel.includes("local");
+      return matchesKeyword && matchesFilter;
+    });
+  }, [data.localSkills, search, skillEnabled, skillFilter]);
+
+  useEffect(() => {
+    if (pendingSkillName !== null) {
+      return;
+    }
+    const changedSkill = data.localSkills.find((skill) => {
+      const nextEnabled = skillEnabled[skill.name];
+      return nextEnabled !== undefined && nextEnabled !== skill.enabled;
+    });
+    if (!changedSkill) {
+      return;
+    }
+    const nextEnabled = skillEnabled[changedSkill.name];
+    if (nextEnabled === undefined) {
+      return;
+    }
+
+    let cancelled = false;
+    setPendingSkillName(changedSkill.name);
+    void toggleSkillMutation
+      .mutateAsync({ enabled: nextEnabled, name: changedSkill.name })
+      .then(async () => {
+        if (cancelled) {
+          return;
+        }
+        await queryClient.invalidateQueries({ queryKey: ["workspace-overview"] });
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+        setSkillEnabled((current) => ({
+          ...current,
+          [changedSkill.name]: changedSkill.enabled,
+        }));
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setPendingSkillName(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [data.localSkills, pendingSkillName, skillEnabled, toggleSkillMutation]);
+
+  const visibleAgents = useMemo(() => {
+    const keyword = search.trim().toLowerCase();
+    return data.localAgents.filter((agent) => {
+      const matchesKeyword =
+        keyword === "" ||
+        [agent.name, agent.summary, agent.providerName, agent.role].join(" ").toLowerCase().includes(keyword);
+      const enabledByStatus = agent.active || agent.status !== "已停用";
+      const enabled = agentEnabled[agent.name] ?? enabledByStatus;
+      const matchesFilter =
+        agentFilter === "all"
+          ? true
+          : agentFilter === "active"
+            ? agent.active
+            : enabled;
+      return matchesKeyword && matchesFilter;
+    });
+  }, [agentEnabled, agentFilter, data.localAgents, search]);
+
+  const usageCards = [
+    { label: "本地 Skill", value: String(data.localSkills.length) },
+    { label: "本地 Agent", value: String(data.localAgents.length) },
+    { label: "活跃渠道", value: String(data.priorityChannels.filter((channel) => channel.enabled || channel.running).length) },
+    { label: "运行会话", value: String(data.runtimeProfile.sessions) },
+  ];
+
+  const currentEnvironment = [
+    { label: "工作区", value: data.runtimeProfile.workspace },
+    { label: "Provider", value: data.runtimeProfile.providerLabel || "未识别" },
+    { label: "模型", value: data.runtimeProfile.model || "未设置" },
+    { label: "网关", value: data.runtimeProfile.address },
+  ];
+
+  function renderGeneralSection() {
+    return (
+      <div className="space-y-6">
+        <div>
+          <div className="text-sm font-medium text-[#667085]">设置</div>
+          <h3 className="mt-2 text-[32px] font-semibold tracking-[-0.04em] text-[#111827]">通用设置</h3>
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+          <section className="rounded-[28px] border border-[#eceff3] bg-white p-5">
+            <div className="text-sm font-medium text-[#667085]">界面摘要</div>
+            <div className="mt-4 space-y-3">
+              {data.appearanceSettings.map((record) => (
+                <div
+                  key={record.label}
+                  className="flex items-center justify-between gap-4 rounded-[18px] bg-[#f8fafc] px-4 py-4"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium text-[#111827]">{record.label}</div>
+                    <div className="mt-1 text-sm text-[#667085]">{record.hint}</div>
+                  </div>
+                  <div className="shrink-0 rounded-full bg-white px-3 py-1.5 text-xs font-medium text-[#475467]">
+                    {record.value}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-[28px] border border-[#eceff3] bg-white p-5">
+            <div className="text-sm font-medium text-[#667085]">当前环境</div>
+            <div className="mt-4">
+              <BackendPropertyList items={currentEnvironment} />
+            </div>
+          </section>
+        </div>
+      </div>
+    );
+  }
+
+  function renderUsageSection() {
+    return (
+      <div className="space-y-6">
+        <div>
+          <div className="text-sm font-medium text-[#667085]">设置</div>
+          <h3 className="mt-2 text-[32px] font-semibold tracking-[-0.04em] text-[#111827]">用量统计</h3>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {usageCards.map((card) => (
+            <article key={card.label} className="rounded-[24px] border border-[#eceff3] bg-white p-5">
+              <div className="text-sm text-[#667085]">{card.label}</div>
+              <div className="mt-4 text-[34px] font-semibold tracking-[-0.05em] text-[#111827]">{card.value}</div>
+            </article>
+          ))}
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.8fr)]">
+          <section className="rounded-[28px] border border-[#eceff3] bg-white p-5">
+            <div className="text-sm font-medium text-[#667085]">运行摘要</div>
+            <div className="mt-4">
+              <BackendPropertyList
+                items={[
+                  { label: "Provider", value: data.runtimeProfile.provider || "unknown" },
+                  { label: "运行时", value: String(data.runtimeProfile.runtimes) },
+                  { label: "工具数", value: String(data.runtimeProfile.tools) },
+                  { label: "事件数", value: String(data.runtimeProfile.events) },
+                ]}
+              />
+            </div>
+          </section>
+
+          <section className="rounded-[28px] border border-[#eceff3] bg-white p-5">
+            <div className="text-sm font-medium text-[#667085]">更新时间</div>
+            <div className="mt-4 text-[24px] font-semibold tracking-[-0.04em] text-[#111827]">
+              {formatDateTime(data.meta.generatedAt)}
+            </div>
+            <div className="mt-3 text-sm leading-7 text-[#667085]">数据源：{data.meta.sourceLabel}</div>
+          </section>
+        </div>
+      </div>
+    );
+  }
+
+  function renderSkillsSection() {
+    return (
+      <div className="space-y-6">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+          <div>
+            <div className="text-sm font-medium text-[#667085]">设置</div>
+            <h3 className="mt-2 text-[32px] font-semibold tracking-[-0.04em] text-[#111827]">Skill 管理</h3>
+            <div className="mt-3 text-sm text-[#667085]">查看当前工作区内已安装或已识别的 Skill。</div>
+          </div>
+
+          <div className="rounded-full bg-[#f4f5f7] px-4 py-2 text-sm text-[#667085]">
+            市场页将在后续 PR 中接入
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+          <label className="flex w-full items-center gap-3 rounded-full border border-[#eceff3] bg-white px-4 py-3 xl:max-w-[560px]">
+            <Search size={18} strokeWidth={2} className="text-[#98a2b3]" />
+            <input
+              className="w-full bg-transparent text-[15px] text-[#111827] outline-none placeholder:text-[#a0a9b7]"
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="搜索已经安装的 Skill"
+              value={search}
+            />
+          </label>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <FilterChip active={skillFilter === "all"} label={`全部 ${data.localSkills.length}`} onClick={() => setSkillFilter("all")} />
+            <FilterChip active={skillFilter === "loaded"} label="已加载" onClick={() => setSkillFilter("loaded")} />
+            <FilterChip active={skillFilter === "local"} label="本地目录" onClick={() => setSkillFilter("local")} />
+            <FilterChip active={skillFilter === "registry"} label="注册表来源" onClick={() => setSkillFilter("registry")} />
+          </div>
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-2">
+          {visibleSkills.length > 0 ? (
+            visibleSkills.map((skill) => {
+              const enabled = skillEnabled[skill.name] ?? skill.enabled;
+
+              return (
+                <article key={skill.name} className="rounded-[28px] border border-[#eceff3] bg-white p-5 shadow-[0_12px_30px_rgba(15,23,42,0.04)]">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex min-w-0 flex-1 items-start gap-4">
+                      <span className="flex h-14 w-14 shrink-0 items-center justify-center rounded-[20px] bg-[linear-gradient(145deg,#e3f0ff,#cfe2ff)] text-[#2563eb]">
+                        <Sparkles size={22} strokeWidth={2.1} />
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="text-[20px] font-semibold tracking-[-0.03em] text-[#111827]">{skill.name}</div>
+                        <div className="mt-1 text-sm text-[#667085]">{skill.description}</div>
+                      </div>
+                    </div>
+                    <StatusSwitch
+                      active={enabled}
+                      label={`${skill.name} 状态`}
+                      onToggle={() =>
+                        setSkillEnabled((current) => ({
+                          ...current,
+                          [skill.name]: !(current[skill.name] ?? skill.enabled),
+                        }))
+                      }
+                    />
+                  </div>
+
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    <span className="rounded-full bg-[#f4f5f7] px-3 py-1.5 text-xs text-[#667085]">
+                      {enabled ? "已加载" : "本地识别"}
+                    </span>
+                    {skill.version ? (
+                      <span className="whitespace-nowrap rounded-full bg-[#f4f5f7] px-3 py-1.5 text-xs text-[#667085]">{skill.version}</span>
+                    ) : null}
+                    <span className="whitespace-nowrap rounded-full bg-[#f4f5f7] px-3 py-1.5 text-xs text-[#667085]">
+                      {skill.registry || skill.source || "local"}
+                    </span>
+                  </div>
+                </article>
+              );
+            })
+          ) : (
+            <div className="rounded-[28px] border border-dashed border-[#d7dbe3] bg-white px-5 py-10 text-sm text-[#667085] xl:col-span-2">
+              没有匹配的 Skill。
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  function renderAgentsSection() {
+    return (
+      <div className="space-y-6">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+          <div>
+            <div className="text-sm font-medium text-[#667085]">设置</div>
+            <h3 className="mt-2 text-[32px] font-semibold tracking-[-0.04em] text-[#111827]">Agent 管理</h3>
+            <div className="mt-3 text-sm text-[#667085]">查看当前工作区内可用的 Agent 和其挂载能力。</div>
+          </div>
+
+          <div className="rounded-full bg-[#f4f5f7] px-4 py-2 text-sm text-[#667085]">
+            Agent 市场将在后续 PR 中接入
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+          <label className="flex w-full items-center gap-3 rounded-full border border-[#eceff3] bg-white px-4 py-3 xl:max-w-[560px]">
+            <Search size={18} strokeWidth={2} className="text-[#98a2b3]" />
+            <input
+              className="w-full bg-transparent text-[15px] text-[#111827] outline-none placeholder:text-[#a0a9b7]"
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="搜索已经安装的 Agent"
+              value={search}
+            />
+          </label>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <FilterChip active={agentFilter === "all"} label={`全部 ${data.localAgents.length}`} onClick={() => setAgentFilter("all")} />
+            <FilterChip active={agentFilter === "active"} label="当前启用" onClick={() => setAgentFilter("active")} />
+            <FilterChip active={agentFilter === "configured"} label="已配置" onClick={() => setAgentFilter("configured")} />
+          </div>
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-2">
+          {visibleAgents.length > 0 ? (
+            visibleAgents.map((agent) => {
+              const enabledByStatus = agent.active || agent.status !== "已停用";
+              const enabled = agentEnabled[agent.name] ?? enabledByStatus;
+
+              return (
+                <article key={agent.name} className="rounded-[28px] border border-[#eceff3] bg-white p-5 shadow-[0_12px_30px_rgba(15,23,42,0.04)]">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex min-w-0 flex-1 items-start gap-4">
+                      <span className="flex h-14 w-14 shrink-0 items-center justify-center rounded-[20px] bg-[linear-gradient(145deg,#ffe8d7,#ffd0b0)] text-[#f97316]">
+                        <Bot size={22} strokeWidth={2.1} />
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="text-[20px] font-semibold tracking-[-0.03em] text-[#111827]">{agent.name}</div>
+                        <div className="mt-1 text-sm text-[#667085]">
+                          {agent.role} · {agent.providerName}
+                        </div>
+                        <div className="mt-3 text-sm leading-6 text-[#667085]">{agent.summary}</div>
+                      </div>
+                    </div>
+                    <StatusSwitch
+                      active={enabled}
+                      label={`${agent.name} 状态`}
+                      onToggle={() =>
+                        setAgentEnabled((current) => ({
+                          ...current,
+                          [agent.name]: !(current[agent.name] ?? enabledByStatus),
+                        }))
+                      }
+                    />
+                  </div>
+
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    <span className="whitespace-nowrap rounded-full bg-[#f4f5f7] px-3 py-1.5 text-xs text-[#667085]">{agent.status}</span>
+                    <span className="whitespace-nowrap rounded-full bg-[#f4f5f7] px-3 py-1.5 text-xs text-[#667085]">{agent.skillsCount} skills</span>
+                    <span className="whitespace-nowrap rounded-full bg-[#f4f5f7] px-3 py-1.5 text-xs text-[#667085]">{agent.permissionLevel}</span>
+                  </div>
+                </article>
+              );
+            })
+          ) : (
+            <div className="rounded-[28px] border border-dashed border-[#d7dbe3] bg-white px-5 py-10 text-sm text-[#667085] xl:col-span-2">
+              没有匹配的 Agent。
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  function renderChannelsSection() {
+    return (
+      <div className="space-y-6">
+        <div>
+          <div className="text-sm font-medium text-[#667085]">设置</div>
+          <h3 className="mt-2 text-[32px] font-semibold tracking-[-0.04em] text-[#111827]">渠道接入</h3>
+        </div>
+
+        <div className="overflow-hidden rounded-[28px] border border-[#eceff3] bg-white">
+          <div className="grid gap-4 border-b border-[#eceff3] bg-[#fafafa] px-5 py-3 text-xs font-medium uppercase tracking-[0.18em] text-[#98a2b3] lg:grid-cols-[180px_minmax(0,1fr)_140px]">
+            <div>渠道</div>
+            <div>摘要</div>
+            <div className="text-right">状态</div>
+          </div>
+
+          {data.priorityChannels.map((channel) => (
+            <div
+              key={channel.slug}
+              className="grid gap-4 border-b border-[#eceff3] px-5 py-4 last:border-b-0 lg:grid-cols-[180px_minmax(0,1fr)_140px]"
+            >
+              <div className="font-medium text-[#111827]">{channel.name}</div>
+              <div className="text-sm text-[#667085]">{channel.summary}</div>
+              <div className="text-right text-sm font-medium text-[#475467]">{channel.status}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  function renderAboutSection() {
+    return (
+      <div className="space-y-6">
+        <div>
+          <div className="text-sm font-medium text-[#667085]">设置</div>
+          <h3 className="mt-2 text-[32px] font-semibold tracking-[-0.04em] text-[#111827]">工作区</h3>
+          <div className="mt-3 text-sm text-[#667085]">这里只保留必要的工作区信息。</div>
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.8fr)]">
+          <section className="rounded-[28px] border border-[#eceff3] bg-white p-5">
+            <div className="flex items-center gap-2 text-sm font-medium text-[#667085]">
+              <FolderKanban size={16} strokeWidth={2.1} />
+              工作区信息
+            </div>
+            <div className="mt-4">
+              <BackendPropertyList
+                items={[
+                  { label: "工作区目录", value: data.runtimeProfile.workspace },
+                  { label: "工作目录", value: data.runtimeProfile.workDir },
+                  { label: "网关地址", value: data.runtimeProfile.address },
+                  { label: "数据源", value: data.meta.sourceLabel },
+                ]}
+              />
+            </div>
+          </section>
+
+          <section className="rounded-[28px] border border-[#eceff3] bg-white p-5">
+            <div className="flex items-center gap-2 text-sm font-medium text-[#667085]">
+              <CheckCircle2 size={16} strokeWidth={2.1} />
+              预留说明
+            </div>
+            <div className="mt-4 text-sm leading-7 text-[#667085]">云端 Skill 和云端 Agent 目前尚未接入。</div>
+          </section>
+        </div>
+      </div>
+    );
+  }
+
+  function renderContent() {
+    switch (settingsSection) {
+      case "usage":
+        return renderUsageSection();
+      case "skills":
+        return renderSkillsSection();
+      case "agents":
+        return renderAgentsSection();
+      case "channels":
+        return renderChannelsSection();
+      case "about":
+        return renderAboutSection();
+      default:
+        return renderGeneralSection();
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby="settings-dialog-title"
+      aria-modal="true"
+      className="pointer-events-auto mx-4 flex h-[88vh] w-full max-w-[1280px] flex-col overflow-hidden rounded-[32px] border border-white/80 bg-[#fcfcfd] shadow-[0_36px_90px_rgba(15,23,42,0.18)] sm:mx-6 lg:h-[82vh]"
+      role="dialog"
+    >
+      <header className="flex items-center justify-between gap-4 border-b border-[#eceff3] px-6 py-5">
+        <h2 className="text-[20px] font-semibold tracking-[-0.03em] text-[#111827]" id="settings-dialog-title">
+          设置
+        </h2>
+
+        <button
+          aria-label="关闭设置"
+          className="flex h-11 w-11 items-center justify-center rounded-full text-[#667085] transition-colors duration-150 hover:bg-[#f3f4f6] hover:text-[#111827]"
+          onClick={onClose}
+          type="button"
+        >
+          <X size={22} strokeWidth={2.1} />
+        </button>
+      </header>
+
+      <div className="grid min-h-0 flex-1 lg:grid-cols-[240px_minmax(0,1fr)]">
+        <aside className="border-b border-[#eceff3] bg-white px-4 py-5 lg:border-b-0 lg:border-r lg:px-5 lg:py-6">
+          <div className="mb-4 text-[34px] font-semibold tracking-[-0.05em] text-[#111827]">设置</div>
+          <div className="space-y-2">
+            {sections.map(({ id, icon, label }) => (
+              <MenuButton
+                key={id}
+                active={settingsSection === id}
+                icon={icon}
+                label={label}
+                onClick={() => setSettingsSection(id)}
+              />
+            ))}
+          </div>
+        </aside>
+
+        <div className="min-h-0 overflow-y-auto px-6 py-6 lg:px-8 lg:py-7">{renderContent()}</div>
+      </div>
+    </section>
+  );
+}

--- a/ui/src/features/settings/SettingsModal.tsx
+++ b/ui/src/features/settings/SettingsModal.tsx
@@ -14,6 +14,7 @@ import {
 import { useEffect, useMemo, useState } from "react";
 
 import { BackendPropertyList } from "@/features/backend-ui/BackendPropertyList";
+import { StatusBadge, type StatusBadgeTone } from "@/features/backend-ui/StatusBadge";
 import { useShellStore, type SettingsSection } from "@/features/shell/useShellStore";
 import { useWorkspaceOverview } from "@/features/workspace/useWorkspaceOverview";
 
@@ -159,7 +160,6 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
   const [skillFilter, setSkillFilter] = useState<SkillFilter>("all");
   const [agentFilter, setAgentFilter] = useState<AgentFilter>("all");
   const [skillEnabled, setSkillEnabled] = useState<Record<string, boolean>>({});
-  const [agentEnabled, setAgentEnabled] = useState<Record<string, boolean>>({});
   const [pendingSkillName, setPendingSkillName] = useState<string | null>(null);
 
   const toggleSkillMutation = useMutation({
@@ -173,14 +173,6 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
   useEffect(() => {
     setSkillEnabled(Object.fromEntries(data.localSkills.map((skill) => [skill.name, skill.enabled])));
   }, [data.localSkills]);
-
-  useEffect(() => {
-    setAgentEnabled(
-      Object.fromEntries(
-        data.localAgents.map((agent) => [agent.name, agent.active || agent.status !== "已停用"]),
-      ),
-    );
-  }, [data.localAgents]);
 
   useEffect(() => {
     setSearch("");
@@ -208,52 +200,6 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
     });
   }, [data.localSkills, search, skillEnabled, skillFilter]);
 
-  useEffect(() => {
-    if (pendingSkillName !== null) {
-      return;
-    }
-    const changedSkill = data.localSkills.find((skill) => {
-      const nextEnabled = skillEnabled[skill.name];
-      return nextEnabled !== undefined && nextEnabled !== skill.enabled;
-    });
-    if (!changedSkill) {
-      return;
-    }
-    const nextEnabled = skillEnabled[changedSkill.name];
-    if (nextEnabled === undefined) {
-      return;
-    }
-
-    let cancelled = false;
-    setPendingSkillName(changedSkill.name);
-    void toggleSkillMutation
-      .mutateAsync({ enabled: nextEnabled, name: changedSkill.name })
-      .then(async () => {
-        if (cancelled) {
-          return;
-        }
-        await queryClient.invalidateQueries({ queryKey: ["workspace-overview"] });
-      })
-      .catch(() => {
-        if (cancelled) {
-          return;
-        }
-        setSkillEnabled((current) => ({
-          ...current,
-          [changedSkill.name]: changedSkill.enabled,
-        }));
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setPendingSkillName(null);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [data.localSkills, pendingSkillName, skillEnabled, toggleSkillMutation]);
-
   const visibleAgents = useMemo(() => {
     const keyword = search.trim().toLowerCase();
     return data.localAgents.filter((agent) => {
@@ -261,16 +207,15 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
         keyword === "" ||
         [agent.name, agent.summary, agent.providerName, agent.role].join(" ").toLowerCase().includes(keyword);
       const enabledByStatus = agent.active || agent.status !== "已停用";
-      const enabled = agentEnabled[agent.name] ?? enabledByStatus;
       const matchesFilter =
         agentFilter === "all"
           ? true
           : agentFilter === "active"
             ? agent.active
-            : enabled;
+            : enabledByStatus;
       return matchesKeyword && matchesFilter;
     });
-  }, [agentEnabled, agentFilter, data.localAgents, search]);
+  }, [agentFilter, data.localAgents, search]);
 
   const usageCards = [
     { label: "本地 Skill", value: String(data.localSkills.length) },
@@ -285,6 +230,39 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
     { label: "模型", value: data.runtimeProfile.model || "未设置" },
     { label: "网关", value: data.runtimeProfile.address },
   ];
+
+  async function handleToggleSkill(name: string, currentEnabled: boolean) {
+    if (pendingSkillName !== null) {
+      return;
+    }
+
+    const nextEnabled = !currentEnabled;
+    setPendingSkillName(name);
+    setSkillEnabled((current) => ({
+      ...current,
+      [name]: nextEnabled,
+    }));
+
+    try {
+      await toggleSkillMutation.mutateAsync({ enabled: nextEnabled, name });
+      await queryClient.invalidateQueries({ queryKey: ["workspace-overview"] });
+    } catch {
+      setSkillEnabled((current) => ({
+        ...current,
+        [name]: currentEnabled,
+      }));
+    } finally {
+      setPendingSkillName(null);
+    }
+  }
+
+  function resolveAgentEnabled(status: string, active: boolean) {
+    return active || status !== "已停用";
+  }
+
+  function resolveAgentStatusTone(enabled: boolean): StatusBadgeTone {
+    return enabled ? "success" : "default";
+  }
 
   function renderGeneralSection() {
     return (
@@ -408,6 +386,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
           {visibleSkills.length > 0 ? (
             visibleSkills.map((skill) => {
               const enabled = skillEnabled[skill.name] ?? skill.enabled;
+              const skillToggleDisabled = pendingSkillName !== null;
 
               return (
                 <article key={skill.name} className="rounded-[28px] border border-[#eceff3] bg-white p-5 shadow-[0_12px_30px_rgba(15,23,42,0.04)]">
@@ -423,13 +402,9 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                     </div>
                     <StatusSwitch
                       active={enabled}
+                      disabled={skillToggleDisabled}
                       label={`${skill.name} 状态`}
-                      onToggle={() =>
-                        setSkillEnabled((current) => ({
-                          ...current,
-                          [skill.name]: !(current[skill.name] ?? skill.enabled),
-                        }))
-                      }
+                      onToggle={() => void handleToggleSkill(skill.name, enabled)}
                     />
                   </div>
 
@@ -493,8 +468,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
         <div className="grid gap-4 xl:grid-cols-2">
           {visibleAgents.length > 0 ? (
             visibleAgents.map((agent) => {
-              const enabledByStatus = agent.active || agent.status !== "已停用";
-              const enabled = agentEnabled[agent.name] ?? enabledByStatus;
+              const enabled = resolveAgentEnabled(agent.status, agent.active);
 
               return (
                 <article key={agent.name} className="rounded-[28px] border border-[#eceff3] bg-white p-5 shadow-[0_12px_30px_rgba(15,23,42,0.04)]">
@@ -511,16 +485,13 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                         <div className="mt-3 text-sm leading-6 text-[#667085]">{agent.summary}</div>
                       </div>
                     </div>
-                    <StatusSwitch
-                      active={enabled}
-                      label={`${agent.name} 状态`}
-                      onToggle={() =>
-                        setAgentEnabled((current) => ({
-                          ...current,
-                          [agent.name]: !(current[agent.name] ?? enabledByStatus),
-                        }))
-                      }
-                    />
+                    <div className="flex shrink-0 flex-col items-end gap-2">
+                      <StatusBadge
+                        label={enabled ? "后端已启用" : "后端已停用"}
+                        tone={resolveAgentStatusTone(enabled)}
+                      />
+                      <span className="text-xs text-[#98a2b3]">当前仅展示状态</span>
+                    </div>
                   </div>
 
                   <div className="mt-5 flex flex-wrap gap-2">

--- a/ui/src/features/shell/ShellOverlays.test.tsx
+++ b/ui/src/features/shell/ShellOverlays.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ShellOverlays } from "@/features/shell/ShellOverlays";
+import { useShellStore } from "@/features/shell/useShellStore";
+
+vi.mock("@/features/agent-drawer/AgentDrawer", () => ({
+  AgentDrawer: () => <div>agent drawer mock</div>,
+}));
+
+vi.mock("@/features/model-settings/ModelSettingsModal", () => ({
+  ModelSettingsModal: () => <div>model settings mock</div>,
+}));
+
+vi.mock("@/features/settings/SettingsModal", () => ({
+  SettingsModal: () => <div>settings modal mock</div>,
+}));
+
+function resetStore() {
+  useShellStore.setState({
+    agentDrawerOpen: false,
+    modelSettingsOpen: false,
+    settingsOpen: false,
+    settingsSection: "general",
+  });
+}
+
+describe("ShellOverlays", () => {
+  beforeEach(() => {
+    resetStore();
+    document.body.style.overflow = "";
+  });
+
+  it("renders the requested overlay", () => {
+    useShellStore.getState().openSettings();
+
+    render(<ShellOverlays />);
+
+    expect(screen.getByText("settings modal mock")).toBeInTheDocument();
+  });
+
+  it("closes overlays when escape is pressed", async () => {
+    useShellStore.getState().openModelSettings();
+
+    render(<ShellOverlays />);
+
+    expect(screen.getByText("model settings mock")).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(useShellStore.getState().modelSettingsOpen).toBe(false);
+    });
+  });
+
+  it("locks body scroll while an overlay is open", () => {
+    useShellStore.getState().openAgentDrawer();
+
+    const { unmount } = render(<ShellOverlays />);
+
+    expect(document.body.style.overflow).toBe("hidden");
+
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+});

--- a/ui/src/features/shell/ShellOverlays.tsx
+++ b/ui/src/features/shell/ShellOverlays.tsx
@@ -1,0 +1,84 @@
+import { useEffect } from "react";
+
+import { AgentDrawer } from "@/features/agent-drawer/AgentDrawer";
+import { ModelSettingsModal } from "@/features/model-settings/ModelSettingsModal";
+import { SettingsModal } from "@/features/settings/SettingsModal";
+import { useShellStore } from "@/features/shell/useShellStore";
+
+export function ShellOverlays() {
+  const {
+    agentDrawerOpen,
+    closeAgentDrawer,
+    closeAll,
+    closeModelSettings,
+    closeSettings,
+    modelSettingsOpen,
+    settingsOpen,
+  } = useShellStore();
+
+  const hasOverlay = agentDrawerOpen || modelSettingsOpen || settingsOpen;
+
+  useEffect(() => {
+    if (!hasOverlay) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeAll();
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [closeAll, hasOverlay]);
+
+  return (
+    <>
+      {settingsOpen && (
+        <div className="fixed inset-0 z-[70] flex items-center justify-center p-3 sm:p-5">
+          <button
+            aria-label="关闭设置遮罩"
+            className="absolute inset-0 z-0 bg-[rgba(23,20,18,0.42)] backdrop-blur-[8px]"
+            onClick={closeSettings}
+            type="button"
+          />
+          <div className="relative z-10 flex w-full items-center justify-center">
+            <SettingsModal onClose={closeSettings} />
+          </div>
+        </div>
+      )}
+
+      {modelSettingsOpen && (
+        <div className="fixed inset-0 z-[76] flex items-center justify-center p-3 sm:p-5">
+          <button
+            aria-label="关闭模型设置遮罩"
+            className="absolute inset-0 z-0 bg-[rgba(23,20,18,0.42)] backdrop-blur-[8px]"
+            onClick={closeModelSettings}
+            type="button"
+          />
+          <div className="relative z-10 flex w-full items-center justify-center">
+            <ModelSettingsModal onClose={closeModelSettings} />
+          </div>
+        </div>
+      )}
+
+      {agentDrawerOpen && (
+        <div className="fixed inset-0 z-[80]">
+          <button
+            aria-label="关闭 Agent 抽屉遮罩"
+            className="absolute inset-0 z-0 bg-[rgba(23,20,18,0.34)] backdrop-blur-[6px]"
+            onClick={closeAgentDrawer}
+            type="button"
+          />
+          <div className="pointer-events-none absolute inset-y-0 right-0 z-10 flex w-full justify-end">
+            <AgentDrawer onClose={closeAgentDrawer} />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/ui/src/features/shell/useShellStore.test.ts
+++ b/ui/src/features/shell/useShellStore.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { useShellStore } from "@/features/shell/useShellStore";
+
+function resetStore() {
+  useShellStore.setState({
+    agentDrawerOpen: false,
+    modelSettingsOpen: false,
+    settingsOpen: false,
+    settingsSection: "general",
+  });
+}
+
+describe("useShellStore", () => {
+  it("opens one overlay at a time", () => {
+    resetStore();
+
+    useShellStore.getState().openAgentDrawer();
+    expect(useShellStore.getState()).toMatchObject({
+      agentDrawerOpen: true,
+      modelSettingsOpen: false,
+      settingsOpen: false,
+    });
+
+    useShellStore.getState().openModelSettings();
+    expect(useShellStore.getState()).toMatchObject({
+      agentDrawerOpen: false,
+      modelSettingsOpen: true,
+      settingsOpen: false,
+    });
+
+    useShellStore.getState().openSettings("channels");
+    expect(useShellStore.getState()).toMatchObject({
+      agentDrawerOpen: false,
+      modelSettingsOpen: false,
+      settingsOpen: true,
+      settingsSection: "channels",
+    });
+  });
+
+  it("closes all overlays together", () => {
+    resetStore();
+    useShellStore.getState().openSettings("skills");
+
+    useShellStore.getState().closeAll();
+
+    expect(useShellStore.getState()).toMatchObject({
+      agentDrawerOpen: false,
+      modelSettingsOpen: false,
+      settingsOpen: false,
+      settingsSection: "skills",
+    });
+  });
+});

--- a/ui/src/features/shell/useShellStore.ts
+++ b/ui/src/features/shell/useShellStore.ts
@@ -1,0 +1,39 @@
+import { create } from "zustand";
+
+export type SettingsSection = "about" | "agents" | "channels" | "general" | "skills" | "usage";
+
+type ShellStore = {
+  agentDrawerOpen: boolean;
+  modelSettingsOpen: boolean;
+  settingsOpen: boolean;
+  settingsSection: SettingsSection;
+  closeAll: () => void;
+  closeAgentDrawer: () => void;
+  closeModelSettings: () => void;
+  closeSettings: () => void;
+  openAgentDrawer: () => void;
+  openModelSettings: () => void;
+  openSettings: (section?: SettingsSection) => void;
+  setSettingsSection: (section: SettingsSection) => void;
+};
+
+export const useShellStore = create<ShellStore>((set) => ({
+  agentDrawerOpen: false,
+  modelSettingsOpen: false,
+  settingsOpen: false,
+  settingsSection: "general",
+  closeAll: () => set({ agentDrawerOpen: false, modelSettingsOpen: false, settingsOpen: false }),
+  closeAgentDrawer: () => set({ agentDrawerOpen: false }),
+  closeModelSettings: () => set({ modelSettingsOpen: false }),
+  closeSettings: () => set({ settingsOpen: false }),
+  openAgentDrawer: () => set({ agentDrawerOpen: true, modelSettingsOpen: false, settingsOpen: false }),
+  openModelSettings: () => set({ agentDrawerOpen: false, modelSettingsOpen: true, settingsOpen: false }),
+  openSettings: (section = "general") =>
+    set({
+      agentDrawerOpen: false,
+      modelSettingsOpen: false,
+      settingsOpen: true,
+      settingsSection: section,
+    }),
+  setSettingsSection: (section) => set({ settingsSection: section }),
+}));


### PR DESCRIPTION
新增前端 shell state 和 settings overlays。

- 新增 shell store 与 overlay 管理逻辑
- 新增 settings modal、model settings modal、agent drawer
- 在 workspace overview 页面接入这些弹层入口
- 补充 shell store 和 overlay 的基础测试