### PR TITLE
feat(ui): add chat message flow and home page

### DIFF
--- a/ui/src/app/router.tsx
+++ b/ui/src/app/router.tsx
@@ -1,8 +1,9 @@
-import { Navigate, createHashRouter } from "react-router-dom";
+import { createHashRouter } from "react-router-dom";
 
 import { AppShell } from "@/layouts/AppShell/AppShell";
 import { DiscoveryPage } from "@/pages/Discovery/DiscoveryPage";
 import { MarketPage } from "@/pages/Market/MarketPage";
+import { ChatHomePage } from "@/pages/ChatHome/ChatHomePage";
 import { StudioPage } from "@/pages/Studio/StudioPage";
 import { WorkspacePage } from "@/pages/Workspace/WorkspacePage";
 
@@ -12,7 +13,7 @@ export const router = createHashRouter([
     path: "/",
     children: [
       {
-        element: <Navigate replace to="/workspace" />,
+        element: <ChatHomePage />,
         index: true,
       },
       {

--- a/ui/src/features/chat/MarkdownMessage.test.tsx
+++ b/ui/src/features/chat/MarkdownMessage.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MarkdownMessage } from "./MarkdownMessage";
+
+describe("MarkdownMessage", () => {
+  it("renders markdown structure and links", () => {
+    render(
+      <MarkdownMessage
+        content={[
+          "# 标题",
+          "",
+          "- 第一项",
+          "- 第二项",
+          "",
+          "这是 **重点** 和 `code`。",
+          "",
+          "[OpenAI](https://openai.com)",
+        ].join("\n")}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "标题" })).toBeInTheDocument();
+    expect(screen.getByText("第一项")).toBeInTheDocument();
+    expect(screen.getByText("重点")).toBeInTheDocument();
+    expect(screen.getByText("code")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "OpenAI" })).toHaveAttribute("href", "https://openai.com");
+    expect(screen.getByRole("link", { name: "OpenAI" })).toHaveAttribute("target", "_blank");
+  });
+
+  it("does not render unsafe markdown urls as clickable links", () => {
+    render(<MarkdownMessage content="[危险链接](javascript:alert(1))" />);
+
+    expect(screen.getByText("危险链接")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "危险链接" })).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/chat/MarkdownMessage.tsx
+++ b/ui/src/features/chat/MarkdownMessage.tsx
@@ -1,0 +1,55 @@
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+type MarkdownMessageProps = {
+  content: string;
+};
+
+function getSafeMarkdownHref(href?: string) {
+  const candidate = href?.trim();
+  if (!candidate) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+export function MarkdownMessage({ content }: MarkdownMessageProps) {
+  return (
+    <div className="chat-markdown">
+      <ReactMarkdown
+        components={{
+          a: ({ node: _node, href, children, ...props }) => {
+            const safeHref = getSafeMarkdownHref(href);
+            if (!safeHref) {
+              return <span>{children}</span>;
+            }
+
+            return (
+              <a {...props} href={safeHref} rel="noreferrer" target="_blank">
+                {children}
+              </a>
+            );
+          },
+          table: ({ node: _node, ...props }) => (
+            <div className="overflow-x-auto">
+              <table {...props} />
+            </div>
+          ),
+        }}
+        remarkPlugins={[remarkGfm]}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/ui/src/features/chat/useWebChat.test.tsx
+++ b/ui/src/features/chat/useWebChat.test.tsx
@@ -402,6 +402,95 @@ describe("useWebChat persistence", () => {
     });
   });
 
+  it("retains previously synced remote sessions when a poll returns a partial list", async () => {
+    window.localStorage.setItem(
+      CHAT_STORAGE_KEY,
+      JSON.stringify({
+        selectedSessionKey: "session-newer",
+        sessions: [
+          {
+            agentName: "binbin",
+            createdAt: "2026-04-11T15:00:00.000Z",
+            key: "session-newer",
+            messages: [
+              {
+                content: "newer session",
+                role: "user",
+                timestamp: "2026-04-11T15:00:00.000Z",
+              },
+            ],
+            remoteSessionId: "sess_newer",
+            title: "newer session",
+            updatedAt: "2026-04-11T15:00:00.000Z",
+          },
+          {
+            agentName: "binbin",
+            createdAt: "2026-04-11T14:00:00.000Z",
+            key: "session-older",
+            messages: [
+              {
+                content: "older remote session",
+                role: "user",
+                timestamp: "2026-04-11T14:00:00.000Z",
+              },
+            ],
+            remoteSessionId: "sess_older",
+            title: "older remote session",
+            updatedAt: "2026-04-11T14:00:00.000Z",
+          },
+        ],
+        version: 2,
+      }),
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = requestURL(input);
+
+      if (url === "/approvals?status=pending") {
+        return jsonResponse([]);
+      }
+
+      if (url.startsWith("/sessions?workspace=")) {
+        return jsonResponse([
+          {
+            agent: "binbin",
+            created_at: "2026-04-11T15:00:00.000Z",
+            id: "sess_newer",
+            messages: [
+              {
+                content: "newer session",
+                created_at: "2026-04-11T15:00:00.000Z",
+                role: "user",
+              },
+            ],
+            title: "newer session",
+            updated_at: "2026-04-11T15:00:00.000Z",
+          },
+        ]);
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<HookProbe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-session-key")).toHaveTextContent("session-newer");
+      expect(screen.getByTestId("session-id")).toHaveTextContent("sess_newer");
+      expect(screen.getByTestId("message-preview")).toHaveTextContent("newer session");
+    });
+
+    await waitFor(() => {
+      const persisted = JSON.parse(window.localStorage.getItem(CHAT_STORAGE_KEY) || "null");
+      expect(persisted.sessions).toHaveLength(2);
+      expect(persisted.sessions.map((session: { remoteSessionId: string | null }) => session.remoteSessionId)).toEqual(
+        expect.arrayContaining(["sess_newer", "sess_older"]),
+      );
+    });
+  });
+
   it("deletes synced sessions through the main sessions api", async () => {
     let deleted = false;
 

--- a/ui/src/features/chat/useWebChat.test.tsx
+++ b/ui/src/features/chat/useWebChat.test.tsx
@@ -1,0 +1,1021 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CHAT_STORAGE_KEY, useWebChat } from "./useWebChat";
+
+const TEST_WORKSPACE_PATH = "D:\\workspace\\anyclaw\\workflows";
+
+type HookProbeProps = {
+  agentName?: string;
+};
+
+function HookProbe({ agentName = "binbin" }: HookProbeProps) {
+  const { deleteSession, error, messages, resetConversation, selectSession, selectedSessionKey, sessionId } = useWebChat(
+    agentName,
+    TEST_WORKSPACE_PATH,
+  );
+
+  return (
+    <div>
+      <div data-testid="error-message">{error ?? ""}</div>
+      <div data-testid="message-count">{messages.length}</div>
+      <div data-testid="message-preview">{messages[0]?.content ?? ""}</div>
+      <div data-testid="selected-session-key">{selectedSessionKey ?? ""}</div>
+      <div data-testid="session-id">{sessionId ?? ""}</div>
+      <button onClick={resetConversation} type="button">
+        reset
+      </button>
+      <button onClick={() => selectSession("session-2")} type="button">
+        select-second
+      </button>
+      <button
+        onClick={() => {
+          if (selectedSessionKey) {
+            void deleteSession(selectedSessionKey);
+          }
+        }}
+        type="button"
+      >
+        delete-selected
+      </button>
+    </div>
+  );
+}
+
+function ApprovalProbe() {
+  const {
+    approvalNoticeApprovals,
+    draft,
+    messages,
+    pendingApprovals,
+    resolveApproval,
+    sessionId,
+    sendMessage,
+    setDraft,
+  } = useWebChat("binbin", TEST_WORKSPACE_PATH);
+
+  return (
+    <div>
+      <input aria-label="draft" onChange={(event) => setDraft(event.target.value)} value={draft} />
+      <button onClick={sendMessage} type="button">
+        send
+      </button>
+      <div data-testid="approval-count">{approvalNoticeApprovals.length}</div>
+      <div data-testid="approval-tool">{approvalNoticeApprovals[0]?.tool_name ?? ""}</div>
+      <div data-testid="session-approval-count">{pendingApprovals.length}</div>
+      <div data-testid="message-count">{messages.length}</div>
+      <div data-testid="message-preview">{messages[messages.length - 1]?.content ?? ""}</div>
+      <div data-testid="session-id">{sessionId ?? ""}</div>
+      <button
+        disabled={approvalNoticeApprovals.length === 0}
+        onClick={() => void resolveApproval(approvalNoticeApprovals[0]?.id ?? "", true)}
+        type="button"
+      >
+        approve
+      </button>
+    </div>
+  );
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "ERROR",
+    text: async () => JSON.stringify(payload),
+  } as Response);
+}
+
+function requestURL(input: RequestInfo | URL) {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+describe("useWebChat persistence", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = requestURL(input);
+
+      if (url === "/approvals?status=pending") {
+        return jsonResponse([]);
+      }
+
+      if (url.startsWith("/sessions?workspace=")) {
+        return jsonResponse([]);
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("migrates legacy single-session storage into multi-session local storage", async () => {
+    const legacyState = {
+      messages: [
+        {
+          content: "hello",
+          role: "user" as const,
+          timestamp: "2026-04-11T12:00:00.000Z",
+        },
+      ],
+      sessionId: "sess_123",
+    };
+
+    window.sessionStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify(legacyState));
+
+    render(<HookProbe />);
+
+    expect(screen.getByTestId("message-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("session-id")).toHaveTextContent("sess_123");
+
+    await waitFor(() => {
+      const persisted = JSON.parse(window.localStorage.getItem(CHAT_STORAGE_KEY) || "null");
+
+      expect(persisted.version).toBe(2);
+      expect(persisted.selectedSessionKey).toBe("sess_123");
+      expect(persisted.sessions).toHaveLength(1);
+      expect(persisted.sessions[0].remoteSessionId).toBe("sess_123");
+      expect(window.sessionStorage.getItem(CHAT_STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  it("keeps previous sessions in history when starting a new conversation", async () => {
+    window.localStorage.setItem(
+      CHAT_STORAGE_KEY,
+      JSON.stringify({
+        selectedSessionKey: "session-1",
+        sessions: [
+          {
+            agentName: "binbin",
+            createdAt: "2026-04-11T12:00:00.000Z",
+            key: "session-1",
+            messages: [
+              {
+                content: "older session",
+                role: "user",
+                timestamp: "2026-04-11T12:00:00.000Z",
+              },
+            ],
+            remoteSessionId: "sess_1",
+            title: "older session",
+            updatedAt: "2026-04-11T12:00:00.000Z",
+          },
+        ],
+        version: 2,
+      }),
+    );
+
+    render(<HookProbe />);
+
+    fireEvent.click(screen.getByRole("button", { name: "reset" }));
+
+    expect(screen.getByTestId("message-count")).toHaveTextContent("0");
+    expect(screen.getByTestId("selected-session-key")).toHaveTextContent("");
+
+    await waitFor(() => {
+      const persisted = JSON.parse(window.localStorage.getItem(CHAT_STORAGE_KEY) || "null");
+
+      expect(persisted.selectedSessionKey).toBeNull();
+      expect(persisted.sessions).toHaveLength(1);
+      expect(persisted.sessions[0].title).toBe("older session");
+    });
+  });
+
+  it("can switch to another stored conversation", async () => {
+    window.localStorage.setItem(
+      CHAT_STORAGE_KEY,
+      JSON.stringify({
+        selectedSessionKey: "session-1",
+        sessions: [
+          {
+            agentName: "binbin",
+            createdAt: "2026-04-11T12:00:00.000Z",
+            key: "session-1",
+            messages: [
+              {
+                content: "first session",
+                role: "user",
+                timestamp: "2026-04-11T12:00:00.000Z",
+              },
+            ],
+            remoteSessionId: "sess_1",
+            title: "first session",
+            updatedAt: "2026-04-11T12:00:00.000Z",
+          },
+          {
+            agentName: "binbin",
+            createdAt: "2026-04-11T13:00:00.000Z",
+            key: "session-2",
+            messages: [
+              {
+                content: "second session",
+                role: "user",
+                timestamp: "2026-04-11T13:00:00.000Z",
+              },
+            ],
+            remoteSessionId: "sess_2",
+            title: "second session",
+            updatedAt: "2026-04-11T13:00:00.000Z",
+          },
+        ],
+        version: 2,
+      }),
+    );
+
+    render(<HookProbe />);
+
+    fireEvent.click(screen.getByRole("button", { name: "select-second" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-session-key")).toHaveTextContent("session-2");
+      expect(screen.getByTestId("session-id")).toHaveTextContent("sess_2");
+      expect(screen.getByTestId("message-preview")).toHaveTextContent("second session");
+    });
+  });
+
+  it("prefers the current agent's latest session on first load", async () => {
+    window.localStorage.setItem(
+      CHAT_STORAGE_KEY,
+      JSON.stringify({
+        selectedSessionKey: "agent-other",
+        sessions: [
+          {
+            agentName: "other-agent",
+            createdAt: "2026-04-11T12:00:00.000Z",
+            key: "agent-other",
+            messages: [
+              {
+                content: "other agent",
+                role: "user",
+                timestamp: "2026-04-11T12:00:00.000Z",
+              },
+            ],
+            remoteSessionId: "sess_other",
+            title: "other agent",
+            updatedAt: "2026-04-11T12:00:00.000Z",
+          },
+          {
+            agentName: "binbin",
+            createdAt: "2026-04-11T13:00:00.000Z",
+            key: "agent-binbin",
+            messages: [
+              {
+                content: "current agent",
+                role: "user",
+                timestamp: "2026-04-11T13:00:00.000Z",
+              },
+            ],
+            remoteSessionId: "sess_binbin",
+            title: "current agent",
+            updatedAt: "2026-04-11T13:00:00.000Z",
+          },
+        ],
+        version: 2,
+      }),
+    );
+
+    render(<HookProbe agentName="binbin" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-session-key")).toHaveTextContent("agent-binbin");
+      expect(screen.getByTestId("session-id")).toHaveTextContent("sess_binbin");
+      expect(screen.getByTestId("message-preview")).toHaveTextContent("current agent");
+    });
+  });
+
+  it("hydrates remote sessions from the gateway list so browser and desktop history can sync", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = requestURL(input);
+
+      if (url === "/approvals?status=pending") {
+        return jsonResponse([]);
+      }
+
+      if (url.startsWith("/sessions?workspace=")) {
+        return jsonResponse([
+          {
+            agent: "binbin",
+            created_at: "2026-04-11T14:00:00.000Z",
+            id: "sess_remote",
+            messages: [
+              {
+                content: "from desktop",
+                created_at: "2026-04-11T14:00:00.000Z",
+                role: "user",
+              },
+            ],
+            title: "from desktop",
+            updated_at: "2026-04-11T14:00:00.000Z",
+          },
+        ]);
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<HookProbe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-session-key")).toHaveTextContent("sess_remote");
+      expect(screen.getByTestId("session-id")).toHaveTextContent("sess_remote");
+      expect(screen.getByTestId("message-preview")).toHaveTextContent("from desktop");
+    });
+  });
+
+  it("keeps the active remote session when the session list temporarily misses it", async () => {
+    window.localStorage.setItem(
+      CHAT_STORAGE_KEY,
+      JSON.stringify({
+        selectedSessionKey: "session-keep",
+        sessions: [
+          {
+            agentName: "binbin",
+            createdAt: "2026-04-11T15:00:00.000Z",
+            key: "session-keep",
+            messages: [
+              {
+                content: "still here",
+                role: "user",
+                timestamp: "2026-04-11T15:00:00.000Z",
+              },
+            ],
+            remoteSessionId: "sess_keep",
+            title: "still here",
+            updatedAt: "2026-04-11T15:00:00.000Z",
+          },
+        ],
+        version: 2,
+      }),
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = requestURL(input);
+
+      if (url.startsWith("/sessions?workspace=")) {
+        return jsonResponse([]);
+      }
+
+      if (url === "/sessions/sess_keep") {
+        return jsonResponse({
+          agent: "binbin",
+          id: "sess_keep",
+          messages: [
+            {
+              content: "still here",
+              created_at: "2026-04-11T15:00:00.000Z",
+              role: "user",
+            },
+          ],
+          presence: "waiting_approval",
+          typing: false,
+        });
+      }
+
+      if (url === "/approvals?status=pending") {
+        return jsonResponse([]);
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<HookProbe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-session-key")).toHaveTextContent("session-keep");
+      expect(screen.getByTestId("session-id")).toHaveTextContent("sess_keep");
+      expect(screen.getByTestId("message-preview")).toHaveTextContent("still here");
+    });
+  });
+
+  it("deletes synced sessions through the main sessions api", async () => {
+    let deleted = false;
+
+    window.localStorage.setItem(
+      CHAT_STORAGE_KEY,
+      JSON.stringify({
+        selectedSessionKey: "session-1",
+        sessions: [
+          {
+            agentName: "binbin",
+            createdAt: "2026-04-11T12:00:00.000Z",
+            key: "session-1",
+            messages: [
+              {
+                content: "delete me",
+                role: "user",
+                timestamp: "2026-04-11T12:00:00.000Z",
+              },
+            ],
+            remoteSessionId: "sess_delete",
+            title: "delete me",
+            updatedAt: "2026-04-11T12:00:00.000Z",
+          },
+        ],
+        version: 2,
+      }),
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestURL(input);
+
+      if (url === "/approvals?status=pending") {
+        return jsonResponse([]);
+      }
+
+      if (url.startsWith("/sessions?workspace=")) {
+        return jsonResponse(
+          deleted
+            ? []
+            : [
+                {
+                  agent: "binbin",
+                  created_at: "2026-04-11T12:00:00.000Z",
+                  id: "sess_delete",
+                  messages: [
+                    {
+                      content: "delete me",
+                      created_at: "2026-04-11T12:00:00.000Z",
+                      role: "user",
+                    },
+                  ],
+                  title: "delete me",
+                  updated_at: "2026-04-11T12:00:00.000Z",
+                },
+              ],
+        );
+      }
+
+      if (url === "/sessions/sess_delete") {
+        expect(init?.method).toBe("DELETE");
+        deleted = true;
+        return jsonResponse({ status: "deleted" });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<HookProbe />);
+
+    fireEvent.click(screen.getByRole("button", { name: "delete-selected" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-session-key")).toHaveTextContent("");
+      expect(screen.getByTestId("session-id")).toHaveTextContent("");
+
+      const persisted = JSON.parse(window.localStorage.getItem(CHAT_STORAGE_KEY) || "null");
+      expect(persisted.sessions).toHaveLength(0);
+    });
+  });
+
+  it("shows plain-text delete errors instead of a JSON parse crash", async () => {
+    window.localStorage.setItem(
+      CHAT_STORAGE_KEY,
+      JSON.stringify({
+        selectedSessionKey: "session-1",
+        sessions: [
+          {
+            agentName: "binbin",
+            createdAt: "2026-04-11T12:00:00.000Z",
+            key: "session-1",
+            messages: [
+              {
+                content: "delete me",
+                role: "user",
+                timestamp: "2026-04-11T12:00:00.000Z",
+              },
+            ],
+            remoteSessionId: "sess_delete_text",
+            title: "delete me",
+            updatedAt: "2026-04-11T12:00:00.000Z",
+          },
+        ],
+        version: 2,
+      }),
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestURL(input);
+
+      if (url.startsWith("/sessions?workspace=")) {
+        return jsonResponse([
+          {
+            agent: "binbin",
+            created_at: "2026-04-11T12:00:00.000Z",
+            id: "sess_delete_text",
+            messages: [
+              {
+                content: "delete me",
+                created_at: "2026-04-11T12:00:00.000Z",
+                role: "user",
+              },
+            ],
+            title: "delete me",
+            updated_at: "2026-04-11T12:00:00.000Z",
+          },
+        ]);
+      }
+
+      if (url === "/sessions/sess_delete_text") {
+        expect(init?.method).toBe("DELETE");
+        return Promise.resolve({
+          ok: false,
+          status: 405,
+          statusText: "Method Not Allowed",
+          text: async () => "method not allowed",
+        } as Response);
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<HookProbe />);
+
+    fireEvent.click(screen.getByRole("button", { name: "delete-selected" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("error-message")).toHaveTextContent("method not allowed");
+      expect(screen.getByTestId("selected-session-key")).toHaveTextContent("session-1");
+    });
+  });
+
+  it("shows pending approvals and resumes the chat after approval", async () => {
+    const approval = {
+      action: "tool_call",
+      id: "approval_1",
+      payload: {
+        args: {
+          command: "mkdir C:\\Users\\TestUser\\Desktop\\Hello",
+        },
+      },
+      requested_at: "2026-04-11T12:00:10.000Z",
+      session_id: "sess_approval",
+      status: "pending",
+      tool_name: "run_command",
+    };
+
+    let approvalPending = true;
+    let sessionMessages = [
+      {
+        content: "please create a folder",
+        created_at: "2026-04-11T12:00:00.000Z",
+        role: "user",
+      },
+    ];
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestURL(input);
+
+      if (url.startsWith("/sessions?workspace=")) {
+        return jsonResponse([
+          {
+            agent: "binbin",
+            created_at: "2026-04-11T12:00:00.000Z",
+            id: "sess_approval",
+            messages: sessionMessages,
+            title: "please create a folder",
+            updated_at: approvalPending ? "2026-04-11T12:00:00.000Z" : "2026-04-11T12:00:20.000Z",
+          },
+        ]);
+      }
+
+      if (url.startsWith("/chat?workspace=")) {
+        return jsonResponse({
+          approvals: [approval],
+          session: {
+            agent: "binbin",
+            id: "sess_approval",
+            messages: sessionMessages,
+            presence: "waiting_approval",
+            typing: false,
+          },
+          status: "waiting_approval",
+        });
+      }
+
+      if (url === "/approvals?status=pending") {
+        return jsonResponse(approvalPending ? [approval] : []);
+      }
+
+      if (url === "/approvals/approval_1/resolve") {
+        expect(init?.method).toBe("POST");
+        approvalPending = false;
+        sessionMessages = [
+          ...sessionMessages,
+          {
+            content: "folder created",
+            created_at: "2026-04-11T12:00:20.000Z",
+            role: "assistant",
+          },
+        ];
+
+        return jsonResponse({
+          ...approval,
+          status: "approved",
+        });
+      }
+
+      if (url === "/sessions/sess_approval") {
+        return jsonResponse({
+          agent: "binbin",
+          id: "sess_approval",
+          messages: sessionMessages,
+          presence: approvalPending ? "waiting_approval" : "idle",
+          typing: false,
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ApprovalProbe />);
+
+    fireEvent.change(screen.getByLabelText("draft"), {
+      target: { value: "please create a folder" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("draft")).toHaveValue("please create a folder");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "send" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("approval-count")).toHaveTextContent("1");
+      expect(screen.getByTestId("approval-tool")).toHaveTextContent("run_command");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "approve" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("approval-count")).toHaveTextContent("0");
+      expect(screen.getByTestId("message-count")).toHaveTextContent("2");
+      expect(screen.getByTestId("message-preview")).toHaveTextContent("folder created");
+    }, { timeout: 4000 });
+  }, 10000);
+
+  it("keeps the resumed assistant message when the remote session list is briefly stale", async () => {
+    const approval = {
+      action: "tool_call",
+      id: "approval_stale_list",
+      payload: {
+        args: {
+          command: "mkdir C:\\Users\\TestUser\\Desktop\\Hello",
+        },
+      },
+      requested_at: "2026-04-11T12:30:10.000Z",
+      session_id: "sess_approval_stale_list",
+      status: "pending",
+      tool_name: "run_command",
+    };
+
+    const createdAt = "2026-04-11T12:30:00.000Z";
+    const staleUpdatedAt = "2026-04-11T12:30:00.000Z";
+    const resumedUpdatedAt = "2026-04-11T12:30:20.000Z";
+    let approvalPending = true;
+    let sessionMessages = [
+      {
+        content: "please create a folder",
+        created_at: createdAt,
+        role: "user",
+      },
+    ];
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestURL(input);
+
+      if (url.startsWith("/sessions?workspace=")) {
+        return jsonResponse(
+          approvalPending
+            ? []
+            : [
+                {
+                  agent: "binbin",
+                  created_at: createdAt,
+                  id: "sess_approval_stale_list",
+                  messages: [
+                    {
+                      content: "please create a folder",
+                      created_at: createdAt,
+                      role: "user",
+                    },
+                  ],
+                  title: "please create a folder",
+                  updated_at: staleUpdatedAt,
+                },
+              ],
+        );
+      }
+
+      if (url.startsWith("/chat?workspace=")) {
+        return jsonResponse({
+          approvals: [approval],
+          session: {
+            agent: "binbin",
+            created_at: createdAt,
+            id: "sess_approval_stale_list",
+            messages: sessionMessages,
+            presence: "waiting_approval",
+            title: "please create a folder",
+            typing: false,
+            updated_at: staleUpdatedAt,
+          },
+          status: "waiting_approval",
+        });
+      }
+
+      if (url === "/approvals?status=pending") {
+        return jsonResponse(approvalPending ? [approval] : []);
+      }
+
+      if (url === "/approvals/approval_stale_list/resolve") {
+        expect(init?.method).toBe("POST");
+        approvalPending = false;
+        sessionMessages = [
+          ...sessionMessages,
+          {
+            content: "folder created",
+            created_at: resumedUpdatedAt,
+            role: "assistant",
+          },
+        ];
+
+        return jsonResponse({
+          ...approval,
+          status: "approved",
+        });
+      }
+
+      if (url === "/sessions/sess_approval_stale_list") {
+        return jsonResponse({
+          agent: "binbin",
+          created_at: createdAt,
+          id: "sess_approval_stale_list",
+          messages: sessionMessages,
+          presence: approvalPending ? "waiting_approval" : "idle",
+          title: "please create a folder",
+          typing: false,
+          updated_at: approvalPending ? staleUpdatedAt : resumedUpdatedAt,
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ApprovalProbe />);
+
+    fireEvent.change(screen.getByLabelText("draft"), {
+      target: { value: "please create a folder" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "send" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("approval-count")).toHaveTextContent("1");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "approve" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("approval-count")).toHaveTextContent("0");
+      expect(screen.getByTestId("message-count")).toHaveTextContent("2");
+      expect(screen.getByTestId("message-preview")).toHaveTextContent("folder created");
+    }, { timeout: 4000 });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 4500));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("message-count")).toHaveTextContent("2");
+      expect(screen.getByTestId("message-preview")).toHaveTextContent("folder created");
+    });
+  }, 15000);
+
+  it("binds a new remote session before approval resume when the waiting response has no messages yet", async () => {
+    const approval = {
+      action: "tool_call",
+      id: "approval_new_session",
+      payload: {
+        args: {
+          path: "Hello.md",
+        },
+      },
+      requested_at: "2026-04-11T12:10:10.000Z",
+      session_id: "sess_new_approval",
+      status: "pending",
+      tool_name: "write_file",
+    };
+
+    let approvalPending = true;
+    let sessionMessages: Array<{ content: string; created_at: string; role: "assistant" | "user" }> = [];
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestURL(input);
+
+      if (url.startsWith("/sessions?workspace=")) {
+        return jsonResponse(
+          approvalPending
+            ? []
+            : [
+                {
+                  agent: "binbin",
+                  created_at: "2026-04-11T12:10:00.000Z",
+                  id: "sess_new_approval",
+                  messages: sessionMessages,
+                  title: "please create a markdown file",
+                  updated_at: "2026-04-11T12:10:20.000Z",
+                },
+              ],
+        );
+      }
+
+      if (url.startsWith("/chat?workspace=")) {
+        return jsonResponse({
+          approvals: [approval],
+          session: {
+            agent: "binbin",
+            id: "sess_new_approval",
+            messages: [],
+            presence: "waiting_approval",
+            typing: false,
+          },
+          status: "waiting_approval",
+        });
+      }
+
+      if (url === "/approvals?status=pending") {
+        return jsonResponse(approvalPending ? [approval] : []);
+      }
+
+      if (url === "/approvals/approval_new_session/resolve") {
+        expect(init?.method).toBe("POST");
+        approvalPending = false;
+        sessionMessages = [
+          {
+            content: "please create a markdown file",
+            created_at: "2026-04-11T12:10:00.000Z",
+            role: "user",
+          },
+          {
+            content: "created Hello.md",
+            created_at: "2026-04-11T12:10:20.000Z",
+            role: "assistant",
+          },
+        ];
+        return jsonResponse({
+          ...approval,
+          status: "approved",
+        });
+      }
+
+      if (url === "/sessions/sess_new_approval") {
+        return jsonResponse({
+          agent: "binbin",
+          id: "sess_new_approval",
+          messages: sessionMessages,
+          presence: approvalPending ? "waiting_approval" : "idle",
+          typing: false,
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ApprovalProbe />);
+
+    fireEvent.change(screen.getByLabelText("draft"), {
+      target: { value: "please create a markdown file" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "send" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("approval-count")).toHaveTextContent("1");
+      expect(screen.getByTestId("session-id")).toHaveTextContent("sess_new_approval");
+      expect(screen.getByTestId("message-count")).toHaveTextContent("1");
+      expect(screen.getByTestId("message-preview")).toHaveTextContent("please create a markdown file");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "approve" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("approval-count")).toHaveTextContent("0");
+      expect(screen.getByTestId("session-id")).toHaveTextContent("sess_new_approval");
+      expect(screen.getByTestId("message-count")).toHaveTextContent("2");
+      expect(screen.getByTestId("message-preview")).toHaveTextContent("created Hello.md");
+    }, { timeout: 4000 });
+  }, 10000);
+
+  it("shows a pending approval even when the current session is not selected", async () => {
+    const approval = {
+      action: "tool_call",
+      id: "approval_orphaned_view",
+      payload: {
+        args: {
+          path: "C:\\Users\\TestUser\\Desktop\\Hello.md",
+        },
+      },
+      requested_at: "2026-04-11T12:20:10.000Z",
+      session_id: "sess_orphaned_view",
+      status: "pending",
+      tool_name: "write_file",
+    };
+
+    let approvalPending = true;
+    let sessionMessages: Array<{ content: string; created_at: string; role: "assistant" | "user" }> = [
+      {
+        content: "please create Hello.md",
+        created_at: "2026-04-11T12:20:00.000Z",
+        role: "user",
+      },
+    ];
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestURL(input);
+
+      if (url.startsWith("/sessions?workspace=")) {
+        return jsonResponse([]);
+      }
+
+      if (url === "/approvals?status=pending") {
+        return jsonResponse(approvalPending ? [approval] : []);
+      }
+
+      if (url === "/approvals/approval_orphaned_view/resolve") {
+        expect(init?.method).toBe("POST");
+        approvalPending = false;
+        sessionMessages = [
+          ...sessionMessages,
+          {
+            content: "created Hello.md",
+            created_at: "2026-04-11T12:20:20.000Z",
+            role: "assistant",
+          },
+        ];
+        return jsonResponse({
+          ...approval,
+          status: "approved",
+        });
+      }
+
+      if (url === "/sessions/sess_orphaned_view") {
+        return jsonResponse({
+          agent: "binbin",
+          created_at: "2026-04-11T12:20:00.000Z",
+          id: "sess_orphaned_view",
+          messages: sessionMessages,
+          presence: approvalPending ? "waiting_approval" : "idle",
+          title: "please create Hello.md",
+          typing: false,
+          updated_at: approvalPending ? "2026-04-11T12:20:00.000Z" : "2026-04-11T12:20:20.000Z",
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ApprovalProbe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("approval-count")).toHaveTextContent("1");
+      expect(screen.getByTestId("session-approval-count")).toHaveTextContent("0");
+      expect(screen.getByTestId("session-id")).toHaveTextContent("");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "approve" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("approval-count")).toHaveTextContent("0");
+      expect(screen.getByTestId("session-id")).toHaveTextContent("sess_orphaned_view");
+      expect(screen.getByTestId("message-count")).toHaveTextContent("2");
+      expect(screen.getByTestId("message-preview")).toHaveTextContent("created Hello.md");
+    }, { timeout: 4000 });
+  }, 10000);
+});

--- a/ui/src/features/chat/useWebChat.ts
+++ b/ui/src/features/chat/useWebChat.ts
@@ -615,14 +615,11 @@ function mergeRemoteSessions(
     .filter((session): session is StoredChatSession => session !== null);
 
   const localOnlySessions = state.sessions.filter((session) => !session.remoteSessionId);
-  const retainedActiveSessions = state.sessions.filter((session) => {
-    if (!session.remoteSessionId || remoteSessionIDs.has(session.remoteSessionId)) {
-      return false;
-    }
-    return session.key === state.selectedSessionKey || session.remoteSessionId === state.sessionId;
-  });
+  const retainedRemoteSessions = state.sessions.filter(
+    (session) => session.remoteSessionId && !remoteSessionIDs.has(session.remoteSessionId),
+  );
 
-  const sessions = sortSessions([...localOnlySessions, ...mergedRemoteSessions, ...retainedActiveSessions]);
+  const sessions = sortSessions([...localOnlySessions, ...mergedRemoteSessions, ...retainedRemoteSessions]);
   const keepBlankConversation =
     state.selectedSessionKey === null &&
     state.sessionId === null &&
@@ -1370,4 +1367,3 @@ export function useWebChat(agentName: string | null, workspacePath: string | nul
     setDraft,
   };
 }
-

--- a/ui/src/features/chat/useWebChat.ts
+++ b/ui/src/features/chat/useWebChat.ts
@@ -1,0 +1,1373 @@
+﻿import { useEffect, useRef, useState } from "react";
+
+export type ChatMessage = {
+  agent_name?: string;
+  content: string;
+  role: "assistant" | "user";
+  timestamp: string;
+};
+
+export type ChatApproval = {
+  action?: string;
+  id: string;
+  payload?: Record<string, unknown>;
+  requested_at?: string;
+  session_id?: string;
+  status?: string;
+  tool_name: string;
+};
+
+export type StoredChatSession = {
+  agentName: string | null;
+  createdAt: string;
+  key: string;
+  messages: ChatMessage[];
+  remoteSessionId: string | null;
+  title: string;
+  updatedAt: string;
+};
+
+export type PersistedChatState = {
+  selectedSessionKey: string | null;
+  sessions: StoredChatSession[];
+  version: 2;
+};
+
+export type ChatSyncPayload = PersistedChatState & {
+  sendingSessionKey: string | null;
+};
+
+type ChatState = {
+  messages: ChatMessage[];
+  selectedSessionKey: string | null;
+  sessionId: string | null;
+  sessions: StoredChatSession[];
+};
+
+type LegacyPersistedChatState = {
+  messages?: unknown;
+  sessionId?: unknown;
+};
+
+type GatewaySessionMessage = {
+  content?: string;
+  created_at?: string;
+  role?: "assistant" | "user";
+};
+
+type GatewaySession = {
+  agent?: string;
+  created_at?: string;
+  id: string;
+  messages?: GatewaySessionMessage[];
+  presence?: string;
+  title?: string;
+  typing?: boolean;
+  updated_at?: string;
+};
+
+type GatewayApproval = {
+  action?: string;
+  id?: string;
+  payload?: Record<string, unknown>;
+  requested_at?: string;
+  session_id?: string;
+  status?: string;
+  tool_name?: string;
+};
+
+type ChatResponse = {
+  approvals?: GatewayApproval[];
+  response?: string;
+  session?: GatewaySession;
+  status?: string;
+};
+
+type GatewayStatus = {
+  working_dir?: string;
+};
+
+type ChatSelectDetail = {
+  sessionKey?: string;
+};
+
+type ChatDeleteDetail = {
+  sessionKey?: string;
+};
+
+export const CHAT_STORAGE_KEY = "anyclaw-control-ui-chat-v1";
+export const CHAT_SYNC_EVENT = "anyclaw:chat-sync";
+export const CHAT_RESET_EVENT = "anyclaw:chat-reset";
+export const CHAT_SELECT_EVENT = "anyclaw:chat-select";
+export const CHAT_DELETE_EVENT = "anyclaw:chat-delete";
+
+const STORAGE_VERSION = 2;
+const DEFAULT_WORKSPACE_ID = "workspace-default";
+const APPROVAL_POLL_ATTEMPTS = 18;
+const APPROVAL_POLL_INTERVAL_MS = 900;
+const REMOTE_SESSION_SYNC_INTERVAL_MS = 4000;
+const EMPTY_PERSISTED_STATE: PersistedChatState = {
+  selectedSessionKey: null,
+  sessions: [],
+  version: STORAGE_VERSION,
+};
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) return error.message;
+  return "发送失败，请稍后重试。";
+}
+
+async function requestJSON<T>(input: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, {
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  });
+
+  const text = await response.text();
+  let payload: T | { error?: string } | string | null = null;
+  if (text !== "") {
+    try {
+      payload = JSON.parse(text) as T | { error?: string };
+    } catch {
+      payload = text;
+    }
+  }
+
+  if (!response.ok) {
+    const message =
+      typeof payload === "string" && payload.trim() !== ""
+        ? payload.trim()
+        : payload && typeof payload === "object" && "error" in payload && typeof payload.error === "string"
+        ? payload.error
+        : `${response.status} ${response.statusText}`.trim();
+
+    throw new Error(message);
+  }
+
+  return payload as T;
+}
+
+function deriveWorkspaceId(workingDir: string | null | undefined) {
+  const source = (workingDir ?? "").trim().toLowerCase();
+  if (source === "") return DEFAULT_WORKSPACE_ID;
+
+  const clean = source.replace(/[:\\/ ]/g, "-").replace(/^[-.]+|[-.]+$/g, "");
+  return clean === "" ? DEFAULT_WORKSPACE_ID : `ws-${clean}`;
+}
+
+function looksAbsoluteWorkspacePath(workingDir: string | null | undefined) {
+  const value = (workingDir ?? "").trim();
+  return /^[a-z]:[\\/]/i.test(value) || value.startsWith("\\\\") || value.startsWith("/");
+}
+
+function normalizeAgentName(value: string | null | undefined) {
+  const normalized = (value ?? "").trim();
+  return normalized === "" ? null : normalized;
+}
+
+function normalizeTextValue(value: string | null | undefined) {
+  const normalized = (value ?? "").trim();
+  return normalized === "" ? null : normalized;
+}
+
+function normalizeTimestamp(value: string | null | undefined) {
+  const normalized = normalizeTextValue(value);
+  if (!normalized) return null;
+  return Number.isNaN(new Date(normalized).getTime()) ? null : normalized;
+}
+
+function getTimeValue(value: string | null | undefined) {
+  const normalized = normalizeTimestamp(value);
+  if (!normalized) return 0;
+  return new Date(normalized).getTime();
+}
+
+function isSameAgentName(left: string | null | undefined, right: string | null | undefined) {
+  return normalizeAgentName(left)?.toLowerCase() === normalizeAgentName(right)?.toLowerCase();
+}
+
+function createSessionKey() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `chat-${crypto.randomUUID()}`;
+  }
+
+  return `chat-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+function truncateText(value: string, maxLength = 36) {
+  const compact = value.replace(/\s+/g, " ").trim();
+  if (compact.length <= maxLength) return compact;
+  return `${compact.slice(0, maxLength).trimEnd()}...`;
+}
+
+function normalizeMessage(input: unknown): ChatMessage | null {
+  if (!input || typeof input !== "object") return null;
+
+  const message = input as Partial<ChatMessage>;
+  if (typeof message.content !== "string") return null;
+  if (message.role !== "assistant" && message.role !== "user") return null;
+
+  return {
+    agent_name: normalizeAgentName(message.agent_name) ?? undefined,
+    content: message.content,
+    role: message.role,
+    timestamp: typeof message.timestamp === "string" && message.timestamp.trim() !== ""
+      ? message.timestamp
+      : new Date().toISOString(),
+  };
+}
+
+function normalizeMessages(input: unknown) {
+  if (!Array.isArray(input)) return [];
+  return input.map((message) => normalizeMessage(message)).filter((message): message is ChatMessage => message !== null);
+}
+
+function normalizeApproval(input: unknown): ChatApproval | null {
+  if (!input || typeof input !== "object") return null;
+
+  const approval = input as GatewayApproval;
+  if (typeof approval.id !== "string" || approval.id.trim() === "") return null;
+  if (typeof approval.tool_name !== "string" || approval.tool_name.trim() === "") return null;
+
+  return {
+    action: typeof approval.action === "string" ? approval.action : undefined,
+    id: approval.id,
+    payload: approval.payload && typeof approval.payload === "object" ? approval.payload : undefined,
+    requested_at: typeof approval.requested_at === "string" ? approval.requested_at : undefined,
+    session_id: typeof approval.session_id === "string" ? approval.session_id : undefined,
+    status: typeof approval.status === "string" ? approval.status : undefined,
+    tool_name: approval.tool_name,
+  };
+}
+
+function normalizeApprovals(input: unknown) {
+  if (!Array.isArray(input)) return [];
+  return input.map((approval) => normalizeApproval(approval)).filter((approval): approval is ChatApproval => approval !== null);
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function isWaitingApprovalStatus(value: string | null | undefined) {
+  const normalized = (value ?? "").trim().toLowerCase();
+  return normalized === "waiting_approval" || normalized === "pending_approval";
+}
+
+function filterSessionApprovals(approvals: ChatApproval[], activeSessionId: string | null) {
+  if (!activeSessionId) return [];
+  return approvals.filter((approval) => approval.session_id === activeSessionId);
+}
+
+function inferAgentName(messages: ChatMessage[], fallbackAgentName?: string | null) {
+  const assistantAgentName = messages.find((message) => normalizeAgentName(message.agent_name))?.agent_name;
+  return normalizeAgentName(assistantAgentName) ?? normalizeAgentName(fallbackAgentName);
+}
+
+function deriveSessionTitle(messages: ChatMessage[]) {
+  const titleSource =
+    messages.find((message) => message.role === "user" && message.content.trim() !== "")?.content ??
+    messages.find((message) => message.content.trim() !== "")?.content ??
+    "新对话";
+
+  return truncateText(titleSource);
+}
+
+function deriveCreatedAt(messages: ChatMessage[]) {
+  return messages[0]?.timestamp ?? new Date().toISOString();
+}
+
+function deriveUpdatedAt(messages: ChatMessage[]) {
+  return messages[messages.length - 1]?.timestamp ?? new Date().toISOString();
+}
+
+function resolveStoredSessionTitle(messages: ChatMessage[], fallbackTitle?: string | null) {
+  const titleSource =
+    messages.find((message) => message.role === "user" && message.content.trim() !== "")?.content ??
+    messages.find((message) => message.content.trim() !== "")?.content ??
+    normalizeTextValue(fallbackTitle) ??
+    "新对话";
+
+  return truncateText(titleSource);
+}
+
+function resolveStoredSessionCreatedAt(
+  messages: ChatMessage[],
+  explicitCreatedAt?: string | null,
+  fallbackCreatedAt?: string | null,
+) {
+  return normalizeTimestamp(explicitCreatedAt) ?? normalizeTimestamp(fallbackCreatedAt) ?? deriveCreatedAt(messages);
+}
+
+function resolveStoredSessionUpdatedAt(
+  messages: ChatMessage[],
+  explicitUpdatedAt?: string | null,
+  fallbackUpdatedAt?: string | null,
+) {
+  const explicit = normalizeTimestamp(explicitUpdatedAt);
+  if (explicit) return explicit;
+
+  const fallback = normalizeTimestamp(fallbackUpdatedAt);
+  const derived = deriveUpdatedAt(messages);
+  if (!fallback) return derived;
+
+  return getTimeValue(derived) > getTimeValue(fallback) ? derived : fallback;
+}
+
+function buildStoredSession(params: {
+  agentName: string | null | undefined;
+  createdAt?: string | null;
+  existing?: StoredChatSession;
+  key?: string | null;
+  messages: ChatMessage[];
+  remoteSessionId: string | null | undefined;
+  title?: string | null;
+  updatedAt?: string | null;
+}) {
+  const normalizedMessages = normalizeMessages(params.messages);
+  const createdAt = resolveStoredSessionCreatedAt(normalizedMessages, params.createdAt, params.existing?.createdAt);
+  const updatedAt = resolveStoredSessionUpdatedAt(normalizedMessages, params.updatedAt, params.existing?.updatedAt);
+  const title = resolveStoredSessionTitle(normalizedMessages, params.title ?? params.existing?.title);
+
+  return {
+    agentName: inferAgentName(normalizedMessages, params.agentName ?? params.existing?.agentName),
+    createdAt,
+    key: params.key || params.existing?.key || params.remoteSessionId || createSessionKey(),
+    messages: normalizedMessages,
+    remoteSessionId: typeof params.remoteSessionId === "string" ? params.remoteSessionId : null,
+    title,
+    updatedAt,
+  } satisfies StoredChatSession;
+}
+
+function normalizeStoredSession(input: unknown): StoredChatSession | null {
+  if (!input || typeof input !== "object") return null;
+
+  const session = input as Partial<StoredChatSession> & {
+    agent?: string;
+    agent_name?: string;
+    created_at?: string;
+    id?: string;
+    sessionId?: string | null;
+    updated_at?: string;
+  };
+  const messages = normalizeMessages(session.messages);
+
+  const remoteSessionId =
+    typeof session.remoteSessionId === "string"
+      ? session.remoteSessionId
+      : typeof session.sessionId === "string"
+        ? session.sessionId
+        : null;
+
+  const key =
+    typeof session.key === "string" && session.key.trim() !== ""
+      ? session.key
+      : typeof session.id === "string" && session.id.trim() !== ""
+        ? session.id
+        : remoteSessionId || createSessionKey();
+  const providedTitle = normalizeTextValue(session.title);
+
+  if (messages.length === 0 && !remoteSessionId && !providedTitle) return null;
+
+  return buildStoredSession({
+    agentName: session.agentName ?? session.agent ?? session.agent_name ?? inferAgentName(messages),
+    createdAt:
+      typeof session.createdAt === "string" && session.createdAt.trim() !== ""
+        ? session.createdAt
+        : typeof session.created_at === "string" && session.created_at.trim() !== ""
+          ? session.created_at
+          : null,
+    existing: {
+      agentName: normalizeAgentName(session.agentName ?? session.agent ?? session.agent_name),
+      createdAt:
+        typeof session.createdAt === "string" && session.createdAt.trim() !== ""
+          ? session.createdAt
+          : typeof session.created_at === "string" && session.created_at.trim() !== ""
+            ? session.created_at
+          : deriveCreatedAt(messages),
+      key,
+      messages,
+      remoteSessionId,
+      title: providedTitle ?? resolveStoredSessionTitle(messages),
+      updatedAt:
+        typeof session.updatedAt === "string" && session.updatedAt.trim() !== ""
+          ? session.updatedAt
+          : typeof session.updated_at === "string" && session.updated_at.trim() !== ""
+            ? session.updated_at
+          : deriveUpdatedAt(messages),
+    },
+    key,
+    messages,
+    remoteSessionId,
+    title: providedTitle,
+    updatedAt:
+      typeof session.updatedAt === "string" && session.updatedAt.trim() !== ""
+        ? session.updatedAt
+        : typeof session.updated_at === "string" && session.updated_at.trim() !== ""
+          ? session.updated_at
+          : null,
+  });
+}
+
+function normalizePersistedState(input: unknown): PersistedChatState | null {
+  if (!input || typeof input !== "object") return null;
+
+  const parsed = input as Partial<PersistedChatState>;
+  if (!Array.isArray(parsed.sessions)) return null;
+
+  const sessions = parsed.sessions
+    .map((session) => normalizeStoredSession(session))
+    .filter((session): session is StoredChatSession => session !== null)
+    .sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime());
+
+  const selectedSessionKey =
+    typeof parsed.selectedSessionKey === "string" && sessions.some((session) => session.key === parsed.selectedSessionKey)
+      ? parsed.selectedSessionKey
+      : null;
+
+  return {
+    selectedSessionKey,
+    sessions,
+    version: STORAGE_VERSION,
+  };
+}
+
+function migrateLegacyState(input: unknown): PersistedChatState | null {
+  if (!input || typeof input !== "object") return null;
+
+  const parsed = input as LegacyPersistedChatState;
+  const messages = normalizeMessages(parsed.messages);
+  if (messages.length === 0) return null;
+
+  const remoteSessionId = typeof parsed.sessionId === "string" ? parsed.sessionId : null;
+  const session = buildStoredSession({
+    agentName: inferAgentName(messages),
+    key: remoteSessionId || createSessionKey(),
+    messages,
+    remoteSessionId,
+  });
+
+  return {
+    selectedSessionKey: session.key,
+    sessions: [session],
+    version: STORAGE_VERSION,
+  };
+}
+
+function parsePersistedState(raw: string | null): PersistedChatState | null {
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return normalizePersistedState(parsed) ?? migrateLegacyState(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function writePersistedState(state: PersistedChatState) {
+  if (typeof window === "undefined") return;
+
+  window.localStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify(state));
+  window.sessionStorage.removeItem(CHAT_STORAGE_KEY);
+}
+
+function emitChatSync(payload: ChatSyncPayload) {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(CHAT_SYNC_EVENT, { detail: payload }));
+}
+
+export function readPersistedChatState(): PersistedChatState {
+  if (typeof window === "undefined") {
+    return EMPTY_PERSISTED_STATE;
+  }
+
+  const localState = parsePersistedState(window.localStorage.getItem(CHAT_STORAGE_KEY));
+  if (localState) {
+    return localState;
+  }
+
+  const legacyState = parsePersistedState(window.sessionStorage.getItem(CHAT_STORAGE_KEY));
+  if (legacyState) {
+    writePersistedState(legacyState);
+    return legacyState;
+  }
+
+  return EMPTY_PERSISTED_STATE;
+}
+
+function mapSessionMessages(session: GatewaySession | undefined, fallbackAgentName: string | null) {
+  const agentName = normalizeAgentName(session?.agent) ?? normalizeAgentName(fallbackAgentName) ?? undefined;
+
+  return (session?.messages ?? [])
+    .filter(
+      (message): message is GatewaySessionMessage & { content: string; role: "assistant" | "user" } =>
+        typeof message.content === "string" &&
+        (message.role === "assistant" || message.role === "user"),
+    )
+    .map((message) => ({
+      agent_name: message.role === "assistant" ? agentName : undefined,
+      content: message.content,
+      role: message.role,
+      timestamp: message.created_at || new Date().toISOString(),
+    }));
+}
+
+function getSessionByKey(sessions: StoredChatSession[], sessionKey: string | null) {
+  if (!sessionKey) return null;
+  return sessions.find((session) => session.key === sessionKey) ?? null;
+}
+
+function findSessionByRemoteId(sessions: StoredChatSession[], remoteSessionId: string | null) {
+  if (!remoteSessionId) return null;
+  return sessions.find((session) => session.remoteSessionId === remoteSessionId) ?? null;
+}
+
+function findLatestSessionForAgent(sessions: StoredChatSession[], agentName: string | null) {
+  const normalizedAgentName = normalizeAgentName(agentName);
+
+  if (!normalizedAgentName) {
+    return sessions[0] ?? null;
+  }
+
+  return sessions.find((session) => isSameAgentName(session.agentName, normalizedAgentName)) ?? null;
+}
+
+function sortSessions(sessions: StoredChatSession[]) {
+  return [...sessions].sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime());
+}
+
+function mapGatewaySessionToStoredSession(session: GatewaySession, existing?: StoredChatSession | null) {
+  if (!session?.id) return null;
+
+  return buildStoredSession({
+    agentName: session.agent ?? existing?.agentName,
+    createdAt: session.created_at ?? existing?.createdAt ?? null,
+    existing: existing ?? undefined,
+    key: existing?.key ?? session.id,
+    messages: mapSessionMessages(session, existing?.agentName ?? session.agent ?? null),
+    remoteSessionId: session.id,
+    title: session.title ?? existing?.title ?? null,
+    updatedAt: session.updated_at ?? existing?.updatedAt ?? null,
+  });
+}
+
+function pickPreferredSessionVersion(
+  localSession: StoredChatSession | null,
+  remoteSession: StoredChatSession,
+  selectedSessionKey: string | null,
+  isSending: boolean,
+) {
+  if (!localSession) {
+    return remoteSession;
+  }
+
+  const localUpdatedAt = getTimeValue(localSession.updatedAt);
+  const remoteUpdatedAt = getTimeValue(remoteSession.updatedAt);
+  const shouldKeepLocalDraft =
+    isSending &&
+    selectedSessionKey === localSession.key &&
+    localSession.messages.length >= remoteSession.messages.length &&
+    localUpdatedAt >= remoteUpdatedAt;
+
+  if (shouldKeepLocalDraft || localUpdatedAt > remoteUpdatedAt) {
+    return {
+      ...localSession,
+      key: localSession.key,
+      remoteSessionId: remoteSession.remoteSessionId,
+    };
+  }
+
+  return {
+    ...remoteSession,
+    key: localSession.key,
+  };
+}
+
+function mergeRemoteSessions(
+  state: ChatState,
+  agentName: string | null,
+  remoteSessions: GatewaySession[],
+  isSending: boolean,
+): ChatState {
+  const remoteSessionIDs = new Set(remoteSessions.map((session) => session.id));
+  const localSessionsByRemoteId = new Map(
+    state.sessions
+      .filter((session) => session.remoteSessionId)
+      .map((session) => [session.remoteSessionId!, session]),
+  );
+
+  const mergedRemoteSessions = remoteSessions
+    .map((session) => {
+      const existing = localSessionsByRemoteId.get(session.id) ?? null;
+      const mapped = mapGatewaySessionToStoredSession(session, existing);
+      if (!mapped) return null;
+
+      return pickPreferredSessionVersion(existing, mapped, state.selectedSessionKey, isSending);
+    })
+    .filter((session): session is StoredChatSession => session !== null);
+
+  const localOnlySessions = state.sessions.filter((session) => !session.remoteSessionId);
+  const retainedActiveSessions = state.sessions.filter((session) => {
+    if (!session.remoteSessionId || remoteSessionIDs.has(session.remoteSessionId)) {
+      return false;
+    }
+    return session.key === state.selectedSessionKey || session.remoteSessionId === state.sessionId;
+  });
+
+  const sessions = sortSessions([...localOnlySessions, ...mergedRemoteSessions, ...retainedActiveSessions]);
+  const keepBlankConversation =
+    state.selectedSessionKey === null &&
+    state.sessionId === null &&
+    state.messages.length === 0 &&
+    state.sessions.length > 0;
+
+  if (keepBlankConversation) {
+    return {
+      ...state,
+      sessions,
+    };
+  }
+
+  const currentSelection =
+    getSessionByKey(sessions, state.selectedSessionKey) ??
+    findSessionByRemoteId(sessions, state.sessionId) ??
+    null;
+
+  if (currentSelection) {
+    return {
+      messages: currentSelection.messages,
+      selectedSessionKey: currentSelection.key,
+      sessionId: currentSelection.remoteSessionId,
+      sessions,
+    };
+  }
+
+  const fallbackSession = findLatestSessionForAgent(sessions, agentName);
+  if (!fallbackSession) {
+    return {
+      messages: [],
+      selectedSessionKey: null,
+      sessionId: null,
+      sessions,
+    };
+  }
+
+  return {
+    messages: fallbackSession.messages,
+    selectedSessionKey: fallbackSession.key,
+    sessionId: fallbackSession.remoteSessionId,
+    sessions,
+  };
+}
+
+function createInitialChatState(agentName: string | null): ChatState {
+  const persistedState = readPersistedChatState();
+  const rememberedSession = getSessionByKey(persistedState.sessions, persistedState.selectedSessionKey);
+  const selectedSession =
+    rememberedSession && (!agentName || isSameAgentName(rememberedSession.agentName, agentName))
+      ? rememberedSession
+      : findLatestSessionForAgent(persistedState.sessions, agentName) ?? rememberedSession;
+
+  return {
+    messages: selectedSession?.messages ?? [],
+    selectedSessionKey: selectedSession?.key ?? null,
+    sessionId: selectedSession?.remoteSessionId ?? null,
+    sessions: persistedState.sessions,
+  };
+}
+
+function toPersistedState(state: ChatState): PersistedChatState {
+  return {
+    selectedSessionKey: state.selectedSessionKey,
+    sessions: sortSessions(state.sessions),
+    version: STORAGE_VERSION,
+  };
+}
+
+function startNewConversation(state: ChatState): ChatState {
+  return {
+    ...state,
+    messages: [],
+    selectedSessionKey: null,
+    sessionId: null,
+  };
+}
+
+function hydrateSession(state: ChatState, sessionKey: string) {
+  const session = getSessionByKey(state.sessions, sessionKey);
+  if (!session) return state;
+
+  return {
+    ...state,
+    messages: session.messages,
+    selectedSessionKey: session.key,
+    sessionId: session.remoteSessionId,
+  };
+}
+
+function upsertConversation(
+  state: ChatState,
+  agentName: string | null,
+  nextMessages: ChatMessage[],
+  nextSessionId: string | null,
+): ChatState {
+  if (nextMessages.length === 0) {
+    return {
+      ...state,
+      messages: [],
+      sessionId: nextSessionId,
+    };
+  }
+
+  const remoteSessionMatch = findSessionByRemoteId(state.sessions, nextSessionId);
+  const sessionKey = remoteSessionMatch?.key ?? state.selectedSessionKey ?? createSessionKey();
+  const existingSession = getSessionByKey(state.sessions, sessionKey) ?? remoteSessionMatch ?? undefined;
+  const storedSession = buildStoredSession({
+    agentName,
+    existing: existingSession,
+    key: sessionKey,
+    messages: nextMessages,
+    remoteSessionId: nextSessionId,
+  });
+
+  const sessions = sortSessions(
+    state.sessions.filter(
+      (session) =>
+        session.key !== storedSession.key &&
+        (!storedSession.remoteSessionId || session.remoteSessionId !== storedSession.remoteSessionId),
+    ),
+  );
+
+  return {
+    messages: storedSession.messages,
+    selectedSessionKey: storedSession.key,
+    sessionId: storedSession.remoteSessionId,
+    sessions: sortSessions([storedSession, ...sessions]),
+  };
+}
+
+function bindRemoteSession(
+  state: ChatState,
+  agentName: string | null,
+  remoteSessionId: string,
+  messages: ChatMessage[],
+  options?: {
+    createdAt?: string | null;
+    title?: string | null;
+    updatedAt?: string | null;
+  },
+) {
+  if (!remoteSessionId) return state;
+
+  const existingSession = findSessionByRemoteId(state.sessions, remoteSessionId) ?? undefined;
+  const storedSession = buildStoredSession({
+    agentName,
+    createdAt: options?.createdAt ?? existingSession?.createdAt ?? null,
+    existing: existingSession,
+    key: existingSession?.key ?? remoteSessionId,
+    messages,
+    remoteSessionId,
+    title: options?.title ?? existingSession?.title ?? null,
+    updatedAt: options?.updatedAt ?? existingSession?.updatedAt ?? null,
+  });
+
+  const sessions = sortSessions(
+    state.sessions.filter((session) => session.key !== storedSession.key && session.remoteSessionId !== storedSession.remoteSessionId),
+  );
+
+  return {
+    messages: storedSession.messages,
+    selectedSessionKey: storedSession.key,
+    sessionId: storedSession.remoteSessionId,
+    sessions: sortSessions([storedSession, ...sessions]),
+  };
+}
+
+function removeConversation(state: ChatState, agentName: string | null, sessionKey: string): ChatState {
+  const sessions = sortSessions(state.sessions.filter((session) => session.key !== sessionKey));
+  if (state.selectedSessionKey !== sessionKey) {
+    return {
+      ...state,
+      sessions,
+    };
+  }
+
+  const fallbackSession = findLatestSessionForAgent(sessions, agentName);
+  if (!fallbackSession) {
+    return {
+      messages: [],
+      selectedSessionKey: null,
+      sessionId: null,
+      sessions,
+    };
+  }
+
+  return {
+    messages: fallbackSession.messages,
+    selectedSessionKey: fallbackSession.key,
+    sessionId: fallbackSession.remoteSessionId,
+    sessions,
+  };
+}
+
+function removeConversationByRemoteId(state: ChatState, agentName: string | null, remoteSessionId: string) {
+  const session = findSessionByRemoteId(state.sessions, remoteSessionId);
+  if (!session) return state;
+  return removeConversation(state, agentName, session.key);
+}
+
+export function useWebChat(agentName: string | null, workspacePath: string | null) {
+  const [chatState, setChatState] = useState<ChatState>(() => createInitialChatState(agentName));
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSending, setIsSending] = useState(false);
+  const [approvalActionId, setApprovalActionId] = useState<string | null>(null);
+  const [allPendingApprovals, setAllPendingApprovals] = useState<ChatApproval[]>([]);
+  const [pendingApprovals, setPendingApprovals] = useState<ChatApproval[]>([]);
+  const [workspaceId, setWorkspaceId] = useState<string | null>(() =>
+    looksAbsoluteWorkspacePath(workspacePath) ? deriveWorkspaceId(workspacePath) : null,
+  );
+  const previousAgentNameRef = useRef<string | null>(normalizeAgentName(agentName));
+
+  const { messages, selectedSessionKey, sessionId, sessions } = chatState;
+  const approvalNoticeApprovals = pendingApprovals.length > 0 ? pendingApprovals : allPendingApprovals;
+
+  useEffect(() => {
+    const payload = toPersistedState(chatState);
+    writePersistedState(payload);
+    emitChatSync({
+      ...payload,
+      sendingSessionKey: isSending ? selectedSessionKey : null,
+    });
+  }, [chatState, isSending, selectedSessionKey]);
+
+  useEffect(() => {
+    setError(null);
+
+    const normalizedAgentName = normalizeAgentName(agentName);
+    if (previousAgentNameRef.current === normalizedAgentName) {
+      return;
+    }
+
+    previousAgentNameRef.current = normalizedAgentName;
+    setDraft("");
+
+    setChatState((current) => {
+      const currentSession = getSessionByKey(current.sessions, current.selectedSessionKey);
+      if (currentSession && isSameAgentName(currentSession.agentName, normalizedAgentName)) {
+        return current;
+      }
+
+      const fallbackSession = findLatestSessionForAgent(current.sessions, normalizedAgentName);
+      if (!fallbackSession) {
+        return startNewConversation(current);
+      }
+
+      return hydrateSession(current, fallbackSession.key);
+    });
+  }, [agentName]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const onReset = () => {
+      setDraft("");
+      setError(null);
+      setApprovalActionId(null);
+      setPendingApprovals([]);
+      setChatState((current) => startNewConversation(current));
+    };
+
+    const onSelect = (event: Event) => {
+      const detail = (event as CustomEvent<ChatSelectDetail>).detail;
+      if (!detail?.sessionKey) return;
+
+      setDraft("");
+      setError(null);
+      setApprovalActionId(null);
+      setPendingApprovals([]);
+      setChatState((current) => hydrateSession(current, detail.sessionKey!));
+    };
+
+    const onDelete = (event: Event) => {
+      const detail = (event as CustomEvent<ChatDeleteDetail>).detail;
+      if (!detail?.sessionKey) return;
+      void deleteSession(detail.sessionKey);
+    };
+
+    window.addEventListener(CHAT_RESET_EVENT, onReset);
+    window.addEventListener(CHAT_SELECT_EVENT, onSelect as EventListener);
+    window.addEventListener(CHAT_DELETE_EVENT, onDelete as EventListener);
+
+    return () => {
+      window.removeEventListener(CHAT_RESET_EVENT, onReset);
+      window.removeEventListener(CHAT_SELECT_EVENT, onSelect as EventListener);
+      window.removeEventListener(CHAT_DELETE_EVENT, onDelete as EventListener);
+    };
+  }, [sessions, selectedSessionKey, agentName]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function syncWorkspaceId() {
+      if (looksAbsoluteWorkspacePath(workspacePath)) {
+        if (!cancelled) {
+          setWorkspaceId(deriveWorkspaceId(workspacePath));
+        }
+        return;
+      }
+
+      try {
+        const status = await requestJSON<GatewayStatus>("/status");
+        if (!cancelled) {
+          setWorkspaceId(deriveWorkspaceId(status.working_dir || workspacePath));
+        }
+      } catch {
+        if (!cancelled) {
+          setWorkspaceId(deriveWorkspaceId(workspacePath));
+        }
+      }
+    }
+
+    void syncWorkspaceId();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [workspacePath]);
+
+  async function resolveWorkspaceId(forceRefresh = false) {
+    if (!forceRefresh && workspaceId) {
+      return workspaceId;
+    }
+
+    try {
+      const status = await requestJSON<GatewayStatus>("/status");
+      const resolvedId = deriveWorkspaceId(status.working_dir || workspacePath);
+      setWorkspaceId(resolvedId);
+      return resolvedId;
+    } catch {
+      const fallbackId = deriveWorkspaceId(workspacePath);
+      setWorkspaceId(fallbackId);
+      return fallbackId;
+    }
+  }
+
+  async function postMessage(message: string, activeSessionId: string | null, activeWorkspaceId: string) {
+    return requestJSON<ChatResponse>(`/chat?workspace=${encodeURIComponent(activeWorkspaceId)}`, {
+      body: JSON.stringify({
+        agent: agentName ?? undefined,
+        message,
+        session_id: activeSessionId ?? undefined,
+        title: activeSessionId ? undefined : "Web Chat",
+      }),
+      method: "POST",
+    });
+  }
+
+  async function fetchSessionsList(activeWorkspaceId: string) {
+    return requestJSON<GatewaySession[]>(`/sessions?workspace=${encodeURIComponent(activeWorkspaceId)}`);
+  }
+
+  async function fetchSessionSnapshot(activeSessionId: string | null) {
+    if (!activeSessionId) return null;
+    return requestJSON<GatewaySession>(`/sessions/${encodeURIComponent(activeSessionId)}`);
+  }
+
+  async function fetchAllPendingApprovals() {
+    return normalizeApprovals(await requestJSON<GatewayApproval[]>("/approvals?status=pending"));
+  }
+
+  function applySessionSnapshot(session: GatewaySession | null) {
+    if (!session) return;
+
+    const mappedMessages = mapSessionMessages(session, agentName);
+    if (mappedMessages.length === 0) return;
+
+    setChatState((current) => {
+      if (session.id) {
+        return bindRemoteSession(current, agentName, session.id, mappedMessages, {
+          createdAt: session.created_at ?? null,
+          title: session.title ?? null,
+          updatedAt: session.updated_at ?? null,
+        });
+      }
+
+      return upsertConversation(current, agentName, mappedMessages, current.sessionId);
+    });
+  }
+
+  function applyApprovalSnapshot(approvals: ChatApproval[], activeSessionId: string | null) {
+    setAllPendingApprovals(approvals);
+    setPendingApprovals(filterSessionApprovals(approvals, activeSessionId));
+  }
+
+  async function focusApprovalSession(targetSessionId: string) {
+    let baselineMessageCount = findSessionByRemoteId(sessions, targetSessionId)?.messages.length ?? 0;
+
+    try {
+      const session = await fetchSessionSnapshot(targetSessionId);
+      if (!session) return baselineMessageCount;
+
+      const mappedMessages = mapSessionMessages(session, agentName);
+      baselineMessageCount = mappedMessages.length;
+
+      setChatState((current) =>
+        bindRemoteSession(current, agentName, targetSessionId, mappedMessages, {
+          createdAt: session.created_at ?? null,
+          title: session.title ?? null,
+          updatedAt: session.updated_at ?? null,
+        }),
+      );
+      return baselineMessageCount;
+    } catch {
+      const existingSession = findSessionByRemoteId(sessions, targetSessionId);
+      if (existingSession) {
+        setChatState((current) => hydrateSession(current, existingSession.key));
+      }
+      return baselineMessageCount;
+    }
+  }
+
+  async function syncSessionState(activeSessionId: string | null, options?: { skipSession?: boolean }) {
+    if (!activeSessionId) {
+      applyApprovalSnapshot(await fetchAllPendingApprovals(), null);
+      return { approvals: [] as ChatApproval[], session: null as GatewaySession | null };
+    }
+
+    const session = options?.skipSession ? null : await fetchSessionSnapshot(activeSessionId);
+    if (session) {
+      applySessionSnapshot(session);
+    }
+
+    const allApprovals = await fetchAllPendingApprovals();
+    const approvals = filterSessionApprovals(allApprovals, session?.id ?? activeSessionId);
+    applyApprovalSnapshot(allApprovals, session?.id ?? activeSessionId);
+
+    return { approvals, session };
+  }
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof fetch !== "function") return;
+
+    let cancelled = false;
+
+    async function syncRemoteSessions(forceRefresh = false) {
+      try {
+        const activeWorkspaceId = await resolveWorkspaceId(forceRefresh);
+        if (cancelled) return;
+
+        const remoteSessions = await fetchSessionsList(activeWorkspaceId);
+        if (cancelled) return;
+
+        setChatState((current) => mergeRemoteSessions(current, agentName, remoteSessions, isSending));
+      } catch {
+        // Keep local sessions when the gateway list is temporarily unavailable.
+      }
+    }
+
+    void syncRemoteSessions();
+
+    const intervalId = window.setInterval(() => {
+      void syncRemoteSessions();
+    }, REMOTE_SESSION_SYNC_INTERVAL_MS);
+
+    const onFocus = () => {
+      void syncRemoteSessions(true);
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void syncRemoteSessions(true);
+      }
+    };
+
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [agentName, isSending, workspaceId, workspacePath]);
+
+  async function waitForApprovalResult(activeSessionId: string, baselineMessageCount: number) {
+    let idleStreak = 0;
+
+    for (let attempt = 0; attempt < APPROVAL_POLL_ATTEMPTS; attempt += 1) {
+      await sleep(APPROVAL_POLL_INTERVAL_MS);
+
+      try {
+        const session = await fetchSessionSnapshot(activeSessionId);
+        applySessionSnapshot(session);
+
+        const allApprovals = await fetchAllPendingApprovals();
+        const approvals = filterSessionApprovals(allApprovals, session?.id ?? activeSessionId);
+        applyApprovalSnapshot(allApprovals, session?.id ?? activeSessionId);
+
+        const messageCount = session?.messages?.length ?? baselineMessageCount;
+        const waitingApproval = isWaitingApprovalStatus(session?.presence);
+        const typing = Boolean(session?.typing);
+
+        if (!waitingApproval && !typing) {
+          idleStreak += 1;
+        } else {
+          idleStreak = 0;
+        }
+
+        if (approvals.length > 0) return;
+        if (messageCount > baselineMessageCount && idleStreak >= 1) return;
+        if (idleStreak >= 2) return;
+      } catch (pollError) {
+        if (getErrorMessage(pollError).includes("session not found")) {
+          applyApprovalSnapshot([], null);
+          setChatState((current) => removeConversationByRemoteId(current, agentName, activeSessionId));
+          return;
+        }
+      }
+    }
+  }
+
+  async function resolveApproval(approvalId: string, approved: boolean, comment?: string) {
+    const activeSessionId = sessionId;
+    const targetApproval =
+      allPendingApprovals.find((approval) => approval.id === approvalId) ??
+      pendingApprovals.find((approval) => approval.id === approvalId) ??
+      null;
+    if (!approvalId || approvalActionId) return;
+    setApprovalActionId(approvalId);
+    setError(null);
+    try {
+      await requestJSON<ChatApproval>(`/approvals/${encodeURIComponent(approvalId)}/resolve`, {
+        body: JSON.stringify({
+          approved,
+          comment: comment ?? "",
+        }),
+        method: "POST",
+      });
+      setPendingApprovals((current) => current.filter((approval) => approval.id !== approvalId));
+      setAllPendingApprovals((current) => current.filter((approval) => approval.id !== approvalId));
+      const targetSessionId = targetApproval?.session_id ?? activeSessionId;
+      if (!targetSessionId) return;
+      if (approved) {
+        const baselineMessageCount =
+          targetSessionId === activeSessionId ? messages.length : await focusApprovalSession(targetSessionId);
+        await waitForApprovalResult(targetSessionId, baselineMessageCount);
+        return;
+      }
+      await syncSessionState(targetSessionId);
+      setError("Approval request was rejected.");
+    } catch (resolveError) {
+      setError(getErrorMessage(resolveError));
+    } finally {
+      setApprovalActionId(null);
+    }
+  }
+  function resetConversation() {
+    setDraft("");
+    setError(null);
+    setApprovalActionId(null);
+    setAllPendingApprovals([]);
+    setPendingApprovals([]);
+    setChatState((current) => startNewConversation(current));
+  }
+
+  function selectSession(sessionKey: string) {
+    setDraft("");
+    setError(null);
+    setApprovalActionId(null);
+    setAllPendingApprovals([]);
+    setPendingApprovals([]);
+    setChatState((current) => hydrateSession(current, sessionKey));
+  }
+
+  async function deleteSession(sessionKey: string) {
+    const sessionToDelete = getSessionByKey(sessions, sessionKey);
+    if (!sessionToDelete) return;
+
+    const deletingSelectedSession = selectedSessionKey === sessionKey;
+    setError(null);
+
+    if (sessionToDelete.remoteSessionId) {
+      try {
+        await requestJSON<{ status: string }>(`/sessions/${encodeURIComponent(sessionToDelete.remoteSessionId)}`, {
+          method: "DELETE",
+        });
+      } catch (deleteError) {
+        if (!getErrorMessage(deleteError).includes("session not found")) {
+          setError(getErrorMessage(deleteError));
+          return;
+        }
+      }
+    }
+
+    if (deletingSelectedSession) {
+      setDraft("");
+      setApprovalActionId(null);
+      setAllPendingApprovals([]);
+      setPendingApprovals([]);
+    }
+
+    setChatState((current) => removeConversation(current, agentName, sessionKey));
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function syncCurrentSession() {
+      if (!sessionId) {
+        applyApprovalSnapshot(await fetchAllPendingApprovals(), null);
+        return;
+      }
+
+      try {
+        const session = await fetchSessionSnapshot(sessionId);
+        if (cancelled) return;
+
+        applySessionSnapshot(session);
+
+        const allApprovals = await fetchAllPendingApprovals();
+        if (cancelled) return;
+
+        applyApprovalSnapshot(allApprovals, session?.id ?? sessionId);
+      } catch (syncError) {
+        if (cancelled) return;
+        if (getErrorMessage(syncError).includes("session not found")) {
+          applyApprovalSnapshot([], null);
+          setChatState((current) => removeConversationByRemoteId(current, agentName, sessionId));
+        }
+      }
+    }
+
+    void syncCurrentSession();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [agentName, sessionId]);
+
+  async function sendMessage() {
+    const message = draft.trim();
+    const currentSessionId = sessionId;
+    if (message === "" || isSending || pendingApprovals.length > 0) return;
+
+    const optimisticMessage: ChatMessage = {
+      content: message,
+      role: "user",
+      timestamp: new Date().toISOString(),
+    };
+
+    setDraft("");
+    setError(null);
+    setIsSending(true);
+    setChatState((current) => upsertConversation(current, agentName, [...current.messages, optimisticMessage], current.sessionId));
+
+    try {
+      let activeWorkspaceId = await resolveWorkspaceId();
+      let response: ChatResponse;
+
+      try {
+        response = await postMessage(message, currentSessionId, activeWorkspaceId);
+      } catch (error) {
+        const messageText = getErrorMessage(error);
+
+        if (currentSessionId && messageText.includes("session not found")) {
+          response = await postMessage(message, null, activeWorkspaceId);
+        } else if (messageText.includes("workspace not found") || messageText.includes("workspace is required")) {
+          activeWorkspaceId = await resolveWorkspaceId(true);
+          response = await postMessage(message, currentSessionId, activeWorkspaceId);
+        } else {
+          throw error;
+        }
+      }
+
+      const resolvedSessionId = response.session?.id ?? currentSessionId;
+      const mappedMessages = mapSessionMessages(response.session, agentName);
+      if (mappedMessages.length > 0) {
+        setChatState((current) => {
+          if (response.session?.id) {
+            return bindRemoteSession(current, agentName, response.session.id, mappedMessages, {
+              createdAt: response.session.created_at ?? null,
+              title: response.session.title ?? null,
+              updatedAt: response.session.updated_at ?? null,
+            });
+          }
+
+          return upsertConversation(current, agentName, mappedMessages, resolvedSessionId ?? current.sessionId);
+        });
+      } else if (response.response) {
+        const assistantMessage: ChatMessage = {
+          agent_name: normalizeAgentName(agentName ?? response.session?.agent) ?? undefined,
+          content: response.response,
+          role: "assistant",
+          timestamp: new Date().toISOString(),
+        };
+
+        setChatState((current) =>
+          upsertConversation(current, agentName, [...current.messages, assistantMessage], resolvedSessionId ?? current.sessionId),
+        );
+      } else if (resolvedSessionId) {
+        // A brand-new remote session can enter waiting_approval before the backend
+        // has persisted any messages. Bind the remote session id now so approval
+        // resolution can poll and resume against the correct session.
+        setChatState((current) =>
+          upsertConversation(
+            current,
+            agentName,
+            current.messages.length > 0 ? current.messages : [optimisticMessage],
+            resolvedSessionId,
+          ),
+        );
+      }
+
+      if (response.status === "waiting_approval") {
+        const immediateApprovals = filterSessionApprovals(normalizeApprovals(response.approvals), resolvedSessionId);
+        if (immediateApprovals.length > 0) {
+          setAllPendingApprovals(immediateApprovals);
+          setPendingApprovals(immediateApprovals);
+        } else {
+          await syncSessionState(resolvedSessionId, { skipSession: true });
+        }
+      }
+      if (response.status === "waiting_approval") {
+        setError(null);
+      } else {
+        await syncSessionState(resolvedSessionId ?? currentSessionId, { skipSession: true });
+      }
+    } catch (error) {
+      setError(getErrorMessage(error));
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  return {
+    approvalActionId,
+    approvalNoticeApprovals,
+    deleteSession,
+    draft,
+    error,
+    isSending,
+    messages,
+    pendingApprovals,
+    resetConversation,
+    resolveApproval,
+    selectedSessionKey,
+    selectSession,
+    sessionId,
+    sessions,
+    sendMessage,
+    setDraft,
+  };
+}
+

--- a/ui/src/features/composer/Composer.tsx
+++ b/ui/src/features/composer/Composer.tsx
@@ -1,0 +1,131 @@
+import { ChevronDown, LoaderCircle, SendHorizontal, SlidersHorizontal, Sparkles } from "lucide-react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+
+import { useShellStore } from "@/features/shell/useShellStore";
+
+type ComposerProps = {
+  activeAgentLabel: string;
+  canSend: boolean;
+  draft: string;
+  error: string | null;
+  isSending: boolean;
+  modelLabel: string;
+  onDraftChange: (value: string) => void;
+  onReset: () => void;
+  onSend: () => void;
+  sessionId: string | null;
+  setupMessage: string;
+  setupRequired: boolean;
+};
+
+export function Composer({
+  activeAgentLabel,
+  canSend,
+  draft,
+  error,
+  isSending,
+  modelLabel,
+  onDraftChange,
+  onReset,
+  onSend,
+  sessionId,
+  setupMessage,
+  setupRequired,
+}: ComposerProps) {
+  const openModelSettings = useShellStore((state) => state.openModelSettings);
+  const openSettings = useShellStore((state) => state.openSettings);
+
+  function handleKeyDown(event: ReactKeyboardEvent<HTMLTextAreaElement>) {
+    if (setupRequired) return;
+    if (event.nativeEvent.isComposing) return;
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      onSend();
+    }
+  }
+
+  return (
+    <section className="sticky bottom-0 z-10 shrink-0 bg-white px-5 pb-4 pt-2 sm:px-6 lg:px-8 lg:pb-5">
+      <div className="mx-auto w-full max-w-[980px]">
+        <div className="overflow-hidden rounded-[30px] border border-[#edf1f5] bg-white shadow-[0_10px_28px_rgba(15,23,42,0.04)]">
+          <div className="flex items-center justify-between gap-3 px-5 pb-0 pt-3 text-[13px] text-[#98a2b3]">
+            <div className="min-w-0 truncate">
+              <span>{activeAgentLabel}</span>
+              <span className="mx-2 text-[#d0d5dd]">/</span>
+              <span>{sessionId ? `会话 ${sessionId.slice(-8)}` : "新会话"}</span>
+            </div>
+
+            <button
+              className="text-[13px] font-medium text-[#98a2b3] transition-colors duration-150 hover:text-[#475467]"
+              onClick={onReset}
+              type="button"
+            >
+              新对话
+            </button>
+          </div>
+
+          <div className="px-5 pt-1.5">
+            <textarea
+              className="min-h-[58px] max-h-[128px] w-full resize-none bg-transparent text-[15px] leading-7 text-ink outline-none placeholder:text-[#b1b8c6] disabled:cursor-not-allowed disabled:text-[#98a2b3]"
+              disabled={setupRequired}
+              onChange={(event) => onDraftChange(event.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={setupRequired ? "先完成模型配置后再开始对话" : "可以描述任务或提出任何问题"}
+              value={draft}
+            />
+          </div>
+
+          {setupRequired ? <div className="px-5 pt-1 text-sm text-[#475467]">{setupMessage}</div> : null}
+          {!setupRequired && error ? <div className="px-5 pt-1 text-sm text-[#c2410c]">{error}</div> : null}
+
+          <div className="mt-1 flex flex-col gap-2.5 border-t border-[#f2f4f7] px-5 py-2.5 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                className={[
+                  "chip-button gap-2 px-4 py-2 text-sm",
+                  setupRequired ? "bg-[#1f2430] text-white hover:bg-[#111827]" : "text-[#667085]",
+                ].join(" ")}
+                onClick={openModelSettings}
+                type="button"
+              >
+                <SlidersHorizontal size={15} strokeWidth={2.1} />
+                <span>{modelLabel}</span>
+                <ChevronDown size={14} strokeWidth={2.1} />
+              </button>
+
+              <button
+                className="chip-button gap-2 px-4 py-2 text-sm text-[#667085]"
+                onClick={() => openSettings("skills")}
+                type="button"
+              >
+                <Sparkles size={15} strokeWidth={2.1} />
+                <span>技能</span>
+                <ChevronDown size={14} strokeWidth={2.1} />
+              </button>
+            </div>
+
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-xs text-[#98a2b3]">
+                {setupRequired ? "先配置模型提供商，再开始当前会话" : isSending ? "正在思考..." : "Enter 发送 · Shift + Enter 换行"}
+              </span>
+
+              <button
+                aria-label={isSending ? "正在思考" : "发送消息"}
+                className="flex h-11 w-11 items-center justify-center rounded-full bg-[#bfc8d8] text-white transition-all duration-150 hover:bg-[#1f2430] disabled:cursor-not-allowed disabled:bg-[#d7dde7]"
+                disabled={!canSend || isSending}
+                onClick={onSend}
+                type="button"
+              >
+                {isSending ? (
+                  <LoaderCircle className="animate-spin" size={17} strokeWidth={2.2} />
+                ) : (
+                  <SendHorizontal size={17} strokeWidth={2.2} />
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/ui/src/features/left-rail/LeftRail.test.tsx
+++ b/ui/src/features/left-rail/LeftRail.test.tsx
@@ -14,8 +14,10 @@ vi.mock("@/features/workspace/useWorkspaceOverview", () => ({
 
 const useWorkspaceOverviewMock = vi.mocked(useWorkspaceOverview);
 
-function Wrapper({ children }: PropsWithChildren) {
-  return <MemoryRouter initialEntries={["/market"]}>{children}</MemoryRouter>;
+function createWrapper(initialEntries: string[]) {
+  return function Wrapper({ children }: PropsWithChildren) {
+    return <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>;
+  };
 }
 
 describe("LeftRail", () => {
@@ -37,19 +39,27 @@ describe("LeftRail", () => {
   });
 
   it("highlights the active route and shows the workspace avatar letter", () => {
-    render(<LeftRail />, { wrapper: Wrapper });
+    render(<LeftRail />, { wrapper: createWrapper(["/market"]) });
 
     expect(screen.getByRole("link", { name: "市场" })).toHaveAttribute("aria-current", "page");
     expect(screen.getByRole("link", { name: "总览" })).not.toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "对话" })).toBeInTheDocument();
     expect(screen.getByText("B")).toBeInTheDocument();
   });
 
   it("opens general settings from the footer action", () => {
-    render(<LeftRail />, { wrapper: Wrapper });
+    render(<LeftRail />, { wrapper: createWrapper(["/market"]) });
 
     fireEvent.click(screen.getByRole("button", { name: "打开设置" }));
 
     expect(useShellStore.getState().settingsOpen).toBe(true);
     expect(useShellStore.getState().settingsSection).toBe("general");
+  });
+
+  it("marks the chat entry active on the home route", () => {
+    render(<LeftRail />, { wrapper: createWrapper(["/"]) });
+
+    expect(screen.getByRole("link", { name: "对话" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "总览" })).not.toHaveAttribute("aria-current", "page");
   });
 });

--- a/ui/src/features/left-rail/LeftRail.tsx
+++ b/ui/src/features/left-rail/LeftRail.tsx
@@ -1,10 +1,11 @@
-import { Compass, LayoutDashboard, Settings, Store, Wrench } from "lucide-react";
+import { Compass, LayoutDashboard, MessageSquare, Settings, Store, Wrench } from "lucide-react";
 import { NavLink } from "react-router-dom";
 
 import { useShellStore } from "@/features/shell/useShellStore";
 import { useWorkspaceOverview } from "@/features/workspace/useWorkspaceOverview";
 
 const navItems = [
+  { icon: MessageSquare, label: "对话", to: "/" },
   { icon: LayoutDashboard, label: "总览", to: "/workspace" },
   { icon: Store, label: "市场", to: "/market" },
   { icon: Compass, label: "发现", to: "/discovery" },

--- a/ui/src/pages/ChatHome/ChatHomePage.test.tsx
+++ b/ui/src/pages/ChatHome/ChatHomePage.test.tsx
@@ -1,0 +1,197 @@
+import { fireEvent, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+
+import { useWebChat } from "@/features/chat/useWebChat";
+import { useShellStore } from "@/features/shell/useShellStore";
+import { useWorkspaceOverview } from "@/features/workspace/useWorkspaceOverview";
+
+import { ChatHomePage } from "./ChatHomePage";
+
+vi.mock("@/features/chat/useWebChat", () => ({
+  useWebChat: vi.fn(),
+}));
+
+vi.mock("@/features/workspace/useWorkspaceOverview", () => ({
+  useWorkspaceOverview: vi.fn(),
+}));
+
+const useWebChatMock = vi.mocked(useWebChat);
+const useWorkspaceOverviewMock = vi.mocked(useWorkspaceOverview);
+let webChatState: ReturnType<typeof useWebChat>;
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/"]}>
+      <ChatHomePage />
+    </MemoryRouter>,
+  );
+}
+
+describe("ChatHomePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useShellStore.setState({
+      agentDrawerOpen: false,
+      modelSettingsOpen: false,
+      settingsOpen: false,
+      settingsSection: "general",
+    });
+
+    useWorkspaceOverviewMock.mockReturnValue({
+      data: {
+        localAgents: [
+          {
+            active: true,
+            model: "gpt-5",
+            name: "binbin",
+          },
+        ],
+        localSkills: [],
+        providers: [
+          {
+            enabled: true,
+            health: "healthy",
+            isDefault: true,
+            model: "gpt-5",
+            name: "OpenAI",
+          },
+        ],
+        runtimeProfile: {
+          model: "gpt-5",
+          name: "AnyClaw",
+          sessions: 2,
+          workspace: "/workspace",
+        },
+      },
+    } as unknown as ReturnType<typeof useWorkspaceOverview>);
+
+    webChatState = {
+      approvalActionId: null,
+      approvalNoticeApprovals: [],
+      deleteSession: vi.fn(),
+      draft: "",
+      error: null,
+      isSending: false,
+      messages: [
+        {
+          content: "first message",
+          role: "assistant",
+          timestamp: "2026-04-11T12:00:00.000Z",
+        },
+      ],
+      pendingApprovals: [],
+      resetConversation: vi.fn(),
+      resolveApproval: vi.fn(),
+      selectSession: vi.fn(),
+      selectedSessionKey: "session-1",
+      sendMessage: vi.fn(),
+      sessionId: "sess_1",
+      sessions: [],
+      setDraft: vi.fn(),
+    } as unknown as ReturnType<typeof useWebChat>;
+
+    useWebChatMock.mockImplementation(() => webChatState);
+
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: vi.fn(),
+      writable: true,
+    });
+  });
+
+  it("does not force auto-scroll when the user has scrolled away from the bottom", () => {
+    const { container, rerender } = renderPage();
+    const viewport = container.querySelector(".chat-scroll-area") as HTMLDivElement;
+    const scrollTo = vi.fn();
+
+    Object.defineProperties(viewport, {
+      clientHeight: {
+        configurable: true,
+        value: 400,
+      },
+      scrollHeight: {
+        configurable: true,
+        value: 1000,
+      },
+      scrollTop: {
+        configurable: true,
+        value: 600,
+        writable: true,
+      },
+    });
+    viewport.scrollTo = scrollTo;
+
+    fireEvent.scroll(viewport);
+    scrollTo.mockClear();
+
+    viewport.scrollTop = 120;
+    fireEvent.scroll(viewport);
+
+    webChatState = {
+      ...webChatState,
+      messages: [
+        {
+          content: "first message",
+          role: "assistant",
+          timestamp: "2026-04-11T12:00:00.000Z",
+        },
+        {
+          content: "background update",
+          role: "assistant",
+          timestamp: "2026-04-11T12:00:05.000Z",
+        },
+      ],
+    };
+
+    rerender(
+      <MemoryRouter initialEntries={["/"]}>
+        <ChatHomePage />
+      </MemoryRouter>,
+    );
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("keeps auto-scroll when a new send starts", () => {
+    const { container, rerender } = renderPage();
+    const viewport = container.querySelector(".chat-scroll-area") as HTMLDivElement;
+    const scrollTo = vi.fn();
+
+    Object.defineProperties(viewport, {
+      clientHeight: {
+        configurable: true,
+        value: 400,
+      },
+      scrollHeight: {
+        configurable: true,
+        value: 1000,
+      },
+      scrollTop: {
+        configurable: true,
+        value: 100,
+        writable: true,
+      },
+    });
+    viewport.scrollTo = scrollTo;
+
+    fireEvent.scroll(viewport);
+    scrollTo.mockClear();
+
+    webChatState = {
+      ...webChatState,
+      isSending: true,
+    };
+
+    rerender(
+      <MemoryRouter initialEntries={["/"]}>
+        <ChatHomePage />
+      </MemoryRouter>,
+    );
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      behavior: "smooth",
+      top: 1000,
+    });
+  });
+});

--- a/ui/src/pages/ChatHome/ChatHomePage.tsx
+++ b/ui/src/pages/ChatHome/ChatHomePage.tsx
@@ -13,6 +13,8 @@ const tabs = [
   { label: "工作室", to: "/studio" },
 ];
 
+const AUTO_SCROLL_THRESHOLD_PX = 96;
+
 function formatMessageTime(value: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "";
@@ -299,6 +301,8 @@ export function ChatHomePage() {
     setDraft,
   } = useWebChat(activeAgentName, data.runtimeProfile.workspace);
   const messagesViewportRef = useRef<HTMLDivElement | null>(null);
+  const shouldStickToBottomRef = useRef(true);
+  const autoScrollOnNextRenderRef = useRef(false);
   const scrollFadeTimerRef = useRef<number | null>(null);
   const setupPromptedRef = useRef(false);
 
@@ -312,7 +316,15 @@ export function ChatHomePage() {
     const viewport = messagesViewportRef.current;
     if (!viewport) return;
 
+    const updateStickiness = () => {
+      const distanceFromBottom = viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop;
+      shouldStickToBottomRef.current = distanceFromBottom <= AUTO_SCROLL_THRESHOLD_PX;
+    };
+
+    updateStickiness();
+
     const markScrolling = () => {
+      updateStickiness();
       viewport.dataset.scrolling = "true";
 
       if (scrollFadeTimerRef.current !== null) {
@@ -341,10 +353,20 @@ export function ChatHomePage() {
     const viewport = messagesViewportRef.current;
     if (!viewport) return;
 
+    if (isSending) {
+      autoScrollOnNextRenderRef.current = true;
+    }
+
+    const shouldAutoScroll = autoScrollOnNextRenderRef.current || shouldStickToBottomRef.current;
+    if (!shouldAutoScroll) return;
+
     viewport.scrollTo({
       behavior: "smooth",
       top: viewport.scrollHeight,
     });
+
+    shouldStickToBottomRef.current = true;
+    autoScrollOnNextRenderRef.current = false;
   }, [isSending, messages]);
 
   return (

--- a/ui/src/pages/ChatHome/ChatHomePage.tsx
+++ b/ui/src/pages/ChatHome/ChatHomePage.tsx
@@ -1,0 +1,461 @@
+import { Check, CircleUserRound, Clock3, Gauge, LoaderCircle, ShieldAlert, Sparkles, X } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { NavLink } from "react-router-dom";
+
+import { MarkdownMessage } from "@/features/chat/MarkdownMessage";
+import { type ChatApproval, useWebChat } from "@/features/chat/useWebChat";
+import { Composer } from "@/features/composer/Composer";
+import { useShellStore } from "@/features/shell/useShellStore";
+import { useWorkspaceOverview } from "@/features/workspace/useWorkspaceOverview";
+
+const tabs = [
+  { label: "对话", to: "/" },
+  { label: "工作室", to: "/studio" },
+];
+
+function formatMessageTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+
+  return date.toLocaleTimeString("zh-CN", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function ThinkingIndicator({ activeAgentLabel }: { activeAgentLabel: string }) {
+  return (
+    <div className="max-w-[680px] pt-1">
+      <div className="flex flex-wrap items-center gap-2 text-[12px] text-[#98a2b3]">
+        <span className="font-medium text-[#4b5563]">{activeAgentLabel}</span>
+        <span className="inline-flex items-center gap-2 text-[#667085]">
+          <Sparkles size={14} strokeWidth={2.1} />
+          <span>正在思考</span>
+          <span aria-hidden="true" className="thinking-dots">
+            <span className="thinking-dot" />
+            <span className="thinking-dot" />
+            <span className="thinking-dot" />
+          </span>
+        </span>
+      </div>
+
+      <div aria-hidden="true" className="mt-4 space-y-2.5">
+        <div className="thinking-line w-[24%]" />
+        <div className="thinking-line w-[54%]" />
+        <div className="thinking-line w-[34%]" />
+      </div>
+    </div>
+  );
+}
+
+function providerNeedsSetup(health?: string, enabled = true) {
+  if (!enabled) return true;
+  return ["disabled", "invalid", "invalid_base_url", "missing_key"].includes((health ?? "").trim().toLowerCase());
+}
+
+function providerSetupMessage(providerName?: string, health?: string) {
+  const label = providerName?.trim() || "当前模型";
+  switch ((health ?? "").trim().toLowerCase()) {
+    case "missing_key":
+      return `${label} 还没有填写 API Key，请先完成模型配置。`;
+    case "invalid_base_url":
+      return `${label} 的 Base URL 不正确，请先修正后再开始对话。`;
+    case "disabled":
+      return `${label} 当前处于停用状态，请先启用或切换到可用模型。`;
+    case "invalid":
+      return `${label} 配置不完整，请先补全供应商信息。`;
+    default:
+      return "第一次使用前，请先选择模型供应商并填写 Base URL / API Key。";
+  }
+}
+
+function SetupEmptyState({ message, onOpen }: { message: string; onOpen: () => void }) {
+  return (
+    <div className="flex flex-1 items-center justify-center py-12">
+      <div className="w-full max-w-[760px] border-b border-[#edf1f5] px-4 pb-8 text-center">
+        <div className="text-[28px] font-semibold tracking-[-0.03em] text-[#111827]">先完成模型配置</div>
+        <p className="mx-auto mt-3 max-w-[560px] text-[15px] leading-7 text-[#667085]">{message}</p>
+        <button
+          className="mt-6 inline-flex items-center justify-center rounded-full bg-[#1f2430] px-5 py-3 text-sm font-medium text-white transition-transform duration-150 hover:-translate-y-0.5"
+          onClick={onOpen}
+          type="button"
+        >
+          去设置 API 与模型
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const approvalFieldLabels: Record<string, string> = {
+  command: "命令",
+  message: "请求",
+  path: "路径",
+  target: "目标",
+  text: "内容",
+  title: "任务",
+  url: "地址",
+  workspace: "工作区",
+};
+
+function formatApprovalTime(value?: string) {
+  if (!value) return "";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+
+  return date.toLocaleTimeString("zh-CN", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function summarizeApprovalValue(value: unknown): string | null {
+  if (typeof value === "string") {
+    const normalized = value.replace(/\s+/g, " ").trim();
+    return normalized === "" ? null : normalized;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    const compact = value
+      .map((item) => summarizeApprovalValue(item))
+      .filter((item): item is string => Boolean(item))
+      .slice(0, 3);
+
+    return compact.length > 0 ? compact.join(", ") : null;
+  }
+
+  return null;
+}
+
+function buildApprovalDetails(approval: ChatApproval) {
+  const payload = approval.payload && typeof approval.payload === "object" ? approval.payload : undefined;
+  const source =
+    payload?.args && typeof payload.args === "object"
+      ? (payload.args as Record<string, unknown>)
+      : payload;
+
+  if (!source) return [];
+
+  const preferredKeys = ["command", "path", "message", "title", "target", "url", "text", "workspace"];
+  const preferredLines = preferredKeys
+    .map((key) => {
+      const value = summarizeApprovalValue(source[key]);
+      if (!value) return null;
+      return `${approvalFieldLabels[key] ?? key}: ${value}`;
+    })
+    .filter((line): line is string => line !== null);
+
+  if (preferredLines.length > 0) {
+    return preferredLines.slice(0, 2);
+  }
+
+  const fallbackEntry = Object.entries(source).find(([, value]) => summarizeApprovalValue(value));
+  if (!fallbackEntry) return [];
+
+  const [key, value] = fallbackEntry;
+  const summary = summarizeApprovalValue(value);
+  return summary ? [`${approvalFieldLabels[key] ?? key}: ${summary}`] : [];
+}
+
+function summarizeApprovalDetails(approval: ChatApproval) {
+  const payload = approval.payload && typeof approval.payload === "object" ? approval.payload : undefined;
+  const source =
+    payload?.args && typeof payload.args === "object"
+      ? (payload.args as Record<string, unknown>)
+      : payload;
+
+  if (!source) return [];
+
+  const preferredKeys = ["command", "path", "message", "title", "target", "url", "text", "workspace"];
+  const preferredLines = preferredKeys
+    .map((key) => {
+      const value = summarizeApprovalValue(source[key]);
+      if (!value) return null;
+      return `${approvalFieldLabels[key] ?? key}：${value}`;
+    })
+    .filter((line): line is string => line !== null);
+
+  if (preferredLines.length > 0) {
+    return preferredLines.slice(0, 2);
+  }
+
+  const fallbackEntry = Object.entries(source).find(([, value]) => summarizeApprovalValue(value));
+  if (!fallbackEntry) return [];
+
+  const [key, value] = fallbackEntry;
+  const summary = summarizeApprovalValue(value);
+  return summary ? [`${approvalFieldLabels[key] ?? key}：${summary}`] : [];
+}
+
+function ApprovalNotice({
+  approvalActionId,
+  approvals,
+  onResolve,
+}: {
+  approvalActionId: string | null;
+  approvals: ChatApproval[];
+  onResolve: (approvalId: string, approved: boolean) => Promise<void>;
+}) {
+  if (approvals.length === 0) return null;
+
+  const actionBusy = approvalActionId !== null;
+
+  return (
+    <div className="shrink-0 px-5 pb-3 pt-1 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-[980px] rounded-[24px] border border-[#e7ebf0] bg-white px-4 py-3 shadow-[0_10px_24px_rgba(15,23,42,0.04)]">
+        <div className="flex items-center gap-3">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#f5f7fa] text-[#344054]">
+            <ShieldAlert size={17} strokeWidth={2.1} />
+          </span>
+          <div className="min-w-0">
+            <div className="text-[14px] font-medium text-[#1f2937]">需要确认权限后才能继续</div>
+            <div className="text-[12px] text-[#667085]">允许后会自动继续执行，拒绝后当前请求会停止。</div>
+          </div>
+        </div>
+
+        <div className="mt-3 divide-y divide-[rgba(15,23,42,0.06)]">
+          {approvals.map((approval) => {
+            const details = buildApprovalDetails(approval);
+            const isCurrentAction = approvalActionId === approval.id;
+
+            return (
+              <div className="flex flex-col gap-3 py-3 first:pt-0 last:pb-0 md:flex-row md:items-start md:justify-between" key={approval.id}>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2 text-[13px]">
+                    <span className="font-medium text-[#1f2937]">{approval.tool_name}</span>
+                    {approval.requested_at ? <span className="text-[#98a2b3]">{formatApprovalTime(approval.requested_at)}</span> : null}
+                  </div>
+
+                  {details.length > 0 ? (
+                    <div className="mt-1.5 space-y-1 text-[13px] leading-6 text-[#667085]">
+                      {details.map((detail) => (
+                        <div className="truncate" key={detail} title={detail}>
+                          {detail}
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+
+                <div className="flex items-center gap-2 md:shrink-0">
+                  <button
+                    className="inline-flex h-9 items-center justify-center gap-1.5 rounded-full border border-[#dbe1e8] px-4 text-[13px] font-medium text-[#475467] transition-colors duration-150 hover:border-[#cfd6de] hover:text-[#1f2937] disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={actionBusy}
+                    onClick={() => void onResolve(approval.id, false)}
+                    type="button"
+                  >
+                    {isCurrentAction ? <LoaderCircle className="animate-spin" size={14} strokeWidth={2.1} /> : <X size={14} strokeWidth={2.1} />}
+                    <span>拒绝</span>
+                  </button>
+
+                  <button
+                    className="inline-flex h-9 items-center justify-center gap-1.5 rounded-full bg-[#1f2430] px-4 text-[13px] font-medium text-white transition-colors duration-150 hover:bg-[#111827] disabled:cursor-not-allowed disabled:bg-[#c7ced8]"
+                    disabled={actionBusy}
+                    onClick={() => void onResolve(approval.id, true)}
+                    type="button"
+                  >
+                    {isCurrentAction ? <LoaderCircle className="animate-spin" size={14} strokeWidth={2.1} /> : <Check size={14} strokeWidth={2.1} />}
+                    <span>允许</span>
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ChatHomePage() {
+  const { data } = useWorkspaceOverview();
+  const openModelSettings = useShellStore((state) => state.openModelSettings);
+  const openSettings = useShellStore((state) => state.openSettings);
+  const activeAgent = data.localAgents.find((agent) => agent.active) ?? data.localAgents[0] ?? null;
+  const defaultProvider = data.providers.find((provider) => provider.isDefault) ?? data.providers[0] ?? null;
+  const defaultProviderHealth = defaultProvider?.health ?? "";
+  const requiresModelSetup = !defaultProvider || providerNeedsSetup(defaultProviderHealth, defaultProvider?.enabled ?? true);
+  const modelSetupMessage = providerSetupMessage(defaultProvider?.name, defaultProviderHealth);
+  const activeAgentName = activeAgent?.name ?? data.runtimeProfile.name ?? null;
+  const activeAgentLabel = activeAgentName || data.runtimeProfile.name || "AnyClaw";
+  const modelLabel = defaultProvider?.model || data.runtimeProfile.model || "默认大模型";
+  const {
+    approvalActionId,
+    approvalNoticeApprovals,
+    draft,
+    error,
+    isSending,
+    messages,
+    pendingApprovals,
+    resetConversation,
+    resolveApproval,
+    sessionId,
+    sendMessage,
+    setDraft,
+  } = useWebChat(activeAgentName, data.runtimeProfile.workspace);
+  const messagesViewportRef = useRef<HTMLDivElement | null>(null);
+  const scrollFadeTimerRef = useRef<number | null>(null);
+  const setupPromptedRef = useRef(false);
+
+  useEffect(() => {
+    if (!requiresModelSetup || setupPromptedRef.current) return;
+    setupPromptedRef.current = true;
+    openModelSettings();
+  }, [openModelSettings, requiresModelSetup]);
+
+  useEffect(() => {
+    const viewport = messagesViewportRef.current;
+    if (!viewport) return;
+
+    const markScrolling = () => {
+      viewport.dataset.scrolling = "true";
+
+      if (scrollFadeTimerRef.current !== null) {
+        window.clearTimeout(scrollFadeTimerRef.current);
+      }
+
+      scrollFadeTimerRef.current = window.setTimeout(() => {
+        delete viewport.dataset.scrolling;
+        scrollFadeTimerRef.current = null;
+      }, 720);
+    };
+
+    viewport.addEventListener("scroll", markScrolling, { passive: true });
+
+    return () => {
+      viewport.removeEventListener("scroll", markScrolling);
+
+      if (scrollFadeTimerRef.current !== null) {
+        window.clearTimeout(scrollFadeTimerRef.current);
+        scrollFadeTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const viewport = messagesViewportRef.current;
+    if (!viewport) return;
+
+    viewport.scrollTo({
+      behavior: "smooth",
+      top: viewport.scrollHeight,
+    });
+  }, [isSending, messages]);
+
+  return (
+    <div className="relative z-10 flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-white lg:absolute lg:inset-0">
+      <header className="shrink-0 px-5 pb-1 pt-4 sm:px-6 lg:px-8 lg:pt-5">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="inline-flex rounded-full bg-[#f5f6f8] p-1">
+              <nav className="flex items-center gap-1">
+                {tabs.map((tab) => (
+                  <NavLink
+                    key={tab.label}
+                    className={({ isActive }) =>
+                      [
+                        "rounded-full px-5 py-2.5 text-[15px] font-medium transition-colors duration-150",
+                        isActive ? "bg-white text-[#111827] shadow-[0_2px_10px_rgba(15,23,42,0.05)]" : "text-[#667085] hover:text-[#1d1f25]",
+                      ].join(" ")
+                    }
+                    end={tab.to === "/"}
+                    to={tab.to}
+                  >
+                    {tab.label}
+                  </NavLink>
+                ))}
+              </nav>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3 text-sm text-[#475467]">
+            <div className="hidden items-center gap-2 md:inline-flex">
+              <Gauge size={17} strokeWidth={2.1} />
+              <span>已装 {data.localSkills.length} 个 Skill</span>
+            </div>
+            <div className="hidden items-center gap-2 md:inline-flex">
+              <Clock3 size={17} strokeWidth={2.1} />
+              <span>{data.runtimeProfile.sessions} 个会话</span>
+            </div>
+            <button
+              aria-label="更多设置"
+              className="flex h-10 w-10 items-center justify-center rounded-full text-[#475467] transition-colors duration-150 hover:bg-[#f4f5f7] hover:text-[#111827]"
+              onClick={() => openSettings("general")}
+              type="button"
+            >
+              <CircleUserRound size={20} strokeWidth={2.1} />
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <section className="flex min-h-0 flex-1 flex-col overflow-hidden bg-white">
+        <div className="min-h-0 flex-1 overflow-hidden px-5 pt-2 sm:px-6 lg:px-8 lg:pt-3">
+          <div
+            className="chat-scroll-area mx-auto flex h-full w-full max-w-[980px] flex-col overflow-y-auto pr-1 sm:pr-2"
+            ref={messagesViewportRef}
+          >
+            {messages.length > 0 || isSending ? (
+              <div className="space-y-8 pb-16 pt-3 sm:space-y-10">
+                {messages.map((message, index) => {
+                  const isUser = message.role === "user";
+
+                  return (
+                    <div
+                      className={isUser ? "ml-auto flex max-w-[300px] flex-col items-end md:max-w-[360px]" : "max-w-[680px]"}
+                      key={`${message.role}:${message.timestamp}:${index}`}
+                    >
+                      {isUser ? (
+                        <div className="rounded-[18px] bg-[#fcf1f1] px-4 py-3 text-[15px] leading-7 text-[#1f2937]">
+                          <div className="whitespace-pre-wrap break-words">{message.content}</div>
+                        </div>
+                      ) : (
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2 text-[12px] text-[#98a2b3]">
+                            <span className="font-medium text-[#4b5563]">{message.agent_name || activeAgentLabel}</span>
+                            <span>{formatMessageTime(message.timestamp)}</span>
+                          </div>
+                          <div className="mt-2.5 break-words text-[15px] leading-[1.9] text-[#1f2937]">
+                            <MarkdownMessage content={message.content} />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+
+                {isSending ? <ThinkingIndicator activeAgentLabel={activeAgentLabel} /> : null}
+              </div>
+            ) : requiresModelSetup ? (
+              <SetupEmptyState message={modelSetupMessage} onOpen={openModelSettings} />
+            ) : (
+              <div className="flex-1" />
+            )}
+          </div>
+        </div>
+
+        <ApprovalNotice approvalActionId={approvalActionId} approvals={approvalNoticeApprovals} onResolve={resolveApproval} />
+
+        <Composer
+          activeAgentLabel={activeAgentLabel}
+          canSend={!requiresModelSetup && Boolean(draft.trim()) && pendingApprovals.length === 0 && approvalActionId === null}
+          draft={draft}
+          error={error}
+          isSending={isSending}
+          modelLabel={modelLabel}
+          onDraftChange={setDraft}
+          onReset={resetConversation}
+          onSend={sendMessage}
+          sessionId={sessionId}
+          setupMessage={modelSetupMessage}
+          setupRequired={requiresModelSetup}
+        />
+      </section>
+    </div>
+  );
+}

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -1,1 +1,39 @@
 import "@testing-library/jest-dom";
+
+function createStorageMock() {
+  const store = new Map<string, string>();
+
+  return {
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value));
+    },
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+function ensureStorage(name: "localStorage" | "sessionStorage") {
+  const storage = window[name];
+  if (storage && typeof storage.clear === "function") return;
+
+  Object.defineProperty(window, name, {
+    configurable: true,
+    value: createStorageMock(),
+  });
+}
+
+ensureStorage("localStorage");
+ensureStorage("sessionStorage");

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -108,6 +108,7 @@ export default defineConfig({
     host: "127.0.0.1",
     port: 4173,
     proxy: {
+      "/approvals": apiTarget,
       "/agents": apiTarget,
       "/channels": apiTarget,
       "/chat": apiTarget,
@@ -116,6 +117,7 @@ export default defineConfig({
       "/market": apiTarget,
       "/providers": apiTarget,
       "/runtimes": apiTarget,
+      "/sessions": apiTarget,
       "/skills": apiTarget,
       "/status": apiTarget,
       "/tasks": apiTarget,


### PR DESCRIPTION
## 变更内容
- 新增聊天首页与输入区，接入基础消息发送流程
- 新增 Web 聊天状态管理与会话持久化
- 新增 Markdown 消息渲染，并限制外链只允许 http/https
- 将根路由切换为聊天首页，同时保留 workspace、market、discovery、studio 页面
- 补充聊天流、Markdown 渲染、左侧导航相关测试
- 补充开发环境下 sessions 和 approvals 的代理配置

## 验证
- npm run typecheck
- npm test
- npm run build