### PR TITLE
feat(config): add modular config helpers

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -244,7 +244,7 @@ func TestLoadUTF8BOMConfig(t *testing.T) {
 	path := filepath.Join(dir, "bom.json")
 
 	cfg := DefaultConfig()
-	cfg.Agent.Name = "personal-assistant"
+	cfg.Agent.Name = "个人助手"
 	data, _ := json.MarshalIndent(cfg, "", "  ")
 	data = append([]byte{0xEF, 0xBB, 0xBF}, data...)
 	if err := os.WriteFile(path, data, 0o644); err != nil {
@@ -255,7 +255,7 @@ func TestLoadUTF8BOMConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected BOM config to load: %v", err)
 	}
-	if loaded.Agent.Name != "personal-assistant" {
+	if loaded.Agent.Name != "个人助手" {
 		t.Fatalf("expected agent name to survive BOM load, got %q", loaded.Agent.Name)
 	}
 }
@@ -471,43 +471,6 @@ func TestSaveRelativizesPathsInsideConfigDirectory(t *testing.T) {
 	}
 	if loaded.Orchestrator.SubAgents[0].WorkingDir != "workflows/worker" {
 		t.Fatalf("expected relative sub-agent working dir, got %q", loaded.Orchestrator.SubAgents[0].WorkingDir)
-	}
-}
-
-func TestSaveDoesNotMutateOriginalConfigPaths(t *testing.T) {
-	dir := t.TempDir()
-	configDir := filepath.Join(dir, "config")
-	path := filepath.Join(configDir, "anyclaw.json")
-
-	cfg := DefaultConfig()
-	profileDir := filepath.Join(configDir, "workflows", "go")
-	subAgentDir := filepath.Join(configDir, "workflows", "worker")
-	cfg.Agent.Profiles = []AgentProfile{
-		{
-			Name:            "Go Expert",
-			Description:     "Go specialist",
-			WorkingDir:      profileDir,
-			PermissionLevel: "limited",
-		},
-	}
-	cfg.Orchestrator.SubAgents = []SubAgentConfig{
-		{
-			Name:            "worker",
-			Description:     "background worker",
-			PermissionLevel: "limited",
-			WorkingDir:      subAgentDir,
-		},
-	}
-
-	if err := cfg.Save(path); err != nil {
-		t.Fatalf("save should succeed: %v", err)
-	}
-
-	if got := cfg.Agent.Profiles[0].WorkingDir; got != profileDir {
-		t.Fatalf("expected original profile working dir to remain %q, got %q", profileDir, got)
-	}
-	if got := cfg.Orchestrator.SubAgents[0].WorkingDir; got != subAgentDir {
-		t.Fatalf("expected original sub-agent working dir to remain %q, got %q", subAgentDir, got)
 	}
 }
 
