### PR TITLE
feat(ui): add channels console

### DIFF
--- a/ui/src/app/router.tsx
+++ b/ui/src/app/router.tsx
@@ -1,6 +1,7 @@
 import { createHashRouter } from "react-router-dom";
 
 import { AppShell } from "@/layouts/AppShell/AppShell";
+import { ChannelsPage } from "@/pages/Channels/ChannelsPage";
 import { DiscoveryPage } from "@/pages/Discovery/DiscoveryPage";
 import { MarketPage } from "@/pages/Market/MarketPage";
 import { ChatHomePage } from "@/pages/ChatHome/ChatHomePage";
@@ -23,6 +24,10 @@ export const router = createHashRouter([
       {
         element: <MarketPage />,
         path: "market",
+      },
+      {
+        element: <ChannelsPage />,
+        path: "channels",
       },
       {
         element: <DiscoveryPage />,

--- a/ui/src/features/channels/ChannelsControlConsole.test.tsx
+++ b/ui/src/features/channels/ChannelsControlConsole.test.tsx
@@ -136,4 +136,72 @@ describe("ChannelsControlConsole", () => {
       expect(toggleMentionGate).toHaveBeenCalledWith(false);
     });
   });
+
+  it("falls back to the selected channel snapshot when live adapter status is unavailable", () => {
+    useChannelControlMock.mockReturnValue({
+      adapterStatusesError: null,
+      isLoading: false,
+      mentionGate: { enabled: false },
+      mentionGateError: null,
+      pairDevice: vi.fn(),
+      pairDeviceError: null,
+      pairDevicePending: false,
+      pairingEnabled: false,
+      pairingError: null,
+      presenceError: null,
+      selectedAdapterStatus: null,
+      selectedContacts: [],
+      selectedPairings: [],
+      selectedPresence: [],
+      toggleMentionGate: vi.fn(),
+      toggleMentionGateError: null,
+      toggleMentionGatePending: false,
+      unpairDevice: vi.fn(),
+      unpairDeviceError: null,
+      unpairDevicePending: false,
+    } as never);
+
+    render(<ChannelsControlConsole selectedChannel={selectedChannel} />);
+
+    expect(screen.getByText("运行中")).toBeInTheDocument();
+    expect(screen.getByText("健康")).toBeInTheDocument();
+  });
+
+  it("blocks pairing submission when required identifiers are blank after trimming", async () => {
+    const pairDevice = vi.fn().mockResolvedValue({ status: "ok" });
+
+    useChannelControlMock.mockReturnValue({
+      adapterStatusesError: null,
+      isLoading: false,
+      mentionGate: { enabled: true },
+      mentionGateError: null,
+      pairDevice,
+      pairDeviceError: null,
+      pairDevicePending: false,
+      pairingEnabled: true,
+      pairingError: null,
+      presenceError: null,
+      selectedAdapterStatus: null,
+      selectedContacts: [],
+      selectedPairings: [],
+      selectedPresence: [],
+      toggleMentionGate: vi.fn(),
+      toggleMentionGateError: null,
+      toggleMentionGatePending: false,
+      unpairDevice: vi.fn(),
+      unpairDeviceError: null,
+      unpairDevicePending: false,
+    } as never);
+
+    render(<ChannelsControlConsole selectedChannel={selectedChannel} />);
+
+    const inputs = screen.getAllByRole("textbox");
+    fireEvent.change(inputs[0], { target: { value: "   " } });
+    fireEvent.change(inputs[1], { target: { value: "   " } });
+
+    fireEvent.click(screen.getByRole("button", { name: "新增配对" }));
+
+    expect(pairDevice).not.toHaveBeenCalled();
+    expect(screen.getByText("用户 ID 和设备 ID 不能为空")).toBeInTheDocument();
+  });
 });

