### PR TITLE
feat(embedding): add standalone embedding

### DIFF
--- a/pkg/embedding/baidu.go
+++ b/pkg/embedding/baidu.go
@@ -1,0 +1,157 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type BaiduProvider struct {
+	apiKey      string
+	secretKey   string
+	accessToken string
+	model       string
+	dimension   int
+	httpClient  *http.Client
+	tokenExpiry time.Time
+}
+
+type BaiduOption func(*BaiduProvider)
+
+func WithBaiduModel(model string) BaiduOption {
+	return func(p *BaiduProvider) { p.model = model }
+}
+
+func WithBaiduSecretKey(secret string) BaiduOption {
+	return func(p *BaiduProvider) { p.secretKey = secret }
+}
+
+func NewBaiduProvider(apiKey string, opts ...BaiduOption) (*BaiduProvider, error) {
+	p := &BaiduProvider{
+		apiKey:     apiKey,
+		model:      "embedding-v1",
+		dimension:  384,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	if p.apiKey == "" {
+		return nil, fmt.Errorf("baidu: api key is required")
+	}
+	return p, nil
+}
+
+func (p *BaiduProvider) Name() string   { return "baidu" }
+func (p *BaiduProvider) Dimension() int { return p.dimension }
+
+func (p *BaiduProvider) getAccessToken(ctx context.Context) (string, error) {
+	if p.accessToken != "" && time.Now().Before(p.tokenExpiry) {
+		return p.accessToken, nil
+	}
+
+	url := fmt.Sprintf("https://aip.baidubce.com/oauth/2.0/token?grant_type=client_credentials&client_id=%s&client_secret=%s",
+		p.apiKey, p.secretKey)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("baidu: create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("baidu: token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("baidu: token error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("baidu: parse token response: %w", err)
+	}
+
+	p.accessToken = result.AccessToken
+	p.tokenExpiry = time.Now().Add(time.Duration(result.ExpiresIn-300) * time.Second)
+	return p.accessToken, nil
+}
+
+func (p *BaiduProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	results, err := p.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("baidu: no embedding returned")
+	}
+	return results[0], nil
+}
+
+func (p *BaiduProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	token, err := p.getAccessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := map[string]any{
+		"input": texts,
+	}
+	body, _ := json.Marshal(payload)
+
+	modelPath := p.model
+	if strings.HasPrefix(p.model, "bge-large-zh") {
+		modelPath = "bge_large_zh"
+	}
+
+	url := fmt.Sprintf("https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/embeddings/%s?access_token=%s",
+		modelPath, token)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("baidu: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("baidu: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("baidu: API error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Data []struct {
+			Index     int       `json:"index"`
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("baidu: parse response: %w", err)
+	}
+
+	embeddings := make([][]float32, len(result.Data))
+	for _, d := range result.Data {
+		embeddings[d.Index] = d.Embedding
+	}
+	return embeddings, nil
+}

--- a/pkg/embedding/baidu.go
+++ b/pkg/embedding/baidu.go
@@ -44,6 +44,9 @@ func NewBaiduProvider(apiKey string, opts ...BaiduOption) (*BaiduProvider, error
 	if p.apiKey == "" {
 		return nil, fmt.Errorf("baidu: api key is required")
 	}
+	if p.secretKey == "" {
+		return nil, fmt.Errorf("baidu: secret key is required")
+	}
 	return p, nil
 }
 

--- a/pkg/embedding/batch.go
+++ b/pkg/embedding/batch.go
@@ -1,0 +1,372 @@
+package embedding
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type BatchConfig struct {
+	ChunkSize       int
+	Concurrency     int
+	MaxRetries      int
+	RetryDelay      time.Duration
+	RateLimitPerSec int
+	Timeout         time.Duration
+	ProgressFunc    func(progress BatchProgress)
+}
+
+func DefaultBatchConfig() BatchConfig {
+	return BatchConfig{
+		ChunkSize:       100,
+		Concurrency:     4,
+		MaxRetries:      3,
+		RetryDelay:      1 * time.Second,
+		RateLimitPerSec: 0,
+		Timeout:         5 * time.Minute,
+	}
+}
+
+type BatchProgress struct {
+	Total     int
+	Processed int
+	Succeeded int
+	Failed    int
+	Elapsed   time.Duration
+	ETA       time.Duration
+	Rate      float64
+	Current   int
+	Message   string
+	Done      bool
+}
+
+type BatchResult struct {
+	Embeddings [][]float32
+	Errors     []BatchError
+	Total      int
+	Succeeded  int
+	Failed     int
+	Duration   time.Duration
+}
+
+type BatchError struct {
+	Index int
+	Text  string
+	Err   error
+}
+
+type BatchProcessor struct {
+	manager *Manager
+	cfg     BatchConfig
+}
+
+func (bp *BatchProcessor) Manager() *Manager   { return bp.manager }
+func (bp *BatchProcessor) Config() BatchConfig { return bp.cfg }
+
+func NewBatchProcessor(manager *Manager, cfg BatchConfig) *BatchProcessor {
+	if cfg.ChunkSize <= 0 {
+		cfg.ChunkSize = 100
+	}
+	if cfg.Concurrency <= 0 {
+		cfg.Concurrency = 4
+	}
+	if cfg.MaxRetries < 0 {
+		cfg.MaxRetries = 3
+	}
+	if cfg.RetryDelay <= 0 {
+		cfg.RetryDelay = 1 * time.Second
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 5 * time.Minute
+	}
+	return &BatchProcessor{
+		manager: manager,
+		cfg:     cfg,
+	}
+}
+
+func (bp *BatchProcessor) Process(ctx context.Context, texts []string) (*BatchResult, error) {
+	if len(texts) == 0 {
+		return &BatchResult{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, bp.cfg.Timeout)
+	defer cancel()
+
+	start := time.Now()
+	total := len(texts)
+	results := make([][]float32, total)
+	var errors []BatchError
+	var errorMu sync.Mutex
+
+	var processed atomic.Int32
+	var succeeded atomic.Int32
+	var failed atomic.Int32
+
+	sem := make(chan struct{}, bp.cfg.Concurrency)
+	var wg sync.WaitGroup
+
+	chunks := bp.splitChunks(texts)
+	for chunkIdx, chunk := range chunks {
+		for itemIdx, text := range chunk {
+			globalIdx := chunkIdx*bp.cfg.ChunkSize + itemIdx
+
+			if ctx.Err() != nil {
+				for i := globalIdx; i < total; i++ {
+					errorMu.Lock()
+					errors = append(errors, BatchError{
+						Index: i,
+						Text:  texts[i],
+						Err:   ctx.Err(),
+					})
+					errorMu.Unlock()
+					failed.Add(1)
+				}
+				goto done
+			}
+
+			sem <- struct{}{}
+			wg.Add(1)
+
+			go func(idx int, t string) {
+				defer wg.Done()
+				defer func() { <-sem }()
+
+				if bp.cfg.RateLimitPerSec > 0 {
+					time.Sleep(time.Duration(float64(time.Second) / float64(bp.cfg.RateLimitPerSec)))
+				}
+
+				emb, err := bp.processWithRetry(ctx, t)
+				if err != nil {
+					failed.Add(1)
+					errorMu.Lock()
+					errors = append(errors, BatchError{
+						Index: idx,
+						Text:  t,
+						Err:   err,
+					})
+					errorMu.Unlock()
+				} else {
+					results[idx] = emb
+					succeeded.Add(1)
+				}
+
+				p := processed.Add(1)
+				elapsed := time.Since(start)
+				rate := float64(p) / elapsed.Seconds()
+				remaining := total - int(p)
+				eta := time.Duration(float64(remaining)/rate) * time.Second
+
+				if bp.cfg.ProgressFunc != nil {
+					bp.cfg.ProgressFunc(BatchProgress{
+						Total:     total,
+						Processed: int(p),
+						Succeeded: int(succeeded.Load()),
+						Failed:    int(failed.Load()),
+						Elapsed:   elapsed,
+						ETA:       eta,
+						Rate:      rate,
+						Current:   idx,
+						Message:   fmt.Sprintf("processed %d/%d", p, total),
+					})
+				}
+			}(globalIdx, text)
+		}
+	}
+
+done:
+	wg.Wait()
+
+	duration := time.Since(start)
+
+	if bp.cfg.ProgressFunc != nil {
+		bp.cfg.ProgressFunc(BatchProgress{
+			Total:     total,
+			Processed: int(processed.Load()),
+			Succeeded: int(succeeded.Load()),
+			Failed:    int(failed.Load()),
+			Elapsed:   duration,
+			Done:      true,
+			Message:   fmt.Sprintf("completed: %d succeeded, %d failed", succeeded.Load(), failed.Load()),
+		})
+	}
+
+	return &BatchResult{
+		Embeddings: results,
+		Errors:     errors,
+		Total:      total,
+		Succeeded:  int(succeeded.Load()),
+		Failed:     int(failed.Load()),
+		Duration:   duration,
+	}, nil
+}
+
+func (bp *BatchProcessor) processWithRetry(ctx context.Context, text string) ([]float32, error) {
+	var lastErr error
+	for attempt := 0; attempt <= bp.cfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := bp.cfg.RetryDelay * time.Duration(attempt)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		emb, err := bp.manager.Embed(ctx, text)
+		if err == nil {
+			return emb, nil
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("after %d retries: %w", bp.cfg.MaxRetries, lastErr)
+}
+
+func (bp *BatchProcessor) splitChunks(texts []string) [][]string {
+	var chunks [][]string
+	for i := 0; i < len(texts); i += bp.cfg.ChunkSize {
+		end := i + bp.cfg.ChunkSize
+		if end > len(texts) {
+			end = len(texts)
+		}
+		chunks = append(chunks, texts[i:end])
+	}
+	return chunks
+}
+
+func (bp *BatchProcessor) ProcessWithProvider(ctx context.Context, texts []string, providerIdx int) (*BatchResult, error) {
+	if len(texts) == 0 {
+		return &BatchResult{}, nil
+	}
+
+	providers := bp.manager.Providers()
+	if providerIdx < 0 || providerIdx >= len(providers) {
+		return nil, fmt.Errorf("invalid provider index: %d", providerIdx)
+	}
+
+	provider := providers[providerIdx]
+	maxBatch := provider.Dimension()
+	if maxBatch == 0 {
+		maxBatch = 100
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, bp.cfg.Timeout)
+	defer cancel()
+
+	start := time.Now()
+	total := len(texts)
+	results := make([][]float32, total)
+	var errors []BatchError
+	var errorMu sync.Mutex
+
+	var processed atomic.Int32
+	var succeeded atomic.Int32
+	var failed atomic.Int32
+
+	for i := 0; i < total; i += bp.cfg.ChunkSize {
+		if ctx.Err() != nil {
+			for j := i; j < total; j++ {
+				errorMu.Lock()
+				errors = append(errors, BatchError{
+					Index: j,
+					Text:  texts[j],
+					Err:   ctx.Err(),
+				})
+				errorMu.Unlock()
+				failed.Add(1)
+			}
+			break
+		}
+
+		end := i + bp.cfg.ChunkSize
+		if end > total {
+			end = total
+		}
+		chunk := texts[i:end]
+
+		embeddings, err := provider.EmbedBatch(ctx, chunk)
+		if err != nil {
+			for j := i; j < end; j++ {
+				errorMu.Lock()
+				errors = append(errors, BatchError{
+					Index: j,
+					Text:  texts[j],
+					Err:   err,
+				})
+				errorMu.Unlock()
+				failed.Add(1)
+			}
+		} else {
+			for j, emb := range embeddings {
+				results[i+j] = emb
+			}
+			succeeded.Add(int32(len(embeddings)))
+		}
+
+		p := processed.Add(int32(end - i))
+		elapsed := time.Since(start)
+		rate := float64(p) / elapsed.Seconds()
+		remaining := total - int(p)
+		eta := time.Duration(float64(remaining)/rate) * time.Second
+
+		if bp.cfg.ProgressFunc != nil {
+			bp.cfg.ProgressFunc(BatchProgress{
+				Total:     total,
+				Processed: int(p),
+				Succeeded: int(succeeded.Load()),
+				Failed:    int(failed.Load()),
+				Elapsed:   elapsed,
+				ETA:       eta,
+				Rate:      rate,
+				Current:   end - 1,
+				Message:   fmt.Sprintf("processed %d/%d", p, total),
+			})
+		}
+	}
+
+	duration := time.Since(start)
+
+	if bp.cfg.ProgressFunc != nil {
+		bp.cfg.ProgressFunc(BatchProgress{
+			Total:     total,
+			Processed: int(processed.Load()),
+			Succeeded: int(succeeded.Load()),
+			Failed:    int(failed.Load()),
+			Elapsed:   duration,
+			Done:      true,
+			Message:   fmt.Sprintf("completed: %d succeeded, %d failed", succeeded.Load(), failed.Load()),
+		})
+	}
+
+	return &BatchResult{
+		Embeddings: results,
+		Errors:     errors,
+		Total:      total,
+		Succeeded:  int(succeeded.Load()),
+		Failed:     int(failed.Load()),
+		Duration:   duration,
+	}, nil
+}
+
+func (bp *BatchProcessor) EstimateCost(texts []string, providerIdx int) (tokens int, cost float64, err error) {
+	providers := bp.manager.Providers()
+	if providerIdx < 0 || providerIdx >= len(providers) {
+		return 0, 0, fmt.Errorf("invalid provider index: %d", providerIdx)
+	}
+
+	provider := providers[providerIdx]
+	_ = provider
+
+	totalTokens := 0
+	for _, text := range texts {
+		tokens := len(text) / 4
+		if tokens < 1 {
+			tokens = 1
+		}
+		totalTokens += tokens
+	}
+
+	return totalTokens, 0, nil
+}

--- a/pkg/embedding/batch.go
+++ b/pkg/embedding/batch.go
@@ -299,10 +299,23 @@ func (bp *BatchProcessor) ProcessWithProvider(ctx context.Context, texts []strin
 				failed.Add(1)
 			}
 		} else {
-			for j, emb := range embeddings {
-				results[i+j] = emb
+			if err := validateBatchEmbeddings(provider, chunk, embeddings); err != nil {
+				for j := i; j < end; j++ {
+					errorMu.Lock()
+					errors = append(errors, BatchError{
+						Index: j,
+						Text:  texts[j],
+						Err:   err,
+					})
+					errorMu.Unlock()
+					failed.Add(1)
+				}
+			} else {
+				for j, emb := range embeddings {
+					results[i+j] = emb
+				}
+				succeeded.Add(int32(len(embeddings)))
 			}
-			succeeded.Add(int32(len(embeddings)))
 		}
 
 		p := processed.Add(int32(end - i))
@@ -348,6 +361,29 @@ func (bp *BatchProcessor) ProcessWithProvider(ctx context.Context, texts []strin
 		Failed:     int(failed.Load()),
 		Duration:   duration,
 	}, nil
+}
+
+func validateBatchEmbeddings(provider Provider, texts []string, embeddings [][]float32) error {
+	if len(embeddings) != len(texts) {
+		return fmt.Errorf(
+			"embedding: provider %s returned %d embeddings for %d texts",
+			provider.Name(),
+			len(embeddings),
+			len(texts),
+		)
+	}
+
+	for i, embedding := range embeddings {
+		if embedding == nil {
+			return fmt.Errorf(
+				"embedding: provider %s returned nil embedding at index %d",
+				provider.Name(),
+				i,
+			)
+		}
+	}
+
+	return nil
 }
 
 func (bp *BatchProcessor) EstimateCost(texts []string, providerIdx int) (tokens int, cost float64, err error) {

--- a/pkg/embedding/batch_test.go
+++ b/pkg/embedding/batch_test.go
@@ -1,0 +1,276 @@
+package embedding
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBatchProcessorBasic(t *testing.T) {
+	provider := &mockProviderBatch{dim: 4}
+	mgr, _ := NewManager([]Provider{provider}, NewCache(1000, time.Hour))
+	bp := NewBatchProcessor(mgr, DefaultBatchConfig())
+
+	texts := make([]string, 10)
+	for i := range texts {
+		texts[i] = fmt.Sprintf("text %d", i)
+	}
+
+	ctx := context.Background()
+	result, err := bp.Process(ctx, texts)
+	if err != nil {
+		t.Fatalf("batch process: %v", err)
+	}
+
+	if result.Total != 10 {
+		t.Errorf("expected total 10, got %d", result.Total)
+	}
+	if result.Succeeded != 10 {
+		t.Errorf("expected succeeded 10, got %d", result.Succeeded)
+	}
+	if result.Failed != 0 {
+		t.Errorf("expected failed 0, got %d", result.Failed)
+	}
+	if len(result.Embeddings) != 10 {
+		t.Errorf("expected 10 embeddings, got %d", len(result.Embeddings))
+	}
+}
+
+func TestBatchProcessorEmpty(t *testing.T) {
+	provider := &mockProviderBatch{dim: 4}
+	mgr, _ := NewManager([]Provider{provider}, nil)
+	bp := NewBatchProcessor(mgr, DefaultBatchConfig())
+
+	ctx := context.Background()
+	result, err := bp.Process(ctx, []string{})
+	if err != nil {
+		t.Fatalf("batch process: %v", err)
+	}
+
+	if result.Total != 0 {
+		t.Errorf("expected total 0, got %d", result.Total)
+	}
+}
+
+func TestBatchProcessorPartialFailure(t *testing.T) {
+	provider := &mockProviderBatch{dim: 4, failIndices: map[int]bool{2: true, 5: true}}
+	mgr, _ := NewManager([]Provider{provider}, nil)
+	bp := NewBatchProcessor(mgr, BatchConfig{
+		ChunkSize:   5,
+		Concurrency: 2,
+		MaxRetries:  0,
+	})
+
+	texts := make([]string, 8)
+	for i := range texts {
+		texts[i] = fmt.Sprintf("text %d", i)
+	}
+
+	ctx := context.Background()
+	result, err := bp.Process(ctx, texts)
+	if err != nil {
+		t.Fatalf("batch process: %v", err)
+	}
+
+	if result.Succeeded != 6 {
+		t.Errorf("expected succeeded 6, got %d", result.Succeeded)
+	}
+	if result.Failed != 2 {
+		t.Errorf("expected failed 2, got %d", result.Failed)
+	}
+	if len(result.Errors) != 2 {
+		t.Errorf("expected 2 errors, got %d", len(result.Errors))
+	}
+}
+
+func TestBatchProcessorProgress(t *testing.T) {
+	provider := &mockProviderBatch{dim: 4}
+	mgr, _ := NewManager([]Provider{provider}, nil)
+
+	var progressCount atomic.Int32
+	bp := NewBatchProcessor(mgr, BatchConfig{
+		ChunkSize:   5,
+		Concurrency: 2,
+		MaxRetries:  0,
+		ProgressFunc: func(p BatchProgress) {
+			progressCount.Add(1)
+		},
+	})
+
+	texts := make([]string, 20)
+	for i := range texts {
+		texts[i] = fmt.Sprintf("text %d", i)
+	}
+
+	ctx := context.Background()
+	_, err := bp.Process(ctx, texts)
+	if err != nil {
+		t.Fatalf("batch process: %v", err)
+	}
+
+	if progressCount.Load() == 0 {
+		t.Error("expected progress callbacks")
+	}
+}
+
+func TestBatchProcessorWithRateLimit(t *testing.T) {
+	provider := &mockProviderBatch{dim: 4}
+	mgr, _ := NewManager([]Provider{provider}, nil)
+
+	start := time.Now()
+	bp := NewBatchProcessor(mgr, BatchConfig{
+		ChunkSize:       10,
+		Concurrency:     1,
+		MaxRetries:      0,
+		RateLimitPerSec: 1000,
+	})
+
+	texts := make([]string, 10)
+	for i := range texts {
+		texts[i] = fmt.Sprintf("text %d", i)
+	}
+
+	ctx := context.Background()
+	result, err := bp.Process(ctx, texts)
+	if err != nil {
+		t.Fatalf("batch process: %v", err)
+	}
+
+	elapsed := time.Since(start)
+	if elapsed < 5*time.Millisecond {
+		t.Logf("rate limiting may not be precise in tests, elapsed: %v", elapsed)
+	}
+
+	if result.Succeeded != 10 {
+		t.Errorf("expected 10 succeeded, got %d", result.Succeeded)
+	}
+}
+
+func TestBatchProcessorWithProvider(t *testing.T) {
+	provider := &mockProviderBatch{dim: 4}
+	mgr, _ := NewManager([]Provider{provider}, nil)
+	bp := NewBatchProcessor(mgr, DefaultBatchConfig())
+
+	texts := []string{"a", "b", "c"}
+
+	ctx := context.Background()
+	result, err := bp.ProcessWithProvider(ctx, texts, 0)
+	if err != nil {
+		t.Fatalf("batch process with provider: %v", err)
+	}
+
+	if result.Succeeded != 3 {
+		t.Errorf("expected 3 succeeded, got %d", result.Succeeded)
+	}
+}
+
+func TestBatchProcessorInvalidProvider(t *testing.T) {
+	provider := &mockProviderBatch{dim: 4}
+	mgr, _ := NewManager([]Provider{provider}, nil)
+	bp := NewBatchProcessor(mgr, DefaultBatchConfig())
+
+	ctx := context.Background()
+	_, err := bp.ProcessWithProvider(ctx, []string{"test"}, 5)
+	if err == nil {
+		t.Error("expected error for invalid provider index")
+	}
+}
+
+func TestBatchProcessorTimeout(t *testing.T) {
+	provider := &mockProviderBatch{dim: 4, delay: 100 * time.Millisecond}
+	mgr, _ := NewManager([]Provider{provider}, nil)
+
+	bp := NewBatchProcessor(mgr, BatchConfig{
+		ChunkSize:   1,
+		Concurrency: 1,
+		MaxRetries:  0,
+		Timeout:     50 * time.Millisecond,
+	})
+
+	texts := make([]string, 10)
+	for i := range texts {
+		texts[i] = fmt.Sprintf("text %d", i)
+	}
+
+	ctx := context.Background()
+	result, err := bp.Process(ctx, texts)
+	if err != nil {
+		t.Fatalf("batch process: %v", err)
+	}
+
+	if result.Failed == 0 {
+		t.Log("timeout may not trigger in all environments")
+	}
+}
+
+func TestBatchProcessorRetry(t *testing.T) {
+	provider := &mockProviderBatch{dim: 4, failUntil: 2}
+	mgr, _ := NewManager([]Provider{provider}, nil)
+
+	bp := NewBatchProcessor(mgr, BatchConfig{
+		ChunkSize:   1,
+		Concurrency: 1,
+		MaxRetries:  3,
+		RetryDelay:  10 * time.Millisecond,
+	})
+
+	ctx := context.Background()
+	result, err := bp.Process(ctx, []string{"retry me"})
+	if err != nil {
+		t.Fatalf("batch process: %v", err)
+	}
+
+	if result.Succeeded != 1 {
+		t.Errorf("expected 1 succeeded after retries, got %d", result.Succeeded)
+	}
+}
+
+type mockProviderBatch struct {
+	dim         int
+	failIndices map[int]bool
+	failUntil   int
+	callCount   atomic.Int32
+	delay       time.Duration
+}
+
+func (m *mockProviderBatch) Embed(ctx context.Context, text string) ([]float32, error) {
+	count := m.callCount.Add(1)
+	if m.delay > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(m.delay):
+		}
+	}
+
+	if m.failIndices != nil && m.failIndices[int(count-1)] {
+		return nil, fmt.Errorf("simulated failure for index %d", count-1)
+	}
+
+	if m.failUntil > 0 && int(count) <= m.failUntil {
+		return nil, fmt.Errorf("simulated failure attempt %d", count)
+	}
+
+	result := make([]float32, m.dim)
+	for i := range result {
+		result[i] = float32(len(text)) / float32(m.dim)
+	}
+	return result, nil
+}
+
+func (m *mockProviderBatch) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	var results [][]float32
+	for _, text := range texts {
+		emb, err := m.Embed(ctx, text)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, emb)
+	}
+	return results, nil
+}
+
+func (m *mockProviderBatch) Name() string   { return "mock" }
+func (m *mockProviderBatch) Dimension() int { return m.dim }