@@ -750,44 +713,5 @@ func TestResolveAgentProfileSupportsMainAgentAlias(t *testing.T) {
 	}
 	if cfg.Agent.ActiveProfile != "Python Expert" {
 		t.Fatalf("expected active profile Python Expert, got %q", cfg.Agent.ActiveProfile)
-	}
-}
-
-func TestChannelSecurityConfigUnmarshalTracksPresenceFlags(t *testing.T) {
-	var cfg ChannelSecurityConfig
-	if err := json.Unmarshal([]byte(`{
-  "pairing_enabled": false,
-  "mention_gate": false,
-  "default_deny_dm": true
-}`), &cfg); err != nil {
-		t.Fatalf("unmarshal channel security config: %v", err)
-	}
-
-	if !cfg.PairingEnabledSet() {
-		t.Fatal("expected pairing_enabled presence flag to be set")
-	}
-	if !cfg.MentionGateSet() {
-		t.Fatal("expected mention_gate presence flag to be set")
-	}
-	if !cfg.DefaultDenyDMSet() {
-		t.Fatal("expected default_deny_dm presence flag to be set")
-	}
-	if cfg.PairingEnabled {
-		t.Fatal("expected explicit pairing_enabled=false to be preserved")
-	}
-	if cfg.MentionGate {
-		t.Fatal("expected explicit mention_gate=false to be preserved")
-	}
-	if !cfg.DefaultDenyDM {
-		t.Fatal("expected explicit default_deny_dm=true to be preserved")
-	}
-
-	var empty ChannelSecurityConfig
-	if err := json.Unmarshal([]byte(`{}`), &empty); err != nil {
-		t.Fatalf("unmarshal empty channel security config: %v", err)
-	}
-	if empty.PairingEnabledSet() || empty.MentionGateSet() || empty.DefaultDenyDMSet() {
-		t.Fatalf("expected absent fields to keep presence flags false, got pairing=%v mention=%v deny=%v",
-			empty.PairingEnabledSet(), empty.MentionGateSet(), empty.DefaultDenyDMSet())
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -715,3 +715,42 @@ func TestResolveAgentProfileSupportsMainAgentAlias(t *testing.T) {
 		t.Fatalf("expected active profile Python Expert, got %q", cfg.Agent.ActiveProfile)
 	}
 }
+
+func TestChannelSecurityConfigUnmarshalTracksPresenceFlags(t *testing.T) {
+	var cfg ChannelSecurityConfig
+	if err := json.Unmarshal([]byte(`{
+  "pairing_enabled": false,
+  "mention_gate": false,
+  "default_deny_dm": true
+}`), &cfg); err != nil {
+		t.Fatalf("unmarshal channel security config: %v", err)
+	}
+
+	if !cfg.PairingEnabledSet() {
+		t.Fatal("expected pairing_enabled presence flag to be set")
+	}
+	if !cfg.MentionGateSet() {
+		t.Fatal("expected mention_gate presence flag to be set")
+	}
+	if !cfg.DefaultDenyDMSet() {
+		t.Fatal("expected default_deny_dm presence flag to be set")
+	}
+	if cfg.PairingEnabled {
+		t.Fatal("expected explicit pairing_enabled=false to be preserved")
+	}
+	if cfg.MentionGate {
+		t.Fatal("expected explicit mention_gate=false to be preserved")
+	}
+	if !cfg.DefaultDenyDM {
+		t.Fatal("expected explicit default_deny_dm=true to be preserved")
+	}
+
+	var empty ChannelSecurityConfig
+	if err := json.Unmarshal([]byte(`{}`), &empty); err != nil {
+		t.Fatalf("unmarshal empty channel security config: %v", err)
+	}
+	if empty.PairingEnabledSet() || empty.MentionGateSet() || empty.DefaultDenyDMSet() {
+		t.Fatalf("expected absent fields to keep presence flags false, got pairing=%v mention=%v deny=%v",
+			empty.PairingEnabledSet(), empty.MentionGateSet(), empty.DefaultDenyDMSet())
+	}
+}

--- a/pkg/config/io.go
+++ b/pkg/config/io.go
@@ -57,12 +57,6 @@ func (c *Config) persistableCopy(path string) *Config {
 	}
 
 	snapshot := *c
-	if len(snapshot.Agent.Profiles) > 0 {
-		snapshot.Agent.Profiles = append([]AgentProfile(nil), snapshot.Agent.Profiles...)
-	}
-	if len(snapshot.Orchestrator.SubAgents) > 0 {
-		snapshot.Orchestrator.SubAgents = append([]SubAgentConfig(nil), snapshot.Orchestrator.SubAgents...)
-	}
 	snapshot.Agent.WorkDir = persistConfigPath(path, snapshot.Agent.WorkDir)
 	snapshot.Agent.WorkingDir = persistConfigPath(path, snapshot.Agent.WorkingDir)
 	for i := range snapshot.Agent.Profiles {
@@ -106,29 +100,4 @@ func persistConfigPath(configPath string, value string) string {
 	}
 
 	return filepath.ToSlash(rel)
-}
-
-func (c *ChannelSecurityConfig) UnmarshalJSON(data []byte) error {
-	type channelSecurityConfigAlias ChannelSecurityConfig
-	type channelSecurityConfigPresence struct {
-		PairingEnabled *bool `json:"pairing_enabled"`
-		MentionGate    *bool `json:"mention_gate"`
-		DefaultDenyDM  *bool `json:"default_deny_dm"`
-	}
-
-	var decoded channelSecurityConfigAlias
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		return err
-	}
-
-	var presence channelSecurityConfigPresence
-	if err := json.Unmarshal(data, &presence); err != nil {
-		return err
-	}
-
-	*c = ChannelSecurityConfig(decoded)
-	c.pairingEnabledSet = presence.PairingEnabled != nil
-	c.mentionGateSet = presence.MentionGate != nil
-	c.defaultDenyDMSet = presence.DefaultDenyDM != nil
-	return nil
 }