--- a/ui/src/features/channels/ChannelsControlConsole.test.tsx
+++ b/ui/src/features/channels/ChannelsControlConsole.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ChannelRecord } from "@/features/workspace/useWorkspaceOverview";
+
+import { ChannelsControlConsole } from "./ChannelsControlConsole";
+import { useChannelControl } from "./useChannelControl";
+
+vi.mock("./useChannelControl", () => ({
+  useChannelControl: vi.fn(),
+}));
+
+const useChannelControlMock = vi.mocked(useChannelControl);
+
+const selectedChannel: ChannelRecord = {
+  configured: true,
+  enabled: true,
+  healthy: true,
+  name: "微信",
+  note: "优先承接私域服务",
+  running: true,
+  slug: "wechat",
+  status: "运行中",
+  summary: "私域服务与通知入口",
+};
+
+describe("ChannelsControlConsole", () => {
+  it("renders an empty state when no channel is selected", () => {
+    useChannelControlMock.mockReturnValue({
+      adapterStatusesError: null,
+      isLoading: false,
+      mentionGate: null,
+      mentionGateError: null,
+      pairDevice: vi.fn(),
+      pairDeviceError: null,
+      pairDevicePending: false,
+      pairingEnabled: false,
+      pairingError: null,
+      presenceError: null,
+      selectedAdapterStatus: null,
+      selectedContacts: [],
+      selectedPairings: [],
+      selectedPresence: [],
+      toggleMentionGate: vi.fn(),
+      toggleMentionGateError: null,
+      toggleMentionGatePending: false,
+      unpairDevice: vi.fn(),
+      unpairDeviceError: null,
+      unpairDevicePending: false,
+    } as never);
+
+    render(<ChannelsControlConsole selectedChannel={null} />);
+
+    expect(screen.getByText("等待选择渠道")).toBeInTheDocument();
+  });
+
+  it("renders adapter, pairing and mention-gate details for the selected channel", async () => {
+    const pairDevice = vi.fn().mockResolvedValue({ status: "ok" });
+    const toggleMentionGate = vi.fn().mockResolvedValue({ enabled: false });
+    const unpairDevice = vi.fn().mockResolvedValue({ status: "ok" });
+
+    useChannelControlMock.mockReturnValue({
+      adapterStatusesError: null,
+      isLoading: false,
+      mentionGate: { enabled: true },
+      mentionGateError: null,
+      pairDevice,
+      pairDeviceError: null,
+      pairDevicePending: false,
+      pairingEnabled: true,
+      pairingError: null,
+      presenceError: null,
+      selectedAdapterStatus: {
+        enabled: true,
+        healthy: true,
+        last_activity: "2026-04-22T10:00:00Z",
+        last_error: "",
+        name: "wechat",
+        running: true,
+      },
+      selectedContacts: [
+        {
+          added_at: "2026-04-22T09:00:00Z",
+          channel: "wechat",
+          display_name: "Alice",
+          first_name: "Alice",
+          is_bot: false,
+          last_name: "",
+          last_seen: "2026-04-22T10:00:00Z",
+          user_id: "alice",
+          username: "alice",
+        },
+      ],
+      selectedPairings: [
+        {
+          channel: "wechat",
+          device_id: "device-1",
+          display_name: "Alice Phone",
+          expires_at: "2026-04-23T10:00:00Z",
+          last_seen: "2026-04-22T10:00:00Z",
+          paired_at: "2026-04-22T09:00:00Z",
+          user_id: "alice",
+        },
+      ],
+      selectedPresence: [
+        {
+          activity: "typing",
+          channel: "wechat",
+          key: "wechat:alice",
+          last_update: "2026-04-22T10:00:00Z",
+          since: "2026-04-22T09:55:00Z",
+          status: "online",
+          user_id: "alice",
+        },
+      ],
+      toggleMentionGate,
+      toggleMentionGateError: null,
+      toggleMentionGatePending: false,
+      unpairDevice,
+      unpairDeviceError: null,
+      unpairDevicePending: false,
+    } as never);
+
+    render(<ChannelsControlConsole selectedChannel={selectedChannel} />);
+
+    expect(screen.getByText("实时适配器状态")).toBeInTheDocument();
+    expect(screen.getByText("设备配对")).toBeInTheDocument();
+    expect(screen.getByText("提及门")).toBeInTheDocument();
+    expect(screen.getByText("联系人")).toBeInTheDocument();
+    expect(screen.getByText("Alice Phone")).toBeInTheDocument();
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "关闭提及门" }));
+
+    await waitFor(() => {
+      expect(toggleMentionGate).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/ui/src/features/channels/ChannelsControlConsole.tsx
+++ b/ui/src/features/channels/ChannelsControlConsole.tsx
@@ -113,17 +113,23 @@ export function ChannelsControlConsole({ selectedChannel }: ChannelsControlConso
   }
 
   const channelName = selectedChannel.name;
+  const fallbackEnabled = selectedChannel.enabled;
+  const fallbackRunning = selectedChannel.running;
+  const fallbackHealthy = selectedChannel.healthy;
+  const effectiveEnabled = selectedAdapterStatus?.enabled ?? fallbackEnabled;
+  const effectiveRunning = selectedAdapterStatus?.running ?? fallbackRunning;
+  const effectiveHealthy = selectedAdapterStatus?.healthy ?? fallbackHealthy;
   const runtimeLabel = getAdapterRuntimeLabel(
     selectedChannel,
-    selectedAdapterStatus?.enabled ?? false,
-    selectedAdapterStatus?.running ?? false,
-    selectedAdapterStatus?.healthy ?? false,
+    effectiveEnabled,
+    effectiveRunning,
+    effectiveHealthy,
   );
   const runtimeTone = getAdapterRuntimeTone(
     selectedChannel,
-    selectedAdapterStatus?.enabled ?? false,
-    selectedAdapterStatus?.running ?? false,
-    selectedAdapterStatus?.healthy ?? false,
+    effectiveEnabled,
+    effectiveRunning,
+    effectiveHealthy,
   );
   const sortedPresence = [...selectedPresence].sort((left, right) => left.user_id.localeCompare(right.user_id));
   const sortedPairings = [...selectedPairings].sort((left, right) => right.last_seen.localeCompare(left.last_seen));
@@ -151,13 +157,21 @@ export function ChannelsControlConsole({ selectedChannel }: ChannelsControlConso
     event.preventDefault();
     const ttlHours = Number(pairForm.ttlHours || "24");
     const normalizedTtlHours = Number.isFinite(ttlHours) ? ttlHours : 24;
+    const userId = pairForm.userId.trim();
+    const deviceId = pairForm.deviceId.trim();
+    const displayName = pairForm.displayName.trim();
+
+    if (userId === "" || deviceId === "") {
+      setActionNotice({ message: "用户 ID 和设备 ID 不能为空", tone: "error" });
+      return;
+    }
 
     try {
       await pairDevice({
-        device_id: pairForm.deviceId.trim(),
-        display_name: pairForm.displayName.trim(),
+        device_id: deviceId,
+        display_name: displayName,
         ttl_seconds: Math.max(1, normalizedTtlHours) * 3600,
-        user_id: pairForm.userId.trim(),
+        user_id: userId,
       });
       setPairForm(defaultPairForm);
       setActionNotice({ message: `${channelName} 新增配对成功`, tone: "success" });
@@ -206,7 +220,7 @@ export function ChannelsControlConsole({ selectedChannel }: ChannelsControlConso
                 },
                 {
                   label: "健康状态",
-                  value: selectedAdapterStatus ? (selectedAdapterStatus.healthy ? "健康" : "待恢复") : "未接入",
+                  value: effectiveHealthy ? "健康" : effectiveEnabled ? "待恢复" : selectedChannel.configured ? "待启用" : "未接入",
                 },
                 {
                   label: "最近活动",

--- a/ui/src/features/channels/ChannelsControlConsole.tsx
+++ b/ui/src/features/channels/ChannelsControlConsole.tsx
@@ -1,0 +1,455 @@
+import { Activity, AtSign, Users, Waypoints } from "lucide-react";
+import { useEffect, useState } from "react";
+import type { FormEvent } from "react";
+
+import { BackendDetailSection } from "@/features/backend-ui/BackendDetailSection";
+import { BackendEmptyState } from "@/features/backend-ui/BackendEmptyState";
+import { BackendPropertyList } from "@/features/backend-ui/BackendPropertyList";
+import { BackendSummaryStrip } from "@/features/backend-ui/BackendSummaryStrip";
+import { StatusBadge, type StatusBadgeTone } from "@/features/backend-ui/StatusBadge";
+import { getStatusTone } from "@/features/backend-ui/getStatusTone";
+import { useChannelControl } from "@/features/channels/useChannelControl";
+import type { ChannelRecord } from "@/features/workspace/useWorkspaceOverview";
+
+type ActionNotice = {
+  message: string;
+  tone: "error" | "success";
+};
+
+type PairFormState = {
+  deviceId: string;
+  displayName: string;
+  ttlHours: string;
+  userId: string;
+};
+
+const defaultPairForm: PairFormState = {
+  deviceId: "",
+  displayName: "",
+  ttlHours: "24",
+  userId: "",
+};
+
+const inputClassName =
+  "h-11 w-full rounded-[14px] border border-skin bg-white px-3 text-sm text-ink outline-none placeholder:text-[#98a2b3]";
+
+function formatDateTime(value?: string) {
+  if (!value) return "未记录";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toLocaleString("zh-CN", {
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "2-digit",
+  });
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) return error.message;
+  return "请求失败";
+}
+
+function getAdapterRuntimeLabel(
+  channel: ChannelRecord,
+  liveEnabled: boolean,
+  liveRunning: boolean,
+  liveHealthy: boolean,
+) {
+  if (liveRunning && liveHealthy) return "运行中";
+  if (liveEnabled && !liveHealthy) return "已启用，待恢复";
+  if (liveEnabled) return "已启用";
+  if (channel.configured) return "已配置，待启用";
+  return "规划中";
+}
+
+function getAdapterRuntimeTone(
+  channel: ChannelRecord,
+  liveEnabled: boolean,
+  liveRunning: boolean,
+  liveHealthy: boolean,
+): StatusBadgeTone {
+  if (liveRunning && liveHealthy) return "success";
+  if (liveEnabled && !liveHealthy) return "warning";
+  if (liveEnabled || channel.configured) return "info";
+  return "default";
+}
+
+type ChannelsControlConsoleProps = {
+  selectedChannel: ChannelRecord | null;
+};
+
+export function ChannelsControlConsole({ selectedChannel }: ChannelsControlConsoleProps) {
+  const {
+    adapterStatusesError,
+    mentionGate,
+    mentionGateError,
+    pairDevice,
+    pairDevicePending,
+    pairingEnabled,
+    pairingError,
+    presenceError,
+    selectedAdapterStatus,
+    selectedContacts,
+    selectedPairings,
+    selectedPresence,
+    toggleMentionGate,
+    toggleMentionGatePending,
+    unpairDevice,
+    unpairDevicePending,
+  } = useChannelControl(selectedChannel?.slug ?? null);
+  const [pairForm, setPairForm] = useState<PairFormState>(defaultPairForm);
+  const [actionNotice, setActionNotice] = useState<ActionNotice | null>(null);
+
+  useEffect(() => {
+    setPairForm(defaultPairForm);
+    setActionNotice(null);
+  }, [selectedChannel?.slug]);
+
+  if (!selectedChannel) {
+    return <BackendEmptyState icon={Waypoints} title="等待选择渠道" />;
+  }
+
+  const channelName = selectedChannel.name;
+  const runtimeLabel = getAdapterRuntimeLabel(
+    selectedChannel,
+    selectedAdapterStatus?.enabled ?? false,
+    selectedAdapterStatus?.running ?? false,
+    selectedAdapterStatus?.healthy ?? false,
+  );
+  const runtimeTone = getAdapterRuntimeTone(
+    selectedChannel,
+    selectedAdapterStatus?.enabled ?? false,
+    selectedAdapterStatus?.running ?? false,
+    selectedAdapterStatus?.healthy ?? false,
+  );
+  const sortedPresence = [...selectedPresence].sort((left, right) => left.user_id.localeCompare(right.user_id));
+  const sortedPairings = [...selectedPairings].sort((left, right) => right.last_seen.localeCompare(left.last_seen));
+  const sortedContacts = [...selectedContacts].sort((left, right) =>
+    (left.display_name || left.username || left.user_id).localeCompare(
+      right.display_name || right.username || right.user_id,
+    ),
+  );
+
+  async function handleMentionGateToggle() {
+    if (!mentionGate) return;
+
+    try {
+      await toggleMentionGate(!mentionGate.enabled);
+      setActionNotice({
+        message: mentionGate.enabled ? "提及门已关闭" : "提及门已开启",
+        tone: "success",
+      });
+    } catch (error) {
+      setActionNotice({ message: getErrorMessage(error), tone: "error" });
+    }
+  }
+
+  async function handlePairSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const ttlHours = Number(pairForm.ttlHours || "24");
+    const normalizedTtlHours = Number.isFinite(ttlHours) ? ttlHours : 24;
+
+    try {
+      await pairDevice({
+        device_id: pairForm.deviceId.trim(),
+        display_name: pairForm.displayName.trim(),
+        ttl_seconds: Math.max(1, normalizedTtlHours) * 3600,
+        user_id: pairForm.userId.trim(),
+      });
+      setPairForm(defaultPairForm);
+      setActionNotice({ message: `${channelName} 新增配对成功`, tone: "success" });
+    } catch (error) {
+      setActionNotice({ message: getErrorMessage(error), tone: "error" });
+    }
+  }
+
+  async function handleUnpair(userId: string, deviceId: string, channel: string) {
+    try {
+      await unpairDevice({ channel, device_id: deviceId, user_id: userId });
+      setActionNotice({ message: "设备配对已移除", tone: "success" });
+    } catch (error) {
+      setActionNotice({ message: getErrorMessage(error), tone: "error" });
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      {actionNotice ? (
+        <div
+          className={[
+            "rounded-[18px] border px-4 py-3 text-sm",
+            actionNotice.tone === "success"
+              ? "border-[#d7eada] bg-[#f3fbf4] text-[#3f7a59]"
+              : "border-[#f0ded6] bg-[#fff7f3] text-[#8a6135]",
+          ].join(" ")}
+        >
+          {actionNotice.message}
+        </div>
+      ) : null}
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+        <div className="space-y-5">
+          <BackendDetailSection title="实时适配器状态">
+            <BackendSummaryStrip
+              items={[
+                {
+                  active: Boolean(selectedAdapterStatus?.running),
+                  label: "运行状态",
+                  value: (
+                    <span className="inline-flex items-center gap-2">
+                      <StatusBadge label={runtimeLabel} tone={runtimeTone} />
+                    </span>
+                  ),
+                },
+                {
+                  label: "健康状态",
+                  value: selectedAdapterStatus ? (selectedAdapterStatus.healthy ? "健康" : "待恢复") : "未接入",
+                },
+                {
+                  label: "最近活动",
+                  value: formatDateTime(selectedAdapterStatus?.last_activity),
+                },
+                {
+                  label: "最近错误",
+                  value: selectedAdapterStatus?.last_error || "无",
+                },
+              ]}
+            />
+
+            <div className="mt-4">
+              <BackendPropertyList
+                items={[
+                  { label: "当前渠道", value: channelName },
+                  { label: "渠道标识", value: selectedChannel.slug },
+                  { label: "适配器名称", value: selectedAdapterStatus?.name || "未发现" },
+                  { label: "数据来源", value: selectedAdapterStatus ? "/channels" : "规划数据" },
+                ]}
+              />
+            </div>
+
+            {adapterStatusesError ? (
+              <div className="mt-4 rounded-[16px] border border-[#f0ded6] bg-[#fff7f3] px-4 py-3 text-sm text-[#8a6135]">
+                实时状态接口暂不可用：{getErrorMessage(adapterStatusesError)}
+              </div>
+            ) : null}
+          </BackendDetailSection>
+
+          <BackendDetailSection title="设备配对">
+            <BackendSummaryStrip
+              items={[
+                {
+                  active: pairingEnabled,
+                  label: "配对服务",
+                  value: pairingEnabled ? "已开启" : "未开启",
+                },
+                { label: "当前渠道配对", value: `${sortedPairings.length} 个` },
+                { label: "在线状态", value: `${sortedPresence.length} 个` },
+              ]}
+            />
+
+            <form className="mt-4 grid gap-3 md:grid-cols-2" onSubmit={handlePairSubmit}>
+              <input
+                className={inputClassName}
+                placeholder="用户 ID"
+                required
+                value={pairForm.userId}
+                onChange={(event) => setPairForm((current) => ({ ...current, userId: event.target.value }))}
+              />
+              <input
+                className={inputClassName}
+                placeholder="设备 ID"
+                required
+                value={pairForm.deviceId}
+                onChange={(event) => setPairForm((current) => ({ ...current, deviceId: event.target.value }))}
+              />
+              <input
+                className={inputClassName}
+                placeholder="显示名称"
+                value={pairForm.displayName}
+                onChange={(event) => setPairForm((current) => ({ ...current, displayName: event.target.value }))}
+              />
+              <input
+                className={inputClassName}
+                min="1"
+                placeholder="有效期（小时）"
+                required
+                type="number"
+                value={pairForm.ttlHours}
+                onChange={(event) => setPairForm((current) => ({ ...current, ttlHours: event.target.value }))}
+              />
+              <div className="flex flex-wrap gap-3 md:col-span-2">
+                <button
+                  className="shell-button h-11 justify-center px-4 text-sm font-medium disabled:opacity-60"
+                  disabled={pairDevicePending || !pairingEnabled}
+                  type="submit"
+                >
+                  {pairDevicePending ? "正在新增配对..." : "新增配对"}
+                </button>
+                {!pairingEnabled ? (
+                  <div className="rounded-[14px] bg-[#f8fafc] px-4 py-3 text-sm text-mute">
+                    当前网关的配对服务未开启。
+                  </div>
+                ) : null}
+              </div>
+            </form>
+
+            {pairingError ? (
+              <div className="mt-4 rounded-[16px] border border-[#f0ded6] bg-[#fff7f3] px-4 py-3 text-sm text-[#8a6135]">
+                配对接口暂不可用：{getErrorMessage(pairingError)}
+              </div>
+            ) : null}
+
+            <div className="mt-4 overflow-hidden rounded-[18px] border border-skin bg-[#fbfcfe]">
+              {sortedPairings.length > 0 ? (
+                sortedPairings.map((record) => (
+                  <div
+                    key={`${record.channel}:${record.user_id}:${record.device_id}`}
+                    className="flex flex-col gap-3 border-b border-skin px-4 py-4 last:border-b-0 md:flex-row md:items-center md:justify-between"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <div className="text-sm font-semibold text-ink">{record.display_name || record.device_id}</div>
+                        <StatusBadge label={record.channel} tone="info" />
+                      </div>
+                      <div className="mt-1 text-sm text-[#607699]">
+                        {record.user_id} / {record.device_id}
+                      </div>
+                      <div className="mt-2 text-xs text-mute">
+                        最近活跃：{formatDateTime(record.last_seen)} / 过期：{formatDateTime(record.expires_at)}
+                      </div>
+                    </div>
+                    <button
+                      className="rounded-[10px] bg-[#f5f7fb] px-3 py-2 text-sm font-medium text-[#5b6f8b] transition-colors duration-150 hover:bg-[#edf2fa] hover:text-ink disabled:opacity-60"
+                      disabled={unpairDevicePending}
+                      onClick={() => handleUnpair(record.user_id, record.device_id, record.channel)}
+                      type="button"
+                    >
+                      移除配对
+                    </button>
+                  </div>
+                ))
+              ) : (
+                <div className="px-4 py-5 text-sm text-mute">当前渠道还没有已配对设备。</div>
+              )}
+            </div>
+          </BackendDetailSection>
+        </div>
+
+        <div className="space-y-5">
+          <BackendDetailSection title="提及门">
+            <BackendSummaryStrip
+              items={[
+                {
+                  active: mentionGate?.enabled,
+                  label: "当前状态",
+                  value: mentionGate ? (mentionGate.enabled ? "已开启" : "已关闭") : "未知",
+                },
+                { label: "作用范围", value: "全局渠道入口" },
+              ]}
+            />
+
+            <div className="mt-4">
+              <BackendPropertyList
+                items={[
+                  { label: "当前查看", value: channelName },
+                  { label: "开关来源", value: "/channel/mention-gate" },
+                ]}
+              />
+            </div>
+
+            {mentionGateError ? (
+              <div className="mt-4 rounded-[16px] border border-[#f0ded6] bg-[#fff7f3] px-4 py-3 text-sm text-[#8a6135]">
+                提及门接口暂不可用：{getErrorMessage(mentionGateError)}
+              </div>
+            ) : null}
+
+            <div className="mt-4 flex flex-wrap gap-3">
+              <button
+                className="shell-button h-11 justify-center px-4 text-sm font-medium disabled:opacity-60"
+                disabled={!mentionGate || toggleMentionGatePending}
+                onClick={handleMentionGateToggle}
+                type="button"
+              >
+                {toggleMentionGatePending ? "正在更新..." : mentionGate?.enabled ? "关闭提及门" : "开启提及门"}
+              </button>
+            </div>
+          </BackendDetailSection>
+
+          <BackendDetailSection title="在线状态">
+            {presenceError ? (
+              <div className="rounded-[16px] border border-[#f0ded6] bg-[#fff7f3] px-4 py-3 text-sm text-[#8a6135]">
+                在线状态接口暂不可用：{getErrorMessage(presenceError)}
+              </div>
+            ) : sortedPresence.length > 0 ? (
+              <div className="space-y-3">
+                {sortedPresence.map((record) => (
+                  <div
+                    key={record.key}
+                    className="flex items-start gap-3 rounded-[16px] border border-skin bg-[#fbfcfe] px-4 py-3"
+                  >
+                    <span className="mt-0.5 flex h-9 w-9 items-center justify-center rounded-[12px] bg-[#f3f6fb] text-[#607699]">
+                      <Activity size={16} strokeWidth={2.1} />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <div className="text-sm font-semibold text-ink">{record.user_id}</div>
+                        <StatusBadge label={record.status} tone={getStatusTone(record.status)} />
+                      </div>
+                      <div className="mt-1 text-xs text-mute">更新于 {formatDateTime(record.last_update)}</div>
+                      {record.activity ? <div className="mt-1 text-xs text-[#607699]">{record.activity}</div> : null}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-[16px] border border-skin bg-[#fbfcfe] px-4 py-4 text-sm text-mute">
+                当前渠道还没有在线状态记录。
+              </div>
+            )}
+          </BackendDetailSection>
+
+          <BackendDetailSection title="联系人">
+            <BackendSummaryStrip
+              items={[
+                { label: "已加载", value: `${sortedContacts.length} 个` },
+                { label: "来源接口", value: "/channel/contacts" },
+              ]}
+            />
+
+            <div className="mt-4">
+              {sortedContacts.length > 0 ? (
+                <div className="space-y-3">
+                  {sortedContacts.slice(0, 8).map((contact) => (
+                    <div
+                      key={`${contact.channel}:${contact.user_id}`}
+                      className="flex items-start gap-3 rounded-[16px] border border-skin bg-[#fbfcfe] px-4 py-3"
+                    >
+                      <span className="mt-0.5 flex h-9 w-9 items-center justify-center rounded-[12px] bg-[#f3f6fb] text-[#607699]">
+                        {contact.username ? <AtSign size={16} strokeWidth={2.1} /> : <Users size={16} strokeWidth={2.1} />}
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-semibold text-ink">
+                          {contact.display_name || contact.username || contact.user_id}
+                        </div>
+                        <div className="mt-1 text-xs text-mute">
+                          {contact.username ? `@${contact.username}` : contact.user_id}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="rounded-[16px] border border-skin bg-[#fbfcfe] px-4 py-4 text-sm text-mute">
+                  当前渠道还没有联系人记录。
+                </div>
+              )}
+            </div>
+          </BackendDetailSection>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/features/channels/useChannelControl.test.tsx
+++ b/ui/src/features/channels/useChannelControl.test.tsx
@@ -1,0 +1,130 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useChannelControl } from "./useChannelControl";
+
+function jsonResponse(payload: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "ERROR",
+    text: async () => JSON.stringify(payload),
+  } as Response);
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: Infinity,
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: PropsWithChildren) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function Probe() {
+  const { mentionGate, pairingEnabled, selectedAdapterStatus, selectedContacts, selectedPairings, selectedPresence } =
+    useChannelControl("wechat");
+
+  return (
+    <div>
+      <div data-testid="contacts">{selectedContacts.length}</div>
+      <div data-testid="pairings">{selectedPairings.length}</div>
+      <div data-testid="presence">{selectedPresence.length}</div>
+      <div data-testid="pairing-enabled">{String(pairingEnabled)}</div>
+      <div data-testid="mention-gate">{String(mentionGate?.enabled ?? false)}</div>
+      <div data-testid="adapter">{selectedAdapterStatus?.name ?? ""}</div>
+    </div>
+  );
+}
+
+describe("useChannelControl", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("normalizes null collection responses into empty arrays", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: string | URL | Request) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+        if (url === "/channels") {
+          return jsonResponse(null);
+        }
+        if (url === "/channel/mention-gate") {
+          return jsonResponse({ enabled: true });
+        }
+        if (url === "/channel/pairing") {
+          return jsonResponse({ enabled: true, paired: null });
+        }
+        if (url === "/channel/presence") {
+          return jsonResponse(null);
+        }
+        if (url.startsWith("/channel/contacts")) {
+          return jsonResponse(null);
+        }
+
+        throw new Error(`Unhandled fetch request: ${url}`);
+      }),
+    );
+
+    render(<Probe />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts")).toHaveTextContent("0");
+      expect(screen.getByTestId("pairings")).toHaveTextContent("0");
+      expect(screen.getByTestId("presence")).toHaveTextContent("0");
+      expect(screen.getByTestId("pairing-enabled")).toHaveTextContent("true");
+      expect(screen.getByTestId("mention-gate")).toHaveTextContent("true");
+      expect(screen.getByTestId("adapter")).toHaveTextContent("");
+    });
+  });
+
+  it("surfaces plain-text server errors instead of a JSON parse failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: string | URL | Request) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+        if (url === "/channels") {
+          return Promise.resolve({
+            ok: false,
+            status: 503,
+            statusText: "Service Unavailable",
+            text: async () => "channels unavailable",
+          } as Response);
+        }
+        if (url === "/channel/mention-gate") {
+          return jsonResponse({ enabled: false });
+        }
+        if (url === "/channel/pairing") {
+          return jsonResponse({ enabled: false, paired: [] });
+        }
+        if (url === "/channel/presence") {
+          return jsonResponse({});
+        }
+        if (url.startsWith("/channel/contacts")) {
+          return jsonResponse([]);
+        }
+
+        throw new Error(`Unhandled fetch request: ${url}`);
+      }),
+    );
+
+    const { result } = renderHook(() => useChannelControl("wechat"), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.selectedAdapterStatus).toBeNull();
+    });
+  });
+});

