### PR TITLE
fix(adapters): preserve aws adapter env for mvp

### DIFF
--- a/pkg/extensions/adapters/cli/adapters/aws/aws.go
+++ b/pkg/extensions/adapters/cli/adapters/aws/aws.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -187,6 +188,7 @@ func (c *Client) configure(ctx context.Context, args []string) (string, error) {
 
 func (c *Client) run(ctx context.Context, args []string) (string, error) {
 	cmd := exec.CommandContext(ctx, c.awsPath, args...)
+	cmd.Env = os.Environ()
 	if c.region != "" {
 		cmd.Env = append(cmd.Env, "AWS_DEFAULT_REGION="+c.region)
 	}

--- a/pkg/extensions/adapters/cli/adapters/aws/smoke_test.go
+++ b/pkg/extensions/adapters/cli/adapters/aws/smoke_test.go
@@ -1,0 +1,42 @@
+package aws
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRunPreservesInheritedEnvironment(t *testing.T) {
+	t.Setenv("ANYCLAW_TEST_INHERITED", "present")
+
+	client := NewClient(Config{Region: "ap-southeast-1", Profile: "team"})
+	var args []string
+	if runtime.GOOS == "windows" {
+		client.awsPath = "cmd"
+		args = []string{"/c", "echo %ANYCLAW_TEST_INHERITED%-%AWS_DEFAULT_REGION%-%AWS_PROFILE%"}
+	} else {
+		client.awsPath = "sh"
+		args = []string{"-c", `printf "%s-%s-%s" "$ANYCLAW_TEST_INHERITED" "$AWS_DEFAULT_REGION" "$AWS_PROFILE"`}
+	}
+
+	out, err := client.run(context.Background(), args)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(out, "present-ap-southeast-1-team") {
+		t.Fatalf("expected inherited and custom env vars, got %q", out)
+	}
+}
+
+func TestRunReturnsCommandError(t *testing.T) {
+	client := NewClient(Config{AWSPath: "definitely-not-a-real-aws-binary"})
+	_, err := client.run(context.Background(), []string{"sts", "get-caller-identity"})
+	if err == nil {
+		t.Fatal("expected missing binary to fail")
+	}
+	if !os.IsNotExist(err) && !strings.Contains(err.Error(), "executable file not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## 说明
这个 PR 从 mvp 分支切出，只保留 AWS adapter 的真实修复。

## 修复内容
- 修复 AWS adapter 执行时丢失宿主环境变量的问题
- 增加成功和失败测试，防止调用看起来成功但运行环境不完整

## 验证
- go test ./pkg/extensions/adapters/cli/adapters/aws`n
旧 PR：#159