### PR TITLE
feat(vec): add vec store

### DIFF
--- a/pkg/vec/store.go
+++ b/pkg/vec/store.go
@@ -1,0 +1,491 @@
+package vec
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strings"
+)
+
+type DistanceMetric string
+
+const (
+	DistanceCosine DistanceMetric = "cosine"
+	DistanceL2     DistanceMetric = "l2"
+)
+
+type VecStore struct {
+	db         *sql.DB
+	tableName  string
+	dimensions int
+	distance   DistanceMetric
+	metadata   []string
+	auxColumns []string
+}
+
+type VecStoreConfig struct {
+	DB         *sql.DB
+	TableName  string
+	Dimensions int
+	Distance   DistanceMetric
+	Metadata   []string
+	AuxColumns []string
+}
+
+func NewVecStore(cfg VecStoreConfig) *VecStore {
+	if cfg.Distance == "" {
+		cfg.Distance = DistanceCosine
+	}
+	return &VecStore{
+		db:         cfg.DB,
+		tableName:  cfg.TableName,
+		dimensions: cfg.Dimensions,
+		distance:   cfg.Distance,
+		metadata:   cfg.Metadata,
+		auxColumns: cfg.AuxColumns,
+	}
+}
+
+func (vs *VecStore) Init(ctx context.Context) error {
+	if err := vs.enableVec(ctx); err != nil {
+		return err
+	}
+	return vs.createTable(ctx)
+}
+
+func (vs *VecStore) enableVec(ctx context.Context) error {
+	var version string
+	err := vs.db.QueryRowContext(ctx, "SELECT vec_version()").Scan(&version)
+	if err != nil {
+		return fmt.Errorf("sqlite-vec not available (requires modernc.org/sqlite/vec): %w", err)
+	}
+	return nil
+}
+
+func (vs *VecStore) createTable(ctx context.Context) error {
+	sql := vs.buildCreateTableSQL()
+	_, err := vs.db.ExecContext(ctx, sql)
+	if err != nil {
+		return fmt.Errorf("create vec0 table: %w", err)
+	}
+	return nil
+}
+
+func (vs *VecStore) buildCreateTableSQL() string {
+	cols := []string{
+		fmt.Sprintf("vector float[%d] distance=%s", vs.dimensions, vs.distance),
+	}
+
+	for _, meta := range vs.metadata {
+		cols = append(cols, fmt.Sprintf("+%s text", meta))
+	}
+
+	for _, aux := range vs.auxColumns {
+		cols = append(cols, fmt.Sprintf("#%s text", aux))
+	}
+
+	return fmt.Sprintf(
+		"CREATE VIRTUAL TABLE IF NOT EXISTS %s USING vec0(%s)",
+		vs.tableName,
+		strings.Join(cols, ", "),
+	)
+}
+
+func (vs *VecStore) Insert(ctx context.Context, id any, vector []float32, metadata map[string]string) error {
+	if len(vector) != vs.dimensions {
+		return fmt.Errorf("vector dimension mismatch: expected %d, got %d", vs.dimensions, len(vector))
+	}
+
+	vs.db.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", vs.tableName), id)
+
+	cols := []string{"rowid", "vector"}
+	args := []any{id, vectorToBlob(vector)}
+
+	for _, key := range vs.metadata {
+		val := ""
+		if metadata != nil {
+			val = metadata[key]
+		}
+		cols = append(cols, key)
+		args = append(args, val)
+	}
+
+	placeholders := make([]string, len(cols))
+	for i := range cols {
+		placeholders[i] = "?"
+	}
+
+	query := fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES (%s)",
+		vs.tableName,
+		strings.Join(cols, ", "),
+		strings.Join(placeholders, ", "),
+	)
+
+	_, err := vs.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("insert vector: %w", err)
+	}
+	return nil
+}
+
+func (vs *VecStore) InsertBatch(ctx context.Context, items []VecItem) error {
+	tx, err := vs.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	cols := []string{"rowid", "vector"}
+	for _, key := range vs.metadata {
+		cols = append(cols, key)
+	}
+
+	placeholders := make([]string, len(cols))
+	for i := range cols {
+		placeholders[i] = "?"
+	}
+
+	query := fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES (%s)",
+		vs.tableName,
+		strings.Join(cols, ", "),
+		strings.Join(placeholders, ", "),
+	)
+
+	delQuery := fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", vs.tableName)
+
+	stmt, err := tx.PrepareContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("prepare insert: %w", err)
+	}
+	defer stmt.Close()
+
+	delStmt, err := tx.PrepareContext(ctx, delQuery)
+	if err != nil {
+		return fmt.Errorf("prepare delete: %w", err)
+	}
+	defer delStmt.Close()
+
+	for _, item := range items {
+		if len(item.Vector) != vs.dimensions {
+			return fmt.Errorf("vector dimension mismatch for id %v: expected %d, got %d",
+				item.ID, vs.dimensions, len(item.Vector))
+		}
+
+		delStmt.ExecContext(ctx, item.ID)
+
+		args := []any{item.ID, vectorToBlob(item.Vector)}
+		for _, key := range vs.metadata {
+			val := ""
+			if item.Metadata != nil {
+				val = item.Metadata[key]
+			}
+			args = append(args, val)
+		}
+
+		if _, err := stmt.ExecContext(ctx, args...); err != nil {
+			return fmt.Errorf("insert item %v: %w", item.ID, err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (vs *VecStore) Search(ctx context.Context, queryVector []float32, limit int) ([]VecSearchResult, error) {
+	return vs.SearchWithFilter(ctx, queryVector, limit, 0, nil)
+}
+
+func (vs *VecStore) SearchWithFilter(ctx context.Context, queryVector []float32, limit int, threshold float64, metadataFilter map[string]string) ([]VecSearchResult, error) {
+	if len(queryVector) != vs.dimensions {
+		return nil, fmt.Errorf("query vector dimension mismatch: expected %d, got %d", vs.dimensions, len(queryVector))
+	}
+
+	if limit <= 0 {
+		limit = 10
+	}
+
+	selectCols := "SELECT rowid, distance"
+	for _, meta := range vs.metadata {
+		selectCols += fmt.Sprintf(", %s", meta)
+	}
+
+	query := fmt.Sprintf(
+		"%s FROM %s WHERE vector MATCH ? AND k = ?",
+		selectCols,
+		vs.tableName,
+	)
+
+	args := []any{vectorToBlob(queryVector), limit}
+
+	if threshold > 0 {
+		query += " AND distance <= ?"
+		args = append(args, threshold)
+	}
+
+	rows, err := vs.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("vector search: %w", err)
+	}
+	defer rows.Close()
+
+	var results []VecSearchResult
+	for rows.Next() {
+		var r VecSearchResult
+		var dist float64
+		var rowID int64
+		scanArgs := []any{&rowID, &dist}
+
+		metaVals := make([]any, len(vs.metadata))
+		for i := range vs.metadata {
+			metaVals[i] = new(string)
+			scanArgs = append(scanArgs, metaVals[i])
+		}
+
+		if err := rows.Scan(scanArgs...); err != nil {
+			continue
+		}
+
+		r.RowID = rowID
+		r.ID = rowID
+		r.Distance = dist
+
+		if len(vs.metadata) > 0 {
+			r.Metadata = make(map[string]any)
+			for i, key := range vs.metadata {
+				if sv, ok := metaVals[i].(*string); ok {
+					r.Metadata[key] = *sv
+				}
+			}
+		}
+
+		results = append(results, r)
+	}
+
+	return results, nil
+}
+
+func (vs *VecStore) Get(ctx context.Context, id any) (*VecItem, error) {
+	selectCols := "SELECT rowid, vector"
+	for _, meta := range vs.metadata {
+		selectCols += fmt.Sprintf(", %s", meta)
+	}
+
+	query := fmt.Sprintf("%s FROM %s WHERE rowid = ?", selectCols, vs.tableName)
+
+	row := vs.db.QueryRowContext(ctx, query, id)
+
+	var item VecItem
+	var vecBlob []byte
+	scanArgs := []any{&item.RowID, &vecBlob}
+
+	metaVals := make([]any, len(vs.metadata))
+	for i := range vs.metadata {
+		metaVals[i] = new(string)
+		scanArgs = append(scanArgs, metaVals[i])
+	}
+
+	if err := row.Scan(scanArgs...); err != nil {
+		return nil, fmt.Errorf("get vector item: %w", err)
+	}
+
+	item.ID = item.RowID
+	item.Vector = blobToVector(vecBlob)
+
+	if len(vs.metadata) > 0 {
+		item.Metadata = make(map[string]string)
+		for i, key := range vs.metadata {
+			if sv, ok := metaVals[i].(*string); ok {
+				item.Metadata[key] = *sv
+			}
+		}
+	}
+
+	return &item, nil
+}
+
+func (vs *VecStore) Delete(ctx context.Context, id any) error {
+	query := fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", vs.tableName)
+	_, err := vs.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("delete vector item: %w", err)
+	}
+	return nil
+}
+
+func (vs *VecStore) UpdateVector(ctx context.Context, id any, vector []float32) error {
+	if len(vector) != vs.dimensions {
+		return fmt.Errorf("vector dimension mismatch: expected %d, got %d", vs.dimensions, len(vector))
+	}
+
+	query := fmt.Sprintf("UPDATE %s SET vector = ? WHERE rowid = ?", vs.tableName)
+	_, err := vs.db.ExecContext(ctx, query, vectorToBlob(vector), id)
+	if err != nil {
+		return fmt.Errorf("update vector: %w", err)
+	}
+	return nil
+}
+
+func (vs *VecStore) UpdateMetadata(ctx context.Context, id any, metadata map[string]string) error {
+	if len(metadata) == 0 {
+		return nil
+	}
+
+	setClauses := make([]string, 0, len(metadata))
+	args := make([]any, 0, len(metadata)+1)
+
+	for _, key := range vs.metadata {
+		if val, ok := metadata[key]; ok {
+			setClauses = append(setClauses, fmt.Sprintf("%s = ?", key))
+			args = append(args, val)
+		}
+	}
+
+	if len(setClauses) == 0 {
+		return nil
+	}
+
+	args = append(args, id)
+	query := fmt.Sprintf("UPDATE %s SET %s WHERE rowid = ?", vs.tableName, strings.Join(setClauses, ", "))
+
+	_, err := vs.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("update metadata: %w", err)
+	}
+	return nil
+}
+
+func (vs *VecStore) Count(ctx context.Context) (int64, error) {
+	var count int64
+	err := vs.db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", vs.tableName)).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (vs *VecStore) List(ctx context.Context, limit int) ([]VecItem, error) {
+	query := fmt.Sprintf("SELECT rowid, vector FROM %s", vs.tableName)
+	if limit > 0 {
+		query += fmt.Sprintf(" LIMIT %d", limit)
+	}
+
+	rows, err := vs.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []VecItem
+	for rows.Next() {
+		var item VecItem
+		var vecBlob []byte
+		if err := rows.Scan(&item.RowID, &vecBlob); err != nil {
+			continue
+		}
+		item.ID = item.RowID
+		item.Vector = blobToVector(vecBlob)
+		items = append(items, item)
+	}
+
+	return items, nil
+}
+
+func (vs *VecStore) VecVersion(ctx context.Context) (string, error) {
+	var version string
+	err := vs.db.QueryRowContext(ctx, "SELECT vec_version()").Scan(&version)
+	return version, err
+}
+
+func (vs *VecStore) TableInfo(ctx context.Context) (*VecTableInfo, error) {
+	var info VecTableInfo
+	info.TableName = vs.tableName
+	info.Dimensions = vs.dimensions
+	info.Distance = string(vs.distance)
+
+	count, err := vs.Count(ctx)
+	if err != nil {
+		return nil, err
+	}
+	info.VectorCount = count
+
+	var vecVersion string
+	if err := vs.db.QueryRowContext(ctx, "SELECT vec_version()").Scan(&vecVersion); err == nil {
+		info.VecVersion = vecVersion
+	}
+
+	return &info, nil
+}
+
+type VecItem struct {
+	RowID    int64
+	ID       any
+	Vector   []float32
+	Metadata map[string]string
+}
+
+type VecSearchResult struct {
+	RowID    int64
+	ID       any
+	Distance float64
+	Metadata map[string]any
+}
+
+type VecTableInfo struct {
+	TableName   string `json:"table_name"`
+	Dimensions  int    `json:"dimensions"`
+	Distance    string `json:"distance"`
+	VectorCount int64  `json:"vector_count"`
+	VecVersion  string `json:"vec_version"`
+}
+
+func vectorToBlob(v []float32) []byte {
+	blob := make([]byte, len(v)*4)
+	for i, f := range v {
+		binary.LittleEndian.PutUint32(blob[i*4:], math.Float32bits(f))
+	}
+	return blob
+}
+
+func blobToVector(blob []byte) []float32 {
+	n := len(blob) / 4
+	v := make([]float32, n)
+	for i := 0; i < n; i++ {
+		v[i] = math.Float32frombits(binary.LittleEndian.Uint32(blob[i*4:]))
+	}
+	return v
+}
+
+func CosineSimilarity(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, normA, normB float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		normA += float64(a[i]) * float64(a[i])
+		normB += float64(b[i]) * float64(b[i])
+	}
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
+}
+
+func CosineDistance(a, b []float32) float64 {
+	return 1.0 - CosineSimilarity(a, b)
+}
+
+func L2Distance(a, b []float32) float64 {
+	if len(a) != len(b) {
+		return math.MaxFloat64
+	}
+	var sum float64
+	for i := range a {
+		diff := float64(a[i]) - float64(b[i])
+		sum += diff * diff
+	}
+	return math.Sqrt(sum)
+}