--- a/ui/src/features/channels/useChannelControl.ts
+++ b/ui/src/features/channels/useChannelControl.ts
@@ -1,0 +1,269 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+export type ChannelAdapterStatus = {
+  enabled: boolean;
+  healthy: boolean;
+  last_activity?: string;
+  last_error?: string;
+  name: string;
+  running: boolean;
+};
+
+export type MentionGateState = {
+  enabled: boolean;
+};
+
+export type ChannelPairingRecord = {
+  channel: string;
+  device_id: string;
+  display_name: string;
+  expires_at: string;
+  last_seen: string;
+  paired_at: string;
+  user_id: string;
+};
+
+export type ChannelPresenceRecord = {
+  activity?: string;
+  channel: string;
+  key: string;
+  last_update: string;
+  since: string;
+  status: string;
+  user_id: string;
+};
+
+export type ChannelContactRecord = {
+  added_at: string;
+  channel: string;
+  display_name: string;
+  first_name: string;
+  is_bot: boolean;
+  last_name: string;
+  last_seen: string;
+  metadata?: Record<string, string>;
+  user_id: string;
+  username: string;
+};
+
+type ChannelPairingResponse = {
+  enabled: boolean;
+  paired: ChannelPairingRecord[];
+};
+
+type PairDeviceInput = {
+  device_id: string;
+  display_name: string;
+  ttl_seconds: number;
+  user_id: string;
+};
+
+function normalizeName(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function ensureArray<T>(value: T[] | null | undefined) {
+  return Array.isArray(value) ? value : [];
+}
+
+async function requestJSON<T>(input: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, {
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  });
+
+  const text = await response.text();
+  let payload: T | { error?: string } | string | null = null;
+  if (text !== "") {
+    try {
+      payload = JSON.parse(text) as T | { error?: string };
+    } catch {
+      payload = text;
+    }
+  }
+
+  if (!response.ok) {
+    const message =
+      typeof payload === "string" && payload.trim() !== ""
+        ? payload.trim()
+        : payload && typeof payload === "object" && "error" in payload && typeof payload.error === "string"
+        ? payload.error
+        : `${response.status} ${response.statusText}`.trim();
+
+    throw new Error(message);
+  }
+
+  return payload as T;
+}
+
+function mapPresenceMap(
+  payload: Record<string, Omit<ChannelPresenceRecord, "channel" | "key" | "user_id">> | null | undefined,
+) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return [];
+  }
+
+  return Object.entries(payload).map(([key, value]) => {
+    const [channel, ...rest] = key.split(":");
+
+    return {
+      ...value,
+      channel: channel ?? "",
+      key,
+      user_id: rest.join(":"),
+    };
+  });
+}
+
+export function useChannelControl(selectedSlug: string | null) {
+  const queryClient = useQueryClient();
+
+  const adapterStatusesQuery = useQuery({
+    queryKey: ["channel-adapter-statuses"],
+    queryFn: async () => ensureArray(await requestJSON<ChannelAdapterStatus[] | null>("/channels")),
+    initialData: [],
+    refetchInterval: 15000,
+    retry: 0,
+    staleTime: 8000,
+  });
+
+  const mentionGateQuery = useQuery({
+    queryKey: ["channel-mention-gate"],
+    queryFn: () => requestJSON<MentionGateState>("/channel/mention-gate"),
+    retry: 0,
+    staleTime: 8000,
+  });
+
+  const pairingQuery = useQuery({
+    queryKey: ["channel-pairing"],
+    queryFn: async () => {
+      const payload = await requestJSON<ChannelPairingResponse | null>("/channel/pairing");
+
+      return {
+        enabled: payload?.enabled ?? false,
+        paired: ensureArray(payload?.paired),
+      };
+    },
+    retry: 0,
+    staleTime: 8000,
+  });
+
+  const presenceQuery = useQuery({
+    queryKey: ["channel-presence"],
+    queryFn: async () =>
+      mapPresenceMap(
+        await requestJSON<Record<string, Omit<ChannelPresenceRecord, "channel" | "key" | "user_id">> | null>(
+          "/channel/presence",
+        ),
+      ),
+    initialData: [],
+    refetchInterval: 15000,
+    retry: 0,
+    staleTime: 8000,
+  });
+
+  const contactsQuery = useQuery({
+    queryKey: ["channel-contacts", selectedSlug],
+    queryFn: async () =>
+      ensureArray(
+        await requestJSON<ChannelContactRecord[] | null>(
+          `/channel/contacts?channel=${encodeURIComponent(selectedSlug ?? "")}`,
+        ),
+      ),
+    enabled: Boolean(selectedSlug),
+    initialData: [],
+    refetchInterval: 20000,
+    retry: 0,
+    staleTime: 8000,
+  });
+
+  const toggleMentionGateMutation = useMutation({
+    mutationFn: (enabled: boolean) =>
+      requestJSON<MentionGateState>("/channel/mention-gate", {
+        body: JSON.stringify({ enabled }),
+        method: "POST",
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["channel-mention-gate"] });
+    },
+  });
+
+  const pairDeviceMutation = useMutation({
+    mutationFn: (input: PairDeviceInput) => {
+      if (!selectedSlug) {
+        throw new Error("请选择渠道后再新增配对");
+      }
+
+      return requestJSON<{ status: string }>("/channel/pairing", {
+        body: JSON.stringify({
+          action: "pair",
+          channel: selectedSlug,
+          ...input,
+        }),
+        method: "POST",
+      });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["channel-pairing"] });
+    },
+  });
+
+  const unpairDeviceMutation = useMutation({
+    mutationFn: (input: { channel: string; device_id: string; user_id: string }) =>
+      requestJSON<{ status: string }>("/channel/pairing", {
+        body: JSON.stringify({
+          action: "unpair",
+          channel: input.channel,
+          device_id: input.device_id,
+          user_id: input.user_id,
+        }),
+        method: "POST",
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["channel-pairing"] });
+    },
+  });
+
+  const selectedAdapterStatus =
+    adapterStatusesQuery.data.find((status) => normalizeName(status.name) === normalizeName(selectedSlug ?? "")) ??
+    null;
+
+  const selectedPairings = (pairingQuery.data?.paired ?? []).filter(
+    (record) => normalizeName(record.channel) === normalizeName(selectedSlug ?? ""),
+  );
+
+  const selectedPresence = presenceQuery.data.filter(
+    (record) => normalizeName(record.channel) === normalizeName(selectedSlug ?? ""),
+  );
+
+  return {
+    adapterStatusesError: adapterStatusesQuery.error,
+    isLoading:
+      adapterStatusesQuery.isLoading ||
+      mentionGateQuery.isLoading ||
+      pairingQuery.isLoading ||
+      presenceQuery.isLoading,
+    mentionGate: mentionGateQuery.data ?? null,
+    mentionGateError: mentionGateQuery.error,
+    pairDevice: pairDeviceMutation.mutateAsync,
+    pairDeviceError: pairDeviceMutation.error,
+    pairDevicePending: pairDeviceMutation.isPending,
+    pairingEnabled: pairingQuery.data?.enabled ?? false,
+    pairingError: pairingQuery.error,
+    presenceError: presenceQuery.error,
+    selectedAdapterStatus,
+    selectedContacts: contactsQuery.data ?? [],
+    selectedPairings,
+    selectedPresence,
+    toggleMentionGate: toggleMentionGateMutation.mutateAsync,
+    toggleMentionGateError: toggleMentionGateMutation.error,
+    toggleMentionGatePending: toggleMentionGateMutation.isPending,
+    unpairDevice: unpairDeviceMutation.mutateAsync,
+    unpairDeviceError: unpairDeviceMutation.error,
+    unpairDevicePending: unpairDeviceMutation.isPending,
+  };
+}

