### PR TITLE
fix(extensions): add discord and irc runtimes for mvp

### DIFF
--- a/extensions/discord/anyclaw.extension.json
+++ b/extensions/discord/anyclaw.extension.json
@@ -19,6 +19,16 @@
         "type": "string",
         "description": "Optional: custom Discord API base URL",
         "default": "https://discord.com/api/v10"
+      },
+      "channel_ids": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Discord channel IDs to poll for messages"
+      },
+      "poll_every": {
+        "type": "integer",
+        "description": "Polling interval in seconds",
+        "default": 3
       }
     },
     "required": ["bot_token"]

--- a/extensions/discord/discord_adapter.go
+++ b/extensions/discord/discord_adapter.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	BotToken   string   `json:"bot_token"`
+	APIBaseURL string   `json:"api_base_url,omitempty"`
+	ChannelIDs []string `json:"channel_ids,omitempty"`
+	PollEvery  int      `json:"poll_every,omitempty"`
+}
+
+type DiscordExtension struct {
+	config         Config
+	client         *http.Client
+	apiBaseURL     string
+	lastMessageIDs map[string]string
+	stdin          io.Reader
+	stdout         io.Writer
+	stderr         io.Writer
+}
+
+func NewDiscordExtension(cfg Config) *DiscordExtension {
+	baseURL := strings.TrimRight(cfg.APIBaseURL, "/")
+	if baseURL == "" {
+		baseURL = "https://discord.com/api/v10"
+	}
+	return &DiscordExtension{
+		config:         cfg,
+		client:         &http.Client{Timeout: 10 * time.Second},
+		apiBaseURL:     baseURL,
+		lastMessageIDs: map[string]string{},
+		stdin:          os.Stdin,
+		stdout:         os.Stdout,
+		stderr:         os.Stderr,
+	}
+}
+
+func (e *DiscordExtension) Run(ctx context.Context) error {
+	if len(e.config.ChannelIDs) == 0 {
+		return fmt.Errorf("channel_ids required")
+	}
+
+	interval := time.Duration(e.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+
+	if err := e.pollOnce(ctx); err != nil {
+		fmt.Fprintf(e.stderr, "discord poll error: %v\n", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := e.pollOnce(ctx); err != nil {
+				fmt.Fprintf(e.stderr, "discord poll error: %v\n", err)
+			}
+		}
+	}
+}
+
+type discordMessage struct {
+	ID      string `json:"id"`
+	Content string `json:"content"`
+	Author  struct {
+		Username string `json:"username"`
+		Bot      bool   `json:"bot"`
+	} `json:"author"`
+}
+
+func (e *DiscordExtension) pollOnce(ctx context.Context) error {
+	for _, channelID := range e.config.ChannelIDs {
+		messages, err := e.fetchMessages(ctx, channelID, e.lastMessageIDs[channelID])
+		if err != nil {
+			return err
+		}
+
+		for i := len(messages) - 1; i >= 0; i-- {
+			message := messages[i]
+			e.lastMessageIDs[channelID] = message.ID
+
+			if message.Author.Bot || strings.TrimSpace(message.Content) == "" {
+				continue
+			}
+
+			payload := map[string]any{
+				"action":     "message",
+				"channel":    "discord",
+				"chat_id":    channelID,
+				"text":       message.Content,
+				"user_id":    message.Author.Username,
+				"message_id": message.ID,
+			}
+			if err := json.NewEncoder(e.stdout).Encode(payload); err != nil {
+				return err
+			}
+
+			reply, err := e.readReply()
+			if err != nil {
+				return fmt.Errorf("failed to read response: %w", err)
+			}
+			if reply != "" {
+				if err := e.sendMessage(channelID, reply); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (e *DiscordExtension) fetchMessages(ctx context.Context, channelID, after string) ([]discordMessage, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.apiBaseURL+"/channels/"+channelID+"/messages?limit=50", nil)
+	if err != nil {
+		return nil, err
+	}
+	if after != "" {
+		query := req.URL.Query()
+		query.Set("after", after)
+		req.URL.RawQuery = query.Encode()
+	}
+	req.Header.Set("Authorization", "Bot "+e.config.BotToken)
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("discord fetch failed: %s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+	}
+
+	var messages []discordMessage
+	if err := json.NewDecoder(resp.Body).Decode(&messages); err != nil {
+		return nil, err
+	}
+	return messages, nil
+}
+
+func (e *DiscordExtension) readReply() (string, error) {
+	var response map[string]any
+	if err := json.NewDecoder(e.stdin).Decode(&response); err != nil {
+		return "", err
+	}
+	reply, _ := response["text"].(string)
+	return strings.TrimSpace(reply), nil
+}
+
+func (e *DiscordExtension) sendMessage(channelID, text string) error {
+	body, _ := json.Marshal(map[string]string{"content": text})
+	req, err := http.NewRequest(http.MethodPost, e.apiBaseURL+"/channels/"+channelID+"/messages", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bot "+e.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("discord send failed: %s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewDiscordExtension(cfg)
+	if err := ext.Run(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/discord/smoke_test.go
+++ b/extensions/discord/smoke_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDiscordPollOnceProcessesIncomingMessage(t *testing.T) {
+	var sent bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/channels/chan/messages":
+			_, _ = io.WriteString(w, `[{"id":"1","content":"hello","author":{"username":"alice","bot":false}}]`)
+		case r.Method == http.MethodPost && r.URL.Path == "/channels/chan/messages":
+			sent = true
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	ext := NewDiscordExtension(Config{BotToken: "token", APIBaseURL: server.URL, ChannelIDs: []string{"chan"}})
+	ext.client = server.Client()
+	ext.stdin = strings.NewReader(`{"text":"pong"}`)
+	ext.stdout = stdout
+
+	if err := ext.pollOnce(context.Background()); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"channel":"discord"`) {
+		t.Fatalf("expected discord event, got %q", stdout.String())
+	}
+	if !sent {
+		t.Fatal("expected reply to be sent")
+	}
+}
+
+func TestDiscordRunRequiresChannelIDs(t *testing.T) {
+	ext := NewDiscordExtension(Config{BotToken: "token"})
+	err := ext.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected missing channel_ids to fail")
+	}
+	if !strings.Contains(err.Error(), "channel_ids required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/extensions/irc/irc_adapter.go
+++ b/extensions/irc/irc_adapter.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+)
+
+type Config struct {
+	Server   string   `json:"server"`
+	Port     int      `json:"port"`
+	Nick     string   `json:"nick"`
+	Channels []string `json:"channels"`
+	UseTLS   bool     `json:"use_tls"`
+}
+
+type IRCExtension struct {
+	config Config
+	conn   net.Conn
+	reader *bufio.Reader
+	writer *bufio.Writer
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func NewIRCExtension(cfg Config) *IRCExtension {
+	if cfg.Server == "" {
+		cfg.Server = "irc.libera.chat"
+	}
+	if cfg.Port == 0 {
+		cfg.Port = 6667
+	}
+	return &IRCExtension{
+		config: cfg,
+		stdin:  os.Stdin,
+		stdout: os.Stdout,
+		stderr: os.Stderr,
+	}
+}
+
+func (e *IRCExtension) Run(ctx context.Context) error {
+	if strings.TrimSpace(e.config.Nick) == "" {
+		return fmt.Errorf("nick is required")
+	}
+	if len(e.config.Channels) == 0 {
+		return fmt.Errorf("channels are required")
+	}
+	if err := e.connect(); err != nil {
+		return err
+	}
+	defer e.conn.Close()
+
+	for _, channel := range e.config.Channels {
+		if err := e.sendRaw("JOIN " + channel); err != nil {
+			return err
+		}
+	}
+
+	lines := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		for {
+			line, err := e.reader.ReadString('\n')
+			if err != nil {
+				errCh <- err
+				return
+			}
+			lines <- strings.TrimSpace(line)
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			_ = e.sendRaw("QUIT :shutdown")
+			return nil
+		case err := <-errCh:
+			return err
+		case line := <-lines:
+			if err := e.handleLine(ctx, line); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (e *IRCExtension) connect() error {
+	address := fmt.Sprintf("%s:%d", e.config.Server, e.config.Port)
+	var conn net.Conn
+	var err error
+	if e.config.UseTLS {
+		conn, err = tls.Dial("tcp", address, &tls.Config{MinVersion: tls.VersionTLS12})
+	} else {
+		conn, err = net.Dial("tcp", address)
+	}
+	if err != nil {
+		return err
+	}
+	e.conn = conn
+	e.reader = bufio.NewReader(conn)
+	e.writer = bufio.NewWriter(conn)
+
+	if err := e.sendRaw("NICK " + e.config.Nick); err != nil {
+		return err
+	}
+	if err := e.sendRaw(fmt.Sprintf("USER %s 0 * :%s", e.config.Nick, e.config.Nick)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *IRCExtension) handleLine(ctx context.Context, line string) error {
+	if strings.HasPrefix(line, "PING :") {
+		return e.sendRaw("PONG :" + strings.TrimPrefix(line, "PING :"))
+	}
+
+	channel, text, user, ok := parsePrivmsg(line)
+	if !ok || strings.TrimSpace(text) == "" {
+		return nil
+	}
+
+	payload := map[string]any{
+		"action":  "message",
+		"channel": "irc",
+		"chat_id": channel,
+		"text":    text,
+		"user_id": user,
+	}
+	if err := json.NewEncoder(e.stdout).Encode(payload); err != nil {
+		return err
+	}
+
+	reply, err := e.readReply()
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+	if reply != "" {
+		return e.sendPrivmsg(channel, reply)
+	}
+	return nil
+}
+
+func parsePrivmsg(line string) (channel, text, user string, ok bool) {
+	parts := strings.SplitN(line, " PRIVMSG ", 2)
+	if len(parts) != 2 {
+		return "", "", "", false
+	}
+
+	prefix := strings.TrimPrefix(parts[0], ":")
+	if bang := strings.Index(prefix, "!"); bang >= 0 {
+		user = prefix[:bang]
+	} else {
+		user = prefix
+	}
+
+	messageParts := strings.SplitN(parts[1], " :", 2)
+	if len(messageParts) != 2 {
+		return "", "", "", false
+	}
+
+	channel = strings.TrimSpace(messageParts[0])
+	text = messageParts[1]
+	return channel, text, user, true
+}
+
+func (e *IRCExtension) readReply() (string, error) {
+	var response map[string]any
+	if err := json.NewDecoder(e.stdin).Decode(&response); err != nil {
+		return "", err
+	}
+	reply, _ := response["text"].(string)
+	return strings.TrimSpace(reply), nil
+}
+
+func (e *IRCExtension) sendPrivmsg(channel, text string) error {
+	return e.sendRaw(fmt.Sprintf("PRIVMSG %s :%s", channel, text))
+}
+
+func (e *IRCExtension) sendRaw(line string) error {
+	if e.writer == nil {
+		return fmt.Errorf("irc connection not established")
+	}
+	if _, err := e.writer.WriteString(line + "\r\n"); err != nil {
+		return err
+	}
+	return e.writer.Flush()
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewIRCExtension(cfg)
+	if err := ext.Run(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/irc/smoke_test.go
+++ b/extensions/irc/smoke_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestIRCHandleLineProcessesIncomingMessage(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	raw := &bytes.Buffer{}
+
+	ext := NewIRCExtension(Config{Nick: "bot", Channels: []string{"#room"}})
+	ext.stdin = strings.NewReader(`{"text":"pong"}`)
+	ext.stdout = stdout
+	ext.writer = bufio.NewWriter(raw)
+
+	if err := ext.handleLine(context.Background(), ":alice!u@h PRIVMSG #room :hello"); err != nil {
+		t.Fatalf("handleLine: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"channel":"irc"`) {
+		t.Fatalf("expected irc event, got %q", stdout.String())
+	}
+	if !strings.Contains(raw.String(), "PRIVMSG #room :pong") {
+		t.Fatalf("expected reply to be written, got %q", raw.String())
+	}
+}
+
+func TestIRCRunRequiresChannels(t *testing.T) {
+	ext := NewIRCExtension(Config{Nick: "bot"})
+	err := ext.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected missing channels to fail")
+	}
+	if !strings.Contains(err.Error(), "channels are required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## 说明
这个 PR 从 mvp 分支切出，只保留 Discord 和 IRC 的运行时补齐。

## 修复内容
- 补齐 extensions/discord 的 runtime 实现
- 补齐 extensions/irc 的 runtime 实现
- 增加成功和失败测试，防止 manifest 存在但运行时不生效

## 验证
- go test ./extensions/discord ./extensions/irc`n
旧 PR：#163