--- a/pkg/vec/store.go
+++ b/pkg/vec/store.go
@@ -79,7 +79,7 @@ func (vs *VecStore) buildCreateTableSQL() string {
 	}
 
 	for _, meta := range vs.metadata {
-		cols = append(cols, fmt.Sprintf("+%s text", meta))
+		cols = append(cols, fmt.Sprintf("%s text", meta))
 	}
 
 	for _, aux := range vs.auxColumns {
@@ -223,6 +223,15 @@ func (vs *VecStore) SearchWithFilter(ctx context.Context, queryVector []float32,
 	if threshold > 0 {
 		query += " AND distance <= ?"
 		args = append(args, threshold)
+	}
+
+	for _, key := range vs.metadata {
+		val, ok := metadataFilter[key]
+		if !ok {
+			continue
+		}
+		query += fmt.Sprintf(" AND %s = ?", key)
+		args = append(args, val)
 	}
 
 	rows, err := vs.db.QueryContext(ctx, query, args...)

--- a/pkg/vec/store.go
+++ b/pkg/vec/store.go
@@ -45,8 +45,8 @@ func NewVecStore(cfg VecStoreConfig) *VecStore {
 		tableName:  cfg.TableName,
 		dimensions: cfg.Dimensions,
 		distance:   cfg.Distance,
-		metadata:   cfg.Metadata,
-		auxColumns: cfg.AuxColumns,
+		metadata:   slices.Clone(cfg.Metadata),
+		auxColumns: slices.Clone(cfg.AuxColumns),
 	}
 }
 
@@ -113,6 +113,12 @@ func (vs *VecStore) InsertWithAux(ctx context.Context, id any, vector []float32,
 	if err := vs.validateConfig(); err != nil {
 		return err
 	}
+	if err := validateColumnValues("metadata", metadata, vs.metadata); err != nil {
+		return err
+	}
+	if err := validateColumnValues("aux", aux, vs.auxColumns); err != nil {
+		return err
+	}
 	if len(vector) != vs.dimensions {
 		return fmt.Errorf("vector dimension mismatch: expected %d, got %d", vs.dimensions, len(vector))
 	}
@@ -156,6 +162,12 @@ func (vs *VecStore) InsertBatch(ctx context.Context, items []VecItem) error {
 	defer delStmt.Close()
 
 	for _, item := range items {
+		if err := validateColumnValues("metadata", item.Metadata, vs.metadata); err != nil {
+			return fmt.Errorf("item %v: %w", item.ID, err)
+		}
+		if err := validateColumnValues("aux", item.Aux, vs.auxColumns); err != nil {
+			return fmt.Errorf("item %v: %w", item.ID, err)
+		}
 		if len(item.Vector) != vs.dimensions {
 			return fmt.Errorf("vector dimension mismatch for id %v: expected %d, got %d",
 				item.ID, vs.dimensions, len(item.Vector))
@@ -374,6 +386,9 @@ func (vs *VecStore) UpdateMetadata(ctx context.Context, id any, metadata map[str
 	if len(metadata) == 0 {
 		return nil
 	}
+	if err := validateColumnValues("metadata", metadata, vs.metadata); err != nil {
+		return err
+	}
 
 	setClauses := make([]string, 0, len(metadata))
 	args := make([]any, 0, len(metadata)+1)
@@ -583,21 +598,41 @@ func (vs *VecStore) execInsert(ctx context.Context, execer sqlExecutor, id any, 
 }
 
 func (vs *VecStore) validateConfig() error {
+	if vs.db == nil {
+		return fmt.Errorf("db cannot be nil")
+	}
 	if err := validateIdentifier("table name", vs.tableName); err != nil {
 		return err
 	}
+	if vs.dimensions <= 0 {
+		return fmt.Errorf("dimensions must be greater than 0")
+	}
 	if err := validateDistanceMetric(vs.distance); err != nil {
 		return err
+	}
+	seen := map[string]string{
+		"rowid":  "reserved column",
+		"vector": "reserved column",
 	}
 	for _, column := range vs.metadata {
 		if err := validateIdentifier("metadata column", column); err != nil {
 			return err
 		}
+		lower := strings.ToLower(column)
+		if prev, ok := seen[lower]; ok {
+			return fmt.Errorf("duplicate column %q conflicts with %s", column, prev)
+		}
+		seen[lower] = "metadata column"
 	}
 	for _, column := range vs.auxColumns {
 		if err := validateIdentifier("aux column", column); err != nil {
 			return err
 		}
+		lower := strings.ToLower(column)
+		if prev, ok := seen[lower]; ok {
+			return fmt.Errorf("duplicate column %q conflicts with %s", column, prev)
+		}
+		seen[lower] = "aux column"
 	}
 	return nil
 }
@@ -633,6 +668,25 @@ func validateIdentifier(kind, value string) error {
 
 func quoteIdentifier(value string) string {
 	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+}
+
+func validateColumnValues(kind string, values map[string]string, allowed []string) error {
+	if len(values) == 0 {
+		return nil
+	}
+
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, key := range allowed {
+		allowedSet[key] = struct{}{}
+	}
+
+	for key := range values {
+		if _, ok := allowedSet[key]; !ok {
+			return fmt.Errorf("unknown %s column %q", kind, key)
+		}
+	}
+
+	return nil
 }
 
 func vectorToBlob(v []float32) []byte {

--- a/pkg/vec/store.go
+++ b/pkg/vec/store.go
@@ -83,7 +83,7 @@ func (vs *VecStore) buildCreateTableSQL() string {
 	}
 
 	for _, aux := range vs.auxColumns {
-		cols = append(cols, fmt.Sprintf("#%s text", aux))
+		cols = append(cols, fmt.Sprintf("+%s text", aux))
 	}
 
 	return fmt.Sprintf(
@@ -94,39 +94,30 @@ func (vs *VecStore) buildCreateTableSQL() string {
 }
 
 func (vs *VecStore) Insert(ctx context.Context, id any, vector []float32, metadata map[string]string) error {
+	return vs.InsertWithAux(ctx, id, vector, metadata, nil)
+}
+
+func (vs *VecStore) InsertWithAux(ctx context.Context, id any, vector []float32, metadata map[string]string, aux map[string]string) error {
 	if len(vector) != vs.dimensions {
 		return fmt.Errorf("vector dimension mismatch: expected %d, got %d", vs.dimensions, len(vector))
 	}
 
-	vs.db.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", vs.tableName), id)
-
-	cols := []string{"rowid", "vector"}
-	args := []any{id, vectorToBlob(vector)}
-
-	for _, key := range vs.metadata {
-		val := ""
-		if metadata != nil {
-			val = metadata[key]
-		}
-		cols = append(cols, key)
-		args = append(args, val)
-	}
-
-	placeholders := make([]string, len(cols))
-	for i := range cols {
-		placeholders[i] = "?"
-	}
-
-	query := fmt.Sprintf(
-		"INSERT INTO %s (%s) VALUES (%s)",
-		vs.tableName,
-		strings.Join(cols, ", "),
-		strings.Join(placeholders, ", "),
-	)
-
-	_, err := vs.db.ExecContext(ctx, query, args...)
+	tx, err := vs.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("insert vector: %w", err)
+		return fmt.Errorf("begin insert transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", vs.tableName), id); err != nil {
+		return fmt.Errorf("delete existing vector: %w", err)
+	}
+
+	if err := vs.execInsert(ctx, tx, id, vector, metadata, aux); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit insert transaction: %w", err)
 	}
 	return nil
 }
@@ -138,30 +129,7 @@ func (vs *VecStore) InsertBatch(ctx context.Context, items []VecItem) error {
 	}
 	defer tx.Rollback()
 
-	cols := []string{"rowid", "vector"}
-	for _, key := range vs.metadata {
-		cols = append(cols, key)
-	}
-
-	placeholders := make([]string, len(cols))
-	for i := range cols {
-		placeholders[i] = "?"
-	}
-
-	query := fmt.Sprintf(
-		"INSERT INTO %s (%s) VALUES (%s)",
-		vs.tableName,
-		strings.Join(cols, ", "),
-		strings.Join(placeholders, ", "),
-	)
-
 	delQuery := fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", vs.tableName)
-
-	stmt, err := tx.PrepareContext(ctx, query)
-	if err != nil {
-		return fmt.Errorf("prepare insert: %w", err)
-	}
-	defer stmt.Close()
 
 	delStmt, err := tx.PrepareContext(ctx, delQuery)
 	if err != nil {
@@ -175,18 +143,11 @@ func (vs *VecStore) InsertBatch(ctx context.Context, items []VecItem) error {
 				item.ID, vs.dimensions, len(item.Vector))
 		}
 
-		delStmt.ExecContext(ctx, item.ID)
-
-		args := []any{item.ID, vectorToBlob(item.Vector)}
-		for _, key := range vs.metadata {
-			val := ""
-			if item.Metadata != nil {
-				val = item.Metadata[key]
-			}
-			args = append(args, val)
+		if _, err := delStmt.ExecContext(ctx, item.ID); err != nil {
+			return fmt.Errorf("delete existing item %v: %w", item.ID, err)
 		}
 
-		if _, err := stmt.ExecContext(ctx, args...); err != nil {
+		if err := vs.execInsert(ctx, tx, item.ID, item.Vector, item.Metadata, item.Aux); err != nil {
 			return fmt.Errorf("insert item %v: %w", item.ID, err)
 		}
 	}
@@ -210,6 +171,9 @@ func (vs *VecStore) SearchWithFilter(ctx context.Context, queryVector []float32,
 	selectCols := "SELECT rowid, distance"
 	for _, meta := range vs.metadata {
 		selectCols += fmt.Sprintf(", %s", meta)
+	}
+	for _, aux := range vs.auxColumns {
+		selectCols += fmt.Sprintf(", %s", aux)
 	}
 
 	query := fmt.Sprintf(
@@ -253,8 +217,14 @@ func (vs *VecStore) SearchWithFilter(ctx context.Context, queryVector []float32,
 			scanArgs = append(scanArgs, metaVals[i])
 		}
 
+		auxVals := make([]any, len(vs.auxColumns))
+		for i := range vs.auxColumns {
+			auxVals[i] = new(string)
+			scanArgs = append(scanArgs, auxVals[i])
+		}
+
 		if err := rows.Scan(scanArgs...); err != nil {
-			continue
+			return nil, fmt.Errorf("scan search result: %w", err)
 		}
 
 		r.RowID = rowID
@@ -270,7 +240,20 @@ func (vs *VecStore) SearchWithFilter(ctx context.Context, queryVector []float32,
 			}
 		}
 
+		if len(vs.auxColumns) > 0 {
+			r.Aux = make(map[string]any)
+			for i, key := range vs.auxColumns {
+				if sv, ok := auxVals[i].(*string); ok {
+					r.Aux[key] = *sv
+				}
+			}
+		}
+
 		results = append(results, r)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate search results: %w", err)
 	}
 
 	return results, nil
@@ -280,6 +263,9 @@ func (vs *VecStore) Get(ctx context.Context, id any) (*VecItem, error) {
 	selectCols := "SELECT rowid, vector"
 	for _, meta := range vs.metadata {
 		selectCols += fmt.Sprintf(", %s", meta)
+	}
+	for _, aux := range vs.auxColumns {
+		selectCols += fmt.Sprintf(", %s", aux)
 	}
 
 	query := fmt.Sprintf("%s FROM %s WHERE rowid = ?", selectCols, vs.tableName)
@@ -296,6 +282,12 @@ func (vs *VecStore) Get(ctx context.Context, id any) (*VecItem, error) {
 		scanArgs = append(scanArgs, metaVals[i])
 	}
 
+	auxVals := make([]any, len(vs.auxColumns))
+	for i := range vs.auxColumns {
+		auxVals[i] = new(string)
+		scanArgs = append(scanArgs, auxVals[i])
+	}
+
 	if err := row.Scan(scanArgs...); err != nil {
 		return nil, fmt.Errorf("get vector item: %w", err)
 	}
@@ -308,6 +300,15 @@ func (vs *VecStore) Get(ctx context.Context, id any) (*VecItem, error) {
 		for i, key := range vs.metadata {
 			if sv, ok := metaVals[i].(*string); ok {
 				item.Metadata[key] = *sv
+			}
+		}
+	}
+
+	if len(vs.auxColumns) > 0 {
+		item.Aux = make(map[string]string)
+		for i, key := range vs.auxColumns {
+			if sv, ok := auxVals[i].(*string); ok {
+				item.Aux[key] = *sv
 			}
 		}
 	}
@@ -376,7 +377,15 @@ func (vs *VecStore) Count(ctx context.Context) (int64, error) {
 }
 
 func (vs *VecStore) List(ctx context.Context, limit int) ([]VecItem, error) {
-	query := fmt.Sprintf("SELECT rowid, vector FROM %s", vs.tableName)
+	selectCols := "SELECT rowid, vector"
+	for _, meta := range vs.metadata {
+		selectCols += fmt.Sprintf(", %s", meta)
+	}
+	for _, aux := range vs.auxColumns {
+		selectCols += fmt.Sprintf(", %s", aux)
+	}
+
+	query := fmt.Sprintf("%s FROM %s", selectCols, vs.tableName)
 	if limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", limit)
 	}
@@ -391,12 +400,50 @@ func (vs *VecStore) List(ctx context.Context, limit int) ([]VecItem, error) {
 	for rows.Next() {
 		var item VecItem
 		var vecBlob []byte
-		if err := rows.Scan(&item.RowID, &vecBlob); err != nil {
-			continue
+		scanArgs := []any{&item.RowID, &vecBlob}
+
+		metaVals := make([]any, len(vs.metadata))
+		for i := range vs.metadata {
+			metaVals[i] = new(string)
+			scanArgs = append(scanArgs, metaVals[i])
 		}
+
+		auxVals := make([]any, len(vs.auxColumns))
+		for i := range vs.auxColumns {
+			auxVals[i] = new(string)
+			scanArgs = append(scanArgs, auxVals[i])
+		}
+
+		if err := rows.Scan(scanArgs...); err != nil {
+			return nil, fmt.Errorf("scan listed item: %w", err)
+		}
+
 		item.ID = item.RowID
 		item.Vector = blobToVector(vecBlob)
+
+		if len(vs.metadata) > 0 {
+			item.Metadata = make(map[string]string)
+			for i, key := range vs.metadata {
+				if sv, ok := metaVals[i].(*string); ok {
+					item.Metadata[key] = *sv
+				}
+			}
+		}
+
+		if len(vs.auxColumns) > 0 {
+			item.Aux = make(map[string]string)
+			for i, key := range vs.auxColumns {
+				if sv, ok := auxVals[i].(*string); ok {
+					item.Aux[key] = *sv
+				}
+			}
+		}
+
 		items = append(items, item)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate listed items: %w", err)
 	}
 
 	return items, nil
@@ -433,6 +480,7 @@ type VecItem struct {
 	ID       any
 	Vector   []float32
 	Metadata map[string]string
+	Aux      map[string]string
 }
 
 type VecSearchResult struct {
@@ -440,6 +488,7 @@ type VecSearchResult struct {
 	ID       any
 	Distance float64
 	Metadata map[string]any
+	Aux      map[string]any
 }
 
 type VecTableInfo struct {
@@ -448,6 +497,51 @@ type VecTableInfo struct {
 	Distance    string `json:"distance"`
 	VectorCount int64  `json:"vector_count"`
 	VecVersion  string `json:"vec_version"`
+}
+
+type sqlExecutor interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func (vs *VecStore) execInsert(ctx context.Context, execer sqlExecutor, id any, vector []float32, metadata map[string]string, aux map[string]string) error {
+	cols := []string{"rowid", "vector"}
+	args := []any{id, vectorToBlob(vector)}
+
+	for _, key := range vs.metadata {
+		val := ""
+		if metadata != nil {
+			val = metadata[key]
+		}
+		cols = append(cols, key)
+		args = append(args, val)
+	}
+
+	for _, key := range vs.auxColumns {
+		val := ""
+		if aux != nil {
+			val = aux[key]
+		}
+		cols = append(cols, key)
+		args = append(args, val)
+	}
+
+	placeholders := make([]string, len(cols))
+	for i := range cols {
+		placeholders[i] = "?"
+	}
+
+	query := fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES (%s)",
+		vs.tableName,
+		strings.Join(cols, ", "),
+		strings.Join(placeholders, ", "),
+	)
+
+	if _, err := execer.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("insert vector: %w", err)
+	}
+
+	return nil
 }
 
 func vectorToBlob(v []float32) []byte {

--- a/pkg/vec/store.go
+++ b/pkg/vec/store.go
@@ -6,7 +6,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
+	"unicode"
 )
 
 type DistanceMetric string
@@ -49,6 +51,9 @@ func NewVecStore(cfg VecStoreConfig) *VecStore {
 }
 
 func (vs *VecStore) Init(ctx context.Context) error {
+	if err := vs.validateConfig(); err != nil {
+		return err
+	}
 	if err := vs.enableVec(ctx); err != nil {
 		return err
 	}
@@ -65,15 +70,22 @@ func (vs *VecStore) enableVec(ctx context.Context) error {
 }
 
 func (vs *VecStore) createTable(ctx context.Context) error {
-	sql := vs.buildCreateTableSQL()
-	_, err := vs.db.ExecContext(ctx, sql)
+	sql, err := vs.buildCreateTableSQL()
+	if err != nil {
+		return err
+	}
+	_, err = vs.db.ExecContext(ctx, sql)
 	if err != nil {
 		return fmt.Errorf("create vec0 table: %w", err)
 	}
 	return nil
 }
 
-func (vs *VecStore) buildCreateTableSQL() string {
+func (vs *VecStore) buildCreateTableSQL() (string, error) {
+	if err := vs.validateConfig(); err != nil {
+		return "", err
+	}
+
 	cols := []string{
 		fmt.Sprintf("vector float[%d] distance=%s", vs.dimensions, vs.distance),
 	}
@@ -88,9 +100,9 @@ func (vs *VecStore) buildCreateTableSQL() string {
 
 	return fmt.Sprintf(
 		"CREATE VIRTUAL TABLE IF NOT EXISTS %s USING vec0(%s)",
-		vs.tableName,
+		quoteIdentifier(vs.tableName),
 		strings.Join(cols, ", "),
-	)
+	), nil
 }
 
 func (vs *VecStore) Insert(ctx context.Context, id any, vector []float32, metadata map[string]string) error {
@@ -98,6 +110,9 @@ func (vs *VecStore) Insert(ctx context.Context, id any, vector []float32, metada
 }
 
 func (vs *VecStore) InsertWithAux(ctx context.Context, id any, vector []float32, metadata map[string]string, aux map[string]string) error {
+	if err := vs.validateConfig(); err != nil {
+		return err
+	}
 	if len(vector) != vs.dimensions {
 		return fmt.Errorf("vector dimension mismatch: expected %d, got %d", vs.dimensions, len(vector))
 	}
@@ -108,7 +123,7 @@ func (vs *VecStore) InsertWithAux(ctx context.Context, id any, vector []float32,
 	}
 	defer tx.Rollback()
 
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", vs.tableName), id); err != nil {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", quoteIdentifier(vs.tableName)), id); err != nil {
 		return fmt.Errorf("delete existing vector: %w", err)
 	}
 
@@ -123,13 +138,16 @@ func (vs *VecStore) InsertWithAux(ctx context.Context, id any, vector []float32,
 }
 
 func (vs *VecStore) InsertBatch(ctx context.Context, items []VecItem) error {
+	if err := vs.validateConfig(); err != nil {
+		return err
+	}
 	tx, err := vs.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
 
-	delQuery := fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", vs.tableName)
+	delQuery := fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", quoteIdentifier(vs.tableName))
 
 	delStmt, err := tx.PrepareContext(ctx, delQuery)
 	if err != nil {
@@ -160,6 +178,9 @@ func (vs *VecStore) Search(ctx context.Context, queryVector []float32, limit int
 }
 
 func (vs *VecStore) SearchWithFilter(ctx context.Context, queryVector []float32, limit int, threshold float64, metadataFilter map[string]string) ([]VecSearchResult, error) {
+	if err := vs.validateConfig(); err != nil {
+		return nil, err
+	}
 	if len(queryVector) != vs.dimensions {
 		return nil, fmt.Errorf("query vector dimension mismatch: expected %d, got %d", vs.dimensions, len(queryVector))
 	}
@@ -170,16 +191,16 @@ func (vs *VecStore) SearchWithFilter(ctx context.Context, queryVector []float32,
 
 	selectCols := "SELECT rowid, distance"
 	for _, meta := range vs.metadata {
-		selectCols += fmt.Sprintf(", %s", meta)
+		selectCols += fmt.Sprintf(", %s", quoteIdentifier(meta))
 	}
 	for _, aux := range vs.auxColumns {
-		selectCols += fmt.Sprintf(", %s", aux)
+		selectCols += fmt.Sprintf(", %s", quoteIdentifier(aux))
 	}
 
 	query := fmt.Sprintf(
 		"%s FROM %s WHERE vector MATCH ? AND k = ?",
 		selectCols,
-		vs.tableName,
+		quoteIdentifier(vs.tableName),
 	)
 
 	args := []any{vectorToBlob(queryVector), limit}
@@ -189,12 +210,11 @@ func (vs *VecStore) SearchWithFilter(ctx context.Context, queryVector []float32,
 		args = append(args, threshold)
 	}
 
-	for _, key := range vs.metadata {
-		val, ok := metadataFilter[key]
-		if !ok {
-			continue
+	for key, val := range metadataFilter {
+		if !slices.Contains(vs.metadata, key) {
+			return nil, fmt.Errorf("unknown metadata filter column %q", key)
 		}
-		query += fmt.Sprintf(" AND %s = ?", key)
+		query += fmt.Sprintf(" AND %s = ?", quoteIdentifier(key))
 		args = append(args, val)
 	}
 
@@ -260,15 +280,18 @@ func (vs *VecStore) SearchWithFilter(ctx context.Context, queryVector []float32,
 }
 
 func (vs *VecStore) Get(ctx context.Context, id any) (*VecItem, error) {
+	if err := vs.validateConfig(); err != nil {
+		return nil, err
+	}
 	selectCols := "SELECT rowid, vector"
 	for _, meta := range vs.metadata {
-		selectCols += fmt.Sprintf(", %s", meta)
+		selectCols += fmt.Sprintf(", %s", quoteIdentifier(meta))
 	}
 	for _, aux := range vs.auxColumns {
-		selectCols += fmt.Sprintf(", %s", aux)
+		selectCols += fmt.Sprintf(", %s", quoteIdentifier(aux))
 	}
 
-	query := fmt.Sprintf("%s FROM %s WHERE rowid = ?", selectCols, vs.tableName)
+	query := fmt.Sprintf("%s FROM %s WHERE rowid = ?", selectCols, quoteIdentifier(vs.tableName))
 
 	row := vs.db.QueryRowContext(ctx, query, id)
 
@@ -317,7 +340,10 @@ func (vs *VecStore) Get(ctx context.Context, id any) (*VecItem, error) {
 }
 
 func (vs *VecStore) Delete(ctx context.Context, id any) error {
-	query := fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", vs.tableName)
+	if err := vs.validateConfig(); err != nil {
+		return err
+	}
+	query := fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", quoteIdentifier(vs.tableName))
 	_, err := vs.db.ExecContext(ctx, query, id)
 	if err != nil {
 		return fmt.Errorf("delete vector item: %w", err)
@@ -326,11 +352,14 @@ func (vs *VecStore) Delete(ctx context.Context, id any) error {
 }
 
 func (vs *VecStore) UpdateVector(ctx context.Context, id any, vector []float32) error {
+	if err := vs.validateConfig(); err != nil {
+		return err
+	}
 	if len(vector) != vs.dimensions {
 		return fmt.Errorf("vector dimension mismatch: expected %d, got %d", vs.dimensions, len(vector))
 	}
 
-	query := fmt.Sprintf("UPDATE %s SET vector = ? WHERE rowid = ?", vs.tableName)
+	query := fmt.Sprintf("UPDATE %s SET vector = ? WHERE rowid = ?", quoteIdentifier(vs.tableName))
 	_, err := vs.db.ExecContext(ctx, query, vectorToBlob(vector), id)
 	if err != nil {
 		return fmt.Errorf("update vector: %w", err)
@@ -339,6 +368,9 @@ func (vs *VecStore) UpdateVector(ctx context.Context, id any, vector []float32) 
 }
 
 func (vs *VecStore) UpdateMetadata(ctx context.Context, id any, metadata map[string]string) error {
+	if err := vs.validateConfig(); err != nil {
+		return err
+	}
 	if len(metadata) == 0 {
 		return nil
 	}
@@ -348,7 +380,7 @@ func (vs *VecStore) UpdateMetadata(ctx context.Context, id any, metadata map[str
 
 	for _, key := range vs.metadata {
 		if val, ok := metadata[key]; ok {
-			setClauses = append(setClauses, fmt.Sprintf("%s = ?", key))
+			setClauses = append(setClauses, fmt.Sprintf("%s = ?", quoteIdentifier(key)))
 			args = append(args, val)
 		}
 	}
@@ -358,7 +390,7 @@ func (vs *VecStore) UpdateMetadata(ctx context.Context, id any, metadata map[str
 	}
 
 	args = append(args, id)
-	query := fmt.Sprintf("UPDATE %s SET %s WHERE rowid = ?", vs.tableName, strings.Join(setClauses, ", "))
+	query := fmt.Sprintf("UPDATE %s SET %s WHERE rowid = ?", quoteIdentifier(vs.tableName), strings.Join(setClauses, ", "))
 
 	_, err := vs.db.ExecContext(ctx, query, args...)
 	if err != nil {
@@ -368,8 +400,11 @@ func (vs *VecStore) UpdateMetadata(ctx context.Context, id any, metadata map[str
 }
 
 func (vs *VecStore) Count(ctx context.Context) (int64, error) {
+	if err := vs.validateConfig(); err != nil {
+		return 0, err
+	}
 	var count int64
-	err := vs.db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", vs.tableName)).Scan(&count)
+	err := vs.db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", quoteIdentifier(vs.tableName))).Scan(&count)
 	if err != nil {
 		return 0, err
 	}
@@ -377,15 +412,18 @@ func (vs *VecStore) Count(ctx context.Context) (int64, error) {
 }
 
 func (vs *VecStore) List(ctx context.Context, limit int) ([]VecItem, error) {
+	if err := vs.validateConfig(); err != nil {
+		return nil, err
+	}
 	selectCols := "SELECT rowid, vector"
 	for _, meta := range vs.metadata {
-		selectCols += fmt.Sprintf(", %s", meta)
+		selectCols += fmt.Sprintf(", %s", quoteIdentifier(meta))
 	}
 	for _, aux := range vs.auxColumns {
-		selectCols += fmt.Sprintf(", %s", aux)
+		selectCols += fmt.Sprintf(", %s", quoteIdentifier(aux))
 	}
 
-	query := fmt.Sprintf("%s FROM %s", selectCols, vs.tableName)
+	query := fmt.Sprintf("%s FROM %s", selectCols, quoteIdentifier(vs.tableName))
 	if limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", limit)
 	}
@@ -512,7 +550,7 @@ func (vs *VecStore) execInsert(ctx context.Context, execer sqlExecutor, id any, 
 		if metadata != nil {
 			val = metadata[key]
 		}
-		cols = append(cols, key)
+		cols = append(cols, quoteIdentifier(key))
 		args = append(args, val)
 	}
 
@@ -521,7 +559,7 @@ func (vs *VecStore) execInsert(ctx context.Context, execer sqlExecutor, id any, 
 		if aux != nil {
 			val = aux[key]
 		}
-		cols = append(cols, key)
+		cols = append(cols, quoteIdentifier(key))
 		args = append(args, val)
 	}
 
@@ -532,7 +570,7 @@ func (vs *VecStore) execInsert(ctx context.Context, execer sqlExecutor, id any, 
 
 	query := fmt.Sprintf(
 		"INSERT INTO %s (%s) VALUES (%s)",
-		vs.tableName,
+		quoteIdentifier(vs.tableName),
 		strings.Join(cols, ", "),
 		strings.Join(placeholders, ", "),
 	)
@@ -542,6 +580,59 @@ func (vs *VecStore) execInsert(ctx context.Context, execer sqlExecutor, id any, 
 	}
 
 	return nil
+}
+
+func (vs *VecStore) validateConfig() error {
+	if err := validateIdentifier("table name", vs.tableName); err != nil {
+		return err
+	}
+	if err := validateDistanceMetric(vs.distance); err != nil {
+		return err
+	}
+	for _, column := range vs.metadata {
+		if err := validateIdentifier("metadata column", column); err != nil {
+			return err
+		}
+	}
+	for _, column := range vs.auxColumns {
+		if err := validateIdentifier("aux column", column); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateDistanceMetric(distance DistanceMetric) error {
+	switch distance {
+	case DistanceCosine, DistanceL2:
+		return nil
+	default:
+		return fmt.Errorf("unsupported distance metric %q", distance)
+	}
+}
+
+func validateIdentifier(kind, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s cannot be empty", kind)
+	}
+
+	for i, r := range value {
+		if i == 0 {
+			if r != '_' && !unicode.IsLetter(r) {
+				return fmt.Errorf("invalid %s %q", kind, value)
+			}
+			continue
+		}
+		if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return fmt.Errorf("invalid %s %q", kind, value)
+		}
+	}
+
+	return nil
+}
+
+func quoteIdentifier(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
 }
 
 func vectorToBlob(v []float32) []byte {

--- a/pkg/vec/store.go
+++ b/pkg/vec/store.go
@@ -18,6 +18,8 @@ const (
 	DistanceL2     DistanceMetric = "l2"
 )
 
+const noDistanceThreshold = -1.0
+
 type VecStore struct {
 	db         *sql.DB
 	tableName  string
@@ -105,11 +107,11 @@ func (vs *VecStore) buildCreateTableSQL() (string, error) {
 	), nil
 }
 
-func (vs *VecStore) Insert(ctx context.Context, id any, vector []float32, metadata map[string]string) error {
+func (vs *VecStore) Insert(ctx context.Context, id int64, vector []float32, metadata map[string]string) error {
 	return vs.InsertWithAux(ctx, id, vector, metadata, nil)
 }
 
-func (vs *VecStore) InsertWithAux(ctx context.Context, id any, vector []float32, metadata map[string]string, aux map[string]string) error {
+func (vs *VecStore) InsertWithAux(ctx context.Context, id int64, vector []float32, metadata map[string]string, aux map[string]string) error {
 	if err := vs.validateConfig(); err != nil {
 		return err
 	}
@@ -186,7 +188,7 @@ func (vs *VecStore) InsertBatch(ctx context.Context, items []VecItem) error {
 }
 
 func (vs *VecStore) Search(ctx context.Context, queryVector []float32, limit int) ([]VecSearchResult, error) {
-	return vs.SearchWithFilter(ctx, queryVector, limit, 0, nil)
+	return vs.SearchWithFilter(ctx, queryVector, limit, noDistanceThreshold, nil)
 }
 
 func (vs *VecStore) SearchWithFilter(ctx context.Context, queryVector []float32, limit int, threshold float64, metadataFilter map[string]string) ([]VecSearchResult, error) {
@@ -217,7 +219,7 @@ func (vs *VecStore) SearchWithFilter(ctx context.Context, queryVector []float32,
 
 	args := []any{vectorToBlob(queryVector), limit}
 
-	if threshold > 0 {
+	if threshold >= 0 {
 		query += " AND distance <= ?"
 		args = append(args, threshold)
 	}
@@ -291,7 +293,7 @@ func (vs *VecStore) SearchWithFilter(ctx context.Context, queryVector []float32,
 	return results, nil
 }
 
-func (vs *VecStore) Get(ctx context.Context, id any) (*VecItem, error) {
+func (vs *VecStore) Get(ctx context.Context, id int64) (*VecItem, error) {
 	if err := vs.validateConfig(); err != nil {
 		return nil, err
 	}
@@ -351,7 +353,7 @@ func (vs *VecStore) Get(ctx context.Context, id any) (*VecItem, error) {
 	return &item, nil
 }
 
-func (vs *VecStore) Delete(ctx context.Context, id any) error {
+func (vs *VecStore) Delete(ctx context.Context, id int64) error {
 	if err := vs.validateConfig(); err != nil {
 		return err
 	}
@@ -363,7 +365,7 @@ func (vs *VecStore) Delete(ctx context.Context, id any) error {
 	return nil
 }
 
-func (vs *VecStore) UpdateVector(ctx context.Context, id any, vector []float32) error {
+func (vs *VecStore) UpdateVector(ctx context.Context, id int64, vector []float32) error {
 	if err := vs.validateConfig(); err != nil {
 		return err
 	}
@@ -379,7 +381,7 @@ func (vs *VecStore) UpdateVector(ctx context.Context, id any, vector []float32) 
 	return nil
 }
 
-func (vs *VecStore) UpdateMetadata(ctx context.Context, id any, metadata map[string]string) error {
+func (vs *VecStore) UpdateMetadata(ctx context.Context, id int64, metadata map[string]string) error {
 	if err := vs.validateConfig(); err != nil {
 		return err
 	}
@@ -503,6 +505,9 @@ func (vs *VecStore) List(ctx context.Context, limit int) ([]VecItem, error) {
 }
 
 func (vs *VecStore) VecVersion(ctx context.Context) (string, error) {
+	if err := vs.validateConfig(); err != nil {
+		return "", err
+	}
 	var version string
 	err := vs.db.QueryRowContext(ctx, "SELECT vec_version()").Scan(&version)
 	return version, err
@@ -520,8 +525,7 @@ func (vs *VecStore) TableInfo(ctx context.Context) (*VecTableInfo, error) {
 	}
 	info.VectorCount = count
 
-	var vecVersion string
-	if err := vs.db.QueryRowContext(ctx, "SELECT vec_version()").Scan(&vecVersion); err == nil {
+	if vecVersion, err := vs.VecVersion(ctx); err == nil {
 		info.VecVersion = vecVersion
 	}
 
@@ -530,7 +534,7 @@ func (vs *VecStore) TableInfo(ctx context.Context) (*VecTableInfo, error) {
 
 type VecItem struct {
 	RowID    int64
-	ID       any
+	ID       int64
 	Vector   []float32
 	Metadata map[string]string
 	Aux      map[string]string
@@ -538,7 +542,7 @@ type VecItem struct {
 
 type VecSearchResult struct {
 	RowID    int64
-	ID       any
+	ID       int64
 	Distance float64
 	Metadata map[string]any
 	Aux      map[string]any
@@ -556,7 +560,7 @@ type sqlExecutor interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
 
-func (vs *VecStore) execInsert(ctx context.Context, execer sqlExecutor, id any, vector []float32, metadata map[string]string, aux map[string]string) error {
+func (vs *VecStore) execInsert(ctx context.Context, execer sqlExecutor, id int64, vector []float32, metadata map[string]string, aux map[string]string) error {
 	cols := []string{"rowid", "vector"}
 	args := []any{id, vectorToBlob(vector)}
 

--- a/pkg/vec/store_test.go
+++ b/pkg/vec/store_test.go
@@ -1,0 +1,362 @@
+package vec
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite/vec"
+)
+
+func setupVecStore(t *testing.T) *VecStore {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	vs := NewVecStore(VecStoreConfig{
+		DB:         db,
+		TableName:  "test_vectors",
+		Dimensions: 4,
+		Distance:   DistanceCosine,
+		Metadata:   []string{"category", "source"},
+	})
+
+	if err := vs.Init(context.Background()); err != nil {
+		t.Fatalf("failed to init vec store: %v", err)
+	}
+
+	return vs
+}
+
+func TestVecStoreInit(t *testing.T) {
+	vs := setupVecStore(t)
+
+	version, err := vs.VecVersion(context.Background())
+	if err != nil {
+		t.Fatalf("failed to get vec version: %v", err)
+	}
+	if version == "" {
+		t.Error("expected non-empty vec version")
+	}
+
+	info, err := vs.TableInfo(context.Background())
+	if err != nil {
+		t.Fatalf("failed to get table info: %v", err)
+	}
+
+	if info.TableName != "test_vectors" {
+		t.Errorf("expected table name test_vectors, got %s", info.TableName)
+	}
+	if info.Dimensions != 4 {
+		t.Errorf("expected dimensions 4, got %d", info.Dimensions)
+	}
+	if info.Distance != "cosine" {
+		t.Errorf("expected distance cosine, got %s", info.Distance)
+	}
+}
+
+func TestVecStoreInsert(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	err := vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{
+		"category": "test",
+		"source":   "unit",
+	})
+	if err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	count, err := vs.Count(ctx)
+	if err != nil {
+		t.Fatalf("failed to count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 vector, got %d", count)
+	}
+}
+
+func TestVecStoreInsertBatch(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	items := []VecItem{
+		{ID: int64(1), Vector: []float32{0.1, 0.2, 0.3, 0.4}, Metadata: map[string]string{"category": "a"}},
+		{ID: int64(2), Vector: []float32{0.5, 0.6, 0.7, 0.8}, Metadata: map[string]string{"category": "b"}},
+		{ID: int64(3), Vector: []float32{0.9, 1.0, 0.1, 0.2}, Metadata: map[string]string{"category": "a"}},
+	}
+
+	if err := vs.InsertBatch(ctx, items); err != nil {
+		t.Fatalf("failed to insert batch: %v", err)
+	}
+
+	count, err := vs.Count(ctx)
+	if err != nil {
+		t.Fatalf("failed to count: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 vectors, got %d", count)
+	}
+}
+
+func TestVecStoreSearch(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, nil)
+	vs.Insert(ctx, 2, []float32{0.11, 0.21, 0.31, 0.41}, nil)
+	vs.Insert(ctx, 3, []float32{0.9, 0.8, 0.7, 0.6}, nil)
+
+	queryVec := []float32{0.1, 0.2, 0.3, 0.4}
+	results, err := vs.Search(ctx, queryVec, 10)
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Errorf("expected 3 results, got %d", len(results))
+	}
+
+	if results[0].RowID != 1 {
+		t.Errorf("expected first result rowid 1, got %d", results[0].RowID)
+	}
+}
+
+func TestVecStoreSearchWithThreshold(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	vs.Insert(ctx, 1, []float32{0.5, 0.5, 0.5, 0.5}, nil)
+	vs.Insert(ctx, 2, []float32{0.51, 0.51, 0.51, 0.51}, nil)
+	vs.Insert(ctx, 3, []float32{0.1, 0.2, 0.3, 0.4}, nil)
+
+	queryVec := []float32{0.5, 0.5, 0.5, 0.5}
+	results, err := vs.SearchWithFilter(ctx, queryVec, 10, 0.01, nil)
+	if err != nil {
+		t.Fatalf("search with threshold failed: %v", err)
+	}
+
+	if len(results) < 1 {
+		t.Errorf("expected at least 1 result, got %d", len(results))
+	}
+
+	if results[0].Distance > 0.01 {
+		t.Errorf("expected distance <= 0.01, got %f", results[0].Distance)
+	}
+}
+
+func TestVecStoreGet(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	meta := map[string]string{"category": "test", "source": "unit"}
+	vs.Insert(ctx, 42, []float32{0.1, 0.2, 0.3, 0.4}, meta)
+
+	item, err := vs.Get(ctx, 42)
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+
+	if item.RowID != 42 {
+		t.Errorf("expected rowid 42, got %d", item.RowID)
+	}
+
+	if len(item.Vector) != 4 {
+		t.Errorf("expected 4 dimensions, got %d", len(item.Vector))
+	}
+
+	if item.Metadata["category"] != "test" {
+		t.Errorf("expected category test, got %s", item.Metadata["category"])
+	}
+}
+
+func TestVecStoreDelete(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, nil)
+
+	count, _ := vs.Count(ctx)
+	if count != 1 {
+		t.Fatalf("expected 1 vector before delete")
+	}
+
+	if err := vs.Delete(ctx, 1); err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+
+	count, _ = vs.Count(ctx)
+	if count != 0 {
+		t.Errorf("expected 0 vectors after delete, got %d", count)
+	}
+}
+
+func TestVecStoreUpdateVector(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, nil)
+
+	newVec := []float32{0.9, 0.8, 0.7, 0.6}
+	if err := vs.UpdateVector(ctx, 1, newVec); err != nil {
+		t.Fatalf("update vector failed: %v", err)
+	}
+
+	item, err := vs.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("get after update failed: %v", err)
+	}
+
+	for i := range newVec {
+		if item.Vector[i] != newVec[i] {
+			t.Errorf("vector[%d] expected %f, got %f", i, newVec[i], item.Vector[i])
+		}
+	}
+}
+
+func TestVecStoreUpdateMetadata(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{
+		"category": "old",
+		"source":   "old",
+	})
+
+	if err := vs.UpdateMetadata(ctx, 1, map[string]string{
+		"category": "new",
+	}); err != nil {
+		t.Fatalf("update metadata failed: %v", err)
+	}
+
+	item, err := vs.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("get after metadata update failed: %v", err)
+	}
+
+	if item.Metadata["category"] != "new" {
+		t.Errorf("expected category new, got %s", item.Metadata["category"])
+	}
+	if item.Metadata["source"] != "old" {
+		t.Errorf("expected source old, got %s", item.Metadata["source"])
+	}
+}
+
+func TestVecStoreList(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, nil)
+	vs.Insert(ctx, 2, []float32{0.5, 0.6, 0.7, 0.8}, nil)
+
+	items, err := vs.List(ctx, 10)
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+
+	if len(items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(items))
+	}
+}
+
+func TestVecStoreDimensionMismatch(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	err := vs.Insert(ctx, 1, []float32{0.1, 0.2}, nil)
+	if err == nil {
+		t.Error("expected dimension mismatch error")
+	}
+
+	if _, err := vs.Search(ctx, []float32{0.1, 0.2}, 10); err == nil {
+		t.Error("expected dimension mismatch error on search")
+	}
+}
+
+func TestCosineSimilarity(t *testing.T) {
+	a := []float32{1.0, 0.0, 0.0}
+	b := []float32{1.0, 0.0, 0.0}
+
+	sim := CosineSimilarity(a, b)
+	if sim < 0.999 {
+		t.Errorf("expected similarity ~1.0, got %f", sim)
+	}
+
+	c := []float32{0.0, 1.0, 0.0}
+	sim = CosineSimilarity(a, c)
+	if sim > 0.001 {
+		t.Errorf("expected similarity ~0.0, got %f", sim)
+	}
+}
+
+func TestCosineDistance(t *testing.T) {
+	a := []float32{1.0, 0.0, 0.0}
+	b := []float32{1.0, 0.0, 0.0}
+
+	dist := CosineDistance(a, b)
+	if dist > 0.001 {
+		t.Errorf("expected distance ~0.0, got %f", dist)
+	}
+}
+
+func TestL2Distance(t *testing.T) {
+	a := []float32{0.0, 0.0}
+	b := []float32{3.0, 4.0}
+
+	dist := L2Distance(a, b)
+	if dist < 4.9 || dist > 5.1 {
+		t.Errorf("expected distance ~5.0, got %f", dist)
+	}
+}
+
+func TestVectorBlobRoundTrip(t *testing.T) {
+	original := []float32{0.1, 0.2, 0.3, 0.4, 0.5}
+	blob := vectorToBlob(original)
+	restored := blobToVector(blob)
+
+	if len(restored) != len(original) {
+		t.Fatalf("length mismatch: %d vs %d", len(restored), len(original))
+	}
+
+	for i := range original {
+		if restored[i] != original[i] {
+			t.Errorf("index %d: expected %f, got %f", i, original[i], restored[i])
+		}
+	}
+}
+
+func TestVecStoreUpsert(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, nil)
+
+	count, _ := vs.Count(ctx)
+	if count != 1 {
+		t.Fatalf("expected 1 vector after first insert")
+	}
+
+	vs.Insert(ctx, 1, []float32{0.5, 0.6, 0.7, 0.8}, nil)
+
+	count, _ = vs.Count(ctx)
+	if count != 1 {
+		t.Errorf("expected 1 vector after upsert, got %d", count)
+	}
+
+	item, err := vs.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("get after upsert failed: %v", err)
+	}
+
+	if len(item.Vector) != 4 || item.Vector[0] != 0.5 {
+		t.Errorf("expected vector updated, got %v", item.Vector)
+	}
+}

--- a/pkg/vec/store_test.go
+++ b/pkg/vec/store_test.go
@@ -153,6 +153,44 @@ func TestVecStoreSearchWithThreshold(t *testing.T) {
 	}
 }
 
+func TestVecStoreSearchWithMetadataFilter(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	if err := vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{
+		"category": "keep",
+		"source":   "unit",
+	}); err != nil {
+		t.Fatalf("insert item 1 failed: %v", err)
+	}
+
+	if err := vs.Insert(ctx, 2, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{
+		"category": "skip",
+		"source":   "unit",
+	}); err != nil {
+		t.Fatalf("insert item 2 failed: %v", err)
+	}
+
+	results, err := vs.SearchWithFilter(ctx, []float32{0.1, 0.2, 0.3, 0.4}, 10, 0, map[string]string{
+		"category": "keep",
+	})
+	if err != nil {
+		t.Fatalf("search with metadata filter failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if results[0].RowID != 1 {
+		t.Fatalf("expected rowid 1, got %d", results[0].RowID)
+	}
+
+	if got := results[0].Metadata["category"]; got != "keep" {
+		t.Fatalf("expected category keep, got %v", got)
+	}
+}
+
 func TestVecStoreGet(t *testing.T) {
 	vs := setupVecStore(t)
 	ctx := context.Background()

--- a/pkg/vec/store_test.go
+++ b/pkg/vec/store_test.go
@@ -612,3 +612,185 @@ func TestVecStoreRejectsUnsupportedDistanceMetric(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestVecStoreRejectsNilDB(t *testing.T) {
+	vs := NewVecStore(VecStoreConfig{
+		TableName:  "vectors",
+		Dimensions: 4,
+		Distance:   DistanceCosine,
+	})
+
+	_, err := vs.Count(context.Background())
+	if err == nil {
+		t.Fatal("expected nil db to fail")
+	}
+	if !strings.Contains(err.Error(), "db cannot be nil") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVecStoreRejectsNonPositiveDimensions(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	tests := []struct {
+		name string
+		dims int
+	}{
+		{name: "zero", dims: 0},
+		{name: "negative", dims: -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vs := NewVecStore(VecStoreConfig{
+				DB:         db,
+				TableName:  "vectors",
+				Dimensions: tt.dims,
+				Distance:   DistanceCosine,
+			})
+
+			_, err := vs.Count(context.Background())
+			if err == nil {
+				t.Fatal("expected invalid dimensions to fail")
+			}
+			if !strings.Contains(err.Error(), "dimensions must be greater than 0") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestVecStoreRejectsDuplicateConfiguredColumns(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	tests := []struct {
+		name string
+		cfg  VecStoreConfig
+		want string
+	}{
+		{
+			name: "duplicate metadata columns",
+			cfg: VecStoreConfig{
+				DB:         db,
+				TableName:  "vectors",
+				Dimensions: 4,
+				Distance:   DistanceCosine,
+				Metadata:   []string{"category", "category"},
+			},
+			want: `duplicate column "category" conflicts with metadata column`,
+		},
+		{
+			name: "metadata aux conflict",
+			cfg: VecStoreConfig{
+				DB:         db,
+				TableName:  "vectors",
+				Dimensions: 4,
+				Distance:   DistanceCosine,
+				Metadata:   []string{"shared"},
+				AuxColumns: []string{"shared"},
+			},
+			want: `duplicate column "shared" conflicts with metadata column`,
+		},
+		{
+			name: "reserved vector column",
+			cfg: VecStoreConfig{
+				DB:         db,
+				TableName:  "vectors",
+				Dimensions: 4,
+				Distance:   DistanceCosine,
+				Metadata:   []string{"vector"},
+			},
+			want: `duplicate column "vector" conflicts with reserved column`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vs := NewVecStore(tt.cfg)
+			_, err := vs.Count(context.Background())
+			if err == nil {
+				t.Fatal("expected duplicate or conflicting columns to fail")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestVecStoreRejectsUnknownInsertColumns(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	if err := vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{
+		"category": "keep",
+		"typo":     "drop",
+	}); err == nil {
+		t.Fatal("expected unknown metadata key to fail")
+	} else if !strings.Contains(err.Error(), `unknown metadata column "typo"`) {
+		t.Fatalf("unexpected metadata error: %v", err)
+	}
+
+	if err := vs.InsertWithAux(ctx, 2, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{
+		"category": "keep",
+	}, map[string]string{
+		"ghost": "drop",
+	}); err == nil {
+		t.Fatal("expected unknown aux key to fail")
+	} else if !strings.Contains(err.Error(), `unknown aux column "ghost"`) {
+		t.Fatalf("unexpected aux error: %v", err)
+	}
+}
+
+func TestVecStoreInsertBatchRejectsUnknownColumns(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	err := vs.InsertBatch(ctx, []VecItem{
+		{
+			ID:       int64(1),
+			Vector:   []float32{0.1, 0.2, 0.3, 0.4},
+			Metadata: map[string]string{"category": "a", "unknown": "bad"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected batch insert with unknown metadata key to fail")
+	}
+	if !strings.Contains(err.Error(), `item 1: unknown metadata column "unknown"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVecStoreUpdateMetadataRejectsUnknownKeys(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	if err := vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{
+		"category": "old",
+		"source":   "unit",
+	}); err != nil {
+		t.Fatalf("insert failed: %v", err)
+	}
+
+	err := vs.UpdateMetadata(ctx, 1, map[string]string{
+		"category": "new",
+		"unknown":  "bad",
+	})
+	if err == nil {
+		t.Fatal("expected unknown update metadata key to fail")
+	}
+	if !strings.Contains(err.Error(), `unknown metadata column "unknown"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/vec/store_test.go
+++ b/pkg/vec/store_test.go
@@ -3,6 +3,7 @@ package vec
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -189,6 +190,28 @@ func TestVecStoreSearchWithMetadataFilter(t *testing.T) {
 
 	if got := results[0].Metadata["category"]; got != "keep" {
 		t.Fatalf("expected category keep, got %v", got)
+	}
+}
+
+func TestVecStoreSearchWithUnknownMetadataFilterFails(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	if err := vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{
+		"category": "keep",
+		"source":   "unit",
+	}); err != nil {
+		t.Fatalf("insert failed: %v", err)
+	}
+
+	_, err := vs.SearchWithFilter(ctx, []float32{0.1, 0.2, 0.3, 0.4}, 10, 0, map[string]string{
+		"typo": "keep",
+	})
+	if err == nil {
+		t.Fatal("expected unknown metadata filter to fail")
+	}
+	if !strings.Contains(err.Error(), `unknown metadata filter column "typo"`) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -500,5 +523,92 @@ func TestVecStoreInsertBatchPersistsAuxColumns(t *testing.T) {
 
 	if got.Aux["tag"] != "second" {
 		t.Fatalf("expected aux tag second, got %s", got.Aux["tag"])
+	}
+}
+
+func TestVecStoreRejectsInvalidIdentifiers(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	tests := []struct {
+		name string
+		cfg  VecStoreConfig
+		want string
+	}{
+		{
+			name: "invalid table name",
+			cfg: VecStoreConfig{
+				DB:         db,
+				TableName:  "bad-name",
+				Dimensions: 4,
+				Distance:   DistanceCosine,
+			},
+			want: `invalid table name "bad-name"`,
+		},
+		{
+			name: "invalid metadata column",
+			cfg: VecStoreConfig{
+				DB:         db,
+				TableName:  "vectors",
+				Dimensions: 4,
+				Distance:   DistanceCosine,
+				Metadata:   []string{"bad-name"},
+			},
+			want: `invalid metadata column "bad-name"`,
+		},
+		{
+			name: "invalid aux column",
+			cfg: VecStoreConfig{
+				DB:         db,
+				TableName:  "vectors",
+				Dimensions: 4,
+				Distance:   DistanceCosine,
+				AuxColumns: []string{"bad-name"},
+			},
+			want: `invalid aux column "bad-name"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vs := NewVecStore(tt.cfg)
+			_, err := vs.Count(context.Background())
+			if err == nil {
+				t.Fatal("expected invalid identifier to fail")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestVecStoreRejectsUnsupportedDistanceMetric(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	vs := NewVecStore(VecStoreConfig{
+		DB:         db,
+		TableName:  "vectors",
+		Dimensions: 4,
+		Distance:   DistanceMetric("dot"),
+	})
+
+	_, err = vs.Count(context.Background())
+	if err == nil {
+		t.Fatal("expected unsupported distance metric to fail")
+	}
+	if !strings.Contains(err.Error(), `unsupported distance metric "dot"`) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/pkg/vec/store_test.go
+++ b/pkg/vec/store_test.go
@@ -27,6 +27,7 @@ func setupVecStore(t *testing.T) *VecStore {
 		Dimensions: 4,
 		Distance:   DistanceCosine,
 		Metadata:   []string{"category", "source"},
+		AuxColumns: []string{"tag"},
 	})
 
 	if err := vs.Init(context.Background()); err != nil {
@@ -196,7 +197,9 @@ func TestVecStoreGet(t *testing.T) {
 	ctx := context.Background()
 
 	meta := map[string]string{"category": "test", "source": "unit"}
-	vs.Insert(ctx, 42, []float32{0.1, 0.2, 0.3, 0.4}, meta)
+	if err := vs.InsertWithAux(ctx, 42, []float32{0.1, 0.2, 0.3, 0.4}, meta, map[string]string{"tag": "primary"}); err != nil {
+		t.Fatalf("insert with aux failed: %v", err)
+	}
 
 	item, err := vs.Get(ctx, 42)
 	if err != nil {
@@ -213,6 +216,9 @@ func TestVecStoreGet(t *testing.T) {
 
 	if item.Metadata["category"] != "test" {
 		t.Errorf("expected category test, got %s", item.Metadata["category"])
+	}
+	if item.Aux["tag"] != "primary" {
+		t.Errorf("expected aux tag primary, got %s", item.Aux["tag"])
 	}
 }
 
@@ -292,8 +298,12 @@ func TestVecStoreList(t *testing.T) {
 	vs := setupVecStore(t)
 	ctx := context.Background()
 
-	vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, nil)
-	vs.Insert(ctx, 2, []float32{0.5, 0.6, 0.7, 0.8}, nil)
+	if err := vs.InsertWithAux(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{"category": "a"}, map[string]string{"tag": "first"}); err != nil {
+		t.Fatalf("insert item 1 failed: %v", err)
+	}
+	if err := vs.InsertWithAux(ctx, 2, []float32{0.5, 0.6, 0.7, 0.8}, map[string]string{"category": "b"}, map[string]string{"tag": "second"}); err != nil {
+		t.Fatalf("insert item 2 failed: %v", err)
+	}
 
 	items, err := vs.List(ctx, 10)
 	if err != nil {
@@ -302,6 +312,12 @@ func TestVecStoreList(t *testing.T) {
 
 	if len(items) != 2 {
 		t.Errorf("expected 2 items, got %d", len(items))
+	}
+	if items[0].Aux["tag"] == "" {
+		t.Fatalf("expected aux column value in list result")
+	}
+	if items[0].Metadata["category"] == "" {
+		t.Fatalf("expected metadata value in list result")
 	}
 }
 
@@ -396,5 +412,93 @@ func TestVecStoreUpsert(t *testing.T) {
 
 	if len(item.Vector) != 4 || item.Vector[0] != 0.5 {
 		t.Errorf("expected vector updated, got %v", item.Vector)
+	}
+}
+
+func TestVecStoreInsertRollsBackOnFailure(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	if err := vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{"category": "before"}); err != nil {
+		t.Fatalf("initial insert failed: %v", err)
+	}
+
+	vs.metadata = append(vs.metadata, "missing_column")
+
+	if err := vs.Insert(ctx, 1, []float32{0.9, 0.8, 0.7, 0.6}, map[string]string{"category": "after"}); err == nil {
+		t.Fatal("expected insert failure after adding missing column")
+	}
+
+	vs.metadata = vs.metadata[:len(vs.metadata)-1]
+
+	item, err := vs.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("get after failed upsert failed: %v", err)
+	}
+
+	if item.Metadata["category"] != "before" {
+		t.Fatalf("expected original row to remain after rollback, got %q", item.Metadata["category"])
+	}
+	if item.Vector[0] != 0.1 {
+		t.Fatalf("expected original vector to remain after rollback, got %v", item.Vector)
+	}
+}
+
+func TestVecStoreSearchReturnsAuxColumns(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	if err := vs.InsertWithAux(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{
+		"category": "keep",
+		"source":   "unit",
+	}, map[string]string{"tag": "visible"}); err != nil {
+		t.Fatalf("insert with aux failed: %v", err)
+	}
+
+	results, err := vs.SearchWithFilter(ctx, []float32{0.1, 0.2, 0.3, 0.4}, 1, 0, map[string]string{
+		"category": "keep",
+	})
+	if err != nil {
+		t.Fatalf("search with metadata filter failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Aux["tag"] != "visible" {
+		t.Fatalf("expected aux tag visible, got %v", results[0].Aux["tag"])
+	}
+}
+
+func TestVecStoreInsertBatchPersistsAuxColumns(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	items := []VecItem{
+		{
+			ID:       int64(1),
+			Vector:   []float32{0.1, 0.2, 0.3, 0.4},
+			Metadata: map[string]string{"category": "a", "source": "batch"},
+			Aux:      map[string]string{"tag": "first"},
+		},
+		{
+			ID:       int64(2),
+			Vector:   []float32{0.4, 0.3, 0.2, 0.1},
+			Metadata: map[string]string{"category": "b", "source": "batch"},
+			Aux:      map[string]string{"tag": "second"},
+		},
+	}
+
+	if err := vs.InsertBatch(ctx, items); err != nil {
+		t.Fatalf("insert batch failed: %v", err)
+	}
+
+	got, err := vs.Get(ctx, 2)
+	if err != nil {
+		t.Fatalf("get after batch insert failed: %v", err)
+	}
+
+	if got.Aux["tag"] != "second" {
+		t.Fatalf("expected aux tag second, got %s", got.Aux["tag"])
 	}
 }

--- a/pkg/vec/store_test.go
+++ b/pkg/vec/store_test.go
@@ -38,6 +38,32 @@ func setupVecStore(t *testing.T) *VecStore {
 	return vs
 }
 
+func setupVecStoreWithDistance(t *testing.T, distance DistanceMetric) *VecStore {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	vs := NewVecStore(VecStoreConfig{
+		DB:         db,
+		TableName:  "distance_vectors",
+		Dimensions: 4,
+		Distance:   distance,
+	})
+
+	if err := vs.Init(context.Background()); err != nil {
+		t.Fatalf("failed to init vec store: %v", err)
+	}
+
+	return vs
+}
+
 func TestVecStoreInit(t *testing.T) {
 	vs := setupVecStore(t)
 
@@ -130,6 +156,9 @@ func TestVecStoreSearch(t *testing.T) {
 	if results[0].RowID != 1 {
 		t.Errorf("expected first result rowid 1, got %d", results[0].RowID)
 	}
+	if results[0].ID != 1 {
+		t.Errorf("expected first result id 1, got %d", results[0].ID)
+	}
 }
 
 func TestVecStoreSearchWithThreshold(t *testing.T) {
@@ -152,6 +181,65 @@ func TestVecStoreSearchWithThreshold(t *testing.T) {
 
 	if results[0].Distance > 0.01 {
 		t.Errorf("expected distance <= 0.01, got %f", results[0].Distance)
+	}
+}
+
+func TestVecStoreSearchWithZeroThresholdReturnsExactMatchesOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		distance DistanceMetric
+		match    []float32
+		other    []float32
+	}{
+		{
+			name:     "cosine",
+			distance: DistanceCosine,
+			match:    []float32{1, 0, 0, 0},
+			other:    []float32{0, 1, 0, 0},
+		},
+		{
+			name:     "l2",
+			distance: DistanceL2,
+			match:    []float32{1, 1, 1, 1},
+			other:    []float32{2, 2, 2, 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vs := setupVecStoreWithDistance(t, tt.distance)
+			ctx := context.Background()
+
+			if err := vs.Insert(ctx, 1, tt.match, nil); err != nil {
+				t.Fatalf("insert exact match failed: %v", err)
+			}
+			if err := vs.Insert(ctx, 2, tt.other, nil); err != nil {
+				t.Fatalf("insert non-match failed: %v", err)
+			}
+
+			results, err := vs.SearchWithFilter(ctx, tt.match, 10, 0, nil)
+			if err != nil {
+				t.Fatalf("search with zero threshold failed: %v", err)
+			}
+
+			if len(results) != 1 {
+				t.Fatalf("expected 1 exact match, got %d", len(results))
+			}
+			if results[0].RowID != 1 {
+				t.Fatalf("expected exact match rowid 1, got %d", results[0].RowID)
+			}
+			if results[0].ID != 1 {
+				t.Fatalf("expected exact match id 1, got %d", results[0].ID)
+			}
+
+			unfiltered, err := vs.Search(ctx, tt.match, 10)
+			if err != nil {
+				t.Fatalf("unfiltered search failed: %v", err)
+			}
+			if len(unfiltered) != 2 {
+				t.Fatalf("expected unfiltered search to return 2 results, got %d", len(unfiltered))
+			}
+		})
 	}
 }
 
@@ -231,6 +319,9 @@ func TestVecStoreGet(t *testing.T) {
 
 	if item.RowID != 42 {
 		t.Errorf("expected rowid 42, got %d", item.RowID)
+	}
+	if item.ID != 42 {
+		t.Errorf("expected id 42, got %d", item.ID)
 	}
 
 	if len(item.Vector) != 4 {
@@ -623,6 +714,22 @@ func TestVecStoreRejectsNilDB(t *testing.T) {
 	_, err := vs.Count(context.Background())
 	if err == nil {
 		t.Fatal("expected nil db to fail")
+	}
+	if !strings.Contains(err.Error(), "db cannot be nil") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVecStoreVecVersionValidatesConfig(t *testing.T) {
+	vs := NewVecStore(VecStoreConfig{
+		TableName:  "vectors",
+		Dimensions: 4,
+		Distance:   DistanceCosine,
+	})
+
+	_, err := vs.VecVersion(context.Background())
+	if err == nil {
+		t.Fatal("expected VecVersion to validate config")
 	}
 	if !strings.Contains(err.Error(), "db cannot be nil") {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary

This PR adds the standalone `pkg/vec` package for SQLite-backed vector storage and nearest-neighbor search helpers.

## Changes

- add a configurable vector store abstraction over SQLite vec tables
- support table initialization, metadata columns, and distance metric configuration
- add insert, count, table inspection, and nearest-neighbor query helpers
- add package tests covering initialization, insert, query, and metadata behavior

## Testing

- `go test ./pkg/vec`