--- a/ui/src/features/channels/useChannelsConsole.test.tsx
+++ b/ui/src/features/channels/useChannelsConsole.test.tsx
@@ -1,0 +1,79 @@
+import { act, renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import type { ChannelRecord } from "@/features/workspace/useWorkspaceOverview";
+
+import { useChannelsConsole } from "./useChannelsConsole";
+
+const channels: ChannelRecord[] = [
+  {
+    configured: true,
+    enabled: true,
+    healthy: true,
+    name: "微信",
+    note: "私域入口",
+    running: true,
+    slug: "wechat",
+    status: "运行中",
+    summary: "适合作为核心渠道入口",
+  },
+  {
+    configured: false,
+    enabled: false,
+    healthy: false,
+    name: "Signal",
+    note: "待规划",
+    running: false,
+    slug: "signal",
+    status: "未接入",
+    summary: "补充型渠道位",
+  },
+];
+
+function createWrapper(initialEntries: string[]) {
+  return function Wrapper({ children }: PropsWithChildren) {
+    return <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>;
+  };
+}
+
+describe("useChannelsConsole", () => {
+  it("defaults to the first visible channel", () => {
+    const { result } = renderHook(() => useChannelsConsole(channels), {
+      wrapper: createWrapper(["/channels"]),
+    });
+
+    expect(result.current.filter).toBe("all");
+    expect(result.current.selectedSlug).toBe("wechat");
+    expect(result.current.filteredChannels.map((channel) => channel.slug)).toEqual(["wechat", "signal"]);
+  });
+
+  it("filters by enabled channels and resets selection", () => {
+    const { result } = renderHook(() => useChannelsConsole(channels), {
+      wrapper: createWrapper(["/channels?selected=signal"]),
+    });
+
+    expect(result.current.selectedSlug).toBe("signal");
+
+    act(() => {
+      result.current.setFilter("enabled");
+    });
+
+    expect(result.current.filteredChannels.map((channel) => channel.slug)).toEqual(["wechat"]);
+    expect(result.current.selectedSlug).toBe("wechat");
+  });
+
+  it("filters channels by the search query", () => {
+    const { result } = renderHook(() => useChannelsConsole(channels), {
+      wrapper: createWrapper(["/channels"]),
+    });
+
+    act(() => {
+      result.current.setQuery("signal");
+    });
+
+    expect(result.current.filteredChannels.map((channel) => channel.slug)).toEqual(["signal"]);
+    expect(result.current.selectedSlug).toBe("signal");
+  });
+});

--- a/ui/src/features/channels/useChannelsConsole.ts
+++ b/ui/src/features/channels/useChannelsConsole.ts
@@ -1,0 +1,87 @@
+import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import type { ChannelRecord } from "@/features/workspace/useWorkspaceOverview";
+
+export type ChannelsFilter = "all" | "enabled" | "planned";
+
+function normalizeFilter(value: string | null): ChannelsFilter {
+  if (value === "enabled") return "enabled";
+  if (value === "planned") return "planned";
+  return "all";
+}
+
+function matchesQuery(query: string, fields: string[]) {
+  if (query === "") return true;
+  return fields.join(" ").toLowerCase().includes(query.toLowerCase());
+}
+
+function matchesFilter(filter: ChannelsFilter, channel: ChannelRecord) {
+  const enabled = channel.enabled || channel.running;
+
+  if (filter === "enabled") return enabled;
+  if (filter === "planned") return !enabled;
+  return true;
+}
+
+export function useChannelsConsole(channels: ChannelRecord[]) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const filter = normalizeFilter(searchParams.get("status"));
+  const query = (searchParams.get("q") ?? "").trim();
+
+  const filteredChannels = useMemo(
+    () =>
+      channels.filter(
+        (channel) =>
+          matchesFilter(filter, channel) &&
+          matchesQuery(query, [channel.name, channel.slug, channel.summary, channel.note, channel.status]),
+      ),
+    [channels, filter, query],
+  );
+
+  const selectedParam = searchParams.get("selected");
+  const selectedChannel =
+    filteredChannels.find((channel) => channel.slug === selectedParam) ?? filteredChannels[0] ?? null;
+
+  function patchParams(
+    patch: Partial<{
+      q: string;
+      selected: string | null;
+      status: ChannelsFilter;
+    }>,
+  ) {
+    const next = new URLSearchParams(searchParams);
+
+    if (patch.status !== undefined) {
+      if (patch.status === "all") next.delete("status");
+      else next.set("status", patch.status);
+      next.delete("selected");
+    }
+
+    if (patch.q !== undefined) {
+      const value = patch.q.trim();
+      if (value === "") next.delete("q");
+      else next.set("q", value);
+      next.delete("selected");
+    }
+
+    if (patch.selected !== undefined) {
+      if (patch.selected) next.set("selected", patch.selected);
+      else next.delete("selected");
+    }
+
+    setSearchParams(next, { replace: true });
+  }
+
+  return {
+    filter,
+    filteredChannels,
+    query,
+    selectedChannel,
+    selectedSlug: selectedChannel?.slug ?? null,
+    setFilter: (nextFilter: ChannelsFilter) => patchParams({ status: nextFilter }),
+    setQuery: (nextQuery: string) => patchParams({ q: nextQuery }),
+    setSelected: (nextSelected: string | null) => patchParams({ selected: nextSelected }),
+  };
+}

