### PR TITLE
fix(adapters): preserve kubectl adapter env for mvp

### DIFF
--- a/pkg/extensions/adapters/cli/adapters/kubectl/kubectl.go
+++ b/pkg/extensions/adapters/cli/adapters/kubectl/kubectl.go
@@ -3,6 +3,7 @@ package kubectl
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -306,6 +307,7 @@ func (c *Client) version(ctx context.Context) (string, error) {
 
 func (c *Client) run(ctx context.Context, args []string) (string, error) {
 	cmd := exec.CommandContext(ctx, c.kubectlPath, args...)
+	cmd.Env = os.Environ()
 	if c.kubeconfig != "" {
 		cmd.Env = append(cmd.Env, "KUBECONFIG="+c.kubeconfig)
 	}

--- a/pkg/extensions/adapters/cli/adapters/kubectl/smoke_test.go
+++ b/pkg/extensions/adapters/cli/adapters/kubectl/smoke_test.go
@@ -1,0 +1,42 @@
+package kubectl
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRunPreservesInheritedEnvironment(t *testing.T) {
+	t.Setenv("ANYCLAW_TEST_INHERITED", "present")
+
+	client := NewClient(Config{Kubeconfig: "/tmp/config"})
+	var args []string
+	if runtime.GOOS == "windows" {
+		client.kubectlPath = "cmd"
+		args = []string{"/c", "echo %ANYCLAW_TEST_INHERITED%-%KUBECONFIG%"}
+	} else {
+		client.kubectlPath = "sh"
+		args = []string{"-c", `printf "%s-%s" "$ANYCLAW_TEST_INHERITED" "$KUBECONFIG"`}
+	}
+
+	out, err := client.run(context.Background(), args)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(out, "present-/tmp/config") {
+		t.Fatalf("expected inherited and kubeconfig env vars, got %q", out)
+	}
+}
+
+func TestRunReturnsCommandError(t *testing.T) {
+	client := NewClient(Config{KubectlPath: "definitely-not-a-real-kubectl-binary"})
+	_, err := client.run(context.Background(), []string{"version", "--client"})
+	if err == nil {
+		t.Fatal("expected missing binary to fail")
+	}
+	if !os.IsNotExist(err) && !strings.Contains(err.Error(), "executable file not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## 说明
这个 PR 从 mvp 分支切出，只保留 kubectl adapter 的真实修复。

## 修复内容
- 修复 kubectl adapter 执行时丢失宿主环境变量的问题
- 增加成功和失败测试，防止调用看起来成功但运行环境不完整

## 验证
- go test ./pkg/extensions/adapters/cli/adapters/kubectl`n
旧 PR：#160