### PR TITLE
fix(extensions): add signal and slack runtimes for mvp

### DIFF
--- a/extensions/signal/anyclaw.extension.json
+++ b/extensions/signal/anyclaw.extension.json
@@ -18,6 +18,11 @@
       "number": {
         "type": "string",
         "description": "Signal phone number with country code"
+      },
+      "poll_every": {
+        "type": "integer",
+        "description": "Polling interval in seconds",
+        "default": 3
       }
     },
     "required": ["number"]

--- a/extensions/signal/signal_adapter.go
+++ b/extensions/signal/signal_adapter.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	SignalURL string `json:"signal_url"`
+	Number    string `json:"number"`
+	PollEvery int    `json:"poll_every"`
+}
+
+type SignalExtension struct {
+	config  Config
+	client  *http.Client
+	baseURL string
+	stdin   io.Reader
+	stdout  io.Writer
+	stderr  io.Writer
+}
+
+func NewSignalExtension(cfg Config) *SignalExtension {
+	baseURL := strings.TrimRight(cfg.SignalURL, "/")
+	if baseURL == "" {
+		baseURL = "http://localhost:8080"
+	}
+	return &SignalExtension{
+		config:  cfg,
+		client:  &http.Client{Timeout: 15 * time.Second},
+		baseURL: baseURL,
+		stdin:   os.Stdin,
+		stdout:  os.Stdout,
+		stderr:  os.Stderr,
+	}
+}
+
+func (e *SignalExtension) Run(ctx context.Context) error {
+	if strings.TrimSpace(e.config.Number) == "" {
+		return fmt.Errorf("number is required")
+	}
+
+	interval := time.Duration(e.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+
+	if err := e.pollOnce(ctx); err != nil {
+		fmt.Fprintf(e.stderr, "signal poll error: %v\n", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := e.pollOnce(ctx); err != nil {
+				fmt.Fprintf(e.stderr, "signal poll error: %v\n", err)
+			}
+		}
+	}
+}
+
+type signalEnvelope struct {
+	Envelope struct {
+		SourceNumber string `json:"sourceNumber"`
+		Timestamp    int64  `json:"timestamp"`
+		DataMessage  struct {
+			Message string `json:"message"`
+		} `json:"dataMessage"`
+	} `json:"envelope"`
+}
+
+func (e *SignalExtension) pollOnce(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.baseURL+"/v1/receive/"+url.PathEscape(e.config.Number), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("signal receive failed: %s", resp.Status)
+	}
+
+	var envelopes []signalEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&envelopes); err != nil {
+		return err
+	}
+
+	for _, envelope := range envelopes {
+		text := strings.TrimSpace(envelope.Envelope.DataMessage.Message)
+		if text == "" {
+			continue
+		}
+
+		payload := map[string]any{
+			"action":    "message",
+			"channel":   "signal",
+			"chat_id":   envelope.Envelope.SourceNumber,
+			"text":      text,
+			"user_id":   envelope.Envelope.SourceNumber,
+			"timestamp": envelope.Envelope.Timestamp,
+		}
+		if err := json.NewEncoder(e.stdout).Encode(payload); err != nil {
+			return err
+		}
+
+		reply, err := e.readReply()
+		if err != nil {
+			return fmt.Errorf("failed to read response: %w", err)
+		}
+		if reply != "" {
+			if err := e.sendMessage(ctx, envelope.Envelope.SourceNumber, reply); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (e *SignalExtension) readReply() (string, error) {
+	var response map[string]any
+	if err := json.NewDecoder(e.stdin).Decode(&response); err != nil {
+		return "", err
+	}
+
+	reply, _ := response["text"].(string)
+	return strings.TrimSpace(reply), nil
+}
+
+func (e *SignalExtension) sendMessage(ctx context.Context, recipient, text string) error {
+	body, _ := json.Marshal(map[string]any{
+		"message":    text,
+		"number":     e.config.Number,
+		"recipients": []string{recipient},
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.baseURL+"/v2/send", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("signal send failed: %s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+	}
+
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewSignalExtension(cfg)
+	if err := ext.Run(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/signal/smoke_test.go
+++ b/extensions/signal/smoke_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSignalPollOnceProcessesIncomingMessage(t *testing.T) {
+	var sendBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/receive/"):
+			_, _ = io.WriteString(w, `[{"envelope":{"sourceNumber":"+10001","timestamp":42,"dataMessage":{"message":"hello"}}}]`)
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/send":
+			sendBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	ext := NewSignalExtension(Config{SignalURL: server.URL, Number: "+19999"})
+	ext.client = server.Client()
+	ext.stdin = strings.NewReader(`{"text":"pong"}`)
+	ext.stdout = stdout
+
+	if err := ext.pollOnce(context.Background()); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), `"channel":"signal"`) {
+		t.Fatalf("expected signal event, got %q", stdout.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(sendBody, &payload); err != nil {
+		t.Fatalf("Unmarshal send payload: %v", err)
+	}
+	if payload["message"] != "pong" {
+		t.Fatalf("unexpected reply payload: %#v", payload)
+	}
+}
+
+func TestSignalPollOnceReturnsSendError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/receive/"):
+			_, _ = io.WriteString(w, `[{"envelope":{"sourceNumber":"+10001","timestamp":42,"dataMessage":{"message":"hello"}}}]`)
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/send":
+			http.Error(w, "boom", http.StatusBadGateway)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	ext := NewSignalExtension(Config{SignalURL: server.URL, Number: "+19999"})
+	ext.client = server.Client()
+	ext.stdin = strings.NewReader(`{"text":"pong"}`)
+	ext.stdout = &bytes.Buffer{}
+
+	err := ext.pollOnce(context.Background())
+	if err == nil {
+		t.Fatal("expected send failure")
+	}
+	if !strings.Contains(err.Error(), "signal send failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/extensions/slack/anyclaw.extension.json
+++ b/extensions/slack/anyclaw.extension.json
@@ -24,6 +24,11 @@
         "type": "string",
         "description": "Slack signing secret for webhook verification",
         "sensitive": true
+      },
+      "port": {
+        "type": "integer",
+        "description": "Webhook port for Slack Events API",
+        "default": 8080
       }
     },
     "required": ["bot_token"]

--- a/extensions/slack/slack_adapter.go
+++ b/extensions/slack/slack_adapter.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	BotToken      string `json:"bot_token"`
+	AppToken      string `json:"app_token,omitempty"`
+	SigningSecret string `json:"signing_secret,omitempty"`
+	Port          int    `json:"port,omitempty"`
+}
+
+type SlackExtension struct {
+	config  Config
+	client  *http.Client
+	baseURL string
+	stdin   io.Reader
+	stdout  io.Writer
+	stderr  io.Writer
+}
+
+func NewSlackExtension(cfg Config) *SlackExtension {
+	if cfg.Port <= 0 {
+		cfg.Port = 8080
+	}
+	return &SlackExtension{
+		config:  cfg,
+		client:  &http.Client{Timeout: 10 * time.Second},
+		baseURL: "https://slack.com/api",
+		stdin:   os.Stdin,
+		stdout:  os.Stdout,
+		stderr:  os.Stderr,
+	}
+}
+
+func (e *SlackExtension) Run(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/slack/events", e.handleWebhook)
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", e.config.Port),
+		Handler: mux,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (e *SlackExtension) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	if !e.verifySignature(body, r.Header.Get("X-Slack-Signature"), r.Header.Get("X-Slack-Request-Timestamp")) {
+		http.Error(w, "invalid signature", http.StatusForbidden)
+		return
+	}
+
+	var payload struct {
+		Type      string `json:"type"`
+		Challenge string `json:"challenge"`
+		Event     struct {
+			Type    string `json:"type"`
+			Text    string `json:"text"`
+			Channel string `json:"channel"`
+			User    string `json:"user"`
+			BotID   string `json:"bot_id"`
+			Subtype string `json:"subtype"`
+		} `json:"event"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	if payload.Type == "url_verification" {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(payload.Challenge))
+		return
+	}
+
+	if payload.Type != "event_callback" || payload.Event.Type != "message" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if payload.Event.BotID != "" || payload.Event.Subtype == "bot_message" || strings.TrimSpace(payload.Event.Text) == "" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	input := map[string]any{
+		"action":  "message",
+		"channel": "slack",
+		"chat_id": payload.Event.Channel,
+		"text":    payload.Event.Text,
+		"user_id": payload.Event.User,
+	}
+	if err := json.NewEncoder(e.stdout).Encode(input); err != nil {
+		http.Error(w, "failed to emit message", http.StatusInternalServerError)
+		return
+	}
+
+	reply, err := e.readReply()
+	if err != nil {
+		fmt.Fprintf(e.stderr, "failed to read response: %v\n", err)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if reply != "" {
+		if err := e.sendMessage(payload.Event.Channel, reply); err != nil {
+			fmt.Fprintf(e.stderr, "slack send error: %v\n", err)
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (e *SlackExtension) verifySignature(body []byte, signature, timestamp string) bool {
+	if e.config.SigningSecret == "" {
+		return true
+	}
+
+	if signature == "" || timestamp == "" {
+		return false
+	}
+	if _, err := strconv.ParseInt(timestamp, 10, 64); err != nil {
+		return false
+	}
+
+	base := "v0:" + timestamp + ":" + string(body)
+	mac := hmac.New(sha256.New, []byte(e.config.SigningSecret))
+	mac.Write([]byte(base))
+	expected := "v0=" + hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(expected), []byte(signature))
+}
+
+func (e *SlackExtension) readReply() (string, error) {
+	var response map[string]any
+	if err := json.NewDecoder(e.stdin).Decode(&response); err != nil {
+		return "", err
+	}
+	reply, _ := response["text"].(string)
+	return strings.TrimSpace(reply), nil
+}
+
+func (e *SlackExtension) sendMessage(channelID, text string) error {
+	body, _ := json.Marshal(map[string]string{
+		"channel": channelID,
+		"text":    text,
+	})
+
+	req, err := http.NewRequest(http.MethodPost, e.baseURL+"/chat.postMessage", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+e.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+	if resp.StatusCode >= 300 || !result.OK {
+		if result.Error == "" {
+			result.Error = resp.Status
+		}
+		return fmt.Errorf("slack send failed: %s", result.Error)
+	}
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewSlackExtension(cfg)
+	if err := ext.Run(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/slack/smoke_test.go
+++ b/extensions/slack/smoke_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSlackHandleWebhookRespondsToVerification(t *testing.T) {
+	ext := NewSlackExtension(Config{})
+
+	req := httptest.NewRequest(http.MethodPost, "/slack/events", strings.NewReader(`{"type":"url_verification","challenge":"abc123"}`))
+	rec := httptest.NewRecorder()
+
+	ext.handleWebhook(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if strings.TrimSpace(rec.Body.String()) != "abc123" {
+		t.Fatalf("unexpected verification response: %q", rec.Body.String())
+	}
+}
+
+func TestSlackSendMessageReturnsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat.postMessage" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"ok":false,"error":"channel_not_found"}`)
+	}))
+	defer server.Close()
+
+	ext := NewSlackExtension(Config{BotToken: "token"})
+	ext.baseURL = server.URL
+	ext.client = server.Client()
+
+	err := ext.sendMessage("C123", "pong")
+	if err == nil {
+		t.Fatal("expected send failure")
+	}
+	if !strings.Contains(err.Error(), "channel_not_found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## 说明
这个 PR 从 mvp 分支切出，只保留 Signal 和 Slack 的运行时补齐。

## 修复内容
- 补齐 extensions/signal 的 runtime 实现
- 补齐 extensions/slack 的 runtime 实现
- 增加成功和失败测试，防止注册成功但运行时不生效

## 验证
- go test ./extensions/signal ./extensions/slack`n
旧 PR：#157