--- a/ui/src/features/left-rail/LeftRail.test.tsx
+++ b/ui/src/features/left-rail/LeftRail.test.tsx
@@ -44,6 +44,7 @@ describe("LeftRail", () => {
     expect(screen.getByRole("link", { name: "市场" })).toHaveAttribute("aria-current", "page");
     expect(screen.getByRole("link", { name: "总览" })).not.toHaveAttribute("aria-current", "page");
     expect(screen.getByRole("link", { name: "对话" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "渠道" })).toBeInTheDocument();
     expect(screen.getByText("B")).toBeInTheDocument();
   });
 
@@ -61,5 +62,12 @@ describe("LeftRail", () => {
 
     expect(screen.getByRole("link", { name: "对话" })).toHaveAttribute("aria-current", "page");
     expect(screen.getByRole("link", { name: "总览" })).not.toHaveAttribute("aria-current", "page");
+  });
+
+  it("marks the channels entry active on the channels route", () => {
+    render(<LeftRail />, { wrapper: createWrapper(["/channels"]) });
+
+    expect(screen.getByRole("link", { name: "渠道" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "市场" })).not.toHaveAttribute("aria-current", "page");
   });
 });

--- a/ui/src/features/left-rail/LeftRail.tsx
+++ b/ui/src/features/left-rail/LeftRail.tsx
@@ -1,4 +1,4 @@
-import { Compass, LayoutDashboard, MessageSquare, Settings, Store, Wrench } from "lucide-react";
+import { Cable, Compass, LayoutDashboard, MessageSquare, Settings, Store, Wrench } from "lucide-react";
 import { NavLink } from "react-router-dom";
 
 import { useShellStore } from "@/features/shell/useShellStore";