--- a/pkg/embedding/batch_test.go
+++ b/pkg/embedding/batch_test.go
@@ -205,6 +205,39 @@ func TestBatchProcessorTimeout(t *testing.T) {
 	}
 }
 
+func TestBatchProcessorWithProviderRejectsInvalidBatchResult(t *testing.T) {
+	provider := &mockProviderBatch{
+		dim:             4,
+		batchEmbeddings: [][][]float32{{{1, 2, 3, 4}}},
+	}
+	mgr, _ := NewManager([]Provider{provider}, nil)
+	bp := NewBatchProcessor(mgr, BatchConfig{
+		ChunkSize: 3,
+		Timeout:   time.Minute,
+	})
+
+	ctx := context.Background()
+	result, err := bp.ProcessWithProvider(ctx, []string{"a", "b", "c"}, 0)
+	if err != nil {
+		t.Fatalf("batch process with provider: %v", err)
+	}
+
+	if result.Succeeded != 0 {
+		t.Fatalf("expected 0 succeeded, got %d", result.Succeeded)
+	}
+	if result.Failed != 3 {
+		t.Fatalf("expected 3 failed, got %d", result.Failed)
+	}
+	if len(result.Errors) != 3 {
+		t.Fatalf("expected 3 errors, got %d", len(result.Errors))
+	}
+	for i, emb := range result.Embeddings {
+		if emb != nil {
+			t.Fatalf("expected nil embedding at index %d when batch result is invalid", i)
+		}
+	}
+}
+
 func TestBatchProcessorRetry(t *testing.T) {
 	provider := &mockProviderBatch{dim: 4, failUntil: 2}
 	mgr, _ := NewManager([]Provider{provider}, nil)
@@ -228,11 +261,13 @@ func TestBatchProcessorRetry(t *testing.T) {
 }
 
 type mockProviderBatch struct {
-	dim         int
-	failIndices map[int]bool
-	failUntil   int
-	callCount   atomic.Int32
-	delay       time.Duration
+	dim             int
+	failIndices     map[int]bool
+	failUntil       int
+	callCount       atomic.Int32
+	delay           time.Duration
+	batchEmbeddings [][][]float32
+	batchCalls      atomic.Int32
 }
 
 func (m *mockProviderBatch) Embed(ctx context.Context, text string) ([]float32, error) {
@@ -261,6 +296,11 @@ func (m *mockProviderBatch) Embed(ctx context.Context, text string) ([]float32, 
 }
 
 func (m *mockProviderBatch) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	call := int(m.batchCalls.Add(1)) - 1
+	if call < len(m.batchEmbeddings) {
+		return m.batchEmbeddings[call], nil
+	}
+
 	var results [][]float32
 	for _, text := range texts {
 		emb, err := m.Embed(ctx, text)

--- a/pkg/embedding/dashscope.go
+++ b/pkg/embedding/dashscope.go
@@ -1,0 +1,109 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type DashScopeProvider struct {
+	apiKey     string
+	model      string
+	dimension  int
+	httpClient *http.Client
+}
+
+type DashScopeOption func(*DashScopeProvider)
+
+func WithDashScopeModel(model string) DashScopeOption {
+	return func(p *DashScopeProvider) { p.model = model }
+}
+
+func NewDashScopeProvider(apiKey string, opts ...DashScopeOption) (*DashScopeProvider, error) {
+	p := &DashScopeProvider{
+		apiKey:     apiKey,
+		model:      "text-embedding-v3",
+		dimension:  1024,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	if p.apiKey == "" {
+		return nil, fmt.Errorf("dashscope: api key is required")
+	}
+	return p, nil
+}
+
+func (p *DashScopeProvider) Name() string   { return "dashscope" }
+func (p *DashScopeProvider) Dimension() int { return p.dimension }
+
+func (p *DashScopeProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	results, err := p.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("dashscope: no embedding returned")
+	}
+	return results[0], nil
+}
+
+func (p *DashScopeProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	payload := map[string]any{
+		"model": p.model,
+		"input": map[string]any{
+			"texts": texts,
+		},
+		"parameters": map[string]any{
+			"text_type": "document",
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	url := "https://dashscope.aliyuncs.com/api/v1/services/embeddings/text-embedding/text-embedding"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("dashscope: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-DashScope-Async", "disable")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("dashscope: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("dashscope: API error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Output struct {
+			Embeddings []struct {
+				Index     int       `json:"text_index"`
+				Embedding []float32 `json:"embedding"`
+			} `json:"embeddings"`
+		} `json:"output"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("dashscope: parse response: %w", err)
+	}
+
+	embeddings := make([][]float32, len(result.Output.Embeddings))
+	for _, d := range result.Output.Embeddings {
+		embeddings[d.Index] = d.Embedding
+	}
+	return embeddings, nil
+}

--- a/pkg/embedding/gemini.go
+++ b/pkg/embedding/gemini.go
@@ -1,0 +1,110 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type GeminiProvider struct {
+	apiKey     string
+	model      string
+	dimension  int
+	httpClient *http.Client
+}
+
+type GeminiOption func(*GeminiProvider)
+
+func WithGeminiModel(model string) GeminiOption {
+	return func(p *GeminiProvider) { p.model = model }
+}
+
+func NewGeminiProvider(apiKey string, opts ...GeminiOption) (*GeminiProvider, error) {
+	p := &GeminiProvider{
+		apiKey:     apiKey,
+		model:      "models/text-embedding-004",
+		dimension:  768,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	if p.apiKey == "" {
+		return nil, fmt.Errorf("gemini: api key is required")
+	}
+	return p, nil
+}
+
+func (p *GeminiProvider) Name() string   { return "gemini" }
+func (p *GeminiProvider) Dimension() int { return p.dimension }
+
+func (p *GeminiProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	results, err := p.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("gemini: no embedding returned")
+	}
+	return results[0], nil
+}
+
+func (p *GeminiProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	var embeddings [][]float32
+	for _, text := range texts {
+		emb, err := p.embedSingle(ctx, text)
+		if err != nil {
+			return nil, err
+		}
+		embeddings = append(embeddings, emb)
+	}
+	return embeddings, nil
+}
+
+func (p *GeminiProvider) embedSingle(ctx context.Context, text string) ([]float32, error) {
+	payload := map[string]any{
+		"content": map[string]any{
+			"parts": []any{
+				map[string]string{"text": text},
+			},
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/%s:embedContent?key=%s", p.model, p.apiKey)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("gemini: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("gemini: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gemini: API error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Embedding struct {
+			Values []float32 `json:"values"`
+		} `json:"embedding"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("gemini: parse response: %w", err)
+	}
+
+	return result.Embedding.Values, nil
+}

--- a/pkg/embedding/manager.go
+++ b/pkg/embedding/manager.go
@@ -1,0 +1,167 @@
+package embedding
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type Manager struct {
+	mu        sync.RWMutex
+	providers []Provider
+	current   int
+	cache     *Cache
+}
+
+type Cache struct {
+	mu      sync.RWMutex
+	items   map[string]cacheItem
+	maxSize int
+	ttl     time.Duration
+}
+
+type cacheItem struct {
+	value     []float32
+	expiresAt time.Time
+}
+
+func NewCache(maxSize int, ttl time.Duration) *Cache {
+	if maxSize <= 0 {
+		maxSize = 10000
+	}
+	if ttl <= 0 {
+		ttl = 24 * time.Hour
+	}
+	return &Cache{
+		items:   make(map[string]cacheItem),
+		maxSize: maxSize,
+		ttl:     ttl,
+	}
+}
+
+func (c *Cache) Get(key string) ([]float32, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	item, ok := c.items[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(item.expiresAt) {
+		return nil, false
+	}
+	return item.value, true
+}
+
+func (c *Cache) Set(key string, value []float32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.items) >= c.maxSize {
+		c.evict()
+	}
+
+	c.items[key] = cacheItem{
+		value:     value,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+}
+
+func (c *Cache) evict() {
+	now := time.Now()
+	for k, v := range c.items {
+		if now.After(v.expiresAt) {
+			delete(c.items, k)
+		}
+	}
+
+	if len(c.items) >= c.maxSize {
+		count := 0
+		half := c.maxSize / 2
+		for k := range c.items {
+			delete(c.items, k)
+			count++
+			if count >= half {
+				break
+			}
+		}
+	}
+}
+
+func (c *Cache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.items)
+}
+
+func (c *Cache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items = make(map[string]cacheItem)
+}
+
+func NewManager(providers []Provider, cache *Cache) (*Manager, error) {
+	if len(providers) == 0 {
+		return nil, fmt.Errorf("embedding: at least one provider is required")
+	}
+	if cache == nil {
+		cache = NewCache(10000, 24*time.Hour)
+	}
+	return &Manager{
+		providers: providers,
+		cache:     cache,
+	}, nil
+}
+
+func (m *Manager) Embed(ctx context.Context, text string) ([]float32, error) {
+	if cached, ok := m.cache.Get(text); ok {
+		return cached, nil
+	}
+
+	var lastErr error
+	for i, provider := range m.providers {
+		embedding, err := provider.Embed(ctx, text)
+		if err == nil {
+			m.mu.Lock()
+			m.current = i
+			m.mu.Unlock()
+			m.cache.Set(text, embedding)
+			return embedding, nil
+		}
+		lastErr = err
+	}
+
+	return nil, fmt.Errorf("embedding: all providers failed, last error: %w", lastErr)
+}
+
+func (m *Manager) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	var results [][]float32
+	for _, text := range texts {
+		embedding, err := m.Embed(ctx, text)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, embedding)
+	}
+	return results, nil
+}
+
+func (m *Manager) CurrentProvider() Provider {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.providers) == 0 {
+		return nil
+	}
+	return m.providers[m.current]
+}
+
+func (m *Manager) Providers() []Provider {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.providers
+}
+
+func (m *Manager) Cache() *Cache {
+	return m.cache
+}

--- a/pkg/embedding/manager.go
+++ b/pkg/embedding/manager.go
@@ -119,8 +119,11 @@ func (m *Manager) Embed(ctx context.Context, text string) ([]float32, error) {
 		return cached, nil
 	}
 
+	start := m.currentProviderIndex()
 	var lastErr error
-	for i, provider := range m.providers {
+	for offset := range m.providers {
+		i := (start + offset) % len(m.providers)
+		provider := m.providers[i]
 		embedding, err := provider.Embed(ctx, text)
 		if err == nil {
 			m.mu.Lock()
@@ -133,6 +136,19 @@ func (m *Manager) Embed(ctx context.Context, text string) ([]float32, error) {
 	}
 
 	return nil, fmt.Errorf("embedding: all providers failed, last error: %w", lastErr)
+}
+
+func (m *Manager) currentProviderIndex() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(m.providers) == 0 {
+		return 0
+	}
+	if m.current < 0 || m.current >= len(m.providers) {
+		return 0
+	}
+	return m.current
 }
 
 func (m *Manager) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {

--- a/pkg/embedding/manager_test.go
+++ b/pkg/embedding/manager_test.go
@@ -1,0 +1,430 @@
+package embedding
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCache(t *testing.T) {
+	cache := NewCache(100, time.Hour)
+
+	cache.Set("hello", []float32{0.1, 0.2, 0.3})
+
+	val, ok := cache.Get("hello")
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if len(val) != 3 || val[0] != 0.1 {
+		t.Errorf("unexpected cached value: %v", val)
+	}
+
+	_, ok = cache.Get("missing")
+	if ok {
+		t.Error("expected cache miss")
+	}
+}
+
+func TestCacheTTL(t *testing.T) {
+	cache := NewCache(100, 50*time.Millisecond)
+
+	cache.Set("expire_me", []float32{0.1, 0.2})
+
+	_, ok := cache.Get("expire_me")
+	if !ok {
+		t.Fatal("expected cache hit before expiry")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	_, ok = cache.Get("expire_me")
+	if ok {
+		t.Error("expected cache miss after TTL")
+	}
+}
+
+func TestCacheEviction(t *testing.T) {
+	cache := NewCache(5, time.Hour)
+
+	for i := 0; i < 10; i++ {
+		cache.Set(string(rune('a'+i)), []float32{float32(i)})
+	}
+
+	if cache.Len() > 5 {
+		t.Errorf("expected cache size <= 5 after eviction, got %d", cache.Len())
+	}
+}
+
+func TestCacheClear(t *testing.T) {
+	cache := NewCache(100, time.Hour)
+	cache.Set("a", []float32{1.0})
+	cache.Set("b", []float32{2.0})
+
+	cache.Clear()
+
+	if cache.Len() != 0 {
+		t.Errorf("expected empty cache after clear, got %d", cache.Len())
+	}
+}
+
+func TestNewProvider(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{
+			name: "openai",
+			cfg: Config{
+				Provider: ProviderOpenAI,
+				APIKey:   "test-key",
+				Model:    "text-embedding-3-small",
+			},
+			wantErr: false,
+		},
+		{
+			name: "openai no key",
+			cfg: Config{
+				Provider: ProviderOpenAI,
+			},
+			wantErr: true,
+		},
+		{
+			name: "gemini",
+			cfg: Config{
+				Provider: ProviderGemini,
+				APIKey:   "test-key",
+			},
+			wantErr: false,
+		},
+		{
+			name: "ollama",
+			cfg: Config{
+				Provider: ProviderOllama,
+				Model:    "nomic-embed-text",
+			},
+			wantErr: false,
+		},
+		{
+			name: "voyage",
+			cfg: Config{
+				Provider: ProviderVoyage,
+				APIKey:   "test-key",
+			},
+			wantErr: false,
+		},
+		{
+			name: "zhipu",
+			cfg: Config{
+				Provider: ProviderZhipu,
+				APIKey:   "test-key",
+			},
+			wantErr: false,
+		},
+		{
+			name: "dashscope",
+			cfg: Config{
+				Provider: ProviderDashScope,
+				APIKey:   "test-key",
+			},
+			wantErr: false,
+		},
+		{
+			name: "baidu",
+			cfg: Config{
+				Provider: ProviderBaidu,
+				APIKey:   "test-key",
+			},
+			wantErr: false,
+		},
+		{
+			name: "siliconflow",
+			cfg: Config{
+				Provider: ProviderSiliconFlow,
+				APIKey:   "test-key",
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown",
+			cfg: Config{
+				Provider: "unknown",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewProvider(tt.cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if p == nil {
+				t.Fatal("expected non-nil provider")
+			}
+		})
+	}
+}
+
+func TestOpenAIProvider(t *testing.T) {
+	p, err := NewOpenAIProvider("test-key")
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+
+	if p.Name() != "openai" {
+		t.Errorf("expected name openai, got %s", p.Name())
+	}
+	if p.Dimension() != 1536 {
+		t.Errorf("expected dimension 1536, got %d", p.Dimension())
+	}
+}
+
+func TestOpenAIProviderOptions(t *testing.T) {
+	p, err := NewOpenAIProvider("test-key",
+		WithOpenAIModel("text-embedding-3-large"),
+		WithOpenAIDimension(3072),
+	)
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+
+	if p.Dimension() != 3072 {
+		t.Errorf("expected dimension 3072, got %d", p.Dimension())
+	}
+}
+
+func TestGeminiProvider(t *testing.T) {
+	p, err := NewGeminiProvider("test-key")
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+
+	if p.Name() != "gemini" {
+		t.Errorf("expected name gemini, got %s", p.Name())
+	}
+	if p.Dimension() != 768 {
+		t.Errorf("expected dimension 768, got %d", p.Dimension())
+	}
+}
+
+func TestOllamaProvider(t *testing.T) {
+	p := NewOllamaProvider(
+		WithOllamaBaseURL("http://localhost:11434"),
+		WithOllamaModel("nomic-embed-text"),
+	)
+
+	if p.Name() != "ollama" {
+		t.Errorf("expected name ollama, got %s", p.Name())
+	}
+	if p.Dimension() != 768 {
+		t.Errorf("expected dimension 768, got %d", p.Dimension())
+	}
+}
+
+func TestVoyageProvider(t *testing.T) {
+	p, err := NewVoyageProvider("test-key")
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+
+	if p.Name() != "voyage" {
+		t.Errorf("expected name voyage, got %s", p.Name())
+	}
+	if p.Dimension() != 1024 {
+		t.Errorf("expected dimension 1024, got %d", p.Dimension())
+	}
+}
+
+func TestZhipuProvider(t *testing.T) {
+	p, err := NewZhipuProvider("test-key")
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+
+	if p.Name() != "zhipu" {
+		t.Errorf("expected name zhipu, got %s", p.Name())
+	}
+	if p.Dimension() != 2048 {
+		t.Errorf("expected dimension 2048, got %d", p.Dimension())
+	}
+}
+
+func TestDashScopeProvider(t *testing.T) {
+	p, err := NewDashScopeProvider("test-key")
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+
+	if p.Name() != "dashscope" {
+		t.Errorf("expected name dashscope, got %s", p.Name())
+	}
+	if p.Dimension() != 1024 {
+		t.Errorf("expected dimension 1024, got %d", p.Dimension())
+	}
+}
+
+func TestBaiduProvider(t *testing.T) {
+	p, err := NewBaiduProvider("test-key")
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+
+	if p.Name() != "baidu" {
+		t.Errorf("expected name baidu, got %s", p.Name())
+	}
+	if p.Dimension() != 384 {
+		t.Errorf("expected dimension 384, got %d", p.Dimension())
+	}
+}
+
+func TestSiliconFlowProvider(t *testing.T) {
+	p, err := NewSiliconFlowProvider("test-key")
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+
+	if p.Name() != "siliconflow" {
+		t.Errorf("expected name siliconflow, got %s", p.Name())
+	}
+	if p.Dimension() != 1024 {
+		t.Errorf("expected dimension 1024, got %d", p.Dimension())
+	}
+}
+
+func TestManager(t *testing.T) {
+	mock := &mockProvider{name: "mock", dim: 4}
+
+	mgr, err := NewManager([]Provider{mock}, nil)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	ctx := context.Background()
+	emb, err := mgr.Embed(ctx, "hello")
+	if err != nil {
+		t.Fatalf("embed failed: %v", err)
+	}
+
+	if len(emb) != 4 {
+		t.Errorf("expected 4 dimensions, got %d", len(emb))
+	}
+
+	if mgr.CurrentProvider().Name() != "mock" {
+		t.Errorf("expected current provider mock, got %s", mgr.CurrentProvider().Name())
+	}
+}
+
+func TestManagerFallback(t *testing.T) {
+	fail := &mockProvider{name: "fail", dim: 4, shouldFail: true}
+	success := &mockProvider{name: "success", dim: 4}
+
+	mgr, err := NewManager([]Provider{fail, success}, nil)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	ctx := context.Background()
+	emb, err := mgr.Embed(ctx, "test")
+	if err != nil {
+		t.Fatalf("embed should succeed with fallback: %v", err)
+	}
+
+	if len(emb) != 4 {
+		t.Errorf("expected 4 dimensions, got %d", len(emb))
+	}
+
+	if mgr.CurrentProvider().Name() != "success" {
+		t.Errorf("expected fallback to success provider")
+	}
+}
+
+func TestManagerAllFail(t *testing.T) {
+	fail1 := &mockProvider{name: "fail1", dim: 4, shouldFail: true}
+	fail2 := &mockProvider{name: "fail2", dim: 4, shouldFail: true}
+
+	mgr, err := NewManager([]Provider{fail1, fail2}, nil)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = mgr.Embed(ctx, "test")
+	if err == nil {
+		t.Error("expected error when all providers fail")
+	}
+}
+
+func TestManagerCache(t *testing.T) {
+	callCount := 0
+	mock := &mockProvider{name: "mock", dim: 4, onEmbed: func() {
+		callCount++
+	}}
+
+	mgr, _ := NewManager([]Provider{mock}, NewCache(100, time.Hour))
+
+	ctx := context.Background()
+
+	mgr.Embed(ctx, "cached")
+	mgr.Embed(ctx, "cached")
+	mgr.Embed(ctx, "cached")
+
+	if callCount != 1 {
+		t.Errorf("expected 1 provider call due to caching, got %d", callCount)
+	}
+}
+
+func TestManagerProviders(t *testing.T) {
+	p1 := &mockProvider{name: "p1", dim: 4}
+	p2 := &mockProvider{name: "p2", dim: 8}
+
+	mgr, _ := NewManager([]Provider{p1, p2}, nil)
+
+	providers := mgr.Providers()
+	if len(providers) != 2 {
+		t.Errorf("expected 2 providers, got %d", len(providers))
+	}
+}
+
+type mockProvider struct {
+	name       string
+	dim        int
+	shouldFail bool
+	onEmbed    func()
+}
+
+func (m *mockProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	if m.onEmbed != nil {
+		m.onEmbed()
+	}
+	if m.shouldFail {
+		return nil, context.Canceled
+	}
+	result := make([]float32, m.dim)
+	for i := range result {
+		result[i] = float32(len(text)) / float32(m.dim)
+	}
+	return result, nil
+}
+
+func (m *mockProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	var results [][]float32
+	for _, text := range texts {
+		emb, err := m.Embed(ctx, text)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, emb)
+	}
+	return results, nil
+}
+
+func (m *mockProvider) Name() string   { return m.name }
+func (m *mockProvider) Dimension() int { return m.dim }

--- a/pkg/embedding/manager_test.go
+++ b/pkg/embedding/manager_test.go
@@ -132,10 +132,19 @@ func TestNewProvider(t *testing.T) {
 		{
 			name: "baidu",
 			cfg: Config{
+				Provider:  ProviderBaidu,
+				APIKey:    "test-key",
+				SecretKey: "test-secret",
+			},
+			wantErr: false,
+		},
+		{
+			name: "baidu no secret",
+			cfg: Config{
 				Provider: ProviderBaidu,
 				APIKey:   "test-key",
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "siliconflow",
@@ -272,7 +281,7 @@ func TestDashScopeProvider(t *testing.T) {
 }
 
 func TestBaiduProvider(t *testing.T) {
-	p, err := NewBaiduProvider("test-key")
+	p, err := NewBaiduProvider("test-key", WithBaiduSecretKey("test-secret"))
 	if err != nil {
 		t.Fatalf("failed to create provider: %v", err)
 	}
@@ -282,6 +291,13 @@ func TestBaiduProvider(t *testing.T) {
 	}
 	if p.Dimension() != 384 {
 		t.Errorf("expected dimension 384, got %d", p.Dimension())
+	}
+}
+
+func TestBaiduProviderRequiresSecretKey(t *testing.T) {
+	_, err := NewBaiduProvider("test-key")
+	if err == nil {
+		t.Fatal("expected error when secret key is missing")
 	}
 }
 
@@ -343,6 +359,37 @@ func TestManagerFallback(t *testing.T) {
 
 	if mgr.CurrentProvider().Name() != "success" {
 		t.Errorf("expected fallback to success provider")
+	}
+}
+
+func TestManagerUsesCurrentProviderAfterFallback(t *testing.T) {
+	failCalls := 0
+	successCalls := 0
+	fail := &mockProvider{name: "fail", dim: 4, shouldFail: true, onEmbed: func() {
+		failCalls++
+	}}
+	success := &mockProvider{name: "success", dim: 4, onEmbed: func() {
+		successCalls++
+	}}
+
+	mgr, err := NewManager([]Provider{fail, success}, nil)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := mgr.Embed(ctx, "first"); err != nil {
+		t.Fatalf("first embed should succeed with fallback: %v", err)
+	}
+	if _, err := mgr.Embed(ctx, "second"); err != nil {
+		t.Fatalf("second embed should succeed with current provider: %v", err)
+	}
+
+	if failCalls != 1 {
+		t.Fatalf("expected failed provider to be tried once, got %d", failCalls)
+	}
+	if successCalls != 2 {
+		t.Fatalf("expected current provider to handle both successful requests, got %d", successCalls)
 	}
 }
 

--- a/pkg/embedding/ollama.go
+++ b/pkg/embedding/ollama.go
@@ -1,0 +1,96 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type OllamaProvider struct {
+	baseURL    string
+	model      string
+	dimension  int
+	httpClient *http.Client
+}
+
+type OllamaOption func(*OllamaProvider)
+
+func WithOllamaBaseURL(url string) OllamaOption {
+	return func(p *OllamaProvider) { p.baseURL = url }
+}
+
+func WithOllamaModel(model string) OllamaOption {
+	return func(p *OllamaProvider) { p.model = model }
+}
+
+func NewOllamaProvider(opts ...OllamaOption) *OllamaProvider {
+	p := &OllamaProvider{
+		baseURL:    "http://localhost:11434",
+		model:      "nomic-embed-text",
+		dimension:  768,
+		httpClient: &http.Client{Timeout: 60 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+func (p *OllamaProvider) Name() string   { return "ollama" }
+func (p *OllamaProvider) Dimension() int { return p.dimension }
+
+func (p *OllamaProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	results, err := p.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("ollama: no embedding returned")
+	}
+	return results[0], nil
+}
+
+func (p *OllamaProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	var embeddings [][]float32
+	for _, text := range texts {
+		payload := map[string]any{
+			"model": p.model,
+			"input": text,
+		}
+		body, _ := json.Marshal(payload)
+
+		url := p.baseURL + "/api/embed"
+		req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("ollama: create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := p.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("ollama: request failed: %w", err)
+		}
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("ollama: API error %d: %s", resp.StatusCode, string(respBody))
+		}
+
+		var result struct {
+			Embeddings [][]float32 `json:"embeddings"`
+		}
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			return nil, fmt.Errorf("ollama: parse response: %w", err)
+		}
+
+		if len(result.Embeddings) > 0 {
+			embeddings = append(embeddings, result.Embeddings[0])
+		}
+	}
+	return embeddings, nil
+}

--- a/pkg/embedding/openai.go
+++ b/pkg/embedding/openai.go
@@ -1,0 +1,118 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type OpenAIProvider struct {
+	apiKey     string
+	model      string
+	baseURL    string
+	dimension  int
+	httpClient *http.Client
+}
+
+type OpenAIOption func(*OpenAIProvider)
+
+func WithOpenAIBaseURL(url string) OpenAIOption {
+	return func(p *OpenAIProvider) { p.baseURL = url }
+}
+
+func WithOpenAIModel(model string) OpenAIOption {
+	return func(p *OpenAIProvider) { p.model = model }
+}
+
+func WithOpenAIDimension(dim int) OpenAIOption {
+	return func(p *OpenAIProvider) { p.dimension = dim }
+}
+
+func NewOpenAIProvider(apiKey string, opts ...OpenAIOption) (*OpenAIProvider, error) {
+	p := &OpenAIProvider{
+		apiKey:     apiKey,
+		model:      "text-embedding-3-small",
+		baseURL:    "https://api.openai.com/v1",
+		dimension:  1536,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	if p.apiKey == "" {
+		return nil, fmt.Errorf("openai: api key is required")
+	}
+	return p, nil
+}
+
+func (p *OpenAIProvider) Name() string   { return "openai" }
+func (p *OpenAIProvider) Dimension() int { return p.dimension }
+
+func (p *OpenAIProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	results, err := p.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("openai: no embedding returned")
+	}
+	return results[0], nil
+}
+
+func (p *OpenAIProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	payload := map[string]any{
+		"model":           p.model,
+		"input":           texts,
+		"encoding_format": "float",
+	}
+	if p.dimension > 0 && p.model != "text-embedding-ada-002" {
+		payload["dimensions"] = p.dimension
+	}
+	body, _ := json.Marshal(payload)
+
+	url := p.baseURL + "/embeddings"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("openai: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("openai: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("openai: API error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Data []struct {
+			Index     int       `json:"index"`
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+		Usage struct {
+			PromptTokens int `json:"prompt_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("openai: parse response: %w", err)
+	}
+
+	embeddings := make([][]float32, len(result.Data))
+	for _, d := range result.Data {
+		embeddings[d.Index] = d.Embedding
+	}
+	return embeddings, nil
+}

--- a/pkg/embedding/provider.go
+++ b/pkg/embedding/provider.go
@@ -1,0 +1,98 @@
+package embedding
+
+import (
+	"context"
+	"fmt"
+)
+
+type Provider interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+	EmbedBatch(ctx context.Context, texts []string) ([][]float32, error)
+	Name() string
+	Dimension() int
+}
+
+type ProviderType string
+
+const (
+	ProviderOpenAI      ProviderType = "openai"
+	ProviderGemini      ProviderType = "gemini"
+	ProviderOllama      ProviderType = "ollama"
+	ProviderVoyage      ProviderType = "voyage"
+	ProviderZhipu       ProviderType = "zhipu"
+	ProviderDashScope   ProviderType = "dashscope"
+	ProviderBaidu       ProviderType = "baidu"
+	ProviderSiliconFlow ProviderType = "siliconflow"
+)
+
+type Config struct {
+	Provider  ProviderType
+	APIKey    string
+	BaseURL   string
+	Model     string
+	Dimension int
+}
+
+func NewProvider(cfg Config) (Provider, error) {
+	switch cfg.Provider {
+	case ProviderOpenAI:
+		opts := []OpenAIOption{}
+		if cfg.BaseURL != "" {
+			opts = append(opts, WithOpenAIBaseURL(cfg.BaseURL))
+		}
+		if cfg.Model != "" {
+			opts = append(opts, WithOpenAIModel(cfg.Model))
+		}
+		if cfg.Dimension > 0 {
+			opts = append(opts, WithOpenAIDimension(cfg.Dimension))
+		}
+		return NewOpenAIProvider(cfg.APIKey, opts...)
+	case ProviderGemini:
+		opts := []GeminiOption{}
+		if cfg.Model != "" {
+			opts = append(opts, WithGeminiModel(cfg.Model))
+		}
+		return NewGeminiProvider(cfg.APIKey, opts...)
+	case ProviderOllama:
+		opts := []OllamaOption{}
+		if cfg.BaseURL != "" {
+			opts = append(opts, WithOllamaBaseURL(cfg.BaseURL))
+		}
+		if cfg.Model != "" {
+			opts = append(opts, WithOllamaModel(cfg.Model))
+		}
+		return NewOllamaProvider(opts...), nil
+	case ProviderVoyage:
+		opts := []VoyageOption{}
+		if cfg.Model != "" {
+			opts = append(opts, WithVoyageModel(cfg.Model))
+		}
+		return NewVoyageProvider(cfg.APIKey, opts...)
+	case ProviderZhipu:
+		opts := []ZhipuOption{}
+		if cfg.Model != "" {
+			opts = append(opts, WithZhipuModel(cfg.Model))
+		}
+		return NewZhipuProvider(cfg.APIKey, opts...)
+	case ProviderDashScope:
+		opts := []DashScopeOption{}
+		if cfg.Model != "" {
+			opts = append(opts, WithDashScopeModel(cfg.Model))
+		}
+		return NewDashScopeProvider(cfg.APIKey, opts...)
+	case ProviderBaidu:
+		opts := []BaiduOption{}
+		if cfg.Model != "" {
+			opts = append(opts, WithBaiduModel(cfg.Model))
+		}
+		return NewBaiduProvider(cfg.APIKey, opts...)
+	case ProviderSiliconFlow:
+		opts := []SiliconFlowOption{}
+		if cfg.Model != "" {
+			opts = append(opts, WithSiliconFlowModel(cfg.Model))
+		}
+		return NewSiliconFlowProvider(cfg.APIKey, opts...)
+	default:
+		return nil, fmt.Errorf("unknown embedding provider: %s", cfg.Provider)
+	}
+}

--- a/pkg/embedding/provider.go
+++ b/pkg/embedding/provider.go
@@ -28,6 +28,7 @@ const (
 type Config struct {
 	Provider  ProviderType
 	APIKey    string
+	SecretKey string
 	BaseURL   string
 	Model     string
 	Dimension int
@@ -84,6 +85,9 @@ func NewProvider(cfg Config) (Provider, error) {
 		opts := []BaiduOption{}
 		if cfg.Model != "" {
 			opts = append(opts, WithBaiduModel(cfg.Model))
+		}
+		if cfg.SecretKey != "" {
+			opts = append(opts, WithBaiduSecretKey(cfg.SecretKey))
 		}
 		return NewBaiduProvider(cfg.APIKey, opts...)
 	case ProviderSiliconFlow:

--- a/pkg/embedding/siliconflow.go
+++ b/pkg/embedding/siliconflow.go
@@ -1,0 +1,102 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type SiliconFlowProvider struct {
+	apiKey     string
+	model      string
+	dimension  int
+	httpClient *http.Client
+}
+
+type SiliconFlowOption func(*SiliconFlowProvider)
+
+func WithSiliconFlowModel(model string) SiliconFlowOption {
+	return func(p *SiliconFlowProvider) { p.model = model }
+}
+
+func NewSiliconFlowProvider(apiKey string, opts ...SiliconFlowOption) (*SiliconFlowProvider, error) {
+	p := &SiliconFlowProvider{
+		apiKey:     apiKey,
+		model:      "BAAI/bge-m3",
+		dimension:  1024,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	if p.apiKey == "" {
+		return nil, fmt.Errorf("siliconflow: api key is required")
+	}
+	return p, nil
+}
+
+func (p *SiliconFlowProvider) Name() string   { return "siliconflow" }
+func (p *SiliconFlowProvider) Dimension() int { return p.dimension }
+
+func (p *SiliconFlowProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	results, err := p.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("siliconflow: no embedding returned")
+	}
+	return results[0], nil
+}
+
+func (p *SiliconFlowProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	payload := map[string]any{
+		"model":           p.model,
+		"input":           texts,
+		"encoding_format": "float",
+	}
+	body, _ := json.Marshal(payload)
+
+	url := "https://api.siliconflow.cn/v1/embeddings"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("siliconflow: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("siliconflow: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("siliconflow: API error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Data []struct {
+			Index     int       `json:"index"`
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("siliconflow: parse response: %w", err)
+	}
+
+	embeddings := make([][]float32, len(result.Data))
+	for _, d := range result.Data {
+		embeddings[d.Index] = d.Embedding
+	}
+	return embeddings, nil
+}

--- a/pkg/embedding/voyage.go
+++ b/pkg/embedding/voyage.go
@@ -1,0 +1,101 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type VoyageProvider struct {
+	apiKey     string
+	model      string
+	dimension  int
+	httpClient *http.Client
+}
+
+type VoyageOption func(*VoyageProvider)
+
+func WithVoyageModel(model string) VoyageOption {
+	return func(p *VoyageProvider) { p.model = model }
+}
+
+func NewVoyageProvider(apiKey string, opts ...VoyageOption) (*VoyageProvider, error) {
+	p := &VoyageProvider{
+		apiKey:     apiKey,
+		model:      "voyage-3",
+		dimension:  1024,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	if p.apiKey == "" {
+		return nil, fmt.Errorf("voyage: api key is required")
+	}
+	return p, nil
+}
+
+func (p *VoyageProvider) Name() string   { return "voyage" }
+func (p *VoyageProvider) Dimension() int { return p.dimension }
+
+func (p *VoyageProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	results, err := p.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("voyage: no embedding returned")
+	}
+	return results[0], nil
+}
+
+func (p *VoyageProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	payload := map[string]any{
+		"model": p.model,
+		"input": texts,
+	}
+	body, _ := json.Marshal(payload)
+
+	url := "https://api.voyageai.com/v1/embeddings"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("voyage: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("voyage: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("voyage: API error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Data []struct {
+			Index     int       `json:"index"`
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("voyage: parse response: %w", err)
+	}
+
+	embeddings := make([][]float32, len(result.Data))
+	for _, d := range result.Data {
+		embeddings[d.Index] = d.Embedding
+	}
+	return embeddings, nil
+}

--- a/pkg/embedding/zhipu.go
+++ b/pkg/embedding/zhipu.go
@@ -1,0 +1,101 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type ZhipuProvider struct {
+	apiKey     string
+	model      string
+	dimension  int
+	httpClient *http.Client
+}
+
+type ZhipuOption func(*ZhipuProvider)
+
+func WithZhipuModel(model string) ZhipuOption {
+	return func(p *ZhipuProvider) { p.model = model }
+}
+
+func NewZhipuProvider(apiKey string, opts ...ZhipuOption) (*ZhipuProvider, error) {
+	p := &ZhipuProvider{
+		apiKey:     apiKey,
+		model:      "embedding-3",
+		dimension:  2048,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	if p.apiKey == "" {
+		return nil, fmt.Errorf("zhipu: api key is required")
+	}
+	return p, nil
+}
+
+func (p *ZhipuProvider) Name() string   { return "zhipu" }
+func (p *ZhipuProvider) Dimension() int { return p.dimension }
+
+func (p *ZhipuProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	results, err := p.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("zhipu: no embedding returned")
+	}
+	return results[0], nil
+}
+
+func (p *ZhipuProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	payload := map[string]any{
+		"model": p.model,
+		"input": texts,
+	}
+	body, _ := json.Marshal(payload)
+
+	url := "https://open.bigmodel.cn/api/paas/v4/embeddings"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("zhipu: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("zhipu: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("zhipu: API error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Data []struct {
+			Index     int       `json:"index"`
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("zhipu: parse response: %w", err)
+	}
+
+	embeddings := make([][]float32, len(result.Data))
+	for _, d := range result.Data {
+		embeddings[d.Index] = d.Embedding
+	}
+	return embeddings, nil
+}


### PR DESCRIPTION
## Summary

This PR adds a standalone `pkg/embedding` package that provides a unified embedding abstraction with multiple providers, failover management, caching, and batch processing support.

## Changes

- add a shared embedding provider interface and config-based provider factory
- add provider implementations for:
  - OpenAI
  - Gemini
  - Ollama
  - Voyage
  - Zhipu
  - DashScope
  - Baidu
  - SiliconFlow
- add an embedding manager with:
  - provider failover
  - in-memory cache
  - current provider tracking
- add batch embedding support with:
  - chunking
  - concurrency control
  - retry handling
  - timeout support
  - progress callback reporting
- add package-level tests for manager and batch behavior

## Testing

- `go test ./pkg/embedding`

## Notes

This PR only introduces `pkg/embedding` and does not wire it into other packages yet.
That keeps the change isolated and makes follow-up PRs such as `pkg/index` easier to review.