--- a/pkg/config/io.go
+++ b/pkg/config/io.go
@@ -101,3 +101,28 @@ func persistConfigPath(configPath string, value string) string {
 
 	return filepath.ToSlash(rel)
 }
+
+func (c *ChannelSecurityConfig) UnmarshalJSON(data []byte) error {
+	type channelSecurityConfigAlias ChannelSecurityConfig
+	type channelSecurityConfigPresence struct {
+		PairingEnabled *bool `json:"pairing_enabled"`
+		MentionGate    *bool `json:"mention_gate"`
+		DefaultDenyDM  *bool `json:"default_deny_dm"`
+	}
+
+	var decoded channelSecurityConfigAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	var presence channelSecurityConfigPresence
+	if err := json.Unmarshal(data, &presence); err != nil {
+		return err
+	}
+
+	*c = ChannelSecurityConfig(decoded)
+	c.pairingEnabledSet = presence.PairingEnabled != nil
+	c.mentionGateSet = presence.MentionGate != nil
+	c.defaultDenyDMSet = presence.DefaultDenyDM != nil
+	return nil
+}

--- a/pkg/config/modular.go
+++ b/pkg/config/modular.go
@@ -1,0 +1,476 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// ConfigValidator 配置验证器接口
+type ConfigValidator interface {
+	Validate(config *Config) error
+}
+
+// ConfigMigrator 配置迁移器接口
+type ConfigMigrator interface {
+	Migrate(config *Config, fromVersion, toVersion string) (*Config, error)
+}
+
+// ModularConfigManager 模块化配置管理器
+type ModularConfigManager struct {
+	mu               sync.RWMutex
+	baseConfig       *Config
+	modules          map[string]ConfigModule
+	validators       []ConfigValidator
+	migrators        []ConfigMigrator
+	envOverrides     map[string]string
+	runtimeOverrides map[string]interface{}
+	configPath       string
+	version          string
+}
+
+// ConfigModule 配置模块接口
+type ConfigModule interface {
+	Name() string
+	Load(configPath string) error
+	Save(configPath string) error
+	Validate() error
+	GetDefaults() interface{}
+}
+
+// NewModularConfigManager 创建模块化配置管理器
+func NewModularConfigManager(configPath string) *ModularConfigManager {
+	return &ModularConfigManager{
+		modules:          make(map[string]ConfigModule),
+		validators:       make([]ConfigValidator, 0),
+		migrators:        make([]ConfigMigrator, 0),
+		envOverrides:     make(map[string]string),
+		runtimeOverrides: make(map[string]interface{}),
+		configPath:       configPath,
+		version:          "1.0.0",
+	}
+}
+
+// RegisterModule 注册配置模块
+func (m *ModularConfigManager) RegisterModule(module ConfigModule) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.modules[module.Name()]; exists {
+		return fmt.Errorf("module %s already registered", module.Name())
+	}
+
+	m.modules[module.Name()] = module
+	return nil
+}
+
+// RegisterValidator 注册配置验证器
+func (m *ModularConfigManager) RegisterValidator(validator ConfigValidator) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.validators = append(m.validators, validator)
+}
+
+// RegisterMigrator 注册配置迁移器
+func (m *ModularConfigManager) RegisterMigrator(migrator ConfigMigrator) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.migrators = append(m.migrators, migrator)
+}
+
+// Load 加载配置
+func (m *ModularConfigManager) Load() (*Config, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// 1. 读取基础配置
+	config, err := m.readConfigFile(m.configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+
+	// 2. 应用环境变量覆盖
+	config = m.applyEnvOverrides(config)
+
+	// 3. 验证配置
+	if err := m.validateConfig(config); err != nil {
+		return nil, fmt.Errorf("config validation failed: %w", err)
+	}
+
+	// 4. 应用运行时覆盖
+	config = m.applyRuntimeOverrides(config)
+
+	// 5. 加载模块
+	if err := m.loadModules(config); err != nil {
+		return nil, fmt.Errorf("failed to load modules: %w", err)
+	}
+
+	m.baseConfig = config
+	return config, nil
+}
+
+// Save 保存配置
+func (m *ModularConfigManager) Save() error {
+	m.mu.RLock()
+	config := m.baseConfig
+	m.mu.RUnlock()
+
+	if config == nil {
+		return fmt.Errorf("no config loaded")
+	}
+
+	// 1. 保存模块
+	if err := m.saveModules(); err != nil {
+		return fmt.Errorf("failed to save modules: %w", err)
+	}
+
+	// 2. 保存基础配置
+	if err := m.saveConfigFile(m.configPath, config); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	return nil
+}
+
+// GetConfig 获取配置
+func (m *ModularConfigManager) GetConfig() *Config {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.baseConfig
+}
+
+// SetEnvOverride 设置环境变量覆盖
+func (m *ModularConfigManager) SetEnvOverride(key, value string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.envOverrides[key] = value
+}
+
+// SetRuntimeOverride 设置运行时覆盖
+func (m *ModularConfigManager) SetRuntimeOverride(key string, value interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.runtimeOverrides[key] = value
+}
+
+// GetModule 获取配置模块
+func (m *ModularConfigManager) GetModule(name string) (ConfigModule, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	module, exists := m.modules[name]
+	if !exists {
+		return nil, fmt.Errorf("module %s not found", name)
+	}
+
+	return module, nil
+}
+
+// Validate 验证配置
+func (m *ModularConfigManager) Validate() error {
+	m.mu.RLock()
+	config := m.baseConfig
+	validators := m.validators
+	m.mu.RUnlock()
+
+	if config == nil {
+		return fmt.Errorf("no config loaded")
+	}
+
+	var errors []string
+	for _, validator := range validators {
+		if err := validator.Validate(config); err != nil {
+			errors = append(errors, err.Error())
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("config validation failed: %s", strings.Join(errors, "; "))
+	}
+
+	return nil
+}
+
+// Migrate 迁移配置
+func (m *ModularConfigManager) Migrate(targetVersion string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.baseConfig == nil {
+		return fmt.Errorf("no config loaded")
+	}
+
+	// 按版本顺序应用迁移器
+	for _, migrator := range m.migrators {
+		config, err := migrator.Migrate(m.baseConfig, m.version, targetVersion)
+		if err != nil {
+			return fmt.Errorf("migration failed: %w", err)
+		}
+		m.baseConfig = config
+	}
+
+	m.version = targetVersion
+	return nil
+}
+
+// readConfigFile 读取配置文件
+func (m *ModularConfigManager) readConfigFile(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return m.getDefaultConfig(), nil
+		}
+		return nil, err
+	}
+
+	var config Config
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+
+	return &config, nil
+}
+
+// saveConfigFile 保存配置文件
+func (m *ModularConfigManager) saveConfigFile(path string, config *Config) error {
+	// 确保目录存在
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+
+	return nil
+}
+
+// applyEnvOverrides 应用环境变量覆盖
+func (m *ModularConfigManager) applyEnvOverrides(config *Config) *Config {
+	// 应用环境变量覆盖
+	for key, value := range m.envOverrides {
+		switch key {
+		case "ANYCLAW_LLM_PROVIDER":
+			config.LLM.Provider = value
+		case "ANYCLAW_LLM_MODEL":
+			config.LLM.Model = value
+		case "ANYCLAW_LLM_API_KEY":
+			config.LLM.APIKey = value
+		case "ANYCLAW_LLM_BASE_URL":
+			config.LLM.BaseURL = value
+		case "ANYCLAW_LLM_PROXY":
+			config.LLM.Proxy = value
+		case "ANYCLAW_AGENT_NAME":
+			config.Agent.Name = value
+		case "ANYCLAW_AGENT_WORK_DIR":
+			config.Agent.WorkDir = value
+		case "ANYCLAW_GATEWAY_HOST":
+			config.Gateway.Host = value
+		case "ANYCLAW_GATEWAY_PORT":
+			// 转换为整数
+			var port int
+			if _, err := fmt.Sscanf(value, "%d", &port); err == nil {
+				config.Gateway.Port = port
+			}
+		}
+	}
+
+	// 也从系统环境变量读取
+	if provider := os.Getenv("ANYCLAW_LLM_PROVIDER"); provider != "" {
+		config.LLM.Provider = provider
+	}
+	if model := os.Getenv("ANYCLAW_LLM_MODEL"); model != "" {
+		config.LLM.Model = model
+	}
+	if apiKey := os.Getenv("ANYCLAW_LLM_API_KEY"); apiKey != "" {
+		config.LLM.APIKey = apiKey
+	}
+	if baseURL := os.Getenv("ANYCLAW_LLM_BASE_URL"); baseURL != "" {
+		config.LLM.BaseURL = baseURL
+	}
+	if proxy := os.Getenv("ANYCLAW_LLM_PROXY"); proxy != "" {
+		config.LLM.Proxy = proxy
+	}
+
+	return config
+}
+
+// applyRuntimeOverrides 应用运行时覆盖
+func (m *ModularConfigManager) applyRuntimeOverrides(config *Config) *Config {
+	// 应用运行时覆盖
+	for key, value := range m.runtimeOverrides {
+		switch key {
+		case "llm.provider":
+			if v, ok := value.(string); ok {
+				config.LLM.Provider = v
+			}
+		case "llm.model":
+			if v, ok := value.(string); ok {
+				config.LLM.Model = v
+			}
+		case "llm.temperature":
+			if v, ok := value.(float64); ok {
+				config.LLM.Temperature = v
+			}
+		case "agent.permission_level":
+			if v, ok := value.(string); ok {
+				config.Agent.PermissionLevel = v
+			}
+		}
+	}
+
+	return config
+}
+
+// validateConfig 验证配置
+func (m *ModularConfigManager) validateConfig(config *Config) error {
+	var errors []string
+
+	// 基础验证
+	if config.LLM.Provider == "" {
+		errors = append(errors, "llm.provider is required")
+	}
+
+	if config.LLM.Model == "" {
+		errors = append(errors, "llm.model is required")
+	}
+
+	// 验证温度范围
+	if config.LLM.Temperature < 0 || config.LLM.Temperature > 2 {
+		errors = append(errors, "llm.temperature must be between 0 and 2")
+	}
+
+	// 验证网关端口
+	if config.Gateway.Port < 0 || config.Gateway.Port > 65535 {
+		errors = append(errors, "gateway.port must be between 0 and 65535")
+	}
+
+	// 验证权限级别
+	validPermissionLevels := map[string]bool{
+		"read-only": true,
+		"limited":   true,
+		"full":      true,
+	}
+	if !validPermissionLevels[config.Agent.PermissionLevel] {
+		errors = append(errors, "agent.permission_level must be one of: read-only, limited, full")
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("config validation failed: %s", strings.Join(errors, "; "))
+	}
+
+	return nil
+}
+
+// loadModules 加载模块
+func (m *ModularConfigManager) loadModules(config *Config) error {
+	for name, module := range m.modules {
+		// 创建模块配置目录
+		moduleDir := filepath.Join(filepath.Dir(m.configPath), "modules", name)
+		if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create module directory for %s: %w", name, err)
+		}
+
+		// 加载模块
+		moduleConfigPath := filepath.Join(moduleDir, "config.json")
+		if err := module.Load(moduleConfigPath); err != nil {
+			// 如果配置文件不存在，使用默认配置
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("failed to load module %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// saveModules 保存模块
+func (m *ModularConfigManager) saveModules() error {
+	for name, module := range m.modules {
+		// 验证模块
+		if err := module.Validate(); err != nil {
+			return fmt.Errorf("module %s validation failed: %w", name, err)
+		}
+
+		// 保存模块
+		moduleDir := filepath.Join(filepath.Dir(m.configPath), "modules", name)
+		moduleConfigPath := filepath.Join(moduleDir, "config.json")
+		if err := module.Save(moduleConfigPath); err != nil {
+			return fmt.Errorf("failed to save module %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// getDefaultConfig 获取默认配置
+func (m *ModularConfigManager) getDefaultConfig() *Config {
+	return &Config{
+		LLM: LLMConfig{
+			Provider:    "openai",
+			Model:       "gpt-4o-mini",
+			Temperature: 0.7,
+			MaxTokens:   4096,
+		},
+		Agent: AgentConfig{
+			Name:                            "AnyClaw",
+			PermissionLevel:                 "full",
+			RequireConfirmationForDangerous: true,
+			Profiles: []AgentProfile{
+				{
+					Name:            "default",
+					Description:     "Default agent profile",
+					PermissionLevel: "full",
+				},
+			},
+		},
+		Skills: SkillsConfig{
+			Dir:      "skills",
+			AutoLoad: true,
+		},
+		Memory: MemoryConfig{
+			Dir:        "memory",
+			MaxHistory: 100,
+			Format:     "json",
+			AutoSave:   true,
+		},
+		Gateway: GatewayConfig{
+			Host:        "localhost",
+			Port:        18789,
+			Bind:        "loopback",
+			WorkerCount: 4,
+		},
+		Channels: ChannelsConfig{
+			Routing: RoutingConfig{
+				Mode: "auto",
+			},
+		},
+		Sandbox: SandboxConfig{
+			Enabled:       false,
+			ExecutionMode: "host-reviewed",
+		},
+		Security: SecurityConfig{
+			ProtectedPaths: []string{
+				"~/.ssh",
+				"~/.gnupg",
+				"~/.config",
+			},
+			CommandTimeoutSeconds: 30,
+		},
+	}
+}

--- a/pkg/config/personality_templates.go
+++ b/pkg/config/personality_templates.go
@@ -1,0 +1,37 @@
+package config
+
+// PersonalityTemplate is a UI-friendly description of a built-in agent personality preset.
+type PersonalityTemplate struct {
+	Key               string   `json:"key"`
+	Name              string   `json:"name"`
+	Description       string   `json:"description"`
+	Tone              string   `json:"tone"`
+	Style             string   `json:"style"`
+	GoalOrientation   string   `json:"goal_orientation"`
+	ConstraintMode    string   `json:"constraint_mode"`
+	ResponseVerbosity string   `json:"response_verbosity"`
+	Traits            []string `json:"traits"`
+}
+
+// BuiltinPersonalityTemplates defines the default personality presets available to operators.
+var BuiltinPersonalityTemplates = []PersonalityTemplate{
+	{Key: "generalist", Name: "閫氱敤鎵ц鑰?", Description: "骞宠　鎵ц鍔涗笌娌熼€氭竻鏅板害锛岄€傚悎浣滀负榛樿宸ヤ綔鍔╂墜銆?", Tone: "涓撲笟绋抽噸", Style: "缁撴瀯鍖?", GoalOrientation: "缁撴灉瀵煎悜", ConstraintMode: "瀹℃厧", ResponseVerbosity: "閫備腑", Traits: []string{"鍙潬", "娓呮櫚", "鍗忎綔"}},
+	{Key: "builder", Name: "寮€鍙戞瀯寤鸿€?", Description: "鍋忓伐绋嬪疄鐜帮紝寮鸿皟鎷嗚В闂銆佸揩閫熼獙璇佸拰浜や粯缁撴灉銆?", Tone: "鐩存帴鍔″疄", Style: "鎶€鏈寲", GoalOrientation: "浜や粯瀵煎悜", ConstraintMode: "涓ユ牸", ResponseVerbosity: "绠€娲?", Traits: []string{"宸ョ▼鍖?", "鍔″疄", "鍙獙璇?"}},
+	{Key: "researcher", Name: "鐮旂┒鍒嗘瀽甯?", Description: "鎿呴暱淇℃伅鏁寸悊銆佹瘮杈冦€佸綊绾冲拰褰㈡垚瑙傜偣銆?", Tone: "鍐烽潤瀹㈣", Style: "鍒嗘瀽鍨?", GoalOrientation: "娲炲療瀵煎悜", ConstraintMode: "瀹℃厧", ResponseVerbosity: "璇︾粏", Traits: []string{"姹傝瘉", "涓ヨ皑", "鏉＄悊"}},
+	{Key: "operator", Name: "娴佺▼杩愯惀瀹?", Description: "寮鸿皟鎵ц瑙勮寖銆侀闄╂帶鍒跺拰姝ラ閫忔槑銆?", Tone: "绋冲仴鍏嬪埗", Style: "娴佺▼鍖?", GoalOrientation: "绋冲畾瀵煎悜", ConstraintMode: "涓ユ牸", ResponseVerbosity: "閫備腑", Traits: []string{"瀹堣", "鍙璁?", "绋冲畾"}},
+}
+
+// DefaultPersonalitySpec returns the default built-in personality configuration.
+func DefaultPersonalitySpec() PersonalitySpec {
+	item := BuiltinPersonalityTemplates[0]
+	return PersonalitySpec{
+		Template:           item.Key,
+		Tone:               item.Tone,
+		Style:              item.Style,
+		GoalOrientation:    item.GoalOrientation,
+		ConstraintMode:     item.ConstraintMode,
+		ResponseVerbosity:  item.ResponseVerbosity,
+		Traits:             append([]string(nil), item.Traits...),
+		CustomInstructions: "",
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -198,22 +198,6 @@ type ChannelSecurityConfig struct {
 	MentionGate      bool     `json:"mention_gate"`
 	RiskAcknowledged bool     `json:"risk_acknowledged"`
 	DefaultDenyDM    bool     `json:"default_deny_dm"`
-
-	pairingEnabledSet bool
-	mentionGateSet    bool
-	defaultDenyDMSet  bool
-}
-
-func (c ChannelSecurityConfig) PairingEnabledSet() bool {
-	return c.pairingEnabledSet
-}
-
-func (c ChannelSecurityConfig) MentionGateSet() bool {
-	return c.mentionGateSet
-}
-
-func (c ChannelSecurityConfig) DefaultDenyDMSet() bool {
-	return c.defaultDenyDMSet
 }
 
 type TelegramChannelConfig struct {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -198,6 +198,22 @@ type ChannelSecurityConfig struct {
 	MentionGate      bool     `json:"mention_gate"`
 	RiskAcknowledged bool     `json:"risk_acknowledged"`
 	DefaultDenyDM    bool     `json:"default_deny_dm"`
+
+	pairingEnabledSet bool
+	mentionGateSet    bool
+	defaultDenyDMSet  bool
+}
+
+func (c ChannelSecurityConfig) PairingEnabledSet() bool {
+	return c.pairingEnabledSet
+}
+
+func (c ChannelSecurityConfig) MentionGateSet() bool {
+	return c.mentionGateSet
+}
+
+func (c ChannelSecurityConfig) DefaultDenyDMSet() bool {
+	return c.defaultDenyDMSet
 }
 
 type TelegramChannelConfig struct {


### PR DESCRIPTION
## Summary
- Add modular config helpers and personality template support extracted from gateway-module-wiring.
- Split out from the larger gateway-module-wiring work (the previous large gateway wiring PR).

## Merge Order
System.Object[]

## Notes
- This PR is intentionally folder-scoped to make the remaining gateway wiring upload reviewable.
- Recommended base branch for merge order is the dependency list above, even though this PR targets `main`.