@@ -7,6 +7,7 @@ import { useWorkspaceOverview } from "@/features/workspace/useWorkspaceOverview"
 const navItems = [
   { icon: MessageSquare, label: "对话", to: "/" },
   { icon: LayoutDashboard, label: "总览", to: "/workspace" },
+  { icon: Cable, label: "渠道", to: "/channels" },
   { icon: Store, label: "市场", to: "/market" },
   { icon: Compass, label: "发现", to: "/discovery" },
   { icon: Wrench, label: "工作台", to: "/studio" },

--- a/ui/src/pages/Channels/ChannelsPage.test.tsx
+++ b/ui/src/pages/Channels/ChannelsPage.test.tsx
@@ -83,4 +83,16 @@ describe("ChannelsPage", () => {
 
     expect(screen.getByTestId("channels-control-console")).toHaveTextContent("signal");
   });
+
+  it("keeps the planned summary aligned with the planned filter logic", () => {
+    render(
+      <MemoryRouter initialEntries={["/channels"]}>
+        <ChannelsPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "待接入" })[0]);
+
+    expect(screen.getByTestId("channels-control-console")).toHaveTextContent("signal");
+  });
 });

--- a/ui/src/pages/Channels/ChannelsPage.test.tsx
+++ b/ui/src/pages/Channels/ChannelsPage.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useWorkspaceOverview } from "@/features/workspace/useWorkspaceOverview";
+
+import { ChannelsPage } from "./ChannelsPage";
+
+vi.mock("@/features/workspace/useWorkspaceOverview", () => ({
+  useWorkspaceOverview: vi.fn(),
+}));
+
+vi.mock("@/features/channels/ChannelsControlConsole", () => ({
+  ChannelsControlConsole: ({ selectedChannel }: { selectedChannel: { slug?: string } | null }) => (
+    <div data-testid="channels-control-console">{selectedChannel?.slug ?? "none"}</div>
+  ),
+}));
+
+const useWorkspaceOverviewMock = vi.mocked(useWorkspaceOverview);
+
+describe("ChannelsPage", () => {
+  beforeEach(() => {
+    useWorkspaceOverviewMock.mockReturnValue({
+      data: {
+        channelSettings: [
+          { hint: "默认拒绝私信", label: "安全策略", value: "提及门已开启" },
+          { hint: "当前优先渠道数", label: "优先接入", value: "微信、飞书" },
+        ],
+        extensionAdapters: ["wechat-adapter", "discord-adapter"],
+        meta: {
+          liveConnected: true,
+          sourceLabel: "网关叠加",
+        },
+        priorityChannels: [
+          {
+            configured: true,
+            enabled: true,
+            healthy: true,
+            name: "微信",
+            note: "优先承接私域服务",
+            running: true,
+            slug: "wechat",
+            status: "运行中",
+            summary: "适合作为核心渠道入口",
+          },
+          {
+            configured: false,
+            enabled: false,
+            healthy: false,
+            name: "Signal",
+            note: "补充型渠道位",
+            running: false,
+            slug: "signal",
+            status: "未接入",
+            summary: "适合补充型渠道接入",
+          },
+        ],
+      },
+    } as never);
+  });
+
+  it("renders channels overview and control console", () => {
+    render(
+      <MemoryRouter initialEntries={["/channels"]}>
+        <ChannelsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: "渠道" })).toBeInTheDocument();
+    expect(screen.getByText("优先渠道表")).toBeInTheDocument();
+    expect(screen.getAllByText("微信").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("channels-control-console")).toHaveTextContent("wechat");
+  });
+
+  it("updates the selected channel from the table action", () => {
+    render(
+      <MemoryRouter initialEntries={["/channels"]}>
+        <ChannelsPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "规划接入" })[1]);
+
+    expect(screen.getByTestId("channels-control-console")).toHaveTextContent("signal");
+  });
+});

