### PR TITLE
fix(extensions): add whatsapp runtime for mvp

### DIFF
--- a/extensions/whatsapp/anyclaw.extension.json
+++ b/extensions/whatsapp/anyclaw.extension.json
@@ -28,6 +28,11 @@
         "type": "string",
         "description": "Facebook app secret for webhook validation",
         "sensitive": true
+      },
+      "port": {
+        "type": "integer",
+        "description": "Webhook port for incoming WhatsApp messages",
+        "default": 8080
       }
     },
     "required": ["access_token", "phone_number_id"]

--- a/extensions/whatsapp/smoke_test.go
+++ b/extensions/whatsapp/smoke_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWhatsAppHandleWebhookProcessesIncomingMessage(t *testing.T) {
+	var sent bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/123/messages" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		sent = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	ext := NewWhatsAppExtension(Config{AccessToken: "token", PhoneNumberID: "123"})
+	ext.apiBaseURL = server.URL
+	ext.client = server.Client()
+	ext.stdin = strings.NewReader(`{"text":"pong"}`)
+	ext.stdout = stdout
+
+	body := `{"entry":[{"changes":[{"value":{"messages":[{"from":"15551234","id":"wamid","type":"text","text":{"body":"hello"}}]}}]}]}`
+	req := httptest.NewRequest(http.MethodPost, "/whatsapp", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	ext.handleWebhook(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if !strings.Contains(stdout.String(), `"channel":"whatsapp"`) {
+		t.Fatalf("expected whatsapp event, got %q", stdout.String())
+	}
+	if !sent {
+		t.Fatal("expected reply to be sent")
+	}
+}
+
+func TestWhatsAppSendTextMessageReturnsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = io.WriteString(w, "upstream failed")
+	}))
+	defer server.Close()
+
+	ext := NewWhatsAppExtension(Config{AccessToken: "token", PhoneNumberID: "123"})
+	ext.apiBaseURL = server.URL
+	ext.client = server.Client()
+
+	err := ext.sendTextMessage("15551234", "pong")
+	if err == nil {
+		t.Fatal("expected send failure")
+	}
+	if !strings.Contains(err.Error(), "whatsapp send failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/extensions/whatsapp/whatsapp_adapter.go
+++ b/extensions/whatsapp/whatsapp_adapter.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	AccessToken   string `json:"access_token"`
+	PhoneNumberID string `json:"phone_number_id"`
+	VerifyToken   string `json:"verify_token,omitempty"`
+	AppSecret     string `json:"app_secret,omitempty"`
+	Port          int    `json:"port,omitempty"`
+}
+
+type WhatsAppExtension struct {
+	config     Config
+	client     *http.Client
+	apiBaseURL string
+	stdin      io.Reader
+	stdout     io.Writer
+	stderr     io.Writer
+}
+
+func NewWhatsAppExtension(cfg Config) *WhatsAppExtension {
+	if cfg.Port <= 0 {
+		cfg.Port = 8080
+	}
+	return &WhatsAppExtension{
+		config:     cfg,
+		client:     &http.Client{Timeout: 10 * time.Second},
+		apiBaseURL: "https://graph.facebook.com/v19.0",
+		stdin:      os.Stdin,
+		stdout:     os.Stdout,
+		stderr:     os.Stderr,
+	}
+}
+
+func (e *WhatsAppExtension) Run(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/whatsapp", e.handleWebhook)
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", e.config.Port),
+		Handler: mux,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (e *WhatsAppExtension) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		mode := r.URL.Query().Get("hub.mode")
+		verifyToken := r.URL.Query().Get("hub.verify_token")
+		challenge := r.URL.Query().Get("hub.challenge")
+		if mode == "subscribe" && verifyToken == e.config.VerifyToken {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(challenge))
+			return
+		}
+		http.Error(w, "invalid verification", http.StatusForbidden)
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var payload struct {
+		Entry []struct {
+			Changes []struct {
+				Value struct {
+					Messages []struct {
+						From string `json:"from"`
+						ID   string `json:"id"`
+						Type string `json:"type"`
+						Text struct {
+							Body string `json:"body"`
+						} `json:"text"`
+					} `json:"messages"`
+				} `json:"value"`
+			} `json:"changes"`
+		} `json:"entry"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	for _, entry := range payload.Entry {
+		for _, change := range entry.Changes {
+			for _, message := range change.Value.Messages {
+				if message.Type != "text" || strings.TrimSpace(message.Text.Body) == "" {
+					continue
+				}
+
+				input := map[string]any{
+					"action":  "message",
+					"channel": "whatsapp",
+					"chat_id": message.From,
+					"text":    message.Text.Body,
+					"user_id": message.From,
+					"msg_id":  message.ID,
+				}
+				if err := json.NewEncoder(e.stdout).Encode(input); err != nil {
+					http.Error(w, "failed to emit message", http.StatusInternalServerError)
+					return
+				}
+
+				reply, err := e.readReply()
+				if err != nil {
+					fmt.Fprintf(e.stderr, "failed to read response: %v\n", err)
+					continue
+				}
+				if reply != "" {
+					if err := e.sendTextMessage(message.From, reply); err != nil {
+						fmt.Fprintf(e.stderr, "whatsapp send error: %v\n", err)
+					}
+				}
+			}
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func (e *WhatsAppExtension) readReply() (string, error) {
+	var response map[string]any
+	if err := json.NewDecoder(e.stdin).Decode(&response); err != nil {
+		return "", err
+	}
+	reply, _ := response["text"].(string)
+	return strings.TrimSpace(reply), nil
+}
+
+func (e *WhatsAppExtension) sendTextMessage(recipient, text string) error {
+	body, _ := json.Marshal(map[string]any{
+		"messaging_product": "whatsapp",
+		"to":                recipient,
+		"type":              "text",
+		"text": map[string]string{
+			"body": text,
+		},
+	})
+
+	req, err := http.NewRequest(http.MethodPost, e.apiBaseURL+"/"+e.config.PhoneNumberID+"/messages", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+e.config.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("whatsapp send failed: %s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewWhatsAppExtension(cfg)
+	if err := ext.Run(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## 说明
这个 PR 从 mvp 分支切出，只保留 WhatsApp 的运行时补齐。

## 修复内容
- 补齐 extensions/whatsapp 的 runtime 实现
- 增加成功和失败测试，防止 manifest 存在但运行时不生效

## 验证
- go test ./extensions/whatsapp`n
旧 PR：#158