### PR TITLE
fix(adapters): reject sqlite and zip fake success for mvp

### DIFF
--- a/pkg/extensions/adapters/cli/adapters/sqlite/smoke_test.go
+++ b/pkg/extensions/adapters/cli/adapters/sqlite/smoke_test.go
@@ -1,0 +1,39 @@
+package sqlite
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRunExecutesCommand(t *testing.T) {
+	client := NewClient(Config{})
+	var args []string
+	if runtime.GOOS == "windows" {
+		client.sqlitePath = "cmd"
+		args = []string{"/c", "echo ok"}
+	} else {
+		client.sqlitePath = "sh"
+		args = []string{"-c", "printf ok"}
+	}
+
+	out, err := client.Run(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if strings.TrimSpace(out) != "ok" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestRunReturnsUsageErrorWhenArgsMissing(t *testing.T) {
+	client := NewClient(Config{})
+	_, err := client.Run(context.Background(), []string{"only-db"})
+	if err == nil {
+		t.Fatal("expected usage error")
+	}
+	if !strings.Contains(err.Error(), "usage: sqlite") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/sqlite/sqlite.go
+++ b/pkg/extensions/adapters/cli/adapters/sqlite/sqlite.go
@@ -25,7 +25,7 @@ func NewClient(cfg Config) *Client {
 
 func (c *Client) Run(ctx context.Context, args []string) (string, error) {
 	if len(args) < 2 {
-		return "Usage: sqlite <db> <sql>", nil
+		return "", fmt.Errorf("usage: sqlite <db> <sql>")
 	}
 
 	dbPath := args[0]

--- a/pkg/extensions/adapters/cli/adapters/zip/smoke_test.go
+++ b/pkg/extensions/adapters/cli/adapters/zip/smoke_test.go
@@ -1,0 +1,42 @@
+package zip
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunCreatesArchive(t *testing.T) {
+	tempDir := t.TempDir()
+	source := filepath.Join(tempDir, "note.txt")
+	if err := os.WriteFile(source, []byte("hello"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	archive := filepath.Join(tempDir, "bundle.zip")
+	client := NewClient(Config{})
+	if _, err := client.Run(context.Background(), []string{"create", archive, source}); err != nil {
+		t.Fatalf("Run create: %v", err)
+	}
+
+	files, err := ListZIP(archive)
+	if err != nil {
+		t.Fatalf("ListZIP: %v", err)
+	}
+	if len(files) != 1 || files[0] != "note.txt" {
+		t.Fatalf("unexpected archive contents: %#v", files)
+	}
+}
+
+func TestRunReturnsUsageErrorWhenArgsMissing(t *testing.T) {
+	client := NewClient(Config{})
+	_, err := client.Run(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected usage error")
+	}
+	if !strings.Contains(err.Error(), "usage: zip") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/zip/zip.go
+++ b/pkg/extensions/adapters/cli/adapters/zip/zip.go
@@ -20,7 +20,7 @@ func NewClient(cfg Config) *Client {
 
 func (c *Client) Run(ctx context.Context, args []string) (string, error) {
 	if len(args) == 0 {
-		return "Usage: zip <command> [args]\nCommands: create, extract, list, add", nil
+		return "", fmt.Errorf("usage: zip <command> [args]")
 	}
 
 	switch args[0] {
@@ -188,36 +188,79 @@ func (c *Client) add(ctx context.Context, args []string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	writer := zip.NewWriter(temp)
 
-	original, err := os.Open(archive)
-	if err == nil {
-		zipReader, _ := zip.OpenReader(archive)
-		if zipReader != nil {
-			writer := zip.NewWriter(temp)
-
-			for _, file := range zipReader.File {
-				rc, _ := file.Open()
-				if rc != nil {
-					header, _ := zip.FileInfoHeader(file.FileInfo())
-					header.Name = file.Name
-					entry, _ := writer.CreateHeader(header)
-					io.Copy(entry, rc)
-					rc.Close()
-				}
+	if _, err := os.Stat(archive); err == nil {
+		zipReader, err := zip.OpenReader(archive)
+		if err != nil {
+			_ = writer.Close()
+			_ = temp.Close()
+			_ = os.Remove(tempFile)
+			return "", err
+		}
+		for _, file := range zipReader.File {
+			rc, err := file.Open()
+			if err != nil {
+				zipReader.Close()
+				_ = writer.Close()
+				_ = temp.Close()
+				_ = os.Remove(tempFile)
+				return "", err
 			}
-
-			for _, file := range files {
-				c.addFile(writer, file)
+			header, err := zip.FileInfoHeader(file.FileInfo())
+			if err != nil {
+				rc.Close()
+				zipReader.Close()
+				_ = writer.Close()
+				_ = temp.Close()
+				_ = os.Remove(tempFile)
+				return "", err
 			}
+			header.Name = file.Name
+			entry, err := writer.CreateHeader(header)
+			if err != nil {
+				rc.Close()
+				zipReader.Close()
+				_ = writer.Close()
+				_ = temp.Close()
+				_ = os.Remove(tempFile)
+				return "", err
+			}
+			if _, err := io.Copy(entry, rc); err != nil {
+				rc.Close()
+				zipReader.Close()
+				_ = writer.Close()
+				_ = temp.Close()
+				_ = os.Remove(tempFile)
+				return "", err
+			}
+			rc.Close()
+		}
+		zipReader.Close()
+	}
 
-			writer.Close()
-			original.Close()
-			zipReader.Close()
+	for _, file := range files {
+		if err := c.addFile(writer, file); err != nil {
+			_ = writer.Close()
+			_ = temp.Close()
+			_ = os.Remove(tempFile)
+			return "", err
 		}
 	}
-	temp.Close()
 
-	os.Rename(tempFile, archive)
+	if err := writer.Close(); err != nil {
+		_ = temp.Close()
+		_ = os.Remove(tempFile)
+		return "", err
+	}
+	if err := temp.Close(); err != nil {
+		_ = os.Remove(tempFile)
+		return "", err
+	}
+	if err := os.Rename(tempFile, archive); err != nil {
+		_ = os.Remove(tempFile)
+		return "", err
+	}
 
 	return fmt.Sprintf("Added %d files to %s", len(files), archive), nil
 }


### PR DESCRIPTION
## 说明
这个 PR 从 mvp 分支切出，只保留 sqlite 和 zip adapter 的假成功修复。

## 修复内容
- 修复 sqlite 参数不足时仍然返回成功的问题
- 修复 zip 参数错误和 add 过程吞错导致的假成功问题
- 增加成功和失败测试，防止后续回归

## 验证
- go test ./pkg/extensions/adapters/cli/adapters/sqlite ./pkg/extensions/adapters/cli/adapters/zip`n
旧 PR：#161