--- a/ui/src/pages/Channels/ChannelsPage.tsx
+++ b/ui/src/pages/Channels/ChannelsPage.tsx
@@ -55,7 +55,7 @@ export function ChannelsPage() {
 
   const enabledCount = data.priorityChannels.filter((channel) => channel.enabled || channel.running).length;
   const configuredCount = data.priorityChannels.filter((channel) => channel.configured).length;
-  const plannedCount = data.priorityChannels.length - configuredCount;
+  const plannedCount = data.priorityChannels.filter((channel) => !channel.enabled && !channel.running).length;
 
   const filteredSettings = useMemo(
     () => data.channelSettings.filter((item) => matchesQuery(query, [item.label, item.value, item.hint])),

--- a/ui/src/pages/Channels/ChannelsPage.tsx
+++ b/ui/src/pages/Channels/ChannelsPage.tsx
@@ -1,0 +1,513 @@
+import { Cable, MessageSquare, ShieldCheck, Waypoints } from "lucide-react";
+import { useMemo } from "react";
+import type { KeyboardEvent } from "react";
+
+import { BackendDetailSection } from "@/features/backend-ui/BackendDetailSection";
+import { BackendEmptyState } from "@/features/backend-ui/BackendEmptyState";
+import { BackendPageHeader } from "@/features/backend-ui/BackendPageHeader";
+import { BackendPropertyList } from "@/features/backend-ui/BackendPropertyList";
+import { BackendSectionHeader } from "@/features/backend-ui/BackendSectionHeader";
+import { BackendSummaryStrip } from "@/features/backend-ui/BackendSummaryStrip";
+import { BackendToolbar } from "@/features/backend-ui/BackendToolbar";
+import { getStatusTone } from "@/features/backend-ui/getStatusTone";
+import { StatusBadge } from "@/features/backend-ui/StatusBadge";
+import { ChannelsControlConsole } from "@/features/channels/ChannelsControlConsole";
+import { useChannelsConsole } from "@/features/channels/useChannelsConsole";
+import { useWorkspaceOverview } from "@/features/workspace/useWorkspaceOverview";
+import type { ChannelRecord } from "@/features/workspace/useWorkspaceOverview";
+
+function matchesQuery(query: string, fields: string[]) {
+  const normalized = query.trim().toLowerCase();
+  if (normalized === "") return true;
+
+  return fields.join(" ").toLowerCase().includes(normalized);
+}
+
+function rowKeyHandler(event: KeyboardEvent<HTMLElement>, onSelect: () => void) {
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    onSelect();
+  }
+}
+
+function scrollToSection(id: string) {
+  document.getElementById(id)?.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+function getChannelActionLabel(channel: ChannelRecord) {
+  if (channel.running && channel.healthy) return "查看运行";
+  if (channel.enabled) return "继续联调";
+  if (channel.configured) return "完成启用";
+  return "规划接入";
+}
+
+function getChannelNextStep(channel: ChannelRecord) {
+  if (channel.running && channel.healthy) return "继续观察运行数据";
+  if (channel.enabled) return "补齐联调与健康检查";
+  if (channel.configured) return "进入启用与验证阶段";
+  return "先完成接入规划与配置";
+}
+
+export function ChannelsPage() {
+  const { data } = useWorkspaceOverview();
+  const { filter, filteredChannels, query, selectedChannel, selectedSlug, setFilter, setQuery, setSelected } =
+    useChannelsConsole(data.priorityChannels);
+
+  const enabledCount = data.priorityChannels.filter((channel) => channel.enabled || channel.running).length;
+  const configuredCount = data.priorityChannels.filter((channel) => channel.configured).length;
+  const plannedCount = data.priorityChannels.length - configuredCount;
+
+  const filteredSettings = useMemo(
+    () => data.channelSettings.filter((item) => matchesQuery(query, [item.label, item.value, item.hint])),
+    [data.channelSettings, query],
+  );
+
+  const filteredAdapters = useMemo(
+    () => data.extensionAdapters.filter((adapter) => matchesQuery(query, [adapter])),
+    [data.extensionAdapters, query],
+  );
+
+  const detailPanel = selectedChannel ? (
+    <div className="space-y-4">
+      <BackendDetailSection title="渠道详情">
+        <div className="flex items-start gap-4">
+          <span className="flex h-14 w-14 shrink-0 items-center justify-center rounded-[18px] bg-[#f3f6fb] text-[#607699]">
+            <MessageSquare size={22} strokeWidth={2.1} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-[24px] font-semibold tracking-[-0.04em] text-ink">{selectedChannel.name}</h3>
+              <StatusBadge label={selectedChannel.status} tone={getStatusTone(selectedChannel.status)} />
+            </div>
+            <div className="mt-2 text-sm text-[#607699]">{selectedChannel.slug}</div>
+            <p className="mt-3 text-sm leading-7 text-mute">{selectedChannel.summary}</p>
+          </div>
+        </div>
+      </BackendDetailSection>
+
+      <BackendDetailSection title="运行状态">
+        <BackendPropertyList
+          items={[
+            { label: "渠道标识", value: selectedChannel.slug },
+            { label: "已配置", value: selectedChannel.configured ? "是" : "否" },
+            { label: "已启用", value: selectedChannel.enabled ? "是" : "否" },
+            { label: "运行中", value: selectedChannel.running ? "是" : "否" },
+            {
+              label: "健康状态",
+              value: selectedChannel.healthy ? "健康" : selectedChannel.enabled ? "待联调" : "未检查",
+            },
+          ]}
+        />
+      </BackendDetailSection>
+
+      <BackendDetailSection title="备注与下一步">
+        <p className="text-sm leading-7 text-mute">{selectedChannel.note}</p>
+
+        <div className="mt-4">
+          <BackendSummaryStrip
+            items={[
+              {
+                active: true,
+                label: "建议动作",
+                value: getChannelActionLabel(selectedChannel),
+              },
+              {
+                label: "下一步",
+                value: getChannelNextStep(selectedChannel),
+              },
+              {
+                label: "接入策略",
+                onClick: () => scrollToSection("channel-strategy-section"),
+                value: "跳转查看",
+              },
+              {
+                label: "渠道控制台",
+                onClick: () => scrollToSection("channel-control-section"),
+                value: "真实接口",
+              },
+              {
+                label: "扩展适配器",
+                onClick: () => scrollToSection("channel-adapters-section"),
+                value: "跳转查看",
+              },
+            ]}
+          />
+        </div>
+      </BackendDetailSection>
+    </div>
+  ) : (
+    <BackendEmptyState icon={Waypoints} title="等待选择" />
+  );
+
+  return (
+    <div className="relative z-10 flex min-h-full flex-1 flex-col px-5 py-5 sm:px-6 lg:px-8 lg:py-7">
+      <BackendPageHeader
+        icon={Waypoints}
+        sectionLabel="Channels"
+        sourceLabel={data.meta.sourceLabel}
+        stats={[
+          { label: "优先渠道", value: String(data.priorityChannels.length) },
+          { label: "当前启用", value: String(enabledCount) },
+          { label: "扩展适配器", value: String(data.extensionAdapters.length) },
+          { label: "数据来源", value: data.meta.liveConnected ? "网关叠加" : "仓库快照" },
+        ]}
+        title="渠道"
+      />
+
+      <BackendToolbar
+        groups={[
+          {
+            items: [
+              { active: filter === "all", label: "全部", onClick: () => setFilter("all") },
+              { active: filter === "enabled", label: "已启用", onClick: () => setFilter("enabled") },
+              { active: filter === "planned", label: "待接入", onClick: () => setFilter("planned") },
+            ],
+          },
+        ]}
+        onSearchChange={setQuery}
+        searchPlaceholder="搜索渠道、状态、配置项或适配器"
+        searchValue={query}
+      />
+
+      <section className="mt-6" id="channel-priority-section">
+        <BackendSectionHeader countLabel={`${filteredChannels.length} rows`} title="优先渠道表" />
+
+        <div className="mt-4">
+          <BackendSummaryStrip
+            items={[
+              {
+                active: filter === "enabled",
+                label: "已启用",
+                value: `${enabledCount} 个`,
+              },
+              {
+                label: "已配置",
+                value: `${configuredCount} 个`,
+              },
+              {
+                active: filter === "planned",
+                label: "待接入",
+                value: `${plannedCount} 个`,
+              },
+              {
+                label: "接入策略",
+                onClick: () => scrollToSection("channel-strategy-section"),
+                value: "跳到策略表",
+              },
+              {
+                label: "渠道控制台",
+                onClick: () => scrollToSection("channel-control-section"),
+                value: "跳到控制台",
+              },
+              {
+                label: "适配器",
+                onClick: () => scrollToSection("channel-adapters-section"),
+                value: "跳到适配器表",
+              },
+            ]}
+          />
+        </div>
+
+        {filteredChannels.length > 0 ? (
+          <div className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1fr)_360px]">
+            <div className="overflow-hidden rounded-[18px] border border-skin bg-white">
+              <div className="hidden border-b border-skin bg-[#fafbfd] lg:block">
+                <table className="w-full table-fixed border-collapse">
+                  <thead>
+                    <tr className="text-left">
+                      <th className="w-[220px] px-5 py-4 text-xs font-medium uppercase tracking-[0.18em] text-[#98a2b3]">
+                        渠道
+                      </th>
+                      <th className="px-4 py-4 text-xs font-medium uppercase tracking-[0.18em] text-[#98a2b3]">
+                        接入定位
+                      </th>
+                      <th className="w-[140px] px-4 py-4 text-xs font-medium uppercase tracking-[0.18em] text-[#98a2b3]">
+                        状态
+                      </th>
+                      <th className="w-[220px] px-4 py-4 text-xs font-medium uppercase tracking-[0.18em] text-[#98a2b3]">
+                        备注
+                      </th>
+                      <th className="w-[110px] px-4 py-4 text-right text-xs font-medium uppercase tracking-[0.18em] text-[#98a2b3]">
+                        操作
+                      </th>
+                    </tr>
+                  </thead>
+                </table>
+              </div>
+
+              <div className="hidden lg:block">
+                <table className="w-full table-fixed border-collapse">
+                  <tbody>
+                    {filteredChannels.map((channel) => {
+                      const active = selectedSlug === channel.slug;
+
+                      return (
+                        <tr
+                          key={channel.slug}
+                          aria-selected={active}
+                          className={[
+                            "cursor-pointer border-b border-skin align-top transition-colors duration-150 last:border-b-0",
+                            active ? "bg-[#f7faff]" : "hover:bg-[#fbfcfe]",
+                          ].join(" ")}
+                          onClick={() => setSelected(channel.slug)}
+                          onKeyDown={(event) => rowKeyHandler(event, () => setSelected(channel.slug))}
+                          role="button"
+                          tabIndex={0}
+                        >
+                          <td className="px-5 py-4">
+                            <div className="flex items-start gap-4">
+                              <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-[14px] bg-[#f3f6fb] text-[#607699]">
+                                <MessageSquare size={17} strokeWidth={2.1} />
+                              </span>
+                              <div>
+                                <div className="text-[18px] font-semibold tracking-[-0.02em] text-ink">
+                                  {channel.name}
+                                </div>
+                                <div className="mt-1 text-sm text-[#607699]">{channel.slug}</div>
+                              </div>
+                            </div>
+                          </td>
+                          <td className="px-4 py-4 text-sm leading-7 text-mute">{channel.summary}</td>
+                          <td className="px-4 py-4">
+                            <StatusBadge label={channel.status} tone={getStatusTone(channel.status)} />
+                          </td>
+                          <td className="px-4 py-4 text-sm leading-7 text-mute">{channel.note}</td>
+                          <td className="px-4 py-4 text-right">
+                            <button
+                              className={[
+                                "rounded-[10px] px-3 py-2 text-sm font-medium transition-colors duration-150",
+                                active
+                                  ? "bg-[#1f2430] text-white"
+                                  : "bg-[#f5f7fb] text-[#5b6f8b] hover:bg-[#edf2fa] hover:text-ink",
+                              ].join(" ")}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                setSelected(channel.slug);
+                              }}
+                              type="button"
+                            >
+                              {getChannelActionLabel(channel)}
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="lg:hidden">
+                {filteredChannels.map((channel) => {
+                  const active = selectedSlug === channel.slug;
+
+                  return (
+                    <article
+                      key={channel.slug}
+                      className={["border-b border-skin px-4 py-4 last:border-b-0", active ? "bg-[#f7faff]" : ""].join(
+                        " ",
+                      )}
+                    >
+                      <div className="flex items-start gap-4">
+                        <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-[14px] bg-[#f3f6fb] text-[#607699]">
+                          <MessageSquare size={17} strokeWidth={2.1} />
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-start justify-between gap-3">
+                            <div>
+                              <div className="text-[18px] font-semibold tracking-[-0.02em] text-ink">
+                                {channel.name}
+                              </div>
+                              <div className="mt-1 text-sm text-[#607699]">{channel.slug}</div>
+                            </div>
+                            <button
+                              className={[
+                                "rounded-[10px] px-3 py-2 text-sm font-medium transition-colors duration-150",
+                                active
+                                  ? "bg-[#1f2430] text-white"
+                                  : "bg-[#f5f7fb] text-[#5b6f8b] hover:bg-[#edf2fa] hover:text-ink",
+                              ].join(" ")}
+                              onClick={() => setSelected(channel.slug)}
+                              type="button"
+                            >
+                              {getChannelActionLabel(channel)}
+                            </button>
+                          </div>
+                          <p className="mt-3 text-sm leading-7 text-mute">{channel.summary}</p>
+                          <div className="mt-3">
+                            <StatusBadge label={channel.status} tone={getStatusTone(channel.status)} />
+                          </div>
+                          <p className="mt-3 text-sm leading-7 text-mute">{channel.note}</p>
+                        </div>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            </div>
+
+            <aside className="hidden xl:block">
+              <div className="sticky top-6">{detailPanel}</div>
+            </aside>
+          </div>
+        ) : (
+          <div className="mt-5">
+            <BackendEmptyState icon={Waypoints} title="没有匹配渠道" />
+          </div>
+        )}
+
+        {filteredChannels.length > 0 ? <div className="mt-5 xl:hidden">{detailPanel}</div> : null}
+      </section>
+
+      <section className="mt-6" id="channel-control-section">
+        <BackendSectionHeader
+          countLabel={selectedChannel ? selectedChannel.slug : "select a channel"}
+          title="渠道控制台"
+        />
+
+        <div className="mt-5">
+          <ChannelsControlConsole selectedChannel={selectedChannel} />
+        </div>
+      </section>
+
+      <section className="mt-6" id="channel-strategy-section">
+        <BackendSectionHeader countLabel={`${filteredSettings.length} rows`} title="接入策略表" />
+
+        {filteredSettings.length > 0 ? (
+          <div className="mt-5 overflow-hidden rounded-[18px] border border-skin bg-white">
+            <div className="hidden border-b border-skin bg-[#fafbfd] lg:block">
+              <table className="w-full table-fixed border-collapse">
+                <thead>
+                  <tr className="text-left">
+                    <th className="w-[220px] px-5 py-4 text-xs font-medium uppercase tracking-[0.18em] text-[#98a2b3]">
+                      项目
+                    </th>
+                    <th className="w-[240px] px-4 py-4 text-xs font-medium uppercase tracking-[0.18em] text-[#98a2b3]">
+                      当前值
+                    </th>
+                    <th className="px-4 py-4 text-xs font-medium uppercase tracking-[0.18em] text-[#98a2b3]">
+                      说明
+                    </th>
+                  </tr>
+                </thead>
+              </table>
+            </div>
+
+            <div className="hidden lg:block">
+              <table className="w-full table-fixed border-collapse">
+                <tbody>
+                  {filteredSettings.map((item) => (
+                    <tr
+                      key={item.label}
+                      className="border-b border-skin align-top transition-colors duration-150 last:border-b-0 hover:bg-[#fbfcfe]"
+                    >
+                      <td className="px-5 py-4">
+                        <div className="flex items-center gap-3 text-[16px] font-semibold text-ink">
+                          <ShieldCheck size={16} strokeWidth={2.1} className="text-[#607699]" />
+                          {item.label}
+                        </div>
+                      </td>
+                      <td className="px-4 py-4 text-sm text-[#607699]">{item.value}</td>
+                      <td className="px-4 py-4 text-sm leading-7 text-mute">{item.hint}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="lg:hidden">
+              {filteredSettings.map((item) => (
+                <article key={item.label} className="border-b border-skin px-4 py-4 last:border-b-0">
+                  <div className="flex items-center gap-3 text-[16px] font-semibold text-ink">
+                    <ShieldCheck size={16} strokeWidth={2.1} className="text-[#607699]" />
+                    {item.label}
+                  </div>
+                  <div className="mt-2 text-sm text-[#607699]">{item.value}</div>
+                  <p className="mt-3 text-sm leading-7 text-mute">{item.hint}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="mt-5">
+            <BackendEmptyState icon={ShieldCheck} title="没有匹配策略" />
+          </div>
+        )}
+      </section>
+
+      <section className="mt-6" id="channel-adapters-section">
+        <BackendSectionHeader countLabel={`${filteredAdapters.length} rows`} title="扩展适配器表" />
+
+        {filteredAdapters.length > 0 ? (
+          <div className="mt-5 overflow-hidden rounded-[18px] border border-skin bg-white">
+            <div className="hidden border-b border-skin bg-[#fafbfd] lg:block">
+              <table className="w-full table-fixed border-collapse">
+                <thead>
+                  <tr className="text-left">
+                    <th className="w-[120px] px-5 py-4 text-xs font-medium uppercase tracking-[0.18em] text-[#98a2b3]">
+                      序号
+                    </th>
+                    <th className="px-4 py-4 text-xs font-medium uppercase tracking-[0.18em] text-[#98a2b3]">
+                      适配器
+                    </th>
+                    <th className="w-[180px] px-4 py-4 text-xs font-medium uppercase tracking-[0.18em] text-[#98a2b3]">
+                      状态
+                    </th>
+                  </tr>
+                </thead>
+              </table>
+            </div>
+
+            <div className="hidden lg:block">
+              <table className="w-full table-fixed border-collapse">
+                <tbody>
+                  {filteredAdapters.map((adapter, index) => (
+                    <tr
+                      key={adapter}
+                      className="border-b border-skin align-top transition-colors duration-150 last:border-b-0 hover:bg-[#fbfcfe]"
+                    >
+                      <td className="px-5 py-4 text-sm text-[#64748b]">{String(index + 1).padStart(2, "0")}</td>
+                      <td className="px-4 py-4">
+                        <div className="flex items-center gap-3">
+                          <span className="flex h-9 w-9 items-center justify-center rounded-[14px] bg-[#f3f6fb] text-[#607699]">
+                            <Cable size={16} strokeWidth={2.1} />
+                          </span>
+                          <span className="text-[16px] font-medium text-ink">{adapter}</span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-4">
+                        <StatusBadge label="已识别" tone="info" />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="lg:hidden">
+              {filteredAdapters.map((adapter, index) => (
+                <article key={adapter} className="border-b border-skin px-4 py-4 last:border-b-0">
+                  <div className="flex items-center gap-3">
+                    <span className="flex h-9 w-9 items-center justify-center rounded-[14px] bg-[#f3f6fb] text-[#607699]">
+                      <Cable size={16} strokeWidth={2.1} />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="text-[16px] font-medium text-ink">{adapter}</div>
+                      <div className="mt-2 flex items-center gap-3 text-sm text-[#64748b]">
+                        <span>#{String(index + 1).padStart(2, "0")}</span>
+                        <StatusBadge label="已识别" tone="info" />
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="mt-5">
+            <BackendEmptyState icon={Cable} title="没有匹配适配器" />
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -108,6 +108,7 @@ export default defineConfig({
     host: "127.0.0.1",
     port: 4173,
     proxy: {
+      "/channel": apiTarget,
       "/approvals": apiTarget,
       "/agents": apiTarget,
       "/channels": apiTarget,


### PR DESCRIPTION
## 变更内容
- 新增 channels 页面与渠道总览表
- 新增渠道控制台，接入适配器状态、提及门、设备配对、在线状态、联系人信息
- 新增 channels 筛选与查询逻辑
- 在路由和左侧导航中接入 /channels
- 补充 /channel 开发代理配置
- 补充 channels 页面、控制台、筛选逻辑与接口处理相关测试
- 优化 channel 接口错误解析，避免纯文本错误响应导致解析异常

## 验证
- tsc --noEmit -p tsconfig.json
- tsc --noEmit -p tsconfig.node.json
- vitest run
- vite build