### PR TITLE
feat(extensions): add plugin runtime support

### DIFF
--- a/pkg/extensions/adapters/webhook/handler.go
+++ b/pkg/extensions/adapters/webhook/handler.go
@@ -1,0 +1,200 @@
+package webhook
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Handler manages incoming webhooks from external services.
+type Handler struct {
+	mu      sync.RWMutex
+	hooks   map[string]*Webhook
+	history []Event
+	maxHist int
+}
+
+type Webhook struct {
+	ID           string            `json:"id"`
+	Name         string            `json:"name"`
+	Path         string            `json:"path"`
+	Secret       string            `json:"secret,omitempty"`
+	Agent        string            `json:"agent,omitempty"`
+	Template     string            `json:"template,omitempty"`
+	Headers      map[string]string `json:"headers,omitempty"`
+	Enabled      bool              `json:"enabled"`
+	CreatedAt    time.Time         `json:"created_at"`
+	LastTrigger  *time.Time        `json:"last_trigger,omitempty"`
+	TriggerCount int               `json:"trigger_count"`
+}
+
+type Event struct {
+	ID        string            `json:"id"`
+	WebhookID string            `json:"webhook_id"`
+	Timestamp time.Time         `json:"timestamp"`
+	Headers   map[string]string `json:"headers,omitempty"`
+	Body      string            `json:"body,omitempty"`
+	Response  string            `json:"response,omitempty"`
+	Status    string            `json:"status"`
+	Error     string            `json:"error,omitempty"`
+	Duration  time.Duration     `json:"duration"`
+}
+
+func NewHandler() *Handler {
+	return &Handler{
+		hooks:   make(map[string]*Webhook),
+		maxHist: 100,
+	}
+}
+
+func (h *Handler) Register(webhook *Webhook) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if webhook.ID == "" {
+		webhook.ID = fmt.Sprintf("wh-%d", time.Now().UnixNano())
+	}
+	if webhook.Path == "" {
+		webhook.Path = fmt.Sprintf("/webhooks/%s", webhook.ID)
+	}
+	webhook.CreatedAt = time.Now()
+	webhook.Enabled = true
+
+	h.hooks[webhook.ID] = webhook
+	return nil
+}
+
+func (h *Handler) Unregister(id string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.hooks[id]; !ok {
+		return fmt.Errorf("webhook not found: %s", id)
+	}
+	delete(h.hooks, id)
+	return nil
+}
+
+func (h *Handler) Get(id string) (*Webhook, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	hook, ok := h.hooks[id]
+	return hook, ok
+}
+
+func (h *Handler) List() []*Webhook {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	list := make([]*Webhook, 0, len(h.hooks))
+	for _, hook := range h.hooks {
+		list = append(list, hook)
+	}
+	return list
+}
+
+func (h *Handler) GetHistory(limit int) []Event {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if limit <= 0 || limit > len(h.history) {
+		limit = len(h.history)
+	}
+	return h.history[len(h.history)-limit:]
+}
+
+func (h *Handler) HandleRequest(ctx context.Context, r *http.Request, processFn func(context.Context, *Webhook, []byte) (string, error)) (int, []byte) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	path := r.URL.Path
+
+	var matched *Webhook
+	for _, hook := range h.hooks {
+		if hook.Enabled && strings.HasPrefix(path, hook.Path) {
+			matched = hook
+			break
+		}
+	}
+
+	if matched == nil {
+		return http.StatusNotFound, []byte(`{"error":"webhook not found"}`)
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return http.StatusBadRequest, []byte(fmt.Sprintf(`{"error":"%s"}`, err.Error()))
+	}
+
+	if matched.Secret != "" {
+		signature := r.Header.Get("X-Hub-Signature-256")
+		if signature == "" {
+			signature = r.Header.Get("X-Signature-256")
+		}
+		if !verifySignature(matched.Secret, body, signature) {
+			return http.StatusUnauthorized, []byte(`{"error":"invalid signature"}`)
+		}
+	}
+
+	event := Event{
+		ID:        fmt.Sprintf("evt-%d", time.Now().UnixNano()),
+		WebhookID: matched.ID,
+		Timestamp: time.Now(),
+		Body:      string(body),
+		Status:    "processing",
+		Headers:   map[string]string{},
+	}
+	for key, values := range r.Header {
+		if len(values) > 0 {
+			event.Headers[key] = values[0]
+		}
+	}
+
+	start := time.Now()
+	response, err := processFn(ctx, matched, body)
+	event.Duration = time.Since(start)
+
+	if err != nil {
+		event.Status = "failed"
+		event.Error = err.Error()
+	} else {
+		event.Status = "success"
+		event.Response = response
+	}
+
+	now := time.Now()
+	matched.LastTrigger = &now
+	matched.TriggerCount++
+
+	h.history = append(h.history, event)
+	if len(h.history) > h.maxHist {
+		h.history = h.history[len(h.history)-h.maxHist:]
+	}
+
+	if err != nil {
+		return http.StatusInternalServerError, []byte(fmt.Sprintf(`{"error":"%s"}`, err.Error()))
+	}
+
+	return http.StatusOK, []byte(response)
+}
+
+func verifySignature(secret string, body []byte, signature string) bool {
+	if signature == "" {
+		return false
+	}
+
+	signature = strings.TrimPrefix(signature, "sha256=")
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+
+	return hmac.Equal([]byte(signature), []byte(expected))
+}

--- a/pkg/extensions/mcp/client.go
+++ b/pkg/extensions/mcp/client.go
@@ -13,24 +13,24 @@ import (
 )
 
 type Client struct {
-	mu        sync.RWMutex
-	name      string
-	command   string
-	args      []string
-	env       map[string]string
-	transport string
-	tools     []Tool
-	resources []Resource
-	prompts   []Prompt
-	cmd       *exec.Cmd
-	stdin     io.WriteCloser
-	stdout    io.ReadCloser
-	stderr    io.ReadCloser
-	running   bool
-	reqID     atomic.Int64
-	pending   map[int64]chan *Response
+	mu         sync.RWMutex
+	name       string
+	command    string
+	args       []string
+	env        map[string]string
+	transport  string
+	tools      []Tool
+	resources  []Resource
+	prompts    []Prompt
+	cmd        *exec.Cmd
+	stdin      io.WriteCloser
+	stdout     io.ReadCloser
+	stderr     io.ReadCloser
+	running    bool
+	reqID      atomic.Int64
+	pending    map[int64]chan *Response
 	readerDone chan struct{}
-	readErr   error
+	readErr    error
 }
 
 type Tool struct {

--- a/pkg/extensions/plugin/app_protocol_test.go
+++ b/pkg/extensions/plugin/app_protocol_test.go
@@ -1,0 +1,407 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/capability/tools"
+	desktopexec "github.com/1024XEngineer/anyclaw/pkg/runtime/execution/desktop"
+)
+
+func TestExecuteProtocolOutputRunsDesktopSteps(t *testing.T) {
+	registry := tools.NewRegistry()
+	var called []string
+	var approvals []tools.ToolApprovalCall
+	registry.RegisterTool("desktop_open", "open desktop app", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		called = append(called, "desktop_open:"+strings.TrimSpace(input["target"].(string)))
+		return "opened", nil
+	})
+	registry.RegisterTool("desktop_type", "type desktop text", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		called = append(called, "desktop_type:"+strings.TrimSpace(input["text"].(string)))
+		return "typed", nil
+	})
+
+	payload, err := json.Marshal(desktopexec.DesktopPlan{
+		Protocol: desktopexec.DesktopProtocolVersion,
+		Summary:  "plan complete",
+		Steps: []desktopexec.DesktopPlanStep{
+			{Tool: "desktop_open", Label: "Launch", Input: map[string]any{"target": "demo.exe"}},
+			{Tool: "desktop_type", Label: "Type", Input: map[string]any{"text": "hello"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	ctx := tools.WithToolApprovalHook(context.Background(), func(ctx context.Context, call tools.ToolApprovalCall) error {
+		approvals = append(approvals, call)
+		return nil
+	})
+
+	result, handled, err := ExecuteProtocolOutput(ctx, registry, ProtocolExecutionMeta{
+		ToolName: "app_demo_run",
+		Plugin:   "demo",
+		App:      "Demo App",
+		Action:   "run",
+		Input:    map[string]any{"task": "hello"},
+	}, payload)
+	if err != nil {
+		t.Fatalf("executeProtocolOutput: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected protocol output to be handled")
+	}
+	if len(approvals) != 1 {
+		t.Fatalf("expected 1 protocol approval request, got %d", len(approvals))
+	}
+	if approvals[0].Name != "desktop_plan" {
+		t.Fatalf("expected desktop_plan approval, got %q", approvals[0].Name)
+	}
+	if len(called) != 2 {
+		t.Fatalf("expected 2 desktop calls, got %d", len(called))
+	}
+	if !strings.Contains(result, "plan complete") || !strings.Contains(result, "Launch: opened") {
+		t.Fatalf("unexpected result: %q", result)
+	}
+}
+
+func TestExecuteProtocolOutputRetriesAndVerifiesSteps(t *testing.T) {
+	registry := tools.NewRegistry()
+	openCalls := 0
+	verifyCalls := 0
+	registry.RegisterTool("desktop_open", "open desktop app", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		openCalls++
+		if openCalls == 1 {
+			return "", fmt.Errorf("transient launch failure")
+		}
+		return "opened", nil
+	})
+	registry.RegisterTool("desktop_verify_text", "verify text", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		verifyCalls++
+		if verifyCalls == 1 {
+			return "", fmt.Errorf("text not visible yet")
+		}
+		return "verified", nil
+	})
+
+	payload, err := json.Marshal(desktopexec.DesktopPlan{
+		Protocol: desktopexec.DesktopProtocolVersion,
+		Summary:  "retry plan complete",
+		Steps: []desktopexec.DesktopPlanStep{
+			{
+				Tool:  "desktop_open",
+				Label: "Launch",
+				Input: map[string]any{"target": "demo.exe"},
+				Retry: 1,
+				Verify: &desktopexec.DesktopPlanCheck{
+					Tool:  "desktop_verify_text",
+					Input: map[string]any{"expected": "ready"},
+					Retry: 1,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	result, handled, err := ExecuteProtocolOutput(context.Background(), registry, ProtocolExecutionMeta{}, payload)
+	if err != nil {
+		t.Fatalf("executeProtocolOutput: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected protocol output to be handled")
+	}
+	if openCalls != 2 {
+		t.Fatalf("expected 2 open attempts, got %d", openCalls)
+	}
+	if verifyCalls != 2 {
+		t.Fatalf("expected 2 verify attempts, got %d", verifyCalls)
+	}
+	if !strings.Contains(result, "retry plan complete") || !strings.Contains(result, "Launch: opened") {
+		t.Fatalf("unexpected result: %q", result)
+	}
+}
+
+func TestExecuteProtocolOutputCanContinueAfterFailure(t *testing.T) {
+	registry := tools.NewRegistry()
+	var called []string
+	registry.RegisterTool("desktop_click", "click", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		return "", fmt.Errorf("button missing")
+	})
+	registry.RegisterTool("desktop_focus_window", "focus window", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		called = append(called, "focus")
+		return "focused", nil
+	})
+	registry.RegisterTool("desktop_type", "type text", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		called = append(called, "type")
+		return "typed", nil
+	})
+
+	payload, err := json.Marshal(desktopexec.DesktopPlan{
+		Protocol: desktopexec.DesktopProtocolVersion,
+		Summary:  "continued",
+		Steps: []desktopexec.DesktopPlanStep{
+			{
+				Tool:            "desktop_click",
+				Label:           "Try button",
+				Input:           map[string]any{"x": 1, "y": 1},
+				ContinueOnError: true,
+				OnFailure: []desktopexec.DesktopPlanStep{
+					{Tool: "desktop_focus_window", Label: "Refocus", Input: map[string]any{"title": "Demo"}},
+				},
+			},
+			{
+				Tool:  "desktop_type",
+				Label: "Fallback typing",
+				Input: map[string]any{"text": "hello"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	result, handled, err := ExecuteProtocolOutput(context.Background(), registry, ProtocolExecutionMeta{}, payload)
+	if err != nil {
+		t.Fatalf("executeProtocolOutput: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected protocol output to be handled")
+	}
+	if strings.Join(called, ",") != "focus,type" {
+		t.Fatalf("unexpected recovery calls: %v", called)
+	}
+	if !strings.Contains(result, "Try button failed") || !strings.Contains(result, "Fallback typing: typed") {
+		t.Fatalf("unexpected result: %q", result)
+	}
+}
+
+func TestExecuteProtocolOutputResumesFromSavedState(t *testing.T) {
+	registry := tools.NewRegistry()
+	var called []string
+	registry.RegisterTool("desktop_open", "open desktop app", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		called = append(called, "open")
+		return "opened", nil
+	})
+	registry.RegisterTool("desktop_type", "type desktop text", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		called = append(called, "type")
+		return "typed", nil
+	})
+
+	payload, err := json.Marshal(desktopexec.DesktopPlan{
+		Protocol: desktopexec.DesktopProtocolVersion,
+		Summary:  "resume complete",
+		Steps: []desktopexec.DesktopPlanStep{
+			{Tool: "desktop_open", Label: "Launch", Input: map[string]any{"target": "demo.exe"}},
+			{Tool: "desktop_type", Label: "Type", Input: map[string]any{"text": "hello"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var states []desktopexec.DesktopPlanExecutionState
+	ctx := desktopexec.WithDesktopPlanResumeState(context.Background(), &desktopexec.DesktopPlanExecutionState{
+		ToolName:          "app_demo_run",
+		Plugin:            "demo",
+		App:               "Demo App",
+		Action:            "run",
+		Status:            "failed",
+		Summary:           "resume complete",
+		TotalSteps:        2,
+		NextStep:          2,
+		LastCompletedStep: 1,
+		LastOutput:        "Launch: opened",
+		Steps: []desktopexec.DesktopPlanStepExecutionState{
+			{Index: 1, Tool: "desktop_open", Label: "Launch", Status: "completed", Attempts: 1, Output: "Launch: opened"},
+			{Index: 2, Tool: "desktop_type", Label: "Type", Status: "failed", Attempts: 1, Error: "typed failed"},
+		},
+	})
+	ctx = desktopexec.WithDesktopPlanStateHook(ctx, func(ctx context.Context, state desktopexec.DesktopPlanExecutionState) {
+		cloned := desktopexec.CloneDesktopPlanExecutionState(&state)
+		if cloned != nil {
+			states = append(states, *cloned)
+		}
+	})
+
+	result, handled, err := ExecuteProtocolOutput(ctx, registry, ProtocolExecutionMeta{
+		ToolName: "app_demo_run",
+		Plugin:   "demo",
+		App:      "Demo App",
+		Action:   "run",
+	}, payload)
+	if err != nil {
+		t.Fatalf("executeProtocolOutput: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected protocol output to be handled")
+	}
+	if strings.Join(called, ",") != "type" {
+		t.Fatalf("expected only the remaining step to run, got %v", called)
+	}
+	if !strings.Contains(result, "Launch: opened") || !strings.Contains(result, "Type: typed") {
+		t.Fatalf("unexpected resumed result: %q", result)
+	}
+	if len(states) == 0 {
+		t.Fatal("expected plan states to be reported")
+	}
+	finalState := states[len(states)-1]
+	if !finalState.Resumed {
+		t.Fatalf("expected resumed state, got %#v", finalState)
+	}
+	if finalState.Status != "completed" {
+		t.Fatalf("expected completed state, got %q", finalState.Status)
+	}
+	if finalState.LastCompletedStep != 2 || finalState.NextStep != 3 {
+		t.Fatalf("unexpected checkpoint progression: %#v", finalState)
+	}
+}
+
+func TestExecuteProtocolOutputSupportsStructuredTargetSteps(t *testing.T) {
+	registry := tools.NewRegistry()
+	var called []string
+	registry.RegisterTool("desktop_activate_target", "activate target", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		called = append(called, "activate:"+strings.TrimSpace(fmt.Sprint(input["title"]))+":"+strings.TrimSpace(fmt.Sprint(input["name"])))
+		return "clicked", nil
+	})
+	registry.RegisterTool("desktop_set_target_value", "set target value", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		called = append(called, "set:"+strings.TrimSpace(fmt.Sprint(input["title"]))+":"+strings.TrimSpace(fmt.Sprint(input["value"])))
+		return "typed", nil
+	})
+
+	value := "hello"
+	payload, err := json.Marshal(desktopexec.DesktopPlan{
+		Protocol: desktopexec.DesktopProtocolVersion,
+		Summary:  "structured target complete",
+		Steps: []desktopexec.DesktopPlanStep{
+			{
+				Label:  "Open composer",
+				Target: map[string]any{"title": "QQ", "name": "消息输入框"},
+				Action: "focus",
+			},
+			{
+				Label:  "Type message",
+				Target: map[string]any{"title": "QQ", "control_type": "edit"},
+				Value:  &value,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	result, handled, err := ExecuteProtocolOutput(context.Background(), registry, ProtocolExecutionMeta{}, payload)
+	if err != nil {
+		t.Fatalf("executeProtocolOutput: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected protocol output to be handled")
+	}
+	if strings.Join(called, ",") != "activate:QQ:消息输入框,set:QQ:hello" {
+		t.Fatalf("unexpected target calls: %v", called)
+	}
+	if !strings.Contains(result, "structured target complete") || !strings.Contains(result, "Open composer: clicked") || !strings.Contains(result, "Type message: typed") {
+		t.Fatalf("unexpected result: %q", result)
+	}
+}
+
+func TestExecuteProtocolOutputSupportsStructuredTargetVerification(t *testing.T) {
+	registry := tools.NewRegistry()
+	resolveCalls := 0
+	registry.RegisterTool("desktop_activate_target", "activate target", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		return "clicked", nil
+	})
+	registry.RegisterTool("desktop_resolve_target", "resolve target", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		resolveCalls++
+		if required, _ := input["require_found"].(bool); !required {
+			t.Fatalf("expected target verification to require a found target")
+		}
+		if resolveCalls == 1 {
+			return "", fmt.Errorf("target not found")
+		}
+		return `{"found":true,"strategy":"text"}`, nil
+	})
+
+	payload, err := json.Marshal(desktopexec.DesktopPlan{
+		Protocol: desktopexec.DesktopProtocolVersion,
+		Summary:  "verify target complete",
+		Steps: []desktopexec.DesktopPlanStep{
+			{
+				Label:  "Click send",
+				Target: map[string]any{"title": "QQ", "text": "发送"},
+				Verify: &desktopexec.DesktopPlanCheck{
+					Target:       map[string]any{"title": "QQ", "text": "已发送"},
+					Retry:        1,
+					RetryDelayMS: 1,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	result, handled, err := ExecuteProtocolOutput(context.Background(), registry, ProtocolExecutionMeta{}, payload)
+	if err != nil {
+		t.Fatalf("executeProtocolOutput: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected protocol output to be handled")
+	}
+	if resolveCalls != 2 {
+		t.Fatalf("expected 2 resolve attempts, got %d", resolveCalls)
+	}
+	if !strings.Contains(result, "verify target complete") || !strings.Contains(result, "Click send: clicked") {
+		t.Fatalf("unexpected result: %q", result)
+	}
+}
+
+func TestExecuteProtocolOutputSupportsStructuredTargetWaitStep(t *testing.T) {
+	registry := tools.NewRegistry()
+	resolveCalls := 0
+	registry.RegisterTool("desktop_resolve_target", "resolve target", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		resolveCalls++
+		if required, _ := input["require_found"].(bool); !required {
+			t.Fatalf("expected wait target step to require a found target")
+		}
+		if resolveCalls == 1 {
+			return "", fmt.Errorf("target not ready")
+		}
+		return `{"found":true,"strategy":"ui"}`, nil
+	})
+
+	payload, err := json.Marshal(desktopexec.DesktopPlan{
+		Protocol: desktopexec.DesktopProtocolVersion,
+		Summary:  "wait target complete",
+		Steps: []desktopexec.DesktopPlanStep{
+			{
+				Label:        "Wait for send button",
+				Target:       map[string]any{"title": "QQ", "text": "发送"},
+				Action:       "wait",
+				Retry:        1,
+				RetryDelayMS: 1,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	result, handled, err := ExecuteProtocolOutput(context.Background(), registry, ProtocolExecutionMeta{}, payload)
+	if err != nil {
+		t.Fatalf("executeProtocolOutput: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected protocol output to be handled")
+	}
+	if resolveCalls != 2 {
+		t.Fatalf("expected 2 resolve attempts, got %d", resolveCalls)
+	}
+	if !strings.Contains(result, "wait target complete") || !strings.Contains(result, "Wait for send button:") {
+		t.Fatalf("unexpected result: %q", result)
+	}
+}

--- a/pkg/extensions/plugin/capability.go
+++ b/pkg/extensions/plugin/capability.go
@@ -1,0 +1,255 @@
+package plugin
+
+import (
+	"strings"
+	"sync"
+)
+
+type CapabilityIndex struct {
+	mu sync.RWMutex
+
+	byPlugin   map[string]*PluginCapabilities
+	byTag      map[string][]string
+	byPlatform map[string][]string
+	byKind     map[string][]string
+	byAction   map[string][]string
+
+	workflows map[string]WorkflowCapability
+	tools     map[string]ToolCapability
+	nodes     map[string]NodeCapability
+	surfaces  map[string]SurfaceCapability
+}
+
+type PluginCapabilities struct {
+	PluginID     string
+	Name         string
+	Description  string
+	Kinds        []string
+	Tags         []string
+	Platforms    []string
+	Capabilities []string
+
+	Tools     []ToolCapability
+	Workflows []WorkflowCapability
+	Nodes     []NodeCapability
+	Surfaces  []SurfaceCapability
+}
+
+type WorkflowCapability struct {
+	PluginID    string
+	Name        string
+	Action      string
+	Tags        []string
+	Description string
+	InputSchema map[string]any
+}
+
+type ToolCapability struct {
+	PluginID    string
+	Name        string
+	Category    string
+	Description string
+	InputSchema map[string]any
+}
+
+type NodeCapability struct {
+	PluginID     string
+	Name         string
+	Platforms    []string
+	Capabilities []string
+	Actions      []NodeActionSpecV2
+}
+
+type SurfaceCapability struct {
+	PluginID     string
+	Name         string
+	Path         string
+	Capabilities []string
+}
+
+func NewCapabilityIndex() *CapabilityIndex {
+	return &CapabilityIndex{
+		byPlugin:   make(map[string]*PluginCapabilities),
+		byTag:      make(map[string][]string),
+		byPlatform: make(map[string][]string),
+		byKind:     make(map[string][]string),
+		byAction:   make(map[string][]string),
+
+		workflows: make(map[string]WorkflowCapability),
+		tools:     make(map[string]ToolCapability),
+		nodes:     make(map[string]NodeCapability),
+		surfaces:  make(map[string]SurfaceCapability),
+	}
+}
+
+func (ci *CapabilityIndex) Index(manifest *ManifestV2) error {
+	ci.mu.Lock()
+	defer ci.mu.Unlock()
+
+	capabilities := &PluginCapabilities{
+		PluginID:     manifest.PluginID,
+		Name:         manifest.Name,
+		Description:  manifest.Description,
+		Kinds:        manifest.Kinds,
+		Tags:         manifest.CapabilityTags,
+		Platforms:    manifest.Platforms,
+		Capabilities: manifest.CapabilityTags,
+	}
+
+	ci.byPlugin[manifest.PluginID] = capabilities
+
+	for _, kind := range manifest.Kinds {
+		ci.byKind[kind] = append(ci.byKind[kind], manifest.PluginID)
+	}
+
+	for _, platform := range manifest.Platforms {
+		ci.byPlatform[platform] = append(ci.byPlatform[platform], manifest.PluginID)
+	}
+
+	for _, tag := range manifest.CapabilityTags {
+		ci.byTag[tag] = append(ci.byTag[tag], manifest.PluginID)
+	}
+
+	if manifest.Tool != nil {
+		toolCap := ToolCapability{
+			PluginID:    manifest.PluginID,
+			Name:        manifest.Tool.Name,
+			Category:    manifest.Tool.Category,
+			Description: manifest.Tool.Description,
+			InputSchema: manifest.Tool.InputSchema,
+		}
+		capabilities.Tools = append(capabilities.Tools, toolCap)
+		ci.tools[manifest.Tool.Name] = toolCap
+		ci.byAction[manifest.Tool.Name] = append(ci.byAction[manifest.Tool.Name], manifest.PluginID)
+	}
+
+	if manifest.Node != nil {
+		nodeCap := NodeCapability{
+			PluginID:     manifest.PluginID,
+			Name:         manifest.Node.Name,
+			Platforms:    manifest.Node.Platforms,
+			Capabilities: manifest.Node.Capabilities,
+			Actions:      manifest.Node.Actions,
+		}
+		capabilities.Nodes = append(capabilities.Nodes, nodeCap)
+		ci.nodes[manifest.Node.Name] = nodeCap
+	}
+
+	if manifest.Surface != nil {
+		surfaceCap := SurfaceCapability{
+			PluginID:     manifest.PluginID,
+			Name:         manifest.Surface.Name,
+			Path:         manifest.Surface.Path,
+			Capabilities: manifest.Surface.Capabilities,
+		}
+		capabilities.Surfaces = append(capabilities.Surfaces, surfaceCap)
+		ci.surfaces[manifest.Surface.Name] = surfaceCap
+	}
+
+	return nil
+}
+
+func (ci *CapabilityIndex) Remove(pluginID string) {
+	ci.mu.Lock()
+	defer ci.mu.Unlock()
+
+	capabilities, ok := ci.byPlugin[pluginID]
+	if !ok {
+		return
+	}
+
+	for _, kind := range capabilities.Kinds {
+		ci.removeFromMap(ci.byKind[kind], pluginID)
+	}
+	for _, platform := range capabilities.Platforms {
+		ci.removeFromMap(ci.byPlatform[platform], pluginID)
+	}
+	for _, tag := range capabilities.Tags {
+		ci.removeFromMap(ci.byTag[tag], pluginID)
+	}
+
+	for _, tool := range capabilities.Tools {
+		delete(ci.tools, tool.Name)
+		ci.removeFromMap(ci.byAction[tool.Name], pluginID)
+	}
+
+	for _, node := range capabilities.Nodes {
+		delete(ci.nodes, node.Name)
+	}
+
+	for _, surface := range capabilities.Surfaces {
+		delete(ci.surfaces, surface.Name)
+	}
+
+	delete(ci.byPlugin, pluginID)
+}
+
+func (ci *CapabilityIndex) removeFromMap(slice []string, item string) {
+	for i, v := range slice {
+		if v == item {
+			_ = append(slice[:i], slice[i+1:]...)
+			break
+		}
+	}
+}
+
+func (ci *CapabilityIndex) GetByPlugin(pluginID string) (*PluginCapabilities, bool) {
+	ci.mu.RLock()
+	defer ci.mu.RUnlock()
+	cap, ok := ci.byPlugin[pluginID]
+	return cap, ok
+}
+
+func (ci *CapabilityIndex) GetByTag(tag string) []string {
+	ci.mu.RLock()
+	defer ci.mu.RUnlock()
+	result := make([]string, len(ci.byTag[tag]))
+	copy(result, ci.byTag[tag])
+	return result
+}
+
+func (ci *CapabilityIndex) GetByPlatform(platform string) []string {
+	ci.mu.RLock()
+	defer ci.mu.RUnlock()
+	result := make([]string, len(ci.byPlatform[platform]))
+	copy(result, ci.byPlatform[platform])
+	return result
+}
+
+func (ci *CapabilityIndex) GetByKind(kind string) []string {
+	ci.mu.RLock()
+	defer ci.mu.RUnlock()
+	result := make([]string, len(ci.byKind[kind]))
+	copy(result, ci.byKind[kind])
+	return result
+}
+
+func (ci *CapabilityIndex) SearchWorkflows(query string, limit int) []WorkflowCapability {
+	ci.mu.RLock()
+	defer ci.mu.RUnlock()
+
+	query = strings.ToLower(query)
+	var results []WorkflowCapability
+
+	for _, wf := range ci.workflows {
+		if strings.Contains(strings.ToLower(wf.Name), query) ||
+			strings.Contains(strings.ToLower(wf.Description), query) {
+			results = append(results, wf)
+			if limit > 0 && len(results) >= limit {
+				break
+			}
+		}
+	}
+
+	return results
+}
+
+func (ci *CapabilityIndex) GetAll() map[string]*PluginCapabilities {
+	ci.mu.RLock()
+	defer ci.mu.RUnlock()
+	result := make(map[string]*PluginCapabilities)
+	for k, v := range ci.byPlugin {
+		result[k] = v
+	}
+	return result
+}

--- a/pkg/extensions/plugin/dependency.go
+++ b/pkg/extensions/plugin/dependency.go
@@ -1,0 +1,379 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Dependency represents a plugin dependency
+type Dependency struct {
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Source   string `json:"source,omitempty"` // npm:, pip:, cargo:, github:
+	Optional bool   `json:"optional,omitempty"`
+}
+
+// DependencyManager manages plugin dependencies
+type DependencyManager struct {
+	mu        sync.RWMutex
+	baseDir   string
+	resolved  map[string]*Dependency
+	installed map[string]string // name -> version
+}
+
+// NewDependencyManager creates a new dependency manager
+func NewDependencyManager(baseDir string) *DependencyManager {
+	dm := &DependencyManager{
+		baseDir:   baseDir,
+		resolved:  make(map[string]*Dependency),
+		installed: make(map[string]string),
+	}
+	dm.loadInstalled()
+	return dm
+}
+
+// loadInstalled loads already installed dependencies
+func (dm *DependencyManager) loadInstalled() {
+	installedDir := filepath.Join(dm.baseDir, "installed")
+	entries, err := os.ReadDir(installedDir)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		manifestPath := filepath.Join(installedDir, entry.Name(), "plugin.json")
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			continue
+		}
+
+		var manifest Manifest
+		if err := json.Unmarshal(data, &manifest); err == nil {
+			dm.installed[manifest.Name] = manifest.Version
+		}
+	}
+}
+
+// Resolve resolves dependencies for a manifest
+func (dm *DependencyManager) Resolve(ctx context.Context, manifest *Manifest) ([]Dependency, error) {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+
+	var deps []Dependency
+
+	// Check manifest dependencies
+	if manifest.MCP != nil {
+		deps = append(deps, Dependency{
+			Name:   manifest.MCP.Name,
+			Source: "mcp:" + manifest.MCP.Command,
+		})
+	}
+
+	// Check for dependencies in manifest metadata
+	if manifest.sourceDir != "" {
+		depsFile := filepath.Join(manifest.sourceDir, "dependencies.json")
+		if data, err := os.ReadFile(depsFile); err == nil {
+			var manifestDeps []Dependency
+			if err := json.Unmarshal(data, &manifestDeps); err == nil {
+				deps = append(deps, manifestDeps...)
+			}
+		}
+	}
+
+	return deps, nil
+}
+
+// Install installs a dependency
+func (dm *DependencyManager) Install(ctx context.Context, dep Dependency) error {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+
+	// Check if already installed
+	if version, ok := dm.installed[dep.Name]; ok {
+		if version == dep.Version || dep.Version == "" {
+			return nil // Already installed
+		}
+	}
+
+	// Determine install method based on source
+	if strings.HasPrefix(dep.Source, "npm:") {
+		return dm.installNPM(ctx, dep)
+	} else if strings.HasPrefix(dep.Source, "pip:") {
+		return dm.installPip(ctx, dep)
+	} else if strings.HasPrefix(dep.Source, "cargo:") {
+		return dm.installCargo(ctx, dep)
+	} else if strings.HasPrefix(dep.Source, "github:") {
+		return dm.installGitHub(ctx, dep)
+	} else if strings.HasPrefix(dep.Source, "mcp:") {
+		return dm.installMCP(ctx, dep)
+	}
+
+	// Default: try to install from local path
+	return dm.installLocal(ctx, dep)
+}
+
+// installNPM installs an npm package
+func (dm *DependencyManager) installNPM(ctx context.Context, dep Dependency) error {
+	packageDir := filepath.Join(dm.baseDir, "installed", dep.Name)
+	os.MkdirAll(packageDir, 0o755)
+
+	// Create package.json
+	packageJSON := fmt.Sprintf(`{"name":"%s","version":"%s"}`, dep.Name, dep.Version)
+	os.WriteFile(filepath.Join(packageDir, "package.json"), []byte(packageJSON), 0o644)
+
+	// Run npm install
+	cmd := exec.CommandContext(ctx, "npm", "install")
+	cmd.Dir = packageDir
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("npm install failed: %w", err)
+	}
+
+	dm.installed[dep.Name] = dep.Version
+	return nil
+}
+
+// installPip installs a Python package
+func (dm *DependencyManager) installPip(ctx context.Context, dep Dependency) error {
+	packageDir := filepath.Join(dm.baseDir, "installed", dep.Name)
+	os.MkdirAll(packageDir, 0o755)
+
+	// Create requirements.txt
+	req := dep.Name
+	if dep.Version != "" {
+		req += "==" + dep.Version
+	}
+	os.WriteFile(filepath.Join(packageDir, "requirements.txt"), []byte(req), 0o644)
+
+	// Run pip install
+	cmd := exec.CommandContext(ctx, "pip", "install", "-r", "requirements.txt", "--target", packageDir)
+	cmd.Dir = packageDir
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("pip install failed: %w", err)
+	}
+
+	dm.installed[dep.Name] = dep.Version
+	return nil
+}
+
+// installCargo installs a Rust crate
+func (dm *DependencyManager) installCargo(ctx context.Context, dep Dependency) error {
+	packageDir := filepath.Join(dm.baseDir, "installed", dep.Name)
+	os.MkdirAll(packageDir, 0o755)
+
+	// Create Cargo.toml
+	cargoToml := fmt.Sprintf(`[package]
+name = "%s"
+version = "%s"
+
+[dependencies]
+%s = "%s"
+`, dep.Name, "1.0.0", dep.Name, dep.Version)
+	os.WriteFile(filepath.Join(packageDir, "Cargo.toml"), []byte(cargoToml), 0o644)
+
+	// Run cargo build
+	cmd := exec.CommandContext(ctx, "cargo", "build", "--release")
+	cmd.Dir = packageDir
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cargo build failed: %w", err)
+	}
+
+	dm.installed[dep.Name] = dep.Version
+	return nil
+}
+
+// installGitHub installs from a GitHub repository
+func (dm *DependencyManager) installGitHub(ctx context.Context, dep Dependency) error {
+	repo := strings.TrimPrefix(dep.Source, "github:")
+	packageDir := filepath.Join(dm.baseDir, "installed", dep.Name)
+
+	// Clone repository
+	cmd := exec.CommandContext(ctx, "git", "clone", fmt.Sprintf("https://github.com/%s.git", repo), packageDir)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git clone failed: %w", err)
+	}
+
+	// Checkout specific version if specified
+	if dep.Version != "" && dep.Version != "latest" {
+		checkoutCmd := exec.CommandContext(ctx, "git", "checkout", dep.Version)
+		checkoutCmd.Dir = packageDir
+		checkoutCmd.Run()
+	}
+
+	dm.installed[dep.Name] = dep.Version
+	return nil
+}
+
+// installMCP installs an MCP server
+func (dm *DependencyManager) installMCP(ctx context.Context, dep Dependency) error {
+	command := strings.TrimPrefix(dep.Source, "mcp:")
+
+	// Check if command exists
+	if _, err := exec.LookPath(command); err != nil {
+		return fmt.Errorf("MCP command not found: %s", command)
+	}
+
+	dm.installed[dep.Name] = dep.Version
+	return nil
+}
+
+// installLocal installs from a local path
+func (dm *DependencyManager) installLocal(ctx context.Context, dep Dependency) error {
+	// Check if source is a valid path
+	if dep.Source != "" {
+		if _, err := os.Stat(dep.Source); err == nil {
+			packageDir := filepath.Join(dm.baseDir, "installed", dep.Name)
+			os.MkdirAll(packageDir, 0o755)
+
+			cmd := exec.CommandContext(ctx, "cp", "-r", dep.Source+"/.", packageDir)
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("copy failed: %w", err)
+			}
+
+			dm.installed[dep.Name] = dep.Version
+			return nil
+		}
+	}
+
+	return fmt.Errorf("cannot install dependency: %s", dep.Name)
+}
+
+// Uninstall removes a dependency
+func (dm *DependencyManager) Uninstall(name string) error {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+
+	packageDir := filepath.Join(dm.baseDir, "installed", name)
+	if err := os.RemoveAll(packageDir); err != nil {
+		return fmt.Errorf("failed to remove package: %w", err)
+	}
+
+	delete(dm.installed, name)
+	return nil
+}
+
+// ListInstalled returns all installed dependencies
+func (dm *DependencyManager) ListInstalled() map[string]string {
+	dm.mu.RLock()
+	defer dm.mu.RUnlock()
+
+	result := make(map[string]string)
+	for k, v := range dm.installed {
+		result[k] = v
+	}
+	return result
+}
+
+// CheckUpdates checks for available updates
+func (dm *DependencyManager) CheckUpdates(ctx context.Context) (map[string]string, error) {
+	updates := make(map[string]string)
+	// This would typically query package registries
+	// For now, return empty
+	return updates, nil
+}
+
+// HotReload watches for plugin changes and reloads them
+type HotReload struct {
+	mu       sync.RWMutex
+	watchDir string
+	loader   *PluginLoader
+	onChange func(manifest *Manifest)
+	watcher  *FileWatcher
+	stopCh   chan struct{}
+}
+
+// FileWatcher watches a directory for changes
+type FileWatcher struct {
+	dir      string
+	interval time.Duration
+	files    map[string]time.Time
+	onChange func(path string)
+	stopCh   chan struct{}
+}
+
+// NewHotReload creates a new hot-reload watcher
+func NewHotReload(watchDir string, loader *PluginLoader, onChange func(manifest *Manifest)) *HotReload {
+	return &HotReload{
+		watchDir: watchDir,
+		loader:   loader,
+		onChange: onChange,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Start starts watching for changes
+func (hr *HotReload) Start(ctx context.Context) error {
+	hr.watcher = &FileWatcher{
+		dir:      hr.watchDir,
+		interval: 5 * time.Second,
+		files:    make(map[string]time.Time),
+		stopCh:   hr.stopCh,
+		onChange: func(path string) {
+			// Reload plugin
+			dir := filepath.Dir(path)
+			name := filepath.Base(dir)
+			manifest, err := hr.loader.LoadPlugin(ctx, dir, name)
+			if err == nil && hr.onChange != nil {
+				hr.onChange(manifest)
+			}
+		},
+	}
+
+	go hr.watcher.Watch(ctx)
+	return nil
+}
+
+// Stop stops watching
+func (hr *HotReload) Stop() {
+	close(hr.stopCh)
+}
+
+// Watch watches a directory for file changes
+func (fw *FileWatcher) Watch(ctx context.Context) {
+	ticker := time.NewTicker(fw.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-fw.stopCh:
+			return
+		case <-ticker.C:
+			fw.scan()
+		}
+	}
+}
+
+// scan scans for changed files
+func (fw *FileWatcher) scan() {
+	filepath.Walk(fw.dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		modTime := info.ModTime()
+		if lastMod, ok := fw.files[path]; ok {
+			if modTime.After(lastMod) {
+				fw.files[path] = modTime
+				if fw.onChange != nil {
+					fw.onChange(path)
+				}
+			}
+		} else {
+			fw.files[path] = modTime
+		}
+
+		return nil
+	})
+}

--- a/pkg/extensions/plugin/hub.go
+++ b/pkg/extensions/plugin/hub.go
@@ -1,0 +1,286 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type HubClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+type HubPlugin struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Version     string    `json:"version"`
+	Description string    `json:"description"`
+	Author      string    `json:"author"`
+	Tags        []string  `json:"tags"`
+	Downloads   int       `json:"downloads"`
+	Stars       int       `json:"stars"`
+	Category    string    `json:"category"`
+	License     string    `json:"license"`
+	Repository  string    `json:"repository"`
+	Homepage    string    `json:"homepage"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type HubSearchResult struct {
+	Plugins []HubPlugin `json:"plugins"`
+	Total   int         `json:"total"`
+	Page    int         `json:"page"`
+	Limit   int         `json:"limit"`
+}
+
+func NewHubClient(baseURL string) *HubClient {
+	return &HubClient{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+func (c *HubClient) Search(ctx context.Context, query string, category string, limit int, offset int) (*HubSearchResult, error) {
+	url := fmt.Sprintf("%s/api/v1/plugins/search?q=%s&limit=%d&offset=%d", c.baseURL, query, limit, offset)
+	if category != "" {
+		url += "&category=" + category
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var result HubSearchResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
+func (c *HubClient) GetPlugin(ctx context.Context, pluginID string) (*HubPlugin, error) {
+	url := fmt.Sprintf("%s/api/v1/plugins/%s", c.baseURL, pluginID)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("plugin not found: %s", pluginID)
+	}
+
+	var plugin HubPlugin
+	if err := json.NewDecoder(resp.Body).Decode(&plugin); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &plugin, nil
+}
+
+func (c *HubClient) Download(ctx context.Context, pluginID string, version string, dest string) error {
+	url := fmt.Sprintf("%s/api/v1/plugins/%s/download?version=%s", c.baseURL, pluginID, version)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed with status: %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	return writeFileAtomic(dest, data)
+}
+
+func writeFileAtomic(path string, data []byte) error {
+	return nil
+}
+
+type HubCategories struct {
+	Categories []HubCategory `json:"categories"`
+}
+
+type HubCategory struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Count       int    `json:"count"`
+}
+
+func (c *HubClient) GetCategories(ctx context.Context) ([]HubCategory, error) {
+	url := fmt.Sprintf("%s/api/v1/categories", c.baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var categories HubCategories
+	if err := json.NewDecoder(resp.Body).Decode(&categories); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return categories.Categories, nil
+}
+
+func (c *HubClient) GetVersions(ctx context.Context, pluginID string) ([]string, error) {
+	url := fmt.Sprintf("%s/api/v1/plugins/%s/versions", c.baseURL, pluginID)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var versions []string
+	if err := json.NewDecoder(resp.Body).Decode(&versions); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return versions, nil
+}
+
+type HubStats struct {
+	TotalPlugins   int `json:"total_plugins"`
+	TotalDownloads int `json:"total_downloads"`
+	TotalStars     int `json:"total_stars"`
+	TotalSigners   int `json:"total_signers"`
+}
+
+func (c *HubClient) GetStats(ctx context.Context) (*HubStats, error) {
+	url := fmt.Sprintf("%s/api/v1/stats", c.baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var stats HubStats
+	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &stats, nil
+}
+
+type HubManager struct {
+	hubClient  *HubClient
+	localCache *LocalCache
+}
+
+type LocalCache struct {
+	dir string
+}
+
+func (lc *LocalCache) GetPlugin(pluginID string) (*HubPlugin, bool) {
+	return nil, false
+}
+
+func NewHubManager(baseURL string, cacheDir string) *HubManager {
+	return &HubManager{
+		hubClient:  NewHubClient(baseURL),
+		localCache: &LocalCache{dir: cacheDir},
+	}
+}
+
+func (hm *HubManager) SearchPlugins(ctx context.Context, query string, category string, limit int) ([]HubPlugin, error) {
+	result, err := hm.hubClient.Search(ctx, query, category, limit, 0)
+	if err != nil {
+		return nil, err
+	}
+	return result.Plugins, nil
+}
+
+func (hm *HubManager) InstallPlugin(ctx context.Context, pluginID string, version string, installDir string) error {
+	versions, err := hm.hubClient.GetVersions(ctx, pluginID)
+	if err != nil {
+		return err
+	}
+
+	targetVersion := version
+	if targetVersion == "" && len(versions) > 0 {
+		targetVersion = versions[0]
+	}
+
+	dest := installDir + "/" + pluginID + ".tar.gz"
+	return hm.hubClient.Download(ctx, pluginID, targetVersion, dest)
+}
+
+func (hm *HubManager) UpdatePlugin(ctx context.Context, pluginID string, installDir string) error {
+	versions, err := hm.hubClient.GetVersions(ctx, pluginID)
+	if err != nil {
+		return err
+	}
+
+	if len(versions) == 0 {
+		return fmt.Errorf("no versions available for plugin %s", pluginID)
+	}
+
+	dest := installDir + "/" + pluginID + ".tar.gz"
+	return hm.hubClient.Download(ctx, pluginID, versions[0], dest)
+}

--- a/pkg/extensions/plugin/lifecycle.go
+++ b/pkg/extensions/plugin/lifecycle.go
@@ -1,0 +1,668 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// LifecycleManager 插件生命周期管理器
+type LifecycleManager struct {
+	plugins             map[string]*PluginLifecycle
+	registry            *Registry
+	capabilityIndex     *CapabilityIndex
+	healthCheckInterval time.Duration
+	metricsStore        MetricsStore
+	trustStore          *TrustStore
+}
+
+// MetricsStore 指标存储
+type MetricsStore interface {
+	RecordExecution(pluginID string, success bool, duration time.Duration)
+	GetMetrics(pluginID string) PluginMetrics
+}
+
+// NewLifecycleManager 创建生命周期管理器
+func NewLifecycleManager(registry *Registry) *LifecycleManager {
+	return &LifecycleManager{
+		plugins:             make(map[string]*PluginLifecycle),
+		registry:            registry,
+		capabilityIndex:     NewCapabilityIndex(),
+		healthCheckInterval: 5 * time.Minute,
+	}
+}
+
+// SetTrustStore 设置信任存储
+func (lm *LifecycleManager) SetTrustStore(ts *TrustStore) {
+	lm.trustStore = ts
+}
+
+// GetCapabilityIndex 获取能力索引
+func (lm *LifecycleManager) GetCapabilityIndex() *CapabilityIndex {
+	return lm.capabilityIndex
+}
+
+// DiscoverPlugins 发现插件
+func (lm *LifecycleManager) DiscoverPlugins(ctx context.Context, pluginDir string) ([]*ManifestV2, error) {
+	var manifests []*ManifestV2
+
+	// 扫描插件目录
+	err := filepath.Walk(pluginDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// 查找 plugin.json 文件
+		if info.Name() == "plugin.json" {
+			manifest, err := lm.LoadManifestV2(path)
+			if err != nil {
+				return fmt.Errorf("failed to load manifest from %s: %v", path, err)
+			}
+
+			// 验证manifest
+			if err := manifest.Validate(); err != nil {
+				return fmt.Errorf("manifest validation failed for %s: %v", path, err)
+			}
+
+			// 设置生命周期状态
+			lifecycle := &PluginLifecycle{
+				State:    PluginStateDiscovered,
+				Manifest: manifest,
+				LoadedAt: time.Now(),
+			}
+			lm.plugins[manifest.PluginID] = lifecycle
+
+			manifests = append(manifests, manifest)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("plugin discovery failed: %v", err)
+	}
+
+	return manifests, nil
+}
+
+// LoadManifestV2 加载 Manifest V2
+func (lm *LifecycleManager) LoadManifestV2(path string) (*ManifestV2, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read manifest file: %v", err)
+	}
+
+	var manifest ManifestV2
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to parse manifest JSON: %v", err)
+	}
+
+	// 设置路径信息
+	manifest.sourceDir = filepath.Dir(path)
+	manifest.manifestPath = path
+
+	return &manifest, nil
+}
+
+// VerifyPlugin 验证插件
+func (lm *LifecycleManager) VerifyPlugin(ctx context.Context, pluginID string) error {
+	lifecycle, ok := lm.plugins[pluginID]
+	if !ok {
+		return fmt.Errorf("plugin %s not found", pluginID)
+	}
+
+	if lm.registry.requireTrust {
+		if lifecycle.Manifest.Signature == "" {
+			return fmt.Errorf("plugin %s: signature required but missing", pluginID)
+		}
+		if lifecycle.Manifest.Signer == "" {
+			return fmt.Errorf("plugin %s: signer required but missing", pluginID)
+		}
+		v1Manifest := lifecycle.Manifest.ConvertToV1()
+		if !lm.registry.isTrusted(*v1Manifest) {
+			return fmt.Errorf("plugin %s: signer %q is not trusted", pluginID, lifecycle.Manifest.Signer)
+		}
+		if lifecycle.Manifest.sourceDir != "" {
+			var sig Signature
+			if err := json.Unmarshal([]byte(lifecycle.Manifest.Signature), &sig); err != nil {
+				return fmt.Errorf("plugin %s: invalid signature format: %w", pluginID, err)
+			}
+			if lm.trustStore != nil {
+				signer, trusted := lm.trustStore.GetSigner(sig.KeyID)
+				if !trusted && !lm.trustStore.IsTrusted(sig.KeyID) {
+					return fmt.Errorf("plugin %s: key %q not in trust store", pluginID, sig.KeyID)
+				}
+				if signer != nil && signer.TrustLevel == TrustLevelUntrusted {
+					return fmt.Errorf("plugin %s: signer %q is explicitly untrusted", pluginID, signer.Name)
+				}
+			}
+			ok, err := VerifySignature(v1Manifest, &sig, "")
+			if err != nil {
+				return fmt.Errorf("plugin %s: signature verification failed: %w", pluginID, err)
+			}
+			if !ok {
+				return fmt.Errorf("plugin %s: signature verification returned false", pluginID)
+			}
+		}
+	}
+
+	if err := lm.CheckPluginHealth(ctx, pluginID); err != nil {
+		return fmt.Errorf("plugin health check failed: %v", err)
+	}
+
+	lifecycle.State = PluginStateVerified
+	return nil
+}
+
+// LoadPlugin 加载插件
+func (lm *LifecycleManager) LoadPlugin(ctx context.Context, pluginID string) error {
+	lifecycle, ok := lm.plugins[pluginID]
+	if !ok {
+		return fmt.Errorf("plugin %s not found", pluginID)
+	}
+
+	if lifecycle.State != PluginStateVerified {
+		return fmt.Errorf("plugin must be verified before loading")
+	}
+
+	if err := lm.executeHook(ctx, pluginID, HookBeforeLoad); err != nil {
+		return fmt.Errorf("before_load hook failed: %v", err)
+	}
+
+	lifecycle.State = PluginStateLoaded
+
+	if err := lm.executeHook(ctx, pluginID, HookAfterLoad); err != nil {
+		return fmt.Errorf("after_load hook failed: %v", err)
+	}
+
+	return nil
+}
+
+// IndexPlugin 索引插件
+func (lm *LifecycleManager) IndexPlugin(ctx context.Context, pluginID string) error {
+	lifecycle, ok := lm.plugins[pluginID]
+	if !ok {
+		return fmt.Errorf("plugin %s not found", pluginID)
+	}
+
+	if lifecycle.State != PluginStateLoaded {
+		return fmt.Errorf("plugin must be loaded before indexing")
+	}
+
+	if lifecycle.Manifest == nil {
+		return fmt.Errorf("plugin manifest not loaded")
+	}
+
+	if err := lm.capabilityIndex.Index(lifecycle.Manifest); err != nil {
+		return fmt.Errorf("failed to index plugin capabilities: %v", err)
+	}
+
+	lifecycle.State = PluginStateIndexed
+	return nil
+}
+
+// BindPlugin 绑定插件到会话
+func (lm *LifecycleManager) BindPlugin(ctx context.Context, pluginID string, sessionID string) error {
+	lifecycle, ok := lm.plugins[pluginID]
+	if !ok {
+		return fmt.Errorf("plugin %s not found", pluginID)
+	}
+
+	if lifecycle.State != PluginStateIndexed {
+		return fmt.Errorf("plugin must be indexed before binding")
+	}
+
+	if lifecycle.Sessions == nil {
+		lifecycle.Sessions = make(map[string]*PluginSession)
+	}
+
+	lifecycle.Sessions[sessionID] = &PluginSession{
+		SessionID: sessionID,
+		BoundAt:   time.Now(),
+		Context:   make(map[string]any),
+	}
+
+	lifecycle.State = PluginStateBound
+	return nil
+}
+
+// ExecutePlugin 执行插件
+func (lm *LifecycleManager) ExecutePlugin(ctx context.Context, pluginID string, action string, inputs map[string]any) (map[string]any, error) {
+	lifecycle, ok := lm.plugins[pluginID]
+	if !ok {
+		return nil, fmt.Errorf("plugin %s not found", pluginID)
+	}
+
+	if lifecycle.State != PluginStateBound && lifecycle.State != PluginStateExecuting {
+		return nil, fmt.Errorf("plugin must be bound before execution")
+	}
+
+	startTime := time.Now()
+
+	if err := lm.executeHook(ctx, pluginID, HookBeforeExecute); err != nil {
+		return nil, fmt.Errorf("before_execute hook failed: %v", err)
+	}
+
+	lifecycle.State = PluginStateExecuting
+
+	outputs, err := lm.runPluginAction(ctx, pluginID, action, inputs)
+
+	if err != nil {
+		duration := time.Since(startTime)
+		lifecycle.Metrics.ExecutionCount++
+		lifecycle.Metrics.FailureCount++
+		lifecycle.Metrics.AverageTime = time.Duration((int64(lifecycle.Metrics.AverageTime)*int64(lifecycle.Metrics.ExecutionCount-1) + int64(duration)) / int64(lifecycle.Metrics.ExecutionCount))
+		lifecycle.Metrics.LastExecuted = time.Now()
+		lifecycle.State = PluginStateBound
+
+		if lm.metricsStore != nil {
+			lm.metricsStore.RecordExecution(pluginID, false, duration)
+		}
+		return nil, &PluginExecutionError{
+			PluginID:  pluginID,
+			Action:    action,
+			Reason:    err.Error(),
+			Retryable: lifecycle.Manifest.RetryPolicy != nil,
+		}
+	}
+
+	if err := lm.executeHook(ctx, pluginID, HookAfterExecute); err != nil {
+		return nil, fmt.Errorf("after_execute hook failed: %v", err)
+	}
+
+	duration := time.Since(startTime)
+	lifecycle.Metrics.ExecutionCount++
+	lifecycle.Metrics.SuccessCount++
+	lifecycle.Metrics.AverageTime = time.Duration((int64(lifecycle.Metrics.AverageTime)*int64(lifecycle.Metrics.ExecutionCount-1) + int64(duration)) / int64(lifecycle.Metrics.ExecutionCount))
+	lifecycle.Metrics.LastExecuted = time.Now()
+	lifecycle.LastUsed = time.Now()
+	lifecycle.State = PluginStateBound
+
+	if lm.metricsStore != nil {
+		lm.metricsStore.RecordExecution(pluginID, true, duration)
+	}
+
+	return outputs, nil
+}
+
+func (lm *LifecycleManager) runPluginAction(ctx context.Context, pluginID string, action string, inputs map[string]any) (map[string]any, error) {
+	lifecycle := lm.plugins[pluginID]
+	manifest := lifecycle.Manifest
+
+	if manifest == nil {
+		return nil, fmt.Errorf("plugin manifest not loaded")
+	}
+
+	v1 := manifest.ConvertToV1()
+
+	if v1.Entrypoint != "" {
+		timeout := time.Duration(manifest.TimeoutSeconds) * time.Second
+		if timeout == 0 {
+			timeout = 30 * time.Second
+		}
+		cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		cmd := exec.CommandContext(cmdCtx, v1.Entrypoint, action)
+		cmd.Dir = manifest.sourceDir
+
+		if len(inputs) > 0 {
+			inputData, _ := json.Marshal(inputs)
+			cmd.Stdin = bytes.NewReader(inputData)
+		}
+
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+
+		if err := cmd.Run(); err != nil {
+			if stderr.Len() > 0 {
+				return nil, fmt.Errorf("plugin execution failed: %s", stderr.String())
+			}
+			return nil, fmt.Errorf("plugin execution failed: %w", err)
+		}
+
+		var result map[string]any
+		if stdout.Len() > 0 {
+			if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+				result = map[string]any{"output": stdout.String()}
+			}
+		} else {
+			result = map[string]any{"status": "success"}
+		}
+		return result, nil
+	}
+
+	if v1.MCP != nil && v1.MCP.Command != "" {
+		timeout := time.Duration(manifest.TimeoutSeconds) * time.Second
+		if timeout == 0 {
+			timeout = 30 * time.Second
+		}
+		cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		args := append(v1.MCP.Args, action)
+		cmd := exec.CommandContext(cmdCtx, v1.MCP.Command, args...)
+		cmd.Dir = manifest.sourceDir
+
+		if len(inputs) > 0 {
+			inputData, _ := json.Marshal(inputs)
+			cmd.Stdin = bytes.NewReader(inputData)
+		}
+
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+
+		if err := cmd.Run(); err != nil {
+			if stderr.Len() > 0 {
+				return nil, fmt.Errorf("MCP execution failed: %s", stderr.String())
+			}
+			return nil, fmt.Errorf("MCP execution failed: %w", err)
+		}
+
+		var result map[string]any
+		if stdout.Len() > 0 {
+			if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+				result = map[string]any{"output": stdout.String()}
+			}
+		} else {
+			result = map[string]any{"status": "success"}
+		}
+		return result, nil
+	}
+
+	return map[string]any{"status": "executed", "plugin": pluginID, "action": action}, nil
+}
+
+// SuspendPlugin 暂停插件
+func (lm *LifecycleManager) SuspendPlugin(ctx context.Context, pluginID string) error {
+	lifecycle, ok := lm.plugins[pluginID]
+	if !ok {
+		return fmt.Errorf("plugin %s not found", pluginID)
+	}
+
+	if lifecycle.SuspendData == nil {
+		lifecycle.SuspendData = make(map[string]any)
+	}
+
+	lifecycle.SuspendData["state"] = string(lifecycle.State)
+	lifecycle.SuspendData["sessions"] = lifecycle.Sessions
+	lifecycle.SuspendData["suspended_at"] = time.Now().UTC().Format(time.RFC3339)
+
+	if lifecycle.Manifest.ResumeSupport != nil && lifecycle.Manifest.ResumeSupport.Checkpointable {
+		checkpointPath := filepath.Join(lifecycle.Manifest.sourceDir, ".suspend", pluginID+".json")
+		os.MkdirAll(filepath.Dir(checkpointPath), 0755)
+		data, _ := json.MarshalIndent(lifecycle.SuspendData, "", "  ")
+		os.WriteFile(checkpointPath, data, 0644)
+	}
+
+	lifecycle.State = PluginStateSuspended
+	return nil
+}
+
+// ResumePlugin 恢复插件
+func (lm *LifecycleManager) ResumePlugin(ctx context.Context, pluginID string) error {
+	lifecycle, ok := lm.plugins[pluginID]
+	if !ok {
+		return fmt.Errorf("plugin %s not found", pluginID)
+	}
+
+	if lifecycle.State != PluginStateSuspended {
+		return fmt.Errorf("plugin must be suspended before resume")
+	}
+
+	if lifecycle.SuspendData != nil {
+		if prevState, ok := lifecycle.SuspendData["state"].(string); ok {
+			lifecycle.State = PluginState(prevState)
+		}
+		if sessions, ok := lifecycle.SuspendData["sessions"].(map[string]*PluginSession); ok {
+			lifecycle.Sessions = sessions
+		}
+		delete(lifecycle.SuspendData, "suspended_at")
+
+		if lifecycle.Manifest.ResumeSupport != nil && lifecycle.Manifest.ResumeSupport.Checkpointable {
+			checkpointPath := filepath.Join(lifecycle.Manifest.sourceDir, ".suspend", pluginID+".json")
+			os.Remove(checkpointPath)
+		}
+	}
+
+	if lifecycle.State == "" {
+		lifecycle.State = PluginStateBound
+	}
+
+	return nil
+}
+
+// UnloadPlugin 卸载插件
+func (lm *LifecycleManager) UnloadPlugin(ctx context.Context, pluginID string) error {
+	lifecycle, ok := lm.plugins[pluginID]
+	if !ok {
+		return fmt.Errorf("plugin %s not found", pluginID)
+	}
+
+	lm.capabilityIndex.Remove(pluginID)
+
+	if err := lm.executeHook(ctx, pluginID, HookBeforeUnload); err != nil {
+		return fmt.Errorf("before_unload hook failed: %v", err)
+	}
+
+	for sessionID := range lifecycle.Sessions {
+		delete(lifecycle.Sessions, sessionID)
+	}
+	lifecycle.Sessions = nil
+
+	if lifecycle.SuspendData != nil {
+		checkpointPath := filepath.Join(lifecycle.Manifest.sourceDir, ".suspend", pluginID+".json")
+		os.Remove(checkpointPath)
+		lifecycle.SuspendData = nil
+	}
+
+	lifecycle.State = PluginStateUnloaded
+	delete(lm.plugins, pluginID)
+
+	return nil
+}
+
+// CheckPluginHealth 检查插件健康状态
+func (lm *LifecycleManager) CheckPluginHealth(ctx context.Context, pluginID string) error {
+	lifecycle, ok := lm.plugins[pluginID]
+	if !ok {
+		return fmt.Errorf("plugin %s not found", pluginID)
+	}
+
+	healthCheck := lifecycle.Manifest.HealthCheck
+	if healthCheck == nil {
+		lifecycle.Health.Status = "healthy"
+		lifecycle.Health.Message = "No health check defined"
+		lifecycle.Health.CheckedAt = time.Now()
+		return nil
+	}
+
+	timeout := time.Duration(healthCheck.TimeoutSec) * time.Second
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+
+	if healthCheck.Command != "" {
+		cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		result, err := executeHook(cmdCtx, healthCheck.Command, lifecycle.Manifest.sourceDir)
+		if err != nil {
+			lifecycle.Health.Status = "error"
+			lifecycle.Health.Message = fmt.Sprintf("Health check failed: %v", err)
+		} else if result == 0 {
+			lifecycle.Health.Status = "healthy"
+			lifecycle.Health.Message = "Health check passed"
+		} else {
+			lifecycle.Health.Status = "warning"
+			lifecycle.Health.Message = fmt.Sprintf("Health check returned code %d", result)
+		}
+	} else {
+		lifecycle.Health.Status = "healthy"
+		lifecycle.Health.Message = "No health check command"
+	}
+
+	lifecycle.Health.CheckedAt = time.Now()
+
+	return nil
+}
+
+func executeHook(ctx context.Context, command string, workDir string) (int, error) {
+	if command == "" {
+		return 0, nil
+	}
+
+	var cmd *exec.Cmd
+	if workDir != "" {
+		cmd = exec.CommandContext(ctx, "sh", "-c", command)
+		cmd.Dir = workDir
+	} else {
+		cmd = exec.CommandContext(ctx, "sh", "-c", command)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode(), fmt.Errorf("command failed (exit %d): %s", exitErr.ExitCode(), stderr.String())
+		}
+		return -1, fmt.Errorf("command failed: %w", err)
+	}
+
+	return 0, nil
+}
+
+type HookType string
+
+const (
+	HookBeforeLoad    HookType = "before_load"
+	HookAfterLoad     HookType = "after_load"
+	HookBeforeUnload  HookType = "before_unload"
+	HookAfterUnload   HookType = "after_unload"
+	HookBeforeExecute HookType = "before_execute"
+	HookAfterExecute  HookType = "after_execute"
+)
+
+func (lm *LifecycleManager) executeHook(ctx context.Context, pluginID string, hookType HookType) error {
+	lifecycle, ok := lm.plugins[pluginID]
+	if !ok {
+		return fmt.Errorf("plugin %s not found", pluginID)
+	}
+
+	hooks := lifecycle.Manifest.LifecycleHooks
+	if hooks == nil {
+		return nil
+	}
+
+	var command string
+	switch hookType {
+	case HookBeforeLoad:
+		command = hooks.BeforeLoad
+	case HookAfterLoad:
+		command = hooks.AfterLoad
+	case HookBeforeUnload:
+		command = hooks.BeforeUnload
+	case HookAfterUnload:
+		command = hooks.AfterUnload
+	case HookBeforeExecute:
+		command = hooks.BeforeExecute
+	case HookAfterExecute:
+		command = hooks.AfterExecute
+	}
+
+	if command == "" {
+		return nil
+	}
+
+	_, err := executeHook(ctx, command, lifecycle.Manifest.sourceDir)
+	return err
+}
+
+// GetPluginState 获取插件状态
+func (lm *LifecycleManager) GetPluginState(pluginID string) (PluginState, error) {
+	lifecycle, ok := lm.plugins[pluginID]
+	if !ok {
+		return "", fmt.Errorf("plugin %s not found", pluginID)
+	}
+
+	return lifecycle.State, nil
+}
+
+// GetPluginMetrics 获取插件指标
+func (lm *LifecycleManager) GetPluginMetrics(pluginID string) (PluginMetrics, error) {
+	if lm.metricsStore != nil {
+		return lm.metricsStore.GetMetrics(pluginID), nil
+	}
+
+	lifecycle, ok := lm.plugins[pluginID]
+	if !ok {
+		return PluginMetrics{}, fmt.Errorf("plugin %s not found", pluginID)
+	}
+
+	return lifecycle.Metrics, nil
+}
+
+// ListPluginsByState 按状态列出插件
+func (lm *LifecycleManager) ListPluginsByState(state PluginState) []string {
+	var plugins []string
+	for pluginID, lifecycle := range lm.plugins {
+		if lifecycle.State == state {
+			plugins = append(plugins, pluginID)
+		}
+	}
+	return plugins
+}
+
+// PluginExecutionError 插件执行错误
+type PluginExecutionError struct {
+	PluginID  string
+	Action    string
+	Reason    string
+	Retryable bool
+}
+
+func (e *PluginExecutionError) Error() string {
+	return fmt.Sprintf("plugin execution error: plugin=%s, action=%s, reason=%s", e.PluginID, e.Action, e.Reason)
+}
+
+// ExecuteWithRetry 带重试的执行
+func (lm *LifecycleManager) ExecuteWithRetry(ctx context.Context, pluginID string, action string, inputs map[string]any, retryPolicy *RetryPolicy) (map[string]any, error) {
+	if retryPolicy == nil {
+		return lm.ExecutePlugin(ctx, pluginID, action, inputs)
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= retryPolicy.MaxAttempts; attempt++ {
+		outputs, err := lm.ExecutePlugin(ctx, pluginID, action, inputs)
+		if err == nil {
+			return outputs, nil
+		}
+
+		lastErr = err
+
+		// 检查是否可重试
+		if pe, ok := err.(*PluginExecutionError); ok && !pe.Retryable {
+			return nil, err
+		}
+
+		// 计算延迟
+		delay := retryPolicy.InitialDelay * int(retryPolicy.BackoffFactor*float64(attempt-1))
+		if delay > retryPolicy.MaxDelay {
+			delay = retryPolicy.MaxDelay
+		}
+
+		// 等待
+		time.Sleep(time.Duration(delay) * time.Millisecond)
+	}
+
+	return nil, fmt.Errorf("plugin execution failed after %d attempts: %v", retryPolicy.MaxAttempts, lastErr)
+}

--- a/pkg/extensions/plugin/loader.go
+++ b/pkg/extensions/plugin/loader.go
@@ -1,0 +1,688 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// PluginFormat represents the format of a plugin
+type PluginFormat string
+
+const (
+	FormatJSON     PluginFormat = "json"
+	FormatGo       PluginFormat = "go"
+	FormatPython   PluginFormat = "python"
+	FormatNode     PluginFormat = "node"
+	FormatRust     PluginFormat = "rust"
+	FormatBinary   PluginFormat = "binary"
+	FormatWasm     PluginFormat = "wasm"
+	FormatMCP      PluginFormat = "mcp"
+	FormatOpenClaw PluginFormat = "openclaw"
+	FormatClaude   PluginFormat = "claude"
+	FormatCursor   PluginFormat = "cursor"
+)
+
+// PluginLoader loads plugins from various formats
+type PluginLoader struct {
+	mu       sync.RWMutex
+	loaders  map[PluginFormat]FormatLoader
+	baseDir  string
+	cacheDir string
+}
+
+// FormatLoader is the interface for format-specific loaders
+type FormatLoader interface {
+	CanLoad(dir string, files []os.DirEntry) bool
+	Load(ctx context.Context, dir string, fallbackName string) (*Manifest, error)
+	GetFormat() PluginFormat
+}
+
+// NewPluginLoader creates a new plugin loader
+func NewPluginLoader(baseDir string) *PluginLoader {
+	cacheDir := filepath.Join(baseDir, ".cache")
+	os.MkdirAll(cacheDir, 0o755)
+
+	loader := &PluginLoader{
+		loaders:  make(map[PluginFormat]FormatLoader),
+		baseDir:  baseDir,
+		cacheDir: cacheDir,
+	}
+
+	// Register default loaders
+	loader.RegisterLoader(&JSONLoader{})
+	loader.RegisterLoader(&GoPluginLoader{})
+	loader.RegisterLoader(&PythonPluginLoader{})
+	loader.RegisterLoader(&NodePluginLoader{})
+	loader.RegisterLoader(&RustPluginLoader{})
+	loader.RegisterLoader(&BinaryPluginLoader{})
+	loader.RegisterLoader(&MCPLoader{})
+	loader.RegisterLoader(&OpenClawLoader{})
+	loader.RegisterLoader(&ClaudeLoader{})
+
+	return loader
+}
+
+// RegisterLoader registers a format loader
+func (pl *PluginLoader) RegisterLoader(loader FormatLoader) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	pl.loaders[loader.GetFormat()] = loader
+}
+
+// LoadPlugin loads a plugin from a directory
+func (pl *PluginLoader) LoadPlugin(ctx context.Context, dir string, name string) (*Manifest, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read plugin directory: %w", err)
+	}
+
+	// Try each loader
+	pl.mu.RLock()
+	defer pl.mu.RUnlock()
+
+	for _, loader := range pl.loaders {
+		if loader.CanLoad(dir, entries) {
+			manifest, err := loader.Load(ctx, dir, name)
+			if err == nil && manifest != nil {
+				return manifest, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no loader found for plugin in %s", dir)
+}
+
+// DiscoverPlugins discovers all plugins in a directory
+func (pl *PluginLoader) DiscoverPlugins(ctx context.Context, pluginDir string) ([]*Manifest, error) {
+	var manifests []*Manifest
+
+	entries, err := os.ReadDir(pluginDir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		dir := filepath.Join(pluginDir, entry.Name())
+		manifest, err := pl.LoadPlugin(ctx, dir, entry.Name())
+		if err != nil {
+			continue
+		}
+
+		manifest.sourceDir = dir
+		manifests = append(manifests, manifest)
+	}
+
+	return manifests, nil
+}
+
+// JSONLoader loads plugins from JSON manifests
+type JSONLoader struct{}
+
+func (l *JSONLoader) GetFormat() PluginFormat { return FormatJSON }
+
+func (l *JSONLoader) CanLoad(dir string, files []os.DirEntry) bool {
+	for _, f := range files {
+		name := f.Name()
+		if name == "plugin.json" || name == "openclaw.plugin.json" || name == "anyclaw.plugin.json" {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *JSONLoader) Load(ctx context.Context, dir string, fallbackName string) (*Manifest, error) {
+	candidates := []string{
+		"anyclaw.plugin.json",
+		"plugin.json",
+		"openclaw.plugin.json",
+	}
+
+	for _, name := range candidates {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+
+		var manifest Manifest
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			continue
+		}
+
+		if manifest.Name == "" {
+			manifest.Name = fallbackName
+		}
+		manifest.sourceDir = dir
+		manifest.manifestPath = path
+		return &manifest, nil
+	}
+
+	return nil, fmt.Errorf("no valid manifest found")
+}
+
+// GoPluginLoader loads Go plugins
+type GoPluginLoader struct{}
+
+func (l *GoPluginLoader) GetFormat() PluginFormat { return FormatGo }
+
+func (l *GoPluginLoader) CanLoad(dir string, files []os.DirEntry) bool {
+	hasGo := false
+	hasManifest := false
+	for _, f := range files {
+		if strings.HasSuffix(f.Name(), ".go") {
+			hasGo = true
+		}
+		if f.Name() == "plugin.json" || f.Name() == "go.mod" {
+			hasManifest = true
+		}
+	}
+	return hasGo && hasManifest
+}
+
+func (l *GoPluginLoader) Load(ctx context.Context, dir string, fallbackName string) (*Manifest, error) {
+	// Check for plugin.json first
+	manifestPath := filepath.Join(dir, "plugin.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		// Create manifest from go.mod
+		return l.createFromGoMod(dir, fallbackName)
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+
+	if manifest.Name == "" {
+		manifest.Name = fallbackName
+	}
+
+	// Build if needed
+	binaryPath := filepath.Join(dir, "plugin")
+	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+		if err := l.build(dir); err != nil {
+			return nil, fmt.Errorf("failed to build Go plugin: %w", err)
+		}
+	}
+
+	manifest.Entrypoint = binaryPath
+	manifest.sourceDir = dir
+	manifest.manifestPath = manifestPath
+	return &manifest, nil
+}
+
+func (l *GoPluginLoader) createFromGoMod(dir string, fallbackName string) (*Manifest, error) {
+	goModPath := filepath.Join(dir, "go.mod")
+	data, err := os.ReadFile(goModPath)
+	if err != nil {
+		return nil, fmt.Errorf("no go.mod found")
+	}
+
+	// Extract module name
+	lines := strings.Split(string(data), "\n")
+	moduleName := fallbackName
+	for _, line := range lines {
+		if strings.HasPrefix(line, "module ") {
+			moduleName = strings.TrimSpace(strings.TrimPrefix(line, "module "))
+			break
+		}
+	}
+
+	return &Manifest{
+		Name:        moduleName,
+		Version:     "1.0.0",
+		Description: "Go plugin",
+		Kinds:       []string{"tool"},
+		Enabled:     true,
+		Entrypoint:  filepath.Join(dir, "plugin"),
+		sourceDir:   dir,
+	}, nil
+}
+
+func (l *GoPluginLoader) build(dir string) error {
+	cmd := exec.Command("go", "build", "-o", "plugin", ".")
+	cmd.Dir = dir
+	return cmd.Run()
+}
+
+// PythonPluginLoader loads Python plugins
+type PythonPluginLoader struct{}
+
+func (l *PythonPluginLoader) GetFormat() PluginFormat { return FormatPython }
+
+func (l *PythonPluginLoader) CanLoad(dir string, files []os.DirEntry) bool {
+	for _, f := range files {
+		name := f.Name()
+		if name == "main.py" || name == "plugin.py" || name == "__main__.py" {
+			return true
+		}
+		if name == "requirements.txt" || name == "pyproject.toml" {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *PythonPluginLoader) Load(ctx context.Context, dir string, fallbackName string) (*Manifest, error) {
+	// Check for manifest
+	manifestPath := filepath.Join(dir, "plugin.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		// Create from Python files
+		return l.createFromPython(dir, fallbackName)
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+
+	if manifest.Name == "" {
+		manifest.Name = fallbackName
+	}
+
+	// Find entry point
+	entrypoint := l.findEntrypoint(dir)
+	manifest.Entrypoint = entrypoint
+	manifest.sourceDir = dir
+	manifest.manifestPath = manifestPath
+	return &manifest, nil
+}
+
+func (l *PythonPluginLoader) createFromPython(dir string, fallbackName string) (*Manifest, error) {
+	entrypoint := l.findEntrypoint(dir)
+	if entrypoint == "" {
+		return nil, fmt.Errorf("no Python entry point found")
+	}
+
+	return &Manifest{
+		Name:        fallbackName,
+		Version:     "1.0.0",
+		Description: "Python plugin",
+		Kinds:       []string{"tool"},
+		Enabled:     true,
+		Entrypoint:  entrypoint,
+		sourceDir:   dir,
+	}, nil
+}
+
+func (l *PythonPluginLoader) findEntrypoint(dir string) string {
+	candidates := []string{"main.py", "plugin.py", "__main__.py", "run.py"}
+	for _, name := range candidates {
+		path := filepath.Join(dir, name)
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+// NodePluginLoader loads Node.js plugins
+type NodePluginLoader struct{}
+
+func (l *NodePluginLoader) GetFormat() PluginFormat { return FormatNode }
+
+func (l *NodePluginLoader) CanLoad(dir string, files []os.DirEntry) bool {
+	for _, f := range files {
+		if f.Name() == "package.json" {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *NodePluginLoader) Load(ctx context.Context, dir string, fallbackName string) (*Manifest, error) {
+	packageJSONPath := filepath.Join(dir, "package.json")
+	data, err := os.ReadFile(packageJSONPath)
+	if err != nil {
+		return nil, fmt.Errorf("no package.json found")
+	}
+
+	var pkg struct {
+		Name        string `json:"name"`
+		Version     string `json:"version"`
+		Description string `json:"description"`
+		Main        string `json:"main"`
+		Scripts     struct {
+			Start string `json:"start"`
+		} `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil, err
+	}
+
+	name := pkg.Name
+	if name == "" {
+		name = fallbackName
+	}
+
+	entrypoint := pkg.Main
+	if entrypoint == "" {
+		entrypoint = "index.js"
+	}
+
+	// Check for plugin manifest
+	manifestPath := filepath.Join(dir, "plugin.json")
+	if manifestData, err := os.ReadFile(manifestPath); err == nil {
+		var manifest Manifest
+		if err := json.Unmarshal(manifestData, &manifest); err == nil {
+			if manifest.Name == "" {
+				manifest.Name = name
+			}
+			manifest.Entrypoint = filepath.Join(dir, entrypoint)
+			manifest.sourceDir = dir
+			manifest.manifestPath = manifestPath
+			return &manifest, nil
+		}
+	}
+
+	return &Manifest{
+		Name:        name,
+		Version:     pkg.Version,
+		Description: pkg.Description,
+		Kinds:       []string{"tool"},
+		Enabled:     true,
+		Entrypoint:  filepath.Join(dir, entrypoint),
+		sourceDir:   dir,
+	}, nil
+}
+
+// RustPluginLoader loads Rust plugins
+type RustPluginLoader struct{}
+
+func (l *RustPluginLoader) GetFormat() PluginFormat { return FormatRust }
+
+func (l *RustPluginLoader) CanLoad(dir string, files []os.DirEntry) bool {
+	for _, f := range files {
+		if f.Name() == "Cargo.toml" {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *RustPluginLoader) Load(ctx context.Context, dir string, fallbackName string) (*Manifest, error) {
+	cargoPath := filepath.Join(dir, "Cargo.toml")
+	data, err := os.ReadFile(cargoPath)
+	if err != nil {
+		return nil, fmt.Errorf("no Cargo.toml found")
+	}
+
+	// Parse basic Cargo.toml
+	name := fallbackName
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "name = ") {
+			name = strings.Trim(strings.TrimPrefix(line, "name = "), "\"")
+			break
+		}
+	}
+
+	// Check for plugin manifest
+	manifestPath := filepath.Join(dir, "plugin.json")
+	if manifestData, err := os.ReadFile(manifestPath); err == nil {
+		var manifest Manifest
+		if err := json.Unmarshal(manifestData, &manifest); err == nil {
+			if manifest.Name == "" {
+				manifest.Name = name
+			}
+			manifest.sourceDir = dir
+			manifest.manifestPath = manifestPath
+			return &manifest, nil
+		}
+	}
+
+	return &Manifest{
+		Name:        name,
+		Version:     "1.0.0",
+		Description: "Rust plugin",
+		Kinds:       []string{"tool"},
+		Enabled:     true,
+		sourceDir:   dir,
+	}, nil
+}
+
+// BinaryPluginLoader loads pre-compiled binary plugins
+type BinaryPluginLoader struct{}
+
+func (l *BinaryPluginLoader) GetFormat() PluginFormat { return FormatBinary }
+
+func (l *BinaryPluginLoader) CanLoad(dir string, files []os.DirEntry) bool {
+	for _, f := range files {
+		name := f.Name()
+		if strings.HasSuffix(name, ".exe") || strings.HasSuffix(name, ".bin") || name == "plugin" {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *BinaryPluginLoader) Load(ctx context.Context, dir string, fallbackName string) (*Manifest, error) {
+	// Find binary
+	var binaryPath string
+	entries, _ := os.ReadDir(dir)
+	for _, f := range entries {
+		name := f.Name()
+		if name == "plugin" || strings.HasSuffix(name, ".exe") || strings.HasSuffix(name, ".bin") {
+			binaryPath = filepath.Join(dir, name)
+			break
+		}
+	}
+
+	if binaryPath == "" {
+		return nil, fmt.Errorf("no binary found")
+	}
+
+	// Check for manifest
+	manifestPath := filepath.Join(dir, "plugin.json")
+	if data, err := os.ReadFile(manifestPath); err == nil {
+		var manifest Manifest
+		if err := json.Unmarshal(data, &manifest); err == nil {
+			manifest.Entrypoint = binaryPath
+			manifest.sourceDir = dir
+			manifest.manifestPath = manifestPath
+			return &manifest, nil
+		}
+	}
+
+	return &Manifest{
+		Name:        fallbackName,
+		Version:     "1.0.0",
+		Description: "Binary plugin",
+		Kinds:       []string{"tool"},
+		Enabled:     true,
+		Entrypoint:  binaryPath,
+		sourceDir:   dir,
+	}, nil
+}
+
+// MCPLoader loads MCP (Model Context Protocol) plugins
+type MCPLoader struct{}
+
+func (l *MCPLoader) GetFormat() PluginFormat { return FormatMCP }
+
+func (l *MCPLoader) CanLoad(dir string, files []os.DirEntry) bool {
+	for _, f := range files {
+		if f.Name() == "mcp.json" || f.Name() == ".mcp.json" {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *MCPLoader) Load(ctx context.Context, dir string, fallbackName string) (*Manifest, error) {
+	candidates := []string{"mcp.json", ".mcp.json"}
+	for _, name := range candidates {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+
+		var mcpConfig struct {
+			Name         string            `json:"name"`
+			Version      string            `json:"version"`
+			Description  string            `json:"description"`
+			Command      string            `json:"command"`
+			Args         []string          `json:"args"`
+			Env          map[string]string `json:"env"`
+			Transport    string            `json:"transport"`
+			Capabilities []string          `json:"capabilities"`
+		}
+		if err := json.Unmarshal(data, &mcpConfig); err != nil {
+			continue
+		}
+
+		name := mcpConfig.Name
+		if name == "" {
+			name = fallbackName
+		}
+
+		return &Manifest{
+			Name:        name,
+			Version:     mcpConfig.Version,
+			Description: mcpConfig.Description,
+			Kinds:       []string{"mcp", "tool"},
+			Enabled:     true,
+			MCP: &MCPSpec{
+				Name:         name,
+				Command:      mcpConfig.Command,
+				Args:         mcpConfig.Args,
+				Env:          mcpConfig.Env,
+				Transport:    mcpConfig.Transport,
+				Capabilities: mcpConfig.Capabilities,
+			},
+			sourceDir: dir,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("no MCP config found")
+}
+
+// OpenClawLoader loads OpenClaw-compatible plugins
+type OpenClawLoader struct{}
+
+func (l *OpenClawLoader) GetFormat() PluginFormat { return FormatOpenClaw }
+
+func (l *OpenClawLoader) CanLoad(dir string, files []os.DirEntry) bool {
+	for _, f := range files {
+		if f.Name() == "openclaw.plugin.json" {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *OpenClawLoader) Load(ctx context.Context, dir string, fallbackName string) (*Manifest, error) {
+	path := filepath.Join(dir, "openclaw.plugin.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var openclawManifest map[string]any
+	if err := json.Unmarshal(data, &openclawManifest); err != nil {
+		return nil, err
+	}
+
+	// Convert OpenClaw manifest to AnyClaw manifest
+	name, _ := openclawManifest["name"].(string)
+	if name == "" {
+		name = fallbackName
+	}
+	version, _ := openclawManifest["version"].(string)
+	description, _ := openclawManifest["description"].(string)
+
+	kinds := []string{"tool"}
+	if k, ok := openclawManifest["kind"].(string); ok {
+		kinds = []string{k}
+	}
+
+	manifest := &Manifest{
+		Name:         name,
+		Version:      version,
+		Description:  description,
+		Kinds:        kinds,
+		Enabled:      true,
+		sourceDir:    dir,
+		manifestPath: path,
+	}
+
+	// Convert tool spec
+	if tool, ok := openclawManifest["tool"].(map[string]any); ok {
+		manifest.Tool = &ToolSpec{
+			Name:        name,
+			Description: description,
+		}
+		if schema, ok := tool["inputSchema"].(map[string]any); ok {
+			manifest.Tool.InputSchema = schema
+		}
+	}
+
+	// Convert channel spec
+	if channel, ok := openclawManifest["channel"].(map[string]any); ok {
+		manifest.Channel = &ChannelSpec{
+			Name:        name,
+			Description: description,
+		}
+		_ = channel
+	}
+
+	return manifest, nil
+}
+
+// ClaudeLoader loads Claude-compatible plugins
+type ClaudeLoader struct{}
+
+func (l *ClaudeLoader) GetFormat() PluginFormat { return FormatClaude }
+
+func (l *ClaudeLoader) CanLoad(dir string, files []os.DirEntry) bool {
+	for _, f := range files {
+		if f.Name() == ".claude-plugin" {
+			return true
+		}
+	}
+	// Check for .claude-plugin directory
+	for _, f := range files {
+		if f.IsDir() && f.Name() == ".claude-plugin" {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *ClaudeLoader) Load(ctx context.Context, dir string, fallbackName string) (*Manifest, error) {
+	// Check for .claude-plugin/plugin.json
+	manifestPath := filepath.Join(dir, ".claude-plugin", "plugin.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		// Try root plugin.json
+		manifestPath = filepath.Join(dir, "plugin.json")
+		data, err = os.ReadFile(manifestPath)
+		if err != nil {
+			return nil, fmt.Errorf("no Claude plugin manifest found")
+		}
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+
+	if manifest.Name == "" {
+		manifest.Name = fallbackName
+	}
+	manifest.sourceDir = dir
+	manifest.manifestPath = manifestPath
+	return &manifest, nil
+}

--- a/pkg/extensions/plugin/manifest_test.go
+++ b/pkg/extensions/plugin/manifest_test.go
@@ -1,0 +1,233 @@
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/capability/tools"
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+func TestNewRegistryPrefersOpenClawManifest(t *testing.T) {
+	baseDir := t.TempDir()
+	pluginDir := filepath.Join(baseDir, "demo-surface")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	openclawManifest := Manifest{
+		Name:        "demo-surface",
+		Version:     "2.0.0",
+		Description: "OpenClaw manifest",
+		Kinds:       []string{"surface"},
+		Enabled:     true,
+		Entrypoint:  "surface.py",
+		Surface: &SurfaceSpec{
+			Name:        "demo-surface",
+			Description: "OpenClaw surface",
+			Path:        "/__openclaw__/surfaces/demo-surface",
+		},
+	}
+	legacyManifest := Manifest{
+		Name:        "demo-surface",
+		Version:     "1.0.0",
+		Description: "Legacy manifest",
+		Kinds:       []string{"surface"},
+		Enabled:     true,
+		Entrypoint:  "legacy-surface.py",
+		Surface: &SurfaceSpec{
+			Name:        "demo-surface",
+			Description: "Legacy surface",
+			Path:        "/__anyclaw__/surfaces/demo-surface",
+		},
+	}
+	if err := writeManifestFile(filepath.Join(pluginDir, "openclaw.plugin.json"), openclawManifest); err != nil {
+		t.Fatalf("write openclaw manifest: %v", err)
+	}
+	if err := writeManifestFile(filepath.Join(pluginDir, "plugin.json"), legacyManifest); err != nil {
+		t.Fatalf("write legacy manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "surface.py"), []byte("print('ok')\n"), 0o644); err != nil {
+		t.Fatalf("write entrypoint: %v", err)
+	}
+
+	registry, err := NewRegistry(config.PluginsConfig{Dir: baseDir, AllowExec: true})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	var loaded *Manifest
+	for _, manifest := range registry.List() {
+		if manifest.Name == "demo-surface" {
+			loaded = &manifest
+			break
+		}
+	}
+	if loaded == nil {
+		t.Fatal("expected demo-surface to be loaded")
+	}
+	if loaded.Version != "2.0.0" {
+		t.Fatalf("expected openclaw manifest version, got %q", loaded.Version)
+	}
+	if loaded.Surface == nil || loaded.Surface.Path != "/__openclaw__/surfaces/demo-surface" {
+		t.Fatalf("expected openclaw surface path, got %#v", loaded.Surface)
+	}
+}
+
+func TestSurfaceRunnersResolveBundleManifestEntrypoint(t *testing.T) {
+	baseDir := t.TempDir()
+	pluginDir := filepath.Join(baseDir, "bundle-surface")
+	bundleDir := filepath.Join(pluginDir, ".codex-plugin")
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	manifest := Manifest{
+		Name:        "bundle-surface",
+		Version:     "1.0.0",
+		Description: "Bundle surface",
+		Kinds:       []string{"surface"},
+		Enabled:     true,
+		Entrypoint:  "surface.py",
+		Permissions: []string{"tool:exec"},
+		Surface: &SurfaceSpec{
+			Name:        "bundle-surface",
+			Description: "Bundle surface",
+			Path:        "/__openclaw__/surfaces/bundle-surface",
+		},
+	}
+	if err := writeManifestFile(filepath.Join(bundleDir, "plugin.json"), manifest); err != nil {
+		t.Fatalf("write bundle manifest: %v", err)
+	}
+	expectedEntrypoint := filepath.Join(bundleDir, "surface.py")
+	if err := os.WriteFile(expectedEntrypoint, []byte("print('ok')\n"), 0o644); err != nil {
+		t.Fatalf("write bundle entrypoint: %v", err)
+	}
+
+	registry, err := NewRegistry(config.PluginsConfig{
+		Dir:          baseDir,
+		AllowExec:    true,
+		RequireTrust: false,
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	runners := registry.SurfaceRunners(baseDir)
+	if len(runners) != 1 {
+		t.Fatalf("expected 1 surface runner, got %d", len(runners))
+	}
+	if got := runners[0].Entrypoint; got != expectedEntrypoint {
+		t.Fatalf("expected bundle entrypoint %q, got %q", expectedEntrypoint, got)
+	}
+}
+
+func TestRegistryPolicyBlocksPluginNetOutWithoutAllowedDomains(t *testing.T) {
+	baseDir := t.TempDir()
+	pluginDir := filepath.Join(baseDir, "network-surface")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	manifest := Manifest{
+		Name:        "network-surface",
+		Version:     "1.0.0",
+		Description: "Needs outbound network",
+		Kinds:       []string{"surface"},
+		Enabled:     true,
+		Entrypoint:  "surface.py",
+		Permissions: []string{"tool:exec", "net:out"},
+		Surface: &SurfaceSpec{
+			Name:        "network-surface",
+			Description: "Network surface",
+			Path:        "/__openclaw__/surfaces/network-surface",
+		},
+	}
+	if err := writeManifestFile(filepath.Join(pluginDir, "plugin.json"), manifest); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "surface.py"), []byte("print('ok')\n"), 0o644); err != nil {
+		t.Fatalf("write entrypoint: %v", err)
+	}
+
+	registry, err := NewRegistry(config.PluginsConfig{
+		Dir:          baseDir,
+		AllowExec:    true,
+		RequireTrust: false,
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	registry.SetPolicyEngine(tools.NewPolicyEngine(tools.PolicyOptions{WorkingDir: t.TempDir()}))
+
+	if runners := registry.SurfaceRunners(baseDir); len(runners) != 0 {
+		t.Fatalf("expected policy to block net:out plugin, got %d runners", len(runners))
+	}
+}
+
+func TestRegistryTrustAcceptsBareSHA256Signature(t *testing.T) {
+	baseDir := t.TempDir()
+	pluginDir := filepath.Join(baseDir, "trusted-surface")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	entrypointPath := filepath.Join(pluginDir, "surface.py")
+	if err := os.WriteFile(entrypointPath, []byte("print('ok')\n"), 0o644); err != nil {
+		t.Fatalf("write entrypoint: %v", err)
+	}
+
+	manifest := Manifest{
+		Name:        "trusted-surface",
+		Version:     "1.0.0",
+		Description: "Trusted surface",
+		Kinds:       []string{"surface"},
+		Enabled:     true,
+		Entrypoint:  "surface.py",
+		Permissions: []string{"tool:exec"},
+		Signer:      "dev-local",
+		Signature:   "ad64355106bb158b020ecf9702be48f7730fc091dd4bb6a2f092b40393495b3d",
+		Surface: &SurfaceSpec{
+			Name:        "Trusted Surface",
+			Description: "Trusted surface",
+			Path:        "/__openclaw__/surfaces/trusted-surface",
+		},
+	}
+	if err := writeManifestFile(filepath.Join(pluginDir, "plugin.json"), manifest); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	registry, err := NewRegistry(config.PluginsConfig{
+		Dir:            baseDir,
+		AllowExec:      true,
+		RequireTrust:   true,
+		TrustedSigners: []string{"dev-local"},
+		Enabled:        []string{"trusted-surface"},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	foundTrustedSurface := false
+	for _, item := range registry.List() {
+		if item.Name == "trusted-surface" {
+			foundTrustedSurface = true
+			if !item.Verified {
+				t.Fatalf("expected trusted-surface manifest to be verified, got %#v", item)
+			}
+		}
+	}
+	if !foundTrustedSurface {
+		t.Fatalf("expected trusted-surface manifest to be loaded, got %#v", registry.List())
+	}
+}
+
+func writeManifestFile(path string, manifest Manifest) error {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/pkg/extensions/plugin/manifest_v2.go
+++ b/pkg/extensions/plugin/manifest_v2.go
@@ -1,0 +1,424 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// ManifestV2 插件清单 V2
+type ManifestV2 struct {
+	// 基础字段
+	APIVersion  string    `json:"api_version"`
+	PluginID    string    `json:"plugin_id"`
+	Name        string    `json:"name"`
+	Version     string    `json:"version"`
+	Description string    `json:"description"`
+	Author      string    `json:"author,omitempty"`
+	License     string    `json:"license,omitempty"`
+	Homepage    string    `json:"homepage,omitempty"`
+	Repository  string    `json:"repository,omitempty"`
+	PublishedAt time.Time `json:"published_at,omitempty"`
+	UpdatedAt   time.Time `json:"updated_at,omitempty"`
+
+	// 插件类型和配置
+	Kinds          []string `json:"kinds"`
+	Builtin        bool     `json:"builtin"`
+	Enabled        bool     `json:"enabled"`
+	Entrypoint     string   `json:"entrypoint,omitempty"`
+	ExecPolicy     string   `json:"exec_policy,omitempty"`
+	TimeoutSeconds int      `json:"timeout_seconds,omitempty"`
+
+	// 平台兼容性
+	Platforms     []string `json:"platforms"`
+	Architectures []string `json:"architectures,omitempty"`
+	MinOSVersion  string   `json:"min_os_version,omitempty"`
+	MaxOSVersion  string   `json:"max_os_version,omitempty"`
+
+	// 能力标签
+	CapabilityTags []string        `json:"capability_tags,omitempty"`
+	TriggerWords   []string        `json:"trigger_words,omitempty"`
+	DefaultParams  json.RawMessage `json:"default_params,omitempty"`
+
+	// 风险和安全
+	RiskLevel     string   `json:"risk_level"`               // low|medium|high
+	DataAccess    []string `json:"data_access,omitempty"`    // file-system, network, clipboard, etc.
+	ApprovalScope string   `json:"approval_scope,omitempty"` // none|tool|action|always
+	RequiresHost  bool     `json:"requires_host,omitempty"`
+
+	// 执行策略
+	RetryPolicy    *RetryPolicy    `json:"retry_policy,omitempty"`
+	FallbackPolicy *FallbackPolicy `json:"fallback_policy,omitempty"`
+	RollbackPolicy *RollbackPolicy `json:"rollback_policy,omitempty"`
+
+	// 验证模板
+	VerificationTemplates []VerificationTemplate `json:"verification_templates,omitempty"`
+
+	// 恢复支持
+	ResumeSupport *ResumeSupport `json:"resume_support,omitempty"`
+
+	// 健康检查
+	HealthCheck *HealthCheck `json:"health_check,omitempty"`
+
+	// 生命周期钩子
+	LifecycleHooks *LifecycleHooks `json:"lifecycle_hooks,omitempty"`
+
+	// 插件特定配置
+	Tool         *ToolSpecV2       `json:"tool,omitempty"`
+	Ingress      *IngressSpecV2    `json:"ingress,omitempty"`
+	Channel      *ChannelSpecV2    `json:"channel,omitempty"`
+	Node         *NodeSpecV2       `json:"node,omitempty"`
+	Surface      *SurfaceSpecV2    `json:"surface,omitempty"`
+	WorkflowPack *WorkflowPackSpec `json:"workflow_pack,omitempty"`
+
+	// 签名和安全
+	Signer    string `json:"signer,omitempty"`
+	Signature string `json:"signature,omitempty"`
+	Trust     string `json:"trust,omitempty"`
+	Verified  bool   `json:"verified,omitempty"`
+
+	// 内部字段
+	sourceDir    string
+	manifestPath string
+}
+
+// ToolSpecV2 工具规范 V2
+type ToolSpecV2 struct {
+	Name          string         `json:"name"`
+	Description   string         `json:"description"`
+	Category      string         `json:"category,omitempty"`
+	InputSchema   map[string]any `json:"input_schema"`
+	OutputSchema  map[string]any `json:"output_schema,omitempty"`
+	Examples      []ToolExample  `json:"examples,omitempty"`
+	Documentation string         `json:"documentation,omitempty"`
+}
+
+type ToolExample struct {
+	Input   map[string]any `json:"input"`
+	Output  map[string]any `json:"output"`
+	Context string         `json:"context,omitempty"`
+}
+
+// WorkflowPackSpec 工作流包规范
+type WorkflowPackSpec struct {
+	Name         string           `json:"name"`
+	Description  string           `json:"description"`
+	Workflows    []WorkflowSpec   `json:"workflows"`
+	Dependencies []DependencySpec `json:"dependencies,omitempty"`
+}
+
+type WorkflowSpec struct {
+	Name         string         `json:"name"`
+	Description  string         `json:"description"`
+	Steps        []WorkflowStep `json:"steps"`
+	InputSchema  map[string]any `json:"input_schema,omitempty"`
+	OutputSchema map[string]any `json:"output_schema,omitempty"`
+	Tags         []string       `json:"tags,omitempty"`
+}
+
+type WorkflowStep struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Plugin      string         `json:"plugin"`
+	Action      string         `json:"action"`
+	Inputs      map[string]any `json:"inputs"`
+	RetryCount  int            `json:"retry_count,omitempty"`
+	TimeoutSec  int            `json:"timeout_sec,omitempty"`
+}
+
+type DependencySpec struct {
+	PluginID string `json:"plugin_id"`
+	Version  string `json:"version,omitempty"`
+}
+
+// 其他规范 V2
+type IngressSpecV2 struct {
+	Name        string   `json:"name"`
+	Path        string   `json:"path"`
+	Description string   `json:"description"`
+	Methods     []string `json:"methods,omitempty"`
+}
+
+type ChannelSpecV2 struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Protocol    string `json:"protocol,omitempty"`
+}
+
+type NodeSpecV2 struct {
+	Name         string             `json:"name"`
+	Description  string             `json:"description"`
+	Platforms    []string           `json:"platforms"`
+	Capabilities []string           `json:"capabilities"`
+	Actions      []NodeActionSpecV2 `json:"actions"`
+}
+
+type NodeActionSpecV2 struct {
+	Name         string         `json:"name"`
+	Description  string         `json:"description"`
+	InputSchema  map[string]any `json:"input_schema"`
+	OutputSchema map[string]any `json:"output_schema,omitempty"`
+}
+
+type SurfaceSpecV2 struct {
+	Name         string   `json:"name"`
+	Description  string   `json:"description"`
+	Path         string   `json:"path"`
+	Capabilities []string `json:"capabilities"`
+}
+
+// 策略定义
+type RetryPolicy struct {
+	MaxAttempts   int     `json:"max_attempts"`
+	InitialDelay  int     `json:"initial_delay"` // 毫秒
+	MaxDelay      int     `json:"max_delay"`     // 毫秒
+	BackoffFactor float64 `json:"backoff_factor"`
+}
+
+type FallbackPolicy struct {
+	AlternativeAction string `json:"alternative_action,omitempty"`
+	AlternativePlugin string `json:"alternative_plugin,omitempty"`
+	ManualFallback    bool   `json:"manual_fallback,omitempty"`
+}
+
+type RollbackPolicy struct {
+	Steps         []RollbackStep `json:"steps,omitempty"`
+	Automatic     bool           `json:"automatic"`
+	OnFailureOnly bool           `json:"on_failure_only"`
+}
+
+type RollbackStep struct {
+	Name   string         `json:"name"`
+	Action string         `json:"action"`
+	Inputs map[string]any `json:"inputs"`
+}
+
+// 验证模板
+type VerificationTemplate struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Type        string         `json:"type"` // file-exists, window-appears, text-contains, etc.
+	Parameters  map[string]any `json:"parameters"`
+	TimeoutSec  int            `json:"timeout_sec,omitempty"`
+}
+
+// 恢复支持
+type ResumeSupport struct {
+	Checkpointable bool     `json:"checkpointable"`
+	StateKeys      []string `json:"state_keys,omitempty"`
+	ResumeActions  []string `json:"resume_actions,omitempty"`
+}
+
+// 健康检查
+type HealthCheck struct {
+	Command     string `json:"command,omitempty"`
+	TimeoutSec  int    `json:"timeout_sec,omitempty"`
+	IntervalSec int    `json:"interval_sec,omitempty"`
+	Retries     int    `json:"retries,omitempty"`
+}
+
+// 生命周期钩子
+type LifecycleHooks struct {
+	BeforeLoad    string `json:"before_load,omitempty"`
+	AfterLoad     string `json:"after_load,omitempty"`
+	BeforeUnload  string `json:"before_unload,omitempty"`
+	AfterUnload   string `json:"after_unload,omitempty"`
+	BeforeExecute string `json:"before_execute,omitempty"`
+	AfterExecute  string `json:"after_execute,omitempty"`
+}
+
+// ConvertToV1 将 V2 Manifest 转换为 V1 Manifest
+func (m *ManifestV2) ConvertToV1() *Manifest {
+	v1 := &Manifest{
+		Name:           m.Name,
+		Version:        m.Version,
+		Description:    m.Description,
+		Kinds:          m.Kinds,
+		Builtin:        m.Builtin,
+		Enabled:        m.Enabled,
+		Entrypoint:     m.Entrypoint,
+		TimeoutSeconds: m.TimeoutSeconds,
+		Signer:         m.Signer,
+		Signature:      m.Signature,
+		Trust:          m.Trust,
+		Verified:       m.Verified,
+		sourceDir:      m.sourceDir,
+		manifestPath:   m.manifestPath,
+	}
+
+	// 转换 ExecPolicy
+	if m.ExecPolicy != "" {
+		v1.ExecPolicy = m.ExecPolicy
+	}
+
+	// 转换 Permissions
+	if len(m.DataAccess) > 0 {
+		v1.Permissions = make([]string, len(m.DataAccess))
+		copy(v1.Permissions, m.DataAccess)
+	}
+
+	// 转换 Tool
+	if m.Tool != nil {
+		v1.Tool = &ToolSpec{
+			Name:        m.Tool.Name,
+			Description: m.Tool.Description,
+			InputSchema: m.Tool.InputSchema,
+		}
+	}
+
+	// 转换 Ingress
+	if m.Ingress != nil {
+		v1.Ingress = &IngressSpec{
+			Name:        m.Ingress.Name,
+			Path:        m.Ingress.Path,
+			Description: m.Ingress.Description,
+		}
+	}
+
+	// 转换 Channel
+	if m.Channel != nil {
+		v1.Channel = &ChannelSpec{
+			Name:        m.Channel.Name,
+			Description: m.Channel.Description,
+		}
+	}
+
+	// 转换 Node
+	if m.Node != nil {
+		v1.Node = &NodeSpec{
+			Name:         m.Node.Name,
+			Description:  m.Node.Description,
+			Platforms:    m.Node.Platforms,
+			Capabilities: m.Node.Capabilities,
+		}
+
+		if len(m.Node.Actions) > 0 {
+			v1.Node.Actions = make([]NodeActionSpec, len(m.Node.Actions))
+			for i, action := range m.Node.Actions {
+				v1.Node.Actions[i] = NodeActionSpec{
+					Name:        action.Name,
+					Description: action.Description,
+					InputSchema: action.InputSchema,
+				}
+			}
+		}
+	}
+
+	// 转换 Surface
+	if m.Surface != nil {
+		v1.Surface = &SurfaceSpec{
+			Name:         m.Surface.Name,
+			Description:  m.Surface.Description,
+			Path:         m.Surface.Path,
+			Capabilities: m.Surface.Capabilities,
+		}
+	}
+
+	return v1
+}
+
+// Validate 验证 Manifest V2
+func (m *ManifestV2) Validate() error {
+	// 必需字段检查
+	if m.APIVersion == "" {
+		return &ValidationError{Field: "api_version", Reason: "required"}
+	}
+	if m.PluginID == "" {
+		return &ValidationError{Field: "plugin_id", Reason: "required"}
+	}
+	if m.Name == "" {
+		return &ValidationError{Field: "name", Reason: "required"}
+	}
+	if m.Version == "" {
+		return &ValidationError{Field: "version", Reason: "required"}
+	}
+	if len(m.Kinds) == 0 {
+		return &ValidationError{Field: "kinds", Reason: "must have at least one kind"}
+	}
+
+	// 平台检查
+	if len(m.Platforms) == 0 {
+		return &ValidationError{Field: "platforms", Reason: "must specify at least one platform"}
+	}
+
+	// 风险等级检查
+	if m.RiskLevel == "" {
+		m.RiskLevel = "medium" // 默认值
+	} else if m.RiskLevel != "low" && m.RiskLevel != "medium" && m.RiskLevel != "high" {
+		return &ValidationError{Field: "risk_level", Reason: "must be low, medium, or high"}
+	}
+
+	// 特定类型验证
+	if contains(m.Kinds, "tool") && m.Tool == nil {
+		return &ValidationError{Field: "tool", Reason: "required for tool kind"}
+	}
+	if contains(m.Kinds, "workflow-pack") && m.WorkflowPack == nil {
+		return &ValidationError{Field: "workflow_pack", Reason: "required for workflow-pack kind"}
+	}
+
+	return nil
+}
+
+// ValidationError 验证错误
+type ValidationError struct {
+	Field  string
+	Reason string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("validation error: field %s - %s", e.Field, e.Reason)
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// PluginLifecycle 插件生命周期管理
+type PluginLifecycle struct {
+	State       PluginState
+	Manifest    *ManifestV2
+	LoadedAt    time.Time
+	LastUsed    time.Time
+	Health      PluginHealth
+	Metrics     PluginMetrics
+	Sessions    map[string]*PluginSession
+	SuspendData map[string]any
+}
+
+type PluginSession struct {
+	SessionID string
+	BoundAt   time.Time
+	Context   map[string]any
+}
+
+type PluginState string
+
+const (
+	PluginStateDiscovered PluginState = "discovered"
+	PluginStateVerified   PluginState = "verified"
+	PluginStateLoaded     PluginState = "loaded"
+	PluginStateIndexed    PluginState = "indexed"
+	PluginStateBound      PluginState = "bound"
+	PluginStateExecuting  PluginState = "executing"
+	PluginStateSuspended  PluginState = "suspended"
+	PluginStateUnloaded   PluginState = "unloaded"
+)
+
+type PluginHealth struct {
+	Status    string // healthy, warning, error
+	Message   string
+	CheckedAt time.Time
+}
+
+type PluginMetrics struct {
+	ExecutionCount int
+	SuccessCount   int
+	FailureCount   int
+	AverageTime    time.Duration
+	LastExecuted   time.Time
+}

--- a/pkg/extensions/plugin/market.go
+++ b/pkg/extensions/plugin/market.go
@@ -1,0 +1,280 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type LocalMarket struct {
+	dir     string
+	index   *MarketIndex
+	plugins map[string]*MarketPlugin
+}
+
+type MarketIndex struct {
+	Version   string        `json:"version"`
+	UpdatedAt string        `json:"updated_at"`
+	Plugins   []MarketEntry `json:"plugins"`
+}
+
+type MarketEntry struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Version     string   `json:"version"`
+	Description string   `json:"description"`
+	Category    string   `json:"category"`
+	Tags        []string `json:"tags"`
+	Author      string   `json:"author"`
+	Repo        string   `json:"repo"`
+	Stars       int      `json:"stars"`
+	Downloads   int      `json:"downloads"`
+	License     string   `json:"license"`
+	Score       int      `json:"score"`
+}
+
+type MarketPlugin struct {
+	Entry       MarketEntry
+	LocalPath   string
+	IsInstalled bool
+}
+
+func NewLocalMarket(dir string) (*LocalMarket, error) {
+	market := &LocalMarket{
+		dir:     dir,
+		index:   &MarketIndex{Version: "1.0"},
+		plugins: make(map[string]*MarketPlugin),
+	}
+
+	if err := market.loadIndex(); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	return market, nil
+}
+
+func (m *LocalMarket) loadIndex() error {
+	indexPath := filepath.Join(m.dir, "market.json")
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, m.index); err != nil {
+		return err
+	}
+	for _, entry := range m.index.Plugins {
+		m.plugins[entry.ID] = &MarketPlugin{
+			Entry:       entry,
+			LocalPath:   filepath.Join(m.dir, entry.ID),
+			IsInstalled: false,
+		}
+	}
+	return nil
+}
+
+func (m *LocalMarket) SaveIndex() error {
+	m.index.UpdatedAt = "2026-03-31"
+	data, err := json.MarshalIndent(m.index, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(m.dir, "market.json"), data, 0644)
+}
+
+func (m *LocalMarket) AddPlugin(entry MarketEntry) {
+	m.plugins[entry.ID] = &MarketPlugin{
+		Entry:       entry,
+		LocalPath:   filepath.Join(m.dir, entry.ID),
+		IsInstalled: false,
+	}
+	m.index.Plugins = append(m.index.Plugins, entry)
+}
+
+func (m *LocalMarket) Search(query string, category string, tags []string, limit int) []MarketEntry {
+	var results []MarketEntry
+	query = strings.ToLower(query)
+
+	for _, entry := range m.index.Plugins {
+		if category != "" && entry.Category != category {
+			continue
+		}
+
+		if len(tags) > 0 {
+			match := false
+			for _, tag := range tags {
+				for _, t := range entry.Tags {
+					if strings.EqualFold(t, tag) {
+						match = true
+						break
+					}
+				}
+			}
+			if !match {
+				continue
+			}
+		}
+
+		if query != "" {
+			score := m.calculateScore(entry, query)
+			if score == 0 {
+				continue
+			}
+			entry.Score = score
+		}
+
+		results = append(results, entry)
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Score != results[j].Score {
+			return results[i].Score > results[j].Score
+		}
+		return results[i].Downloads > results[j].Downloads
+	})
+
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+
+	return results
+}
+
+func (m *LocalMarket) calculateScore(entry MarketEntry, query string) int {
+	score := 0
+
+	if strings.Contains(strings.ToLower(entry.Name), query) {
+		score += 50
+	}
+	if strings.Contains(strings.ToLower(entry.Description), query) {
+		score += 20
+	}
+	for _, tag := range entry.Tags {
+		if strings.Contains(strings.ToLower(tag), query) {
+			score += 15
+		}
+	}
+	if strings.Contains(strings.ToLower(entry.Category), query) {
+		score += 10
+	}
+
+	return score
+}
+
+func (m *LocalMarket) GetPlugin(id string) (*MarketPlugin, bool) {
+	plugin, exists := m.plugins[id]
+	return plugin, exists
+}
+
+func (m *LocalMarket) ListByCategory() map[string][]MarketEntry {
+	result := make(map[string][]MarketEntry)
+	for _, entry := range m.index.Plugins {
+		result[entry.Category] = append(result[entry.Category], entry)
+	}
+	return result
+}
+
+func (m *LocalMarket) ListCategories() []string {
+	seen := make(map[string]bool)
+	var categories []string
+	for _, entry := range m.index.Plugins {
+		if !seen[entry.Category] {
+			seen[entry.Category] = true
+			categories = append(categories, entry.Category)
+		}
+	}
+	sort.Strings(categories)
+	return categories
+}
+
+type MarketManager struct {
+	localMarket *LocalMarket
+	hubClient   *HubClient
+}
+
+func NewMarketManager(localDir string, hubURL string) (*MarketManager, error) {
+	market, err := NewLocalMarket(localDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize local market: %w", err)
+	}
+
+	mm := &MarketManager{
+		localMarket: market,
+	}
+
+	if hubURL != "" {
+		mm.hubClient = NewHubClient(hubURL)
+	}
+
+	return mm, nil
+}
+
+func (mm *MarketManager) Search(ctx interface{}, query string, category string, limit int) ([]MarketEntry, error) {
+	entries := mm.localMarket.Search(query, category, nil, limit)
+	return entries, nil
+}
+
+func (mm *MarketManager) Install(id string, version string, targetDir string) error {
+	plugin, ok := mm.localMarket.GetPlugin(id)
+	if !ok {
+		return fmt.Errorf("plugin not found in market: %s", id)
+	}
+
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return err
+	}
+
+	sourcePath := plugin.LocalPath
+	if _, err := os.Stat(sourcePath); err != nil {
+		return fmt.Errorf("plugin source not found: %s", sourcePath)
+	}
+
+	_ = version
+
+	destPath := filepath.Join(targetDir, id)
+	return copyDir(sourcePath, destPath)
+}
+
+func copyDir(src, dst string) error {
+	return nil
+}
+
+func (mm *MarketManager) Update(id string, targetDir string) error {
+	plugin, ok := mm.localMarket.GetPlugin(id)
+	if !ok {
+		return fmt.Errorf("plugin not found: %s", id)
+	}
+
+	destPath := filepath.Join(targetDir, id)
+	if _, err := os.Stat(destPath); err != nil {
+		return fmt.Errorf("plugin not installed: %s", id)
+	}
+
+	sourcePath := plugin.LocalPath
+	return copyDir(sourcePath, destPath)
+}
+
+func (mm *MarketManager) ListInstalled(pluginDir string) []MarketEntry {
+	var entries []MarketEntry
+
+	entries_, err := os.ReadDir(pluginDir)
+	if err != nil {
+		return entries
+	}
+
+	for _, entry := range entries_ {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if plugin, ok := mm.localMarket.GetPlugin(name); ok {
+			entry := plugin.Entry
+			entry.Score = 100
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries
+}

--- a/pkg/extensions/plugin/mcp_client.go
+++ b/pkg/extensions/plugin/mcp_client.go
@@ -1,0 +1,427 @@
+package plugin
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// MCPClient implements the Model Context Protocol client
+type MCPClient struct {
+	mu       sync.RWMutex
+	server   *MCPServer
+	tools    []MCPTool
+	handlers map[string]MCPToolHandler
+}
+
+// MCPServer represents an MCP server process
+type MCPServer struct {
+	Name      string
+	Command   string
+	Args      []string
+	Env       map[string]string
+	Transport string
+	cmd       *exec.Cmd
+	stdin     io.WriteCloser
+	stdout    io.ReadCloser
+	stderr    io.ReadCloser
+	running   bool
+}
+
+// MCPTool represents a tool exposed by an MCP server
+type MCPTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+// MCPToolHandler handles MCP tool calls
+type MCPToolHandler func(ctx context.Context, input map[string]any) (any, error)
+
+// MCPRequest represents an MCP JSON-RPC request
+type MCPRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+// MCPResponse represents an MCP JSON-RPC response
+type MCPResponse struct {
+	JSONRPC string    `json:"jsonrpc"`
+	ID      int       `json:"id"`
+	Result  any       `json:"result,omitempty"`
+	Error   *MCPError `json:"error,omitempty"`
+}
+
+// MCPError represents an MCP error
+type MCPError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// NewMCPClient creates a new MCP client
+func NewMCPClient(spec *MCPSpec) *MCPClient {
+	if spec == nil {
+		return nil
+	}
+
+	server := &MCPServer{
+		Name:      spec.Name,
+		Command:   spec.Command,
+		Args:      spec.Args,
+		Env:       spec.Env,
+		Transport: spec.Transport,
+	}
+
+	return &MCPClient{
+		server:   server,
+		handlers: make(map[string]MCPToolHandler),
+	}
+}
+
+// Connect starts the MCP server and connects to it
+func (c *MCPClient) Connect(ctx context.Context) error {
+	if c.server == nil {
+		return fmt.Errorf("no MCP server configured")
+	}
+
+	cmd := exec.CommandContext(ctx, c.server.Command, c.server.Args...)
+
+	// Set environment variables
+	if c.server.Env != nil {
+		for k, v := range c.server.Env {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdin pipe: %w", err)
+	}
+	c.server.stdin = stdin
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+	c.server.stdout = stdout
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stderr pipe: %w", err)
+	}
+	c.server.stderr = stderr
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start MCP server: %w", err)
+	}
+
+	c.server.cmd = cmd
+	c.server.running = true
+
+	// Initialize the connection
+	if err := c.initialize(ctx); err != nil {
+		c.Close()
+		return fmt.Errorf("failed to initialize MCP: %w", err)
+	}
+
+	// Discover tools
+	if err := c.discoverTools(ctx); err != nil {
+		return fmt.Errorf("failed to discover tools: %w", err)
+	}
+
+	return nil
+}
+
+// initialize sends the initialize request
+func (c *MCPClient) initialize(ctx context.Context) error {
+	req := MCPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+		Params: map[string]any{
+			"protocolVersion": "2024-11-05",
+			"capabilities": map[string]any{
+				"tools": map[string]any{},
+			},
+			"clientInfo": map[string]any{
+				"name":    "anyclaw",
+				"version": "1.0.0",
+			},
+		},
+	}
+
+	resp, err := c.sendRequest(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	if resp.Error != nil {
+		return fmt.Errorf("MCP initialize error: %s", resp.Error.Message)
+	}
+
+	// Send initialized notification
+	notif := MCPRequest{
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+	}
+	return c.sendNotification(notif)
+}
+
+// discoverTools discovers available tools from the MCP server
+func (c *MCPClient) discoverTools(ctx context.Context) error {
+	req := MCPRequest{
+		JSONRPC: "2.0",
+		ID:      2,
+		Method:  "tools/list",
+	}
+
+	resp, err := c.sendRequest(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	if resp.Error != nil {
+		return fmt.Errorf("tools/list error: %s", resp.Error.Message)
+	}
+
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		return fmt.Errorf("invalid tools/list response")
+	}
+
+	toolsRaw, ok := result["tools"].([]any)
+	if !ok {
+		return fmt.Errorf("no tools in response")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.tools = make([]MCPTool, 0, len(toolsRaw))
+	for _, t := range toolsRaw {
+		toolMap, ok := t.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := toolMap["name"].(string)
+		desc, _ := toolMap["description"].(string)
+		schema, _ := toolMap["inputSchema"].(map[string]any)
+
+		c.tools = append(c.tools, MCPTool{
+			Name:        name,
+			Description: desc,
+			InputSchema: schema,
+		})
+	}
+
+	return nil
+}
+
+// ListTools returns all discovered tools
+func (c *MCPClient) ListTools() []MCPTool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.tools
+}
+
+// CallTool calls a tool on the MCP server
+func (c *MCPClient) CallTool(ctx context.Context, name string, args map[string]any) (any, error) {
+	req := MCPRequest{
+		JSONRPC: "2.0",
+		ID:      int(time.Now().UnixNano()),
+		Method:  "tools/call",
+		Params: map[string]any{
+			"name":      name,
+			"arguments": args,
+		},
+	}
+
+	resp, err := c.sendRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Error != nil {
+		return nil, fmt.Errorf("tool call error: %s", resp.Error.Message)
+	}
+
+	return resp.Result, nil
+}
+
+// sendRequest sends a request and waits for response
+func (c *MCPClient) sendRequest(ctx context.Context, req MCPRequest) (*MCPResponse, error) {
+	if !c.server.running {
+		return nil, fmt.Errorf("MCP server not running")
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Write request
+	if _, err := c.server.stdin.Write(append(data, '\n')); err != nil {
+		return nil, fmt.Errorf("failed to write request: %w", err)
+	}
+
+	// Read response
+	scanner := bufio.NewScanner(c.server.stdout)
+	if scanner.Scan() {
+		var resp MCPResponse
+		if err := json.Unmarshal(scanner.Bytes(), &resp); err != nil {
+			return nil, fmt.Errorf("failed to parse response: %w", err)
+		}
+		return &resp, nil
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	return nil, fmt.Errorf("no response received")
+}
+
+// sendNotification sends a notification (no response expected)
+func (c *MCPClient) sendNotification(req MCPRequest) error {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.server.stdin.Write(append(data, '\n'))
+	return err
+}
+
+// Close closes the MCP connection
+func (c *MCPClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.server.stdin != nil {
+		c.server.stdin.Close()
+	}
+
+	if c.server.cmd != nil && c.server.running {
+		c.server.cmd.Process.Kill()
+		c.server.cmd.Wait()
+	}
+
+	c.server.running = false
+	return nil
+}
+
+// IsConnected returns whether the client is connected
+func (c *MCPClient) IsConnected() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.server != nil && c.server.running
+}
+
+// MCPRegistry manages multiple MCP clients
+type MCPRegistry struct {
+	mu      sync.RWMutex
+	clients map[string]*MCPClient
+}
+
+// NewMCPRegistry creates a new MCP registry
+func NewMCPRegistry() *MCPRegistry {
+	return &MCPRegistry{
+		clients: make(map[string]*MCPClient),
+	}
+}
+
+// Register registers an MCP client
+func (r *MCPRegistry) Register(name string, client *MCPClient) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.clients[name]; exists {
+		return fmt.Errorf("MCP client already registered: %s", name)
+	}
+
+	r.clients[name] = client
+	return nil
+}
+
+// Get retrieves an MCP client by name
+func (r *MCPRegistry) Get(name string) (*MCPClient, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	client, ok := r.clients[name]
+	return client, ok
+}
+
+// List returns all registered MCP clients
+func (r *MCPRegistry) List() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var names []string
+	for name := range r.clients {
+		names = append(names, name)
+	}
+	return names
+}
+
+// ConnectAll connects all registered MCP clients
+func (r *MCPRegistry) ConnectAll(ctx context.Context) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for name, client := range r.clients {
+		if err := client.Connect(ctx); err != nil {
+			return fmt.Errorf("failed to connect MCP client %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// ListAllTools returns all tools from all connected MCP clients
+func (r *MCPRegistry) ListAllTools() map[string][]MCPTool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make(map[string][]MCPTool)
+	for name, client := range r.clients {
+		if client.IsConnected() {
+			result[name] = client.ListTools()
+		}
+	}
+	return result
+}
+
+// CallTool calls a tool on a specific MCP client
+func (r *MCPRegistry) CallTool(ctx context.Context, clientName string, toolName string, args map[string]any) (any, error) {
+	r.mu.RLock()
+	client, ok := r.clients[clientName]
+	r.mu.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("MCP client not found: %s", clientName)
+	}
+
+	if !client.IsConnected() {
+		return nil, fmt.Errorf("MCP client not connected: %s", clientName)
+	}
+
+	return client.CallTool(ctx, toolName, args)
+}
+
+// Close closes all MCP clients
+func (r *MCPRegistry) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, client := range r.clients {
+		client.Close()
+	}
+	return nil
+}

--- a/pkg/extensions/plugin/plugin.go
+++ b/pkg/extensions/plugin/plugin.go
@@ -1,0 +1,1263 @@
+package plugin
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/1024XEngineer/anyclaw/pkg/capability/tools"
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	desktopexec "github.com/1024XEngineer/anyclaw/pkg/runtime/execution/desktop"
+	"github.com/1024XEngineer/anyclaw/pkg/runtime/execution/verification"
+)
+
+type Manifest struct {
+	Name           string             `json:"name"`
+	Version        string             `json:"version"`
+	Description    string             `json:"description"`
+	Kinds          []string           `json:"kinds"`
+	Builtin        bool               `json:"builtin"`
+	Enabled        bool               `json:"enabled"`
+	Entrypoint     string             `json:"entrypoint,omitempty"`
+	Tool           *ToolSpec          `json:"tool,omitempty"`
+	Ingress        *IngressSpec       `json:"ingress,omitempty"`
+	Channel        *ChannelSpec       `json:"channel,omitempty"`
+	Node           *NodeSpec          `json:"node,omitempty"`
+	Surface        *SurfaceSpec       `json:"surface,omitempty"`
+	Permissions    []string           `json:"permissions,omitempty"`
+	ExecPolicy     string             `json:"exec_policy,omitempty"`
+	TimeoutSeconds int                `json:"timeout_seconds,omitempty"`
+	Signer         string             `json:"signer,omitempty"`
+	Signature      string             `json:"signature,omitempty"`
+	Trust          string             `json:"trust,omitempty"`
+	Verified       bool               `json:"verified,omitempty"`
+	CapabilityTags []string           `json:"capability_tags,omitempty"`
+	RiskLevel      string             `json:"risk_level,omitempty"`
+	ApprovalScope  string             `json:"approval_scope,omitempty"`
+	RequiresHost   bool               `json:"requires_host,omitempty"`
+	ModelProvider  *ModelProviderSpec `json:"model_provider,omitempty"`
+	Speech         *SpeechSpec        `json:"speech,omitempty"`
+	MCP            *MCPSpec           `json:"mcp,omitempty"`
+	ContextEngine  *ContextEngineSpec `json:"context_engine,omitempty"`
+	sourceDir      string
+	manifestPath   string
+}
+
+type ToolSpec struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"input_schema"`
+}
+
+type IngressSpec struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Description string `json:"description"`
+}
+
+type ChannelSpec struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type NodeSpec struct {
+	Name         string           `json:"name"`
+	Description  string           `json:"description"`
+	Platforms    []string         `json:"platforms,omitempty"`
+	Capabilities []string         `json:"capabilities,omitempty"`
+	Actions      []NodeActionSpec `json:"actions,omitempty"`
+}
+
+type NodeActionSpec struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"input_schema,omitempty"`
+}
+
+type SurfaceSpec struct {
+	Name         string   `json:"name"`
+	Description  string   `json:"description"`
+	Path         string   `json:"path,omitempty"`
+	Capabilities []string `json:"capabilities,omitempty"`
+}
+
+type Registry struct {
+	manifests      []Manifest
+	allowExec      bool
+	execTimeout    time.Duration
+	trustedSigners map[string]bool
+	requireTrust   bool
+	policy         *tools.PolicyEngine
+}
+
+type IngressRunner struct {
+	Manifest   Manifest
+	Entrypoint string
+	Timeout    time.Duration
+}
+
+type ChannelRunner struct {
+	Manifest   Manifest
+	Entrypoint string
+	Timeout    time.Duration
+}
+
+type ProtocolExecutionMeta struct {
+	ToolName string
+	Plugin   string
+	App      string
+	Action   string
+	Workflow string
+	Binding  map[string]any
+	Input    map[string]any
+}
+
+const maxDesktopPlanExecutions = 60
+
+func NewRegistry(cfg config.PluginsConfig) (*Registry, error) {
+	timeout := time.Duration(cfg.ExecTimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	trusted := map[string]bool{}
+	for _, signer := range cfg.TrustedSigners {
+		trusted[signer] = true
+	}
+	registry := &Registry{allowExec: cfg.AllowExec, execTimeout: timeout, trustedSigners: trusted, requireTrust: cfg.RequireTrust}
+	registry.registerBuiltin(Manifest{Name: "telegram-channel", Version: "1.0.0", Description: "Telegram channel adapter", Kinds: []string{"channel"}, Builtin: true, Enabled: true})
+	registry.registerBuiltin(Manifest{Name: "slack-channel", Version: "1.0.0", Description: "Slack channel adapter", Kinds: []string{"channel"}, Builtin: true, Enabled: true})
+	registry.registerBuiltin(Manifest{Name: "discord-channel", Version: "1.0.0", Description: "Discord channel adapter", Kinds: []string{"channel"}, Builtin: true, Enabled: true})
+	registry.registerBuiltin(Manifest{Name: "whatsapp-channel", Version: "1.0.0", Description: "WhatsApp channel adapter", Kinds: []string{"channel"}, Builtin: true, Enabled: true})
+	registry.registerBuiltin(Manifest{Name: "signal-channel", Version: "1.0.0", Description: "Signal channel adapter", Kinds: []string{"channel"}, Builtin: true, Enabled: true})
+	registry.registerBuiltin(Manifest{Name: "builtin-tools", Version: "1.0.0", Description: "Core file and web tools", Kinds: []string{"tools"}, Builtin: true, Enabled: true})
+	if cfg.Dir != "" {
+		if err := registry.loadDir(cfg.Dir); err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+	registry.verifySignatures(cfg.Dir)
+	registry.applyEnabled(cfg.Enabled)
+	return registry, nil
+}
+
+func (r *Registry) registerBuiltin(manifest Manifest) {
+	r.manifests = append(r.manifests, manifest)
+}
+
+func (r *Registry) SetPolicyEngine(policy *tools.PolicyEngine) {
+	if r == nil {
+		return
+	}
+	r.policy = policy
+}
+
+func (r *Registry) loadDir(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		manifest, ok := loadPluginManifest(filepath.Join(dir, entry.Name()), entry.Name())
+		if !ok {
+			continue
+		}
+		r.manifests = append(r.manifests, manifest)
+	}
+	return nil
+}
+
+var pluginManifestCandidates = []string{
+	"openclaw.plugin.json",
+	"plugin.json",
+	".codex-plugin/plugin.json",
+	".claude-plugin/plugin.json",
+	".cursor-plugin/plugin.json",
+}
+
+func loadPluginManifest(pluginDir string, fallbackName string) (Manifest, bool) {
+	for _, relPath := range pluginManifestCandidates {
+		manifestPath := filepath.Join(pluginDir, filepath.FromSlash(relPath))
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			continue
+		}
+		var manifest Manifest
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			continue
+		}
+		if manifest.Name == "" {
+			manifest.Name = fallbackName
+		}
+		manifest.sourceDir = pluginDir
+		manifest.manifestPath = manifestPath
+		return manifest, true
+	}
+	return Manifest{}, false
+}
+
+func (r *Registry) verifySignatures(baseDir string) {
+	for i := range r.manifests {
+		manifest := &r.manifests[i]
+		if manifest.Builtin || manifest.Entrypoint == "" || strings.TrimSpace(baseDir) == "" {
+			continue
+		}
+		entrypoint := resolveEntrypoint(baseDir, *manifest)
+		digest, err := fileSHA256(entrypoint)
+		if err != nil {
+			manifest.Verified = false
+			continue
+		}
+		manifest.Verified = signatureMatchesDigest(manifest.Signature, digest)
+		if manifest.Verified {
+			manifest.Trust = "verified"
+		} else if manifest.Trust == "" {
+			manifest.Trust = "unverified"
+		}
+	}
+}
+
+func (r *Registry) applyEnabled(enabled []string) {
+	if len(enabled) == 0 {
+		return
+	}
+	allowed := map[string]bool{}
+	for _, name := range enabled {
+		allowed[name] = true
+	}
+	for i := range r.manifests {
+		if r.manifests[i].Builtin {
+			continue
+		}
+		r.manifests[i].Enabled = allowed[r.manifests[i].Name]
+	}
+}
+
+func (r *Registry) List() []Manifest {
+	items := append([]Manifest(nil), r.manifests...)
+	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+	return items
+}
+
+func (r *Registry) EnabledPluginNames() []string {
+	var names []string
+	for _, manifest := range r.manifests {
+		if manifest.Enabled {
+			names = append(names, manifest.Name)
+		}
+	}
+	return names
+}
+
+func (r *Registry) RegisterToolPlugins(registry *tools.Registry, baseDir string) {
+	for _, manifest := range r.manifests {
+		if !manifest.Enabled || manifest.Tool == nil || manifest.Entrypoint == "" {
+			continue
+		}
+		if !r.canExecute(manifest) {
+			continue
+		}
+		entrypoint := resolveEntrypoint(baseDir, manifest)
+		toolName := manifest.Tool.Name
+		if toolName == "" {
+			toolName = manifest.Name
+		}
+		description := manifest.Tool.Description
+		if description == "" {
+			description = manifest.Description
+		}
+		schema := manifest.Tool.InputSchema
+		registry.RegisterTool(toolName, description, schema, func(ctx context.Context, input map[string]any) (string, error) {
+			timeout := r.execTimeout
+			if manifest.TimeoutSeconds > 0 {
+				timeout = time.Duration(manifest.TimeoutSeconds) * time.Second
+			}
+			ctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			payload, err := json.Marshal(input)
+			if err != nil {
+				return "", err
+			}
+			cmd, err := pluginCommandContext(ctx, entrypoint)
+			if err != nil {
+				return "", err
+			}
+			pluginDir := filepath.Join(baseDir, manifest.Name)
+			cmd.Dir = pluginDir
+			cmd.Stdin = nil
+			cmd.Env = append(os.Environ(),
+				"ANYCLAW_PLUGIN_INPUT="+string(payload),
+				"ANYCLAW_PLUGIN_DIR="+pluginDir,
+				"ANYCLAW_PLUGIN_TIMEOUT_SECONDS="+fmt.Sprintf("%d", int(timeout/time.Second)),
+			)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				if ctx.Err() == context.DeadlineExceeded {
+					return "", fmt.Errorf("plugin tool timed out after %s", timeout)
+				}
+				return "", fmt.Errorf("plugin tool failed: %w: %s", err, string(output))
+			}
+			return string(output), nil
+		})
+	}
+}
+
+func (r *Registry) IngressRunners(baseDir string) []IngressRunner {
+	var runners []IngressRunner
+	for _, manifest := range r.manifests {
+		if !manifest.Enabled || manifest.Ingress == nil || manifest.Entrypoint == "" {
+			continue
+		}
+		if !r.canExecute(manifest) {
+			continue
+		}
+		timeout := r.execTimeout
+		if manifest.TimeoutSeconds > 0 {
+			timeout = time.Duration(manifest.TimeoutSeconds) * time.Second
+		}
+		runners = append(runners, IngressRunner{
+			Manifest:   manifest,
+			Entrypoint: resolveEntrypoint(baseDir, manifest),
+			Timeout:    timeout,
+		})
+	}
+	return runners
+}
+
+func (r *Registry) ChannelRunners(baseDir string) []ChannelRunner {
+	var runners []ChannelRunner
+	for _, manifest := range r.manifests {
+		if !manifest.Enabled || manifest.Channel == nil || manifest.Entrypoint == "" {
+			continue
+		}
+		if !r.canExecute(manifest) {
+			continue
+		}
+		timeout := r.execTimeout
+		if manifest.TimeoutSeconds > 0 {
+			timeout = time.Duration(manifest.TimeoutSeconds) * time.Second
+		}
+		runners = append(runners, ChannelRunner{
+			Manifest:   manifest,
+			Entrypoint: resolveEntrypoint(baseDir, manifest),
+			Timeout:    timeout,
+		})
+	}
+	return runners
+}
+
+type SurfaceRunner struct {
+	Manifest   Manifest
+	Entrypoint string
+	Timeout    time.Duration
+}
+
+func (r *Registry) SurfaceRunners(baseDir string) []SurfaceRunner {
+	var runners []SurfaceRunner
+	for _, manifest := range r.manifests {
+		if !manifest.Enabled || manifest.Surface == nil || manifest.Entrypoint == "" {
+			continue
+		}
+		if !r.canExecute(manifest) {
+			continue
+		}
+		timeout := r.execTimeout
+		if manifest.TimeoutSeconds > 0 {
+			timeout = time.Duration(manifest.TimeoutSeconds) * time.Second
+		}
+		runners = append(runners, SurfaceRunner{
+			Manifest:   manifest,
+			Entrypoint: resolveEntrypoint(baseDir, manifest),
+			Timeout:    timeout,
+		})
+	}
+	return runners
+}
+
+func resolveEntrypoint(baseDir string, manifest Manifest) string {
+	entrypoint := strings.TrimSpace(manifest.Entrypoint)
+	if entrypoint == "" {
+		return ""
+	}
+	candidates := uniqueNonEmptyPaths(
+		filepath.Join(filepath.Dir(manifest.manifestPath), entrypoint),
+		filepath.Join(manifest.sourceDir, entrypoint),
+		filepath.Join(baseDir, manifest.Name, entrypoint),
+	)
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	if len(candidates) > 0 {
+		return candidates[0]
+	}
+	return entrypoint
+}
+
+func uniqueNonEmptyPaths(values ...string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		cleaned := filepath.Clean(value)
+		if _, ok := seen[cleaned]; ok {
+			continue
+		}
+		seen[cleaned] = struct{}{}
+		result = append(result, cleaned)
+	}
+	return result
+}
+
+func uniqueStrings(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		key := strings.ToLower(item)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result = append(result, item)
+	}
+	return result
+}
+
+func (r *Registry) canExecute(manifest Manifest) bool {
+	if manifest.Builtin {
+		return true
+	}
+	if !r.allowExec {
+		return false
+	}
+	if !r.isTrusted(manifest) {
+		return false
+	}
+	policy := manifest.ExecPolicy
+	if policy == "" {
+		policy = "manual-allow"
+	}
+	if policy != "manual-allow" && policy != "trusted" {
+		return false
+	}
+	for _, permission := range manifest.Permissions {
+		switch permission {
+		case "tool:exec", "fs:read", "fs:write", "net:out":
+		default:
+			return false
+		}
+	}
+	if r.policy != nil {
+		if err := r.policy.ValidatePluginPermissions(manifest.Name, manifest.Permissions); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func pluginCommandContext(ctx context.Context, entrypoint string) (*exec.Cmd, error) {
+	ext := strings.ToLower(strings.TrimSpace(filepath.Ext(entrypoint)))
+	switch ext {
+	case ".py":
+		for _, candidate := range []struct {
+			name string
+			args []string
+		}{
+			{name: "py", args: []string{"-3", entrypoint}},
+			{name: "python", args: []string{entrypoint}},
+			{name: "python3", args: []string{entrypoint}},
+		} {
+			if path, err := exec.LookPath(candidate.name); err == nil {
+				return exec.CommandContext(ctx, path, candidate.args...), nil
+			}
+		}
+		return nil, fmt.Errorf("python interpreter not found for plugin entrypoint: %s", entrypoint)
+	case ".ps1":
+		if path, err := exec.LookPath("powershell"); err == nil {
+			return exec.CommandContext(ctx, path, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", entrypoint), nil
+		}
+		return nil, fmt.Errorf("powershell not found for plugin entrypoint: %s", entrypoint)
+	default:
+		return exec.CommandContext(ctx, entrypoint), nil
+	}
+}
+
+func (r *Registry) isTrusted(manifest Manifest) bool {
+	if manifest.Builtin {
+		return true
+	}
+	if !r.requireTrust {
+		return true
+	}
+	if manifest.Signer == "" || manifest.Signature == "" {
+		return false
+	}
+	if !r.trustedSigners[manifest.Signer] {
+		return false
+	}
+	return manifest.Verified
+}
+
+func fileSHA256(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
+}
+
+func signatureMatchesDigest(signature string, digest string) bool {
+	signature = strings.TrimSpace(strings.ToLower(signature))
+	digest = strings.TrimSpace(strings.ToLower(digest))
+	if signature == "" || digest == "" {
+		return false
+	}
+	return strings.TrimPrefix(signature, "sha256:") == strings.TrimPrefix(digest, "sha256:")
+}
+
+func (r *Registry) Summary() (int, error) {
+	if r == nil {
+		return 0, fmt.Errorf("plugin registry not initialized")
+	}
+	return len(r.manifests), nil
+}
+
+func normalizeIdentifierToken(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" {
+		return ""
+	}
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func ExecuteProtocolOutput(ctx context.Context, registry *tools.Registry, meta ProtocolExecutionMeta, output []byte) (string, bool, error) {
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return "", false, nil
+	}
+	var plan desktopexec.DesktopPlan
+	if err := json.Unmarshal([]byte(trimmed), &plan); err != nil {
+		return "", false, nil
+	}
+	if strings.TrimSpace(plan.Protocol) != desktopexec.DesktopProtocolVersion {
+		return "", false, nil
+	}
+	state := buildDesktopPlanExecutionState(meta, plan, desktopexec.DesktopPlanResumeStateFromContext(ctx))
+	state.Status = "pending_approval"
+	state.UpdatedAt = desktopexec.TimestampNowRFC3339()
+	desktopexec.ReportDesktopPlanState(ctx, state)
+	if err := requestProtocolApproval(ctx, meta, plan); err != nil {
+		state.Status = desktopPlanStatusFromError(err)
+		state.LastError = strings.TrimSpace(err.Error())
+		state.UpdatedAt = desktopexec.TimestampNowRFC3339()
+		desktopexec.ReportDesktopPlanState(ctx, state)
+		return "", true, err
+	}
+	result, err := executeDesktopPlan(ctx, registry, plan, &state)
+	return result, true, err
+}
+
+func requestProtocolApproval(ctx context.Context, meta ProtocolExecutionMeta, plan desktopexec.DesktopPlan) error {
+	payload := map[string]any{
+		"tool_name": meta.ToolName,
+		"plugin":    meta.Plugin,
+		"app":       meta.App,
+		"action":    meta.Action,
+		"workflow":  meta.Workflow,
+		"binding":   cloneMap(meta.Binding),
+		"input":     cloneMap(meta.Input),
+		"protocol":  plan.Protocol,
+		"summary":   strings.TrimSpace(plan.Summary),
+		"result":    strings.TrimSpace(plan.Result),
+		"steps":     desktopPlanStepsPayload(plan.Steps),
+	}
+	return tools.RequestToolApproval(ctx, "desktop_plan", payload)
+}
+
+func desktopPlanStepsPayload(steps []desktopexec.DesktopPlanStep) []map[string]any {
+	items := make([]map[string]any, 0, len(steps))
+	for _, step := range steps {
+		toolName, resolvedInput, _ := resolveDesktopPlanStepCall(step)
+		item := map[string]any{
+			"tool":              toolName,
+			"label":             strings.TrimSpace(step.Label),
+			"target":            cloneMap(step.Target),
+			"action":            strings.TrimSpace(step.Action),
+			"input":             resolvedInput,
+			"retry":             step.Retry,
+			"retry_delay_ms":    step.RetryDelayMS,
+			"wait_after_ms":     step.WaitAfterMS,
+			"continue_on_error": step.ContinueOnError,
+		}
+		if step.Value != nil {
+			item["value"] = *step.Value
+		}
+		if step.Append != nil {
+			item["append"] = *step.Append
+		}
+		if step.Submit != nil {
+			item["submit"] = *step.Submit
+		}
+		if step.Verify != nil {
+			verifyTool, verifyInput, _ := resolveDesktopPlanCheckCall(*step.Verify)
+			item["verify"] = map[string]any{
+				"tool":           verifyTool,
+				"target":         cloneMap(step.Verify.Target),
+				"input":          verifyInput,
+				"retry":          step.Verify.Retry,
+				"retry_delay_ms": step.Verify.RetryDelayMS,
+			}
+		}
+		if len(step.OnFailure) > 0 {
+			item["on_failure"] = desktopPlanStepsPayload(step.OnFailure)
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+func cloneMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(input))
+	for key, value := range input {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneStringMap(items map[string]string) map[string]string {
+	if len(items) == 0 {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(items))
+	for key, value := range items {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func mergeMaps(base map[string]any, overlay map[string]any) map[string]any {
+	if base == nil && overlay == nil {
+		return nil
+	}
+	merged := cloneMap(base)
+	if merged == nil {
+		merged = map[string]any{}
+	}
+	for key, value := range overlay {
+		merged[key] = value
+	}
+	return merged
+}
+
+type desktopPlanStepResult struct {
+	Output    string
+	Attempts  int
+	Continued bool
+	Verified  bool
+}
+
+func executeDesktopPlan(ctx context.Context, registry *tools.Registry, plan desktopexec.DesktopPlan, state *desktopexec.DesktopPlanExecutionState) (string, error) {
+	if registry == nil {
+		return "", errors.New("tool registry not available")
+	}
+	if len(plan.Steps) > 20 {
+		return "", fmt.Errorf("desktop plan exceeds 20 steps")
+	}
+	startIndex := 0
+	if state != nil {
+		startIndex = desktopPlanStartIndex(state, len(plan.Steps))
+		state.TotalSteps = len(plan.Steps)
+		if state.NextStep == 0 {
+			state.NextStep = startIndex + 1
+		}
+		if startIndex > 0 {
+			state.Status = "resuming"
+			state.Resumed = true
+		} else {
+			state.Status = "running"
+		}
+		state.CurrentStep = 0
+		state.LastError = ""
+		state.UpdatedAt = desktopexec.TimestampNowRFC3339()
+		desktopexec.ReportDesktopPlanState(ctx, *state)
+	}
+	results := make([]string, 0, len(plan.Steps))
+	if state != nil && startIndex > 0 {
+		for i := 0; i < startIndex && i < len(state.Steps); i++ {
+			if output := strings.TrimSpace(state.Steps[i].Output); output != "" {
+				results = append(results, output)
+			}
+		}
+	}
+	executions := 0
+	for idx := startIndex; idx < len(plan.Steps); idx++ {
+		step := plan.Steps[idx]
+		if state != nil {
+			markDesktopPlanStepRunning(state, idx+1, step)
+			desktopexec.ReportDesktopPlanState(ctx, *state)
+		}
+		stepResult, err := executeDesktopPlanStep(ctx, registry, step, idx+1, &executions)
+		if err != nil {
+			if state != nil {
+				markDesktopPlanStepFailed(state, idx+1, stepResult.Attempts, err)
+				desktopexec.ReportDesktopPlanState(ctx, *state)
+			}
+			return "", err
+		}
+		output := strings.TrimSpace(stepResult.Output)
+		if output != "" {
+			results = append(results, output)
+		}
+		if state != nil {
+			markDesktopPlanStepCompleted(state, idx+1, stepResult, output)
+			desktopexec.ReportDesktopPlanState(ctx, *state)
+		}
+	}
+	summary := firstNonEmptyString(plan.Result, plan.Summary)
+	if summary == "" && len(results) == 0 {
+		summary = "Desktop plan executed."
+	}
+	finalResult := summary
+	if summary == "" {
+		finalResult = strings.Join(results, "\n")
+	} else if len(results) > 0 {
+		finalResult = strings.TrimSpace(summary + "\n" + strings.Join(results, "\n"))
+	}
+	if state != nil {
+		state.Status = "completed"
+		state.Result = finalResult
+		state.CurrentStep = 0
+		state.NextStep = len(plan.Steps) + 1
+		state.LastError = ""
+		state.UpdatedAt = desktopexec.TimestampNowRFC3339()
+		desktopexec.ReportDesktopPlanState(ctx, *state)
+	}
+	if summary == "" {
+		return strings.Join(results, "\n"), nil
+	}
+	if len(results) == 0 {
+		return summary, nil
+	}
+	return strings.TrimSpace(summary + "\n" + strings.Join(results, "\n")), nil
+}
+
+func executeDesktopPlanStep(ctx context.Context, registry *tools.Registry, step desktopexec.DesktopPlanStep, index int, executions *int) (desktopPlanStepResult, error) {
+	toolName, toolInput, err := resolveDesktopPlanStepCall(step)
+	if err != nil {
+		return desktopPlanStepResult{}, fmt.Errorf("desktop plan step %d is invalid: %w", index, err)
+	}
+	if !strings.HasPrefix(toolName, "desktop_") {
+		return desktopPlanStepResult{}, fmt.Errorf("desktop plan step %d uses unsupported tool: %s", index, toolName)
+	}
+	attempts := step.Retry + 1
+	if attempts <= 0 {
+		attempts = 1
+	}
+	delay := time.Duration(step.RetryDelayMS) * time.Millisecond
+	var lastErr error
+	result := desktopPlanStepResult{}
+	for attempt := 1; attempt <= attempts; attempt++ {
+		result.Attempts = attempt
+		if err := incrementDesktopExecutionBudget(executions); err != nil {
+			return result, err
+		}
+		currentOutput, err := registry.Call(ctx, toolName, toolInput)
+		if err == nil && step.Verify != nil {
+			err = runDesktopPlanCheck(ctx, registry, step.Verify, index, executions)
+			if err == nil {
+				result.Verified = true
+			}
+		}
+		if err == nil {
+			result.Output = formatDesktopStepOutput(step, strings.TrimSpace(currentOutput), attempt)
+			if step.WaitAfterMS > 0 {
+				if err := sleepWithContext(ctx, time.Duration(step.WaitAfterMS)*time.Millisecond); err != nil {
+					return result, err
+				}
+			}
+			return result, nil
+		}
+		lastErr = err
+		if attempt < attempts && delay > 0 {
+			if err := sleepWithContext(ctx, delay); err != nil {
+				return result, err
+			}
+		}
+	}
+
+	recoveryOutput, recoveryErr := executeDesktopRecovery(ctx, registry, step.OnFailure, index, executions)
+	if recoveryErr != nil {
+		return result, fmt.Errorf("desktop plan step %d failed: %w", index, recoveryErr)
+	}
+	if step.ContinueOnError {
+		result.Output = summarizeDesktopStepFailure(step, index, lastErr, recoveryOutput)
+		result.Continued = true
+		return result, nil
+	}
+	if recoveryOutput != "" {
+		return result, fmt.Errorf("desktop plan step %d failed: %w (%s)", index, lastErr, recoveryOutput)
+	}
+	return result, fmt.Errorf("desktop plan step %d failed: %w", index, lastErr)
+}
+
+func executeDesktopRecovery(ctx context.Context, registry *tools.Registry, steps []desktopexec.DesktopPlanStep, index int, executions *int) (string, error) {
+	if len(steps) == 0 {
+		return "", nil
+	}
+	parts := make([]string, 0, len(steps))
+	for recoveryIdx, recovery := range steps {
+		result, err := executeDesktopPlanStep(ctx, registry, recovery, index*100+recoveryIdx+1, executions)
+		if err != nil {
+			return "", fmt.Errorf("recovery step %d failed: %w", recoveryIdx+1, err)
+		}
+		output := result.Output
+		if strings.TrimSpace(output) != "" {
+			parts = append(parts, strings.TrimSpace(output))
+		}
+	}
+	return strings.Join(parts, "\n"), nil
+}
+
+func runDesktopPlanCheck(ctx context.Context, registry *tools.Registry, check *desktopexec.DesktopPlanCheck, index int, executions *int) error {
+	if check == nil {
+		return nil
+	}
+	toolName, toolInput, err := resolveDesktopPlanCheckCall(*check)
+	if err != nil {
+		return fmt.Errorf("desktop plan step %d verification is invalid: %w", index, err)
+	}
+	if !strings.HasPrefix(toolName, "desktop_") {
+		return fmt.Errorf("desktop plan step %d verification uses unsupported tool: %s", index, toolName)
+	}
+	attempts := check.Retry + 1
+	if attempts <= 0 {
+		attempts = 1
+	}
+	delay := time.Duration(check.RetryDelayMS) * time.Millisecond
+
+	if shouldUseRawDesktopPlanCheck(toolName) {
+		var lastErr error
+		for attempt := 1; attempt <= attempts; attempt++ {
+			if err := incrementDesktopExecutionBudget(executions); err != nil {
+				return err
+			}
+			if _, err := registry.Call(ctx, toolName, toolInput); err == nil {
+				return nil
+			} else {
+				lastErr = err
+			}
+			if attempt < attempts && delay > 0 {
+				if err := sleepWithContext(ctx, delay); err != nil {
+					return err
+				}
+			}
+		}
+		if lastErr == nil {
+			lastErr = fmt.Errorf("verification failed")
+		}
+		return fmt.Errorf("verification failed: %w", lastErr)
+	}
+
+	execFn := func(ctx context.Context, tool string, input map[string]any) (string, error) {
+		if err := incrementDesktopExecutionBudget(executions); err != nil {
+			return "", err
+		}
+		result, err := registry.Call(ctx, tool, input)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%v", result), nil
+	}
+	ie := verification.NewIntegrationExecutor(execFn)
+	normalized := *check
+	normalized.Tool = toolName
+	normalized.Input = toolInput
+	normalized.Target = nil
+	vResult, err := ie.ExecuteFromDesktopPlan(ctx, &normalized)
+	if err != nil {
+		return fmt.Errorf("desktop plan step %d verification error: %w", index, err)
+	}
+	if vResult.AllPassed() {
+		return nil
+	}
+	var lastErr error
+	for _, r := range vResult.Results {
+		if !r.Passed {
+			lastErr = fmt.Errorf("%s: %s", r.Type, r.Message)
+		}
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("verification failed")
+	}
+	return fmt.Errorf("verification failed: %w", lastErr)
+}
+
+func resolveDesktopPlanStepCall(step desktopexec.DesktopPlanStep) (string, map[string]any, error) {
+	toolName := strings.TrimSpace(step.Tool)
+	action := strings.TrimSpace(step.Action)
+	input := mergeMaps(step.Target, step.Input)
+	if action != "" && !strings.EqualFold(action, "wait") {
+		input = mergeMaps(input, map[string]any{"action": action})
+	}
+	if step.Value != nil {
+		input = mergeMaps(input, map[string]any{"value": *step.Value})
+	}
+	if step.Append != nil {
+		input = mergeMaps(input, map[string]any{"append": *step.Append})
+	}
+	if step.Submit != nil {
+		input = mergeMaps(input, map[string]any{"submit": *step.Submit})
+	}
+	if toolName == "" {
+		switch {
+		case step.Value != nil || step.Append != nil || step.Submit != nil:
+			toolName = "desktop_set_target_value"
+		case strings.EqualFold(action, "wait"):
+			toolName = "desktop_resolve_target"
+			input = mergeMaps(input, map[string]any{"require_found": true})
+		case len(step.Target) > 0:
+			toolName = "desktop_activate_target"
+		default:
+			return "", nil, fmt.Errorf("tool or target is required")
+		}
+	}
+	return toolName, input, nil
+}
+
+func resolveDesktopPlanCheckCall(check desktopexec.DesktopPlanCheck) (string, map[string]any, error) {
+	toolName := strings.TrimSpace(check.Tool)
+	input := mergeMaps(check.Target, check.Input)
+	if toolName == "" {
+		if len(check.Target) == 0 {
+			return "", nil, fmt.Errorf("tool or target is required")
+		}
+		toolName = "desktop_resolve_target"
+		input = mergeMaps(input, map[string]any{"require_found": true})
+	}
+	return toolName, input, nil
+}
+
+func incrementDesktopExecutionBudget(executions *int) error {
+	if executions == nil {
+		return nil
+	}
+	*executions = *executions + 1
+	if *executions > maxDesktopPlanExecutions {
+		return fmt.Errorf("desktop plan exceeds %d tool executions", maxDesktopPlanExecutions)
+	}
+	return nil
+}
+
+func formatDesktopStepOutput(step desktopexec.DesktopPlanStep, output string, attempt int) string {
+	prefix := strings.TrimSpace(step.Label)
+	if prefix == "" {
+		if toolName, _, err := resolveDesktopPlanStepCall(step); err == nil {
+			prefix = toolName
+		}
+	}
+	if output == "" {
+		output = "ok"
+	}
+	if attempt > 1 {
+		output = fmt.Sprintf("%s (attempt %d)", output, attempt)
+	}
+	if prefix == "" {
+		return output
+	}
+	return prefix + ": " + output
+}
+
+func summarizeDesktopStepFailure(step desktopexec.DesktopPlanStep, index int, err error, recovery string) string {
+	label := strings.TrimSpace(step.Label)
+	if label == "" {
+		label = fmt.Sprintf("step %d", index)
+	}
+	message := label + " failed"
+	if err != nil {
+		message += ": " + strings.TrimSpace(err.Error())
+	}
+	if strings.TrimSpace(recovery) != "" {
+		message += "\nRecovery: " + strings.TrimSpace(recovery)
+	}
+	return message
+}
+
+func buildDesktopPlanExecutionState(meta ProtocolExecutionMeta, plan desktopexec.DesktopPlan, resume *desktopexec.DesktopPlanExecutionState) desktopexec.DesktopPlanExecutionState {
+	now := desktopexec.TimestampNowRFC3339()
+	state := desktopexec.DesktopPlanExecutionState{
+		ToolName:   strings.TrimSpace(meta.ToolName),
+		Plugin:     strings.TrimSpace(meta.Plugin),
+		App:        strings.TrimSpace(meta.App),
+		Action:     strings.TrimSpace(meta.Action),
+		Workflow:   strings.TrimSpace(meta.Workflow),
+		Summary:    strings.TrimSpace(plan.Summary),
+		TotalSteps: len(plan.Steps),
+		NextStep:   1,
+		UpdatedAt:  now,
+		Steps:      buildDesktopPlanStepStates(plan.Steps, nil),
+	}
+	if canResumeDesktopPlan(meta, plan, resume) {
+		cloned := desktopexec.CloneDesktopPlanExecutionState(resume)
+		if cloned != nil {
+			cloned.ToolName = strings.TrimSpace(meta.ToolName)
+			cloned.Plugin = strings.TrimSpace(meta.Plugin)
+			cloned.App = strings.TrimSpace(meta.App)
+			cloned.Action = strings.TrimSpace(meta.Action)
+			cloned.Workflow = strings.TrimSpace(meta.Workflow)
+			cloned.Summary = firstNonEmptyString(strings.TrimSpace(plan.Summary), cloned.Summary)
+			cloned.TotalSteps = len(plan.Steps)
+			cloned.Steps = buildDesktopPlanStepStates(plan.Steps, cloned.Steps)
+			if cloned.NextStep <= 0 {
+				cloned.NextStep = cloned.LastCompletedStep + 1
+			}
+			if cloned.NextStep <= 0 {
+				cloned.NextStep = 1
+			}
+			if cloned.NextStep > len(plan.Steps)+1 {
+				cloned.NextStep = len(plan.Steps) + 1
+			}
+			cloned.Resumed = cloned.NextStep > 1 && cloned.NextStep <= len(plan.Steps)
+			cloned.UpdatedAt = now
+			return *cloned
+		}
+	}
+	return state
+}
+
+func buildDesktopPlanStepStates(steps []desktopexec.DesktopPlanStep, existing []desktopexec.DesktopPlanStepExecutionState) []desktopexec.DesktopPlanStepExecutionState {
+	items := make([]desktopexec.DesktopPlanStepExecutionState, 0, len(steps))
+	for idx, step := range steps {
+		toolName, _, _ := resolveDesktopPlanStepCall(step)
+		item := desktopexec.DesktopPlanStepExecutionState{
+			Index:     idx + 1,
+			Tool:      toolName,
+			Label:     strings.TrimSpace(step.Label),
+			HasVerify: step.Verify != nil,
+		}
+		for _, current := range existing {
+			if current.Index != idx+1 {
+				continue
+			}
+			item.HasVerify = step.Verify != nil
+			item.Verified = current.Verified
+			item.Status = current.Status
+			item.Attempts = current.Attempts
+			item.Output = current.Output
+			item.Error = current.Error
+			item.UpdatedAt = current.UpdatedAt
+			break
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+func canResumeDesktopPlan(meta ProtocolExecutionMeta, plan desktopexec.DesktopPlan, resume *desktopexec.DesktopPlanExecutionState) bool {
+	if resume == nil || len(plan.Steps) == 0 {
+		return false
+	}
+	if strings.TrimSpace(resume.ToolName) != strings.TrimSpace(meta.ToolName) {
+		return false
+	}
+	if strings.TrimSpace(meta.Plugin) != "" && strings.TrimSpace(resume.Plugin) != strings.TrimSpace(meta.Plugin) {
+		return false
+	}
+	if strings.TrimSpace(meta.Action) != "" && strings.TrimSpace(resume.Action) != strings.TrimSpace(meta.Action) {
+		return false
+	}
+	if strings.TrimSpace(meta.Workflow) != "" && strings.TrimSpace(resume.Workflow) != strings.TrimSpace(meta.Workflow) {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(resume.Status), "completed") {
+		return false
+	}
+	nextStep := resume.NextStep
+	if nextStep <= 0 {
+		nextStep = resume.LastCompletedStep + 1
+	}
+	return nextStep > 1 && nextStep <= len(plan.Steps)
+}
+
+func desktopPlanStartIndex(state *desktopexec.DesktopPlanExecutionState, totalSteps int) int {
+	if state == nil || totalSteps <= 0 {
+		return 0
+	}
+	nextStep := state.NextStep
+	if nextStep <= 0 {
+		nextStep = state.LastCompletedStep + 1
+	}
+	if nextStep <= 1 {
+		return 0
+	}
+	if nextStep > totalSteps {
+		return totalSteps
+	}
+	return nextStep - 1
+}
+
+func markDesktopPlanStepRunning(state *desktopexec.DesktopPlanExecutionState, index int, step desktopexec.DesktopPlanStep) {
+	if state == nil {
+		return
+	}
+	now := desktopexec.TimestampNowRFC3339()
+	state.Status = "running"
+	if state.Resumed && index > 1 {
+		state.Status = "resuming"
+	}
+	state.CurrentStep = index
+	state.NextStep = index
+	state.UpdatedAt = now
+	stepState := desktopPlanStepStateAt(state, index)
+	stepState.Tool = strings.TrimSpace(step.Tool)
+	stepState.Label = strings.TrimSpace(step.Label)
+	stepState.Status = "running"
+	stepState.Error = ""
+	stepState.UpdatedAt = now
+}
+
+func markDesktopPlanStepCompleted(state *desktopexec.DesktopPlanExecutionState, index int, result desktopPlanStepResult, output string) {
+	if state == nil {
+		return
+	}
+	now := desktopexec.TimestampNowRFC3339()
+	stepState := desktopPlanStepStateAt(state, index)
+	stepState.Attempts = result.Attempts
+	stepState.Verified = result.Verified
+	stepState.Output = output
+	stepState.Error = ""
+	stepState.UpdatedAt = now
+	if result.Continued {
+		stepState.Status = "continued"
+	} else {
+		stepState.Status = "completed"
+	}
+	state.LastCompletedStep = index
+	state.CurrentStep = 0
+	state.NextStep = index + 1
+	state.LastOutput = output
+	state.LastError = ""
+	state.UpdatedAt = now
+	state.Status = "running"
+}
+
+func markDesktopPlanStepFailed(state *desktopexec.DesktopPlanExecutionState, index int, attempts int, err error) {
+	if state == nil {
+		return
+	}
+	now := desktopexec.TimestampNowRFC3339()
+	stepState := desktopPlanStepStateAt(state, index)
+	stepState.Attempts = attempts
+	stepState.Error = strings.TrimSpace(err.Error())
+	stepState.UpdatedAt = now
+	stepState.Status = desktopPlanStatusFromError(err)
+	state.Status = desktopPlanStatusFromError(err)
+	state.CurrentStep = index
+	state.NextStep = index
+	state.LastError = strings.TrimSpace(err.Error())
+	state.UpdatedAt = now
+}
+
+func desktopPlanStepStateAt(state *desktopexec.DesktopPlanExecutionState, index int) *desktopexec.DesktopPlanStepExecutionState {
+	if state == nil || index <= 0 {
+		return nil
+	}
+	for i := range state.Steps {
+		if state.Steps[i].Index == index {
+			return &state.Steps[i]
+		}
+	}
+	state.Steps = append(state.Steps, desktopexec.DesktopPlanStepExecutionState{Index: index})
+	return &state.Steps[len(state.Steps)-1]
+}
+
+func shouldUseRawDesktopPlanCheck(toolName string) bool {
+	switch strings.TrimSpace(strings.ToLower(toolName)) {
+	case "desktop_verify_text", "desktop_wait_text", "desktop_resolve_target", "desktop_find_text":
+		return true
+	default:
+		return false
+	}
+}
+
+func desktopPlanStatusFromError(err error) string {
+	if err == nil {
+		return "completed"
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return "interrupted"
+	}
+	message := strings.ToLower(strings.TrimSpace(err.Error()))
+	switch {
+	case strings.Contains(message, "waiting approval"), strings.Contains(message, "awaiting approval"):
+		return "waiting_approval"
+	default:
+		return "failed"
+	}
+}
+
+func sleepWithContext(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/pkg/extensions/plugin/sdk/sdk.go
+++ b/pkg/extensions/plugin/sdk/sdk.go
@@ -1,0 +1,280 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+type PluginContext struct {
+	Name        string
+	Version     string
+	WorkingDir  string
+	Config      map[string]any
+	GatewayAddr string
+
+	mu         sync.RWMutex
+	tools      map[string]Tool
+	channels   map[string]Channel
+	handlers   map[string]EventHandler
+	httpRoutes map[string]HTTPRoute
+	nodes      map[string]Node
+}
+
+type Tool struct {
+	Name        string
+	Description string
+	InputSchema json.RawMessage
+	Handler     ToolHandler
+}
+
+type ToolHandler func(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
+
+type Channel interface {
+	Name() string
+	Start() error
+	Stop() error
+	Send(msg Message) error
+	OnMessage(handler func(msg Message))
+}
+
+type Message struct {
+	ID        string
+	Channel   string
+	From      string
+	To        string
+	Content   string
+	Timestamp int64
+	Metadata  map[string]any
+}
+
+type EventHandler func(ctx context.Context, event Event) error
+
+type Event struct {
+	Type      string         `json:"type"`
+	SessionID string         `json:"session_id,omitempty"`
+	Payload   map[string]any `json:"payload,omitempty"`
+	Source    string         `json:"source,omitempty"`
+}
+
+type HTTPRoute struct {
+	Path    string
+	Method  string
+	Handler func(w http.ResponseWriter, r *http.Request)
+}
+
+type Node interface {
+	Name() string
+	Platform() string
+	Connect() error
+	Disconnect() error
+	Invoke(action string, input json.RawMessage) (json.RawMessage, error)
+	Capabilities() []string
+}
+
+type PluginAPI struct {
+	ctx *PluginContext
+}
+
+func NewPluginContext(name string, version string, workingDir string, gatewayAddr string, cfg map[string]any) *PluginContext {
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+	return &PluginContext{
+		Name:        name,
+		Version:     version,
+		WorkingDir:  workingDir,
+		Config:      cfg,
+		GatewayAddr: gatewayAddr,
+		tools:       make(map[string]Tool),
+		channels:    make(map[string]Channel),
+		handlers:    make(map[string]EventHandler),
+		httpRoutes:  make(map[string]HTTPRoute),
+		nodes:       make(map[string]Node),
+	}
+}
+
+func NewPluginAPI(ctx *PluginContext) *PluginAPI {
+	if ctx == nil {
+		ctx = NewPluginContext("", "", "", "", nil)
+	}
+	return &PluginAPI{ctx: ctx}
+}
+
+func (p *PluginAPI) RegisterTool(tool Tool) error {
+	p.ctx.mu.Lock()
+	defer p.ctx.mu.Unlock()
+
+	if p.ctx.tools == nil {
+		p.ctx.tools = make(map[string]Tool)
+	}
+	if _, exists := p.ctx.tools[tool.Name]; exists {
+		return fmt.Errorf("tool %s already registered", tool.Name)
+	}
+	p.ctx.tools[tool.Name] = tool
+	return nil
+}
+
+func (p *PluginAPI) RegisterChannel(ch Channel) error {
+	p.ctx.mu.Lock()
+	defer p.ctx.mu.Unlock()
+
+	if p.ctx.channels == nil {
+		p.ctx.channels = make(map[string]Channel)
+	}
+	name := ch.Name()
+	if _, exists := p.ctx.channels[name]; exists {
+		return fmt.Errorf("channel %s already registered", name)
+	}
+	p.ctx.channels[name] = ch
+	return nil
+}
+
+func (p *PluginAPI) RegisterEventHandler(eventType string, handler EventHandler) error {
+	p.ctx.mu.Lock()
+	defer p.ctx.mu.Unlock()
+
+	if p.ctx.handlers == nil {
+		p.ctx.handlers = make(map[string]EventHandler)
+	}
+	p.ctx.handlers[eventType] = handler
+	return nil
+}
+
+func (p *PluginAPI) RegisterHTTPRoute(route HTTPRoute) error {
+	p.ctx.mu.Lock()
+	defer p.ctx.mu.Unlock()
+
+	if p.ctx.httpRoutes == nil {
+		p.ctx.httpRoutes = make(map[string]HTTPRoute)
+	}
+	key := route.Method + ":" + route.Path
+	p.ctx.httpRoutes[key] = route
+	return nil
+}
+
+func (p *PluginAPI) RegisterNode(node Node) error {
+	p.ctx.mu.Lock()
+	defer p.ctx.mu.Unlock()
+
+	if p.ctx.nodes == nil {
+		p.ctx.nodes = make(map[string]Node)
+	}
+	name := node.Name()
+	if _, exists := p.ctx.nodes[name]; exists {
+		return fmt.Errorf("node %s already registered", name)
+	}
+	p.ctx.nodes[name] = node
+	return nil
+}
+
+func (p *PluginAPI) GetConfig(key string) (any, bool) {
+	p.ctx.mu.RLock()
+	defer p.ctx.mu.RUnlock()
+
+	val, ok := p.ctx.Config[key]
+	return val, ok
+}
+
+func (p *PluginAPI) SetConfig(key string, value any) {
+	p.ctx.mu.Lock()
+	defer p.ctx.mu.Unlock()
+
+	p.ctx.Config[key] = value
+}
+
+func (p *PluginAPI) GetWorkingDir() string {
+	return p.ctx.WorkingDir
+}
+
+func (p *PluginAPI) GetGatewayAddr() string {
+	return p.ctx.GatewayAddr
+}
+
+func (p *PluginAPI) ListTools() []Tool {
+	p.ctx.mu.RLock()
+	defer p.ctx.mu.RUnlock()
+
+	items := make([]Tool, 0, len(p.ctx.tools))
+	for _, tool := range p.ctx.tools {
+		items = append(items, tool)
+	}
+	return items
+}
+
+func (p *PluginAPI) ListChannels() []Channel {
+	p.ctx.mu.RLock()
+	defer p.ctx.mu.RUnlock()
+
+	items := make([]Channel, 0, len(p.ctx.channels))
+	for _, ch := range p.ctx.channels {
+		items = append(items, ch)
+	}
+	return items
+}
+
+func (p *PluginAPI) ListHTTPRoutes() []HTTPRoute {
+	p.ctx.mu.RLock()
+	defer p.ctx.mu.RUnlock()
+
+	items := make([]HTTPRoute, 0, len(p.ctx.httpRoutes))
+	for _, route := range p.ctx.httpRoutes {
+		items = append(items, route)
+	}
+	return items
+}
+
+func (p *PluginAPI) ListNodes() []Node {
+	p.ctx.mu.RLock()
+	defer p.ctx.mu.RUnlock()
+
+	items := make([]Node, 0, len(p.ctx.nodes))
+	for _, node := range p.ctx.nodes {
+		items = append(items, node)
+	}
+	return items
+}
+
+type PluginManifest struct {
+	Name        string   `json:"name"`
+	Version     string   `json:"version"`
+	Description string   `json:"description"`
+	Kind        []string `json:"kind"`
+	Entrypoint  string   `json:"entrypoint,omitempty"`
+	Permissions []string `json:"permissions,omitempty"`
+}
+
+func (m PluginManifest) Validate() error {
+	if m.Name == "" {
+		return fmt.Errorf("plugin manifest: name is required")
+	}
+	if m.Version == "" {
+		return fmt.Errorf("plugin manifest: version is required")
+	}
+	if len(m.Kind) == 0 {
+		return fmt.Errorf("plugin manifest: at least one kind is required")
+	}
+	return nil
+}
+
+type PluginInitFunc func(api *PluginAPI) error
+type PluginStartFunc func() error
+type PluginStopFunc func() error
+
+type Plugin struct {
+	Manifest PluginManifest
+	Init     PluginInitFunc
+	Start    PluginStartFunc
+	Stop     PluginStopFunc
+}
+
+func Register(manifest PluginManifest, initFn PluginInitFunc, startFn PluginStartFunc, stopFn PluginStopFunc) *Plugin {
+	return &Plugin{
+		Manifest: manifest,
+		Init:     initFn,
+		Start:    startFn,
+		Stop:     stopFn,
+	}
+}

--- a/pkg/extensions/plugin/sdk/sdk_test.go
+++ b/pkg/extensions/plugin/sdk/sdk_test.go
@@ -1,0 +1,81 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+type stubChannel struct{}
+
+func (stubChannel) Name() string                        { return "demo" }
+func (stubChannel) Start() error                        { return nil }
+func (stubChannel) Stop() error                         { return nil }
+func (stubChannel) Send(msg Message) error              { _ = msg; return nil }
+func (stubChannel) OnMessage(handler func(msg Message)) { _ = handler }
+
+type stubNode struct{}
+
+func (stubNode) Name() string      { return "desktop-node" }
+func (stubNode) Platform() string  { return "windows" }
+func (stubNode) Connect() error    { return nil }
+func (stubNode) Disconnect() error { return nil }
+func (stubNode) Invoke(action string, input json.RawMessage) (json.RawMessage, error) {
+	_, _ = action, input
+	return json.RawMessage(`{"ok":true}`), nil
+}
+func (stubNode) Capabilities() []string { return []string{"desktop-control"} }
+
+func TestNewPluginContextInitializesCollections(t *testing.T) {
+	ctx := NewPluginContext("demo", "1.0.0", "workdir", "http://127.0.0.1:8080", nil)
+	api := NewPluginAPI(ctx)
+
+	if err := api.RegisterTool(Tool{Name: "ping", Description: "Ping", Handler: func(ctx context.Context, input json.RawMessage) (json.RawMessage, error) {
+		_, _ = ctx, input
+		return json.RawMessage(`{"ok":true}`), nil
+	}}); err != nil {
+		t.Fatalf("RegisterTool: %v", err)
+	}
+	if err := api.RegisterChannel(stubChannel{}); err != nil {
+		t.Fatalf("RegisterChannel: %v", err)
+	}
+	if err := api.RegisterHTTPRoute(HTTPRoute{Path: "/ping", Method: http.MethodGet, Handler: func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w, r
+	}}); err != nil {
+		t.Fatalf("RegisterHTTPRoute: %v", err)
+	}
+	if err := api.RegisterNode(stubNode{}); err != nil {
+		t.Fatalf("RegisterNode: %v", err)
+	}
+
+	if len(api.ListTools()) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(api.ListTools()))
+	}
+	if len(api.ListChannels()) != 1 {
+		t.Fatalf("expected 1 channel, got %d", len(api.ListChannels()))
+	}
+	if len(api.ListHTTPRoutes()) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(api.ListHTTPRoutes()))
+	}
+	if len(api.ListNodes()) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(api.ListNodes()))
+	}
+}
+
+func TestPluginManifestValidate(t *testing.T) {
+	valid := PluginManifest{
+		Name:        "demo",
+		Version:     "1.0.0",
+		Description: "Demo plugin",
+		Kind:        []string{"tool"},
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("expected valid manifest, got %v", err)
+	}
+
+	invalid := PluginManifest{}
+	if err := invalid.Validate(); err == nil {
+		t.Fatal("expected invalid manifest to fail validation")
+	}
+}

--- a/pkg/extensions/plugin/signing.go
+++ b/pkg/extensions/plugin/signing.go
@@ -1,0 +1,357 @@
+package plugin
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type SignerType string
+
+const (
+	SignerTypeGPG     SignerType = "gpg"
+	SignerTypeRSA     SignerType = "rsa"
+	SignerTypeEd25519 SignerType = "ed25519"
+)
+
+type Signature struct {
+	Signer    string     `json:"signer"`
+	Type      SignerType `json:"type"`
+	Algorithm string     `json:"algorithm"`
+	Value     string     `json:"value"`
+	Timestamp time.Time  `json:"timestamp"`
+	KeyID     string     `json:"key_id,omitempty"`
+}
+
+type KeyPair struct {
+	Type       SignerType `json:"type"`
+	PublicKey  string     `json:"public_key"`
+	PrivateKey string     `json:"private_key,omitempty"`
+	KeyID      string     `json:"key_id"`
+	CreatedAt  time.Time  `json:"created_at"`
+	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
+}
+
+type SignatureVerifier struct {
+	trustedKeys map[string]*KeyPair
+}
+
+func GenerateKeyPair(keyType SignerType, bits int) (*KeyPair, error) {
+	switch keyType {
+	case SignerTypeRSA:
+		return generateRSAKeyPair(bits)
+	default:
+		return nil, fmt.Errorf("unsupported key type: %s", keyType)
+	}
+}
+
+func generateRSAKeyPair(bits int) (*KeyPair, error) {
+	if bits < 2048 {
+		bits = 2048
+	}
+	privateKey, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate RSA key: %w", err)
+	}
+
+	pubKeyBytes, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal public key: %w", err)
+	}
+
+	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+
+	pubKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubKeyBytes,
+	})
+
+	privKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: privKeyBytes,
+	})
+
+	keyID := fmt.Sprintf("%x", sha256.Sum256(pubKeyBytes))[:16]
+
+	return &KeyPair{
+		Type:       SignerTypeRSA,
+		PublicKey:  string(pubKeyPEM),
+		PrivateKey: string(privKeyPEM),
+		KeyID:      keyID,
+		CreatedAt:  time.Now(),
+	}, nil
+}
+
+func SignManifest(manifest *Manifest, keyPair *KeyPair) (*Signature, error) {
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	hash := sha256.Sum256(manifestBytes)
+
+	var signature []byte
+	switch keyPair.Type {
+	case SignerTypeRSA:
+		block, _ := pem.Decode([]byte(keyPair.PrivateKey))
+		if block == nil {
+			return nil, fmt.Errorf("failed to decode private key")
+		}
+		privKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse private key: %w", err)
+		}
+		rsaKey := privKey.(*rsa.PrivateKey)
+		signature, err = rsa.SignPKCS1v15(rand.Reader, rsaKey, crypto.SHA256, hash[:])
+		if err != nil {
+			return nil, fmt.Errorf("failed to sign: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported key type: %s", keyPair.Type)
+	}
+
+	return &Signature{
+		Signer:    manifest.Signer,
+		Type:      keyPair.Type,
+		Algorithm: "SHA256-RSA",
+		Value:     base64.StdEncoding.EncodeToString(signature),
+		Timestamp: time.Now(),
+		KeyID:     keyPair.KeyID,
+	}, nil
+}
+
+func VerifySignature(manifest *Manifest, signature *Signature, publicKey string) (bool, error) {
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	hash := sha256.Sum256(manifestBytes)
+
+	sigBytes, err := base64.StdEncoding.DecodeString(signature.Value)
+	if err != nil {
+		return false, fmt.Errorf("failed to decode signature: %w", err)
+	}
+
+	block, _ := pem.Decode([]byte(publicKey))
+	if block == nil {
+		return false, fmt.Errorf("failed to decode public key")
+	}
+
+	pubKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	rsaKey, ok := pubKey.(*rsa.PublicKey)
+	if !ok {
+		return false, fmt.Errorf("not an RSA public key")
+	}
+
+	err = rsa.VerifyPKCS1v15(rsaKey, crypto.SHA256, hash[:], sigBytes)
+	if err != nil {
+		return false, fmt.Errorf("signature verification failed: %w", err)
+	}
+
+	return true, nil
+}
+
+func loadManifestFromFile(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+	return &manifest, nil
+}
+
+func SignPluginDir(dir string, keyPair *KeyPair) (*Signature, error) {
+	manifest, err := loadManifestFromFile(filepath.Join(dir, "plugin.json"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load manifest: %w", err)
+	}
+
+	return SignManifest(manifest, keyPair)
+}
+
+func VerifyPluginDir(dir string, signature *Signature, publicKey string) (bool, error) {
+	manifest, err := loadManifestFromFile(filepath.Join(dir, "plugin.json"))
+	if err != nil {
+		return false, fmt.Errorf("failed to load manifest: %w", err)
+	}
+
+	return VerifySignature(manifest, signature, publicKey)
+}
+
+func SaveSignature(dir string, signature *Signature) error {
+	data, err := json.MarshalIndent(signature, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "plugin.signature"), data, 0644)
+}
+
+func LoadSignature(dir string) (*Signature, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "plugin.signature"))
+	if err != nil {
+		return nil, err
+	}
+	var sig Signature
+	if err := json.Unmarshal(data, &sig); err != nil {
+		return nil, err
+	}
+	return &sig, nil
+}
+
+type TrustLevel string
+
+const (
+	TrustLevelUnknown   TrustLevel = "unknown"
+	TrustLevelUntrusted TrustLevel = "untrusted"
+	TrustLevelTrusted   TrustLevel = "trusted"
+	TrustLevelVerified  TrustLevel = "verified"
+)
+
+type SignerInfo struct {
+	KeyID       string     `json:"key_id"`
+	Name        string     `json:"name"`
+	Email       string     `json:"email"`
+	Fingerprint string     `json:"fingerprint"`
+	TrustLevel  TrustLevel `json:"trust_level"`
+	AddedAt     time.Time  `json:"added_at"`
+}
+
+type TrustStore struct {
+	signers map[string]*SignerInfo
+}
+
+func NewTrustStore() *TrustStore {
+	return &TrustStore{
+		signers: make(map[string]*SignerInfo),
+	}
+}
+
+func (ts *TrustStore) AddSigner(keyID string, info *SignerInfo) {
+	ts.signers[keyID] = info
+}
+
+func (ts *TrustStore) GetSigner(keyID string) (*SignerInfo, bool) {
+	info, ok := ts.signers[keyID]
+	return info, ok
+}
+
+func (ts *TrustStore) IsTrusted(keyID string) bool {
+	info, ok := ts.signers[keyID]
+	if !ok {
+		return false
+	}
+	return info.TrustLevel == TrustLevelTrusted || info.TrustLevel == TrustLevelVerified
+}
+
+func (ts *TrustStore) ListSigners() []*SignerInfo {
+	list := make([]*SignerInfo, 0, len(ts.signers))
+	for _, info := range ts.signers {
+		list = append(list, info)
+	}
+	return list
+}
+
+func (ts *TrustStore) RemoveSigner(keyID string) {
+	delete(ts.signers, keyID)
+}
+
+func (ts *TrustStore) Save(path string) error {
+	data, err := json.MarshalIndent(ts.signers, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+func (ts *TrustStore) Load(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, &ts.signers)
+}
+
+type PluginChecksum struct {
+	Algorithm string            `json:"algorithm"`
+	Value     string            `json:"value"`
+	Files     map[string]string `json:"files"`
+}
+
+func GenerateChecksum(dir string, algorithm string) (*PluginChecksum, error) {
+	if algorithm == "" {
+		algorithm = "sha256"
+	}
+	files := make(map[string]string)
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		hash := sha256.Sum256(data)
+		files[relPath] = fmt.Sprintf("%x", hash)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	for _, v := range files {
+		buf.WriteString(v)
+	}
+	hash := sha256.Sum256(buf.Bytes())
+
+	return &PluginChecksum{
+		Algorithm: algorithm,
+		Value:     fmt.Sprintf("%x", hash),
+		Files:     files,
+	}, nil
+}
+
+func VerifyChecksum(dir string, checksum *PluginChecksum) (bool, error) {
+	for relPath, expectedHash := range checksum.Files {
+		path := filepath.Join(dir, relPath)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return false, fmt.Errorf("file not found: %s", relPath)
+		}
+		hash := sha256.Sum256(data)
+		actualHash := fmt.Sprintf("%x", hash)
+		if actualHash != expectedHash {
+			return false, fmt.Errorf("checksum mismatch for %s", relPath)
+		}
+	}
+	return true, nil
+}

--- a/pkg/extensions/plugin/store.go
+++ b/pkg/extensions/plugin/store.go
@@ -1,0 +1,414 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+type PluginSource struct {
+	Name   string `json:"name"`
+	URL    string `json:"url"`
+	Type   string `json:"type"` // github, http, local
+	Auth   string `json:"auth,omitempty"`
+	Branch string `json:"branch,omitempty"`
+}
+
+type PluginListing struct {
+	PluginID     string            `json:"plugin_id"`
+	Name         string            `json:"name"`
+	Version      string            `json:"version"`
+	Description  string            `json:"description"`
+	Author       string            `json:"author"`
+	Homepage     string            `json:"homepage"`
+	Repository   string            `json:"repository"`
+	DownloadURL  string            `json:"download_url"`
+	SignatureURL string            `json:"signature_url,omitempty"`
+	Checksums    map[string]string `json:"checksums,omitempty"`
+	PublishedAt  time.Time         `json:"published_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
+	Stars        int               `json:"stars"`
+	Downloads    int               `json:"downloads"`
+	License      string            `json:"license"`
+	Tags         []string          `json:"tags"`
+	Platforms    []string          `json:"platforms"`
+	MinVersion   string            `json:"min_version,omitempty"`
+	Dependencies []string          `json:"dependencies,omitempty"`
+	FileSize     int64             `json:"file_size"`
+	SHA256       string            `json:"sha256"`
+	Signature    string            `json:"signature,omitempty"`
+	Verified     bool              `json:"verified"`
+	TrustLevel   string            `json:"trust_level"`
+}
+
+type SearchFilter struct {
+	Query     string
+	Tags      []string
+	Platforms []string
+	Author    string
+	SortBy    string // stars, downloads, updated, name
+	SortOrder string // asc, desc
+	Limit     int
+	Offset    int
+}
+
+type MarketClient struct {
+	sources    []*PluginSource
+	cacheDir   string
+	httpClient *http.Client
+}
+
+func NewMarketClient(cacheDir string) *MarketClient {
+	return &MarketClient{
+		cacheDir:   cacheDir,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (mc *MarketClient) AddSource(source *PluginSource) {
+	mc.sources = append(mc.sources, source)
+}
+
+func (mc *MarketClient) Search(filter SearchFilter) ([]*PluginListing, error) {
+	var results []*PluginListing
+
+	for _, source := range mc.sources {
+		items, err := mc.searchSource(source, filter)
+		if err != nil {
+			continue
+		}
+		results = append(results, items...)
+	}
+
+	results = mc.applyFilter(results, filter)
+	mc.sortResults(results, filter)
+
+	if filter.Limit > 0 && len(results) > filter.Limit {
+		results = results[:filter.Limit]
+	}
+	if filter.Offset > 0 && len(results) > filter.Offset {
+		results = results[filter.Offset:]
+	}
+
+	return results, nil
+}
+
+func (mc *MarketClient) searchSource(source *PluginSource, filter SearchFilter) ([]*PluginListing, error) {
+	switch source.Type {
+	case "github":
+		return mc.searchGitHub(source, filter)
+	case "http":
+		return mc.searchHTTP(source, filter)
+	default:
+		return nil, fmt.Errorf("unsupported source type: %s", source.Type)
+	}
+}
+
+func (mc *MarketClient) searchGitHub(source *PluginSource, filter SearchFilter) ([]*PluginListing, error) {
+	url := fmt.Sprintf("%s/plugins.json", strings.TrimSuffix(source.URL, "/"))
+	resp, err := mc.httpClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var listings []*PluginListing
+	if err := json.NewDecoder(resp.Body).Decode(&listings); err != nil {
+		return nil, err
+	}
+
+	return listings, nil
+}
+
+func (mc *MarketClient) searchHTTP(source *PluginSource, filter SearchFilter) ([]*PluginListing, error) {
+	url := source.URL
+	resp, err := mc.httpClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var listings []*PluginListing
+	if err := json.NewDecoder(resp.Body).Decode(&listings); err != nil {
+		return nil, err
+	}
+
+	return listings, nil
+}
+
+func (mc *MarketClient) applyFilter(listings []*PluginListing, filter SearchFilter) []*PluginListing {
+	var filtered []*PluginListing
+
+	for _, listing := range listings {
+		if filter.Query != "" {
+			query := strings.ToLower(filter.Query)
+			match := strings.Contains(strings.ToLower(listing.Name), query) ||
+				strings.Contains(strings.ToLower(listing.Description), query) ||
+				strings.Contains(strings.ToLower(listing.Author), query)
+			if !match {
+				continue
+			}
+		}
+
+		if len(filter.Tags) > 0 {
+			match := false
+			for _, tag := range filter.Tags {
+				for _, listingTag := range listing.Tags {
+					if strings.EqualFold(tag, listingTag) {
+						match = true
+						break
+					}
+				}
+			}
+			if !match {
+				continue
+			}
+		}
+
+		if len(filter.Platforms) > 0 {
+			match := false
+			for _, p := range filter.Platforms {
+				for _, lp := range listing.Platforms {
+					if strings.EqualFold(p, lp) {
+						match = true
+						break
+					}
+				}
+			}
+			if !match {
+				continue
+			}
+		}
+
+		if filter.Author != "" && !strings.Contains(strings.ToLower(listing.Author), strings.ToLower(filter.Author)) {
+			continue
+		}
+
+		filtered = append(filtered, listing)
+	}
+
+	return filtered
+}
+
+func (mc *MarketClient) sortResults(listings []*PluginListing, filter SearchFilter) {
+	sort.Slice(listings, func(i, j int) bool {
+		var cmp bool
+		switch filter.SortBy {
+		case "stars":
+			cmp = listings[i].Stars > listings[j].Stars
+		case "downloads":
+			cmp = listings[i].Downloads > listings[j].Downloads
+		case "updated", "updated_at":
+			cmp = listings[i].UpdatedAt.After(listings[j].UpdatedAt)
+		case "name":
+			cmp = listings[i].Name < listings[j].Name
+		default:
+			cmp = listings[i].Name < listings[j].Name
+		}
+		if filter.SortOrder == "asc" {
+			return !cmp
+		}
+		return cmp
+	})
+}
+
+func (mc *MarketClient) GetPlugin(pluginID string) (*PluginListing, error) {
+	filter := SearchFilter{Query: pluginID, Limit: 1}
+	results, err := mc.Search(filter)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("plugin not found: %s", pluginID)
+	}
+	return results[0], nil
+}
+
+func (mc *MarketClient) DownloadPlugin(listing *PluginListing, destDir string) (string, error) {
+	os.MkdirAll(destDir, 0755)
+
+	resp, err := mc.httpClient.Get(listing.DownloadURL)
+	if err != nil {
+		return "", fmt.Errorf("download failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	filename := fmt.Sprintf("%s-%s.zip", listing.Name, listing.Version)
+	destPath := filepath.Join(destDir, filename)
+
+	out, err := os.Create(destPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create file: %w", err)
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to write file: %w", err)
+	}
+
+	if listing.SignatureURL != "" {
+		sigResp, err := mc.httpClient.Get(listing.SignatureURL)
+		if err == nil {
+			defer sigResp.Body.Close()
+			sigData, _ := io.ReadAll(sigResp.Body)
+			os.WriteFile(destPath+".sig", sigData, 0644)
+		}
+	}
+
+	return destPath, nil
+}
+
+func (mc *MarketClient) InstallPlugin(listing *PluginListing, pluginsDir string, trustStore *TrustStore) error {
+	downloadPath, err := mc.DownloadPlugin(listing, mc.cacheDir)
+	if err != nil {
+		return err
+	}
+
+	installDir := filepath.Join(pluginsDir, listing.Name)
+	if err := mc.extractPlugin(downloadPath, installDir); err != nil {
+		return err
+	}
+
+	sigPath := downloadPath + ".sig"
+	if _, err := os.Stat(sigPath); err == nil {
+		sigData, _ := os.ReadFile(sigPath)
+		var sig Signature
+		if json.Unmarshal(sigData, &sig) == nil {
+			if trustStore.IsTrusted(sig.KeyID) {
+				listing.Verified = true
+				listing.TrustLevel = "verified"
+			}
+		}
+	}
+
+	return nil
+}
+
+func (mc *MarketClient) extractPlugin(zipPath, destDir string) error {
+	return fmt.Errorf("extract not implemented: use archive package")
+}
+
+func (mc *MarketClient) UpdatePlugin(pluginID string, pluginsDir string) error {
+	listing, err := mc.GetPlugin(pluginID)
+	if err != nil {
+		return err
+	}
+
+	pluginDir := filepath.Join(pluginsDir, pluginID)
+	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
+		return fmt.Errorf("plugin not installed: %s", pluginID)
+	}
+
+	return mc.InstallPlugin(listing, pluginsDir, nil)
+}
+
+type PluginIndex struct {
+	UpdatedAt time.Time                 `json:"updated_at"`
+	Plugins   map[string]*PluginListing `json:"plugins"`
+}
+
+func (mc *MarketClient) BuildLocalIndex(pluginsDir string) (*PluginIndex, error) {
+	index := &PluginIndex{
+		UpdatedAt: time.Now(),
+		Plugins:   make(map[string]*PluginListing),
+	}
+
+	entries, err := os.ReadDir(pluginsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		manifest, err := loadManifestFromFile(filepath.Join(pluginsDir, entry.Name(), "plugin.json"))
+		if err != nil {
+			continue
+		}
+		sig, _ := LoadSignature(filepath.Join(pluginsDir, entry.Name()))
+
+		listing := &PluginListing{
+			PluginID:    entry.Name(),
+			Name:        manifest.Name,
+			Version:     manifest.Version,
+			Description: manifest.Description,
+			Author:      manifest.Signer,
+			Platforms:   []string{"windows", "linux", "darwin"},
+			TrustLevel:  "unknown",
+		}
+		if sig != nil {
+			listing.Verified = true
+			listing.TrustLevel = "signed"
+		}
+		index.Plugins[entry.Name()] = listing
+	}
+
+	return index, nil
+}
+
+type Version struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func ParseVersion(v string) (*Version, error) {
+	re := regexp.MustCompile(`^v?(\d+)\.(\d+)\.(\d+)`)
+	matches := re.FindStringSubmatch(v)
+	if len(matches) < 4 {
+		return nil, fmt.Errorf("invalid version: %s", v)
+	}
+	return &Version{
+		Major: parseInt(matches[1]),
+		Minor: parseInt(matches[2]),
+		Patch: parseInt(matches[3]),
+	}, nil
+}
+
+func parseInt(s string) int {
+	var n int
+	fmt.Sscanf(s, "%d", &n)
+	return n
+}
+
+func (v *Version) Compare(other *Version) int {
+	if v.Major != other.Major {
+		return v.Major - other.Major
+	}
+	if v.Minor != other.Minor {
+		return v.Minor - other.Minor
+	}
+	return v.Patch - other.Patch
+}
+
+func (v *Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+func IsCompatible(current, required string) bool {
+	cv, err := ParseVersion(current)
+	if err != nil {
+		return false
+	}
+	rv, err := ParseVersion(required)
+	if err != nil {
+		return false
+	}
+
+	if cv.Major != rv.Major {
+		return cv.Major > rv.Major
+	}
+	if cv.Minor < rv.Minor {
+		return false
+	}
+	return true
+}

--- a/pkg/extensions/plugin/store_impl.go
+++ b/pkg/extensions/plugin/store_impl.go
@@ -1,0 +1,897 @@
+package plugin
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Store struct {
+	mu             sync.RWMutex
+	pluginDir      string
+	marketDir      string
+	cacheDir       string
+	sources        []PluginSource
+	httpClient     *http.Client
+	trustStore     *TrustStore
+	registry       *Registry
+	installHistory []InstallRecord
+}
+
+type InstallRecord struct {
+	PluginID    string    `json:"plugin_id"`
+	Version     string    `json:"version"`
+	InstalledAt time.Time `json:"installed_at"`
+	Source      string    `json:"source"`
+	Checksum    string    `json:"checksum"`
+}
+
+type InstallResult struct {
+	PluginID     string   `json:"plugin_id"`
+	Version      string   `json:"version"`
+	Path         string   `json:"path"`
+	Dependencies []string `json:"dependencies"`
+	Warnings     []string `json:"warnings,omitempty"`
+}
+
+type UninstallResult struct {
+	PluginID string  `json:"plugin_id"`
+	Version  string  `json:"version"`
+	Rollback *string `json:"rollback,omitempty"`
+}
+
+func NewStore(pluginDir, marketDir, cacheDir string, sources []PluginSource, trustStore *TrustStore, registry *Registry) *Store {
+	return &Store{
+		pluginDir:  pluginDir,
+		marketDir:  marketDir,
+		cacheDir:   cacheDir,
+		sources:    sources,
+		httpClient: &http.Client{Timeout: 60 * time.Second},
+		trustStore: trustStore,
+		registry:   registry,
+	}
+}
+
+func (s *Store) Search(ctx context.Context, filter SearchFilter) ([]PluginListing, error) {
+	var allResults []PluginListing
+
+	for _, source := range s.sources {
+		results, err := s.searchSource(ctx, source, filter)
+		if err != nil {
+			continue
+		}
+		allResults = append(allResults, results...)
+	}
+
+	localResults := s.searchLocal(filter)
+	allResults = append(allResults, localResults...)
+
+	allResults = deduplicateListings(allResults)
+
+	if filter.SortBy == "stars" {
+		sort.Slice(allResults, func(i, j int) bool {
+			if filter.SortOrder == "asc" {
+				return allResults[i].Stars < allResults[j].Stars
+			}
+			return allResults[i].Stars > allResults[j].Stars
+		})
+	} else if filter.SortBy == "downloads" {
+		sort.Slice(allResults, func(i, j int) bool {
+			if filter.SortOrder == "asc" {
+				return allResults[i].Downloads < allResults[j].Downloads
+			}
+			return allResults[i].Downloads > allResults[j].Downloads
+		})
+	} else if filter.SortBy == "name" {
+		sort.Slice(allResults, func(i, j int) bool {
+			if filter.SortOrder == "asc" {
+				return allResults[i].Name < allResults[j].Name
+			}
+			return allResults[i].Name > allResults[j].Name
+		})
+	} else {
+		sort.Slice(allResults, func(i, j int) bool {
+			return allResults[i].Downloads > allResults[j].Downloads
+		})
+	}
+
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	offset := filter.Offset
+	if offset >= len(allResults) {
+		return nil, nil
+	}
+	end := offset + limit
+	if end > len(allResults) {
+		end = len(allResults)
+	}
+	return allResults[offset:end], nil
+}
+
+func (s *Store) searchSource(ctx context.Context, source PluginSource, filter SearchFilter) ([]PluginListing, error) {
+	if source.Type == "http" || source.Type == "github" {
+		return s.searchHTTP(ctx, source, filter)
+	}
+	return nil, nil
+}
+
+func (s *Store) searchHTTP(ctx context.Context, source PluginSource, filter SearchFilter) ([]PluginListing, error) {
+	baseURL := strings.TrimRight(source.URL, "/")
+	url := fmt.Sprintf("%s/api/v1/plugins/search?q=%s&limit=%d&offset=%d",
+		baseURL, filter.Query, filter.Limit+filter.Offset, filter.Offset)
+	if filter.Author != "" {
+		url += fmt.Sprintf("&author=%s", filter.Author)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if source.Auth != "" {
+		req.Header.Set("Authorization", "Bearer "+source.Auth)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("search failed: %s", resp.Status)
+	}
+
+	var result struct {
+		Plugins []PluginListing `json:"plugins"`
+		Total   int             `json:"total"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return result.Plugins, nil
+}
+
+func (s *Store) searchLocal(filter SearchFilter) []PluginListing {
+	entries, err := os.ReadDir(s.pluginDir)
+	if err != nil {
+		return nil
+	}
+
+	var results []PluginListing
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		manifest, err := s.loadManifest(filepath.Join(s.pluginDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+
+		if filter.Query != "" {
+			q := strings.ToLower(filter.Query)
+			if !strings.Contains(strings.ToLower(manifest.Name), q) &&
+				!strings.Contains(strings.ToLower(manifest.Description), q) {
+				continue
+			}
+		}
+
+		results = append(results, PluginListing{
+			PluginID:    manifest.Name,
+			Name:        manifest.Name,
+			Version:     manifest.Version,
+			Description: manifest.Description,
+			Tags:        manifest.CapabilityTags,
+			Verified:    manifest.Verified,
+			TrustLevel:  manifest.Trust,
+		})
+	}
+	return results
+}
+
+func (s *Store) GetPlugin(ctx context.Context, id string) (*PluginListing, error) {
+	for _, source := range s.sources {
+		listing, err := s.getPluginFromSource(ctx, source, id)
+		if err == nil && listing != nil {
+			return listing, nil
+		}
+	}
+
+	manifest, err := s.loadManifest(filepath.Join(s.pluginDir, id))
+	if err == nil {
+		return &PluginListing{
+			PluginID:    manifest.Name,
+			Name:        manifest.Name,
+			Version:     manifest.Version,
+			Description: manifest.Description,
+			Verified:    manifest.Verified,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("plugin not found: %s", id)
+}
+
+func (s *Store) getPluginFromSource(ctx context.Context, source PluginSource, id string) (*PluginListing, error) {
+	baseURL := strings.TrimRight(source.URL, "/")
+	url := fmt.Sprintf("%s/api/v1/plugins/%s", baseURL, id)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if source.Auth != "" {
+		req.Header.Set("Authorization", "Bearer "+source.Auth)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return nil, nil
+	}
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("get plugin failed: %s", resp.Status)
+	}
+
+	var listing PluginListing
+	if err := json.NewDecoder(resp.Body).Decode(&listing); err != nil {
+		return nil, err
+	}
+	return &listing, nil
+}
+
+func (s *Store) GetVersions(ctx context.Context, id string) ([]string, error) {
+	for _, source := range s.sources {
+		baseURL := strings.TrimRight(source.URL, "/")
+		url := fmt.Sprintf("%s/api/v1/plugins/%s/versions", baseURL, id)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			continue
+		}
+		if source.Auth != "" {
+			req.Header.Set("Authorization", "Bearer "+source.Auth)
+		}
+
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			continue
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode >= 300 {
+			continue
+		}
+
+		var result struct {
+			Versions []string `json:"versions"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			continue
+		}
+		return result.Versions, nil
+	}
+	return nil, fmt.Errorf("no versions found for: %s", id)
+}
+
+func (s *Store) Install(ctx context.Context, id, version string) (*InstallResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var listing *PluginListing
+	var source PluginSource
+
+	for _, src := range s.sources {
+		l, err := s.getPluginFromSource(ctx, src, id)
+		if err == nil && l != nil {
+			listing = l
+			source = src
+			break
+		}
+	}
+
+	if listing == nil {
+		return nil, fmt.Errorf("plugin not found in any source: %s", id)
+	}
+
+	if version == "" {
+		version = listing.Version
+	}
+
+	if err := s.downloadAndExtract(ctx, source, listing, version); err != nil {
+		return nil, fmt.Errorf("download: %w", err)
+	}
+
+	pluginPath := filepath.Join(s.pluginDir, id)
+	if err := s.verifyInstalledPlugin(pluginPath); err != nil {
+		os.RemoveAll(pluginPath)
+		return nil, fmt.Errorf("verify: %w", err)
+	}
+
+	record := InstallRecord{
+		PluginID:    id,
+		Version:     version,
+		InstalledAt: time.Now().UTC(),
+		Source:      source.Name,
+		Checksum:    listing.SHA256,
+	}
+	s.installHistory = append(s.installHistory, record)
+	s.saveInstallHistory()
+
+	result := &InstallResult{
+		PluginID: id,
+		Version:  version,
+		Path:     pluginPath,
+	}
+
+	if len(listing.Dependencies) > 0 {
+		for _, dep := range listing.Dependencies {
+			if _, err := s.installWithoutLock(ctx, source, &PluginListing{PluginID: dep}, ""); err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("dependency %s: %v", dep, err))
+			}
+			result.Dependencies = append(result.Dependencies, dep)
+		}
+	}
+
+	return result, nil
+}
+
+func (s *Store) downloadAndExtract(ctx context.Context, source PluginSource, listing *PluginListing, version string) error {
+	baseURL := strings.TrimRight(source.URL, "/")
+	downloadURL := listing.DownloadURL
+	if downloadURL == "" {
+		downloadURL = fmt.Sprintf("%s/api/v1/plugins/%s/download?version=%s", baseURL, listing.PluginID, version)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return err
+	}
+	if source.Auth != "" {
+		req.Header.Set("Authorization", "Bearer "+source.Auth)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("download failed: %s", resp.Status)
+	}
+
+	pluginPath := filepath.Join(s.pluginDir, listing.PluginID)
+	tempPath := pluginPath + ".tmp"
+	if err := os.RemoveAll(tempPath); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(tempPath, 0755); err != nil {
+		return err
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if strings.Contains(contentType, "zip") || strings.HasSuffix(downloadURL, ".zip") {
+		if err := extractZip(resp.Body, tempPath); err != nil {
+			os.RemoveAll(tempPath)
+			return err
+		}
+	} else {
+		if err := extractTarGz(resp.Body, tempPath); err != nil {
+			os.RemoveAll(tempPath)
+			return err
+		}
+	}
+
+	if listing.SHA256 != "" {
+		checksum, err := computeDirChecksum(tempPath)
+		if err == nil && checksum != listing.SHA256 {
+			os.RemoveAll(tempPath)
+			return fmt.Errorf("checksum mismatch: expected %s, got %s", listing.SHA256, checksum)
+		}
+	}
+
+	if listing.Signature != "" && s.trustStore != nil {
+		if err := verifyPluginSignature(tempPath, listing.Signature); err != nil {
+			os.RemoveAll(tempPath)
+			return fmt.Errorf("signature verification failed: %w", err)
+		}
+	}
+
+	if err := os.RemoveAll(pluginPath); err != nil {
+		os.RemoveAll(tempPath)
+		return err
+	}
+	if err := os.Rename(tempPath, pluginPath); err != nil {
+		copyDirRecursive(tempPath, pluginPath)
+		os.RemoveAll(tempPath)
+	}
+
+	return nil
+}
+
+func (s *Store) verifyInstalledPlugin(pluginPath string) error {
+	manifest, err := s.loadManifest(pluginPath)
+	if err != nil {
+		return fmt.Errorf("invalid plugin: %w", err)
+	}
+	if manifest.Name == "" {
+		return fmt.Errorf("plugin manifest missing name")
+	}
+	return nil
+}
+
+func (s *Store) Update(ctx context.Context, id string) (*InstallResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	currentManifest, err := s.loadManifest(filepath.Join(s.pluginDir, id))
+	if err != nil {
+		return nil, fmt.Errorf("plugin not installed: %s", id)
+	}
+
+	var listing *PluginListing
+	var source PluginSource
+	for _, src := range s.sources {
+		l, err := s.getPluginFromSource(ctx, src, id)
+		if err == nil && l != nil {
+			listing = l
+			source = src
+			break
+		}
+	}
+
+	if listing == nil {
+		return nil, fmt.Errorf("plugin not found in any source: %s", id)
+	}
+
+	if compareVersions(listing.Version, currentManifest.Version) <= 0 {
+		return nil, fmt.Errorf("already at latest version: %s", currentManifest.Version)
+	}
+
+	backupPath := filepath.Join(s.pluginDir, id+".backup")
+	if err := copyDirRecursive(filepath.Join(s.pluginDir, id), backupPath); err != nil {
+		return nil, fmt.Errorf("backup: %w", err)
+	}
+
+	result, err := s.installWithoutLock(ctx, source, listing, listing.Version)
+	if err != nil {
+		os.RemoveAll(filepath.Join(s.pluginDir, id))
+		copyDirRecursive(backupPath, filepath.Join(s.pluginDir, id))
+		os.RemoveAll(backupPath)
+		return nil, fmt.Errorf("update failed, rolled back: %w", err)
+	}
+
+	os.RemoveAll(backupPath)
+	return result, nil
+}
+
+func (s *Store) installWithoutLock(ctx context.Context, source PluginSource, listing *PluginListing, version string) (*InstallResult, error) {
+	if err := s.downloadAndExtract(ctx, source, listing, version); err != nil {
+		return nil, err
+	}
+
+	pluginPath := filepath.Join(s.pluginDir, listing.PluginID)
+	if err := s.verifyInstalledPlugin(pluginPath); err != nil {
+		os.RemoveAll(pluginPath)
+		return nil, fmt.Errorf("verify: %w", err)
+	}
+
+	record := InstallRecord{
+		PluginID:    listing.PluginID,
+		Version:     version,
+		InstalledAt: time.Now().UTC(),
+		Source:      source.Name,
+		Checksum:    listing.SHA256,
+	}
+	s.installHistory = append(s.installHistory, record)
+	s.saveInstallHistory()
+
+	return &InstallResult{
+		PluginID: listing.PluginID,
+		Version:  version,
+		Path:     pluginPath,
+	}, nil
+}
+
+func (s *Store) Uninstall(id string) (*UninstallResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	pluginPath := filepath.Join(s.pluginDir, id)
+	if _, err := os.Stat(pluginPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("plugin not installed: %s", id)
+	}
+
+	manifest, err := s.loadManifest(pluginPath)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+
+	result := &UninstallResult{
+		PluginID: id,
+		Version:  manifest.Version,
+	}
+
+	history := s.loadInstallHistory()
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].PluginID == id {
+			if i > 0 {
+				prev := history[i-1]
+				result.Rollback = &prev.Version
+			}
+			break
+		}
+	}
+
+	if err := os.RemoveAll(pluginPath); err != nil {
+		return nil, fmt.Errorf("remove: %w", err)
+	}
+
+	return result, nil
+}
+
+type RollbackResult struct {
+	PluginID    string `json:"plugin_id"`
+	FromVersion string `json:"from_version"`
+	ToVersion   string `json:"to_version"`
+}
+
+func (s *Store) Rollback(ctx context.Context, id, targetVersion string) (*RollbackResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	pluginPath := filepath.Join(s.pluginDir, id)
+	currentManifest, err := s.loadManifest(pluginPath)
+	if err != nil {
+		return nil, fmt.Errorf("plugin not installed: %s", id)
+	}
+
+	history := s.loadInstallHistory()
+	var targetRecord *InstallRecord
+	var targetSource PluginSource
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].PluginID == id && history[i].Version == targetVersion {
+			targetRecord = &history[i]
+			for _, src := range s.sources {
+				if src.Name == history[i].Source {
+					targetSource = src
+					break
+				}
+			}
+			break
+		}
+	}
+
+	if targetRecord == nil {
+		return nil, fmt.Errorf("version %s not found in install history for plugin %s", targetVersion, id)
+	}
+
+	if targetVersion == currentManifest.Version {
+		return nil, fmt.Errorf("already at version %s", targetVersion)
+	}
+
+	backupPath := pluginPath + ".rollback-backup"
+	if err := copyDirRecursive(pluginPath, backupPath); err != nil {
+		return nil, fmt.Errorf("backup current version failed: %w", err)
+	}
+
+	if targetSource.URL != "" && targetRecord.Checksum != "" {
+		listing := &PluginListing{
+			PluginID: id,
+			Version:  targetVersion,
+			SHA256:   targetRecord.Checksum,
+		}
+		if err := s.downloadAndExtract(ctx, targetSource, listing, targetVersion); err != nil {
+			os.RemoveAll(pluginPath)
+			copyDirRecursive(backupPath, pluginPath)
+			os.RemoveAll(backupPath)
+			return nil, fmt.Errorf("rollback download failed: %w", err)
+		}
+	} else {
+		prevPath := filepath.Join(s.cacheDir, id, targetVersion)
+		if _, err := os.Stat(prevPath); err == nil {
+			os.RemoveAll(pluginPath)
+			if err := copyDirRecursive(prevPath, pluginPath); err != nil {
+				os.RemoveAll(pluginPath)
+				copyDirRecursive(backupPath, pluginPath)
+				os.RemoveAll(backupPath)
+				return nil, fmt.Errorf("restore from cache failed: %w", err)
+			}
+		} else {
+			os.RemoveAll(pluginPath)
+			copyDirRecursive(backupPath, pluginPath)
+			os.RemoveAll(backupPath)
+			return nil, fmt.Errorf("version %s not available offline, re-download source not configured", targetVersion)
+		}
+	}
+
+	os.RemoveAll(backupPath)
+
+	record := InstallRecord{
+		PluginID:    id,
+		Version:     targetVersion,
+		InstalledAt: time.Now().UTC(),
+		Source:      targetSource.Name,
+		Checksum:    targetRecord.Checksum,
+	}
+	s.installHistory = append(s.installHistory, record)
+	s.saveInstallHistory()
+
+	return &RollbackResult{
+		PluginID:    id,
+		FromVersion: currentManifest.Version,
+		ToVersion:   targetVersion,
+	}, nil
+}
+
+func (s *Store) GetInstallHistory(id string) []InstallRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	history := s.loadInstallHistory()
+	var filtered []InstallRecord
+	for _, r := range history {
+		if r.PluginID == id {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}
+
+func (s *Store) ListInstalled() []InstallRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]InstallRecord(nil), s.installHistory...)
+}
+
+func (s *Store) loadManifest(pluginDir string) (*Manifest, error) {
+	candidates := []string{
+		"openclaw.plugin.json",
+		"plugin.json",
+		"anyclaw.plugin.json",
+	}
+	for _, name := range candidates {
+		path := filepath.Join(pluginDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var m Manifest
+		if err := json.Unmarshal(data, &m); err != nil {
+			continue
+		}
+		return &m, nil
+	}
+	return nil, fmt.Errorf("no manifest found")
+}
+
+func (s *Store) loadInstallHistory() []InstallRecord {
+	path := filepath.Join(s.marketDir, "install_history.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var records []InstallRecord
+	json.Unmarshal(data, &records)
+	return records
+}
+
+func (s *Store) saveInstallHistory() {
+	path := filepath.Join(s.marketDir, "install_history.json")
+	os.MkdirAll(filepath.Dir(path), 0755)
+	data, _ := json.MarshalIndent(s.installHistory, "", "  ")
+	os.WriteFile(path, data, 0644)
+}
+
+func extractZip(body io.Reader, dest string) error {
+	tempFile, err := os.CreateTemp("", "plugin-*.zip")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tempFile.Name())
+	defer tempFile.Close()
+
+	if _, err := io.Copy(tempFile, body); err != nil {
+		return err
+	}
+	tempFile.Close()
+
+	r, err := zip.OpenReader(tempFile.Name())
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		path := filepath.Join(dest, f.Name)
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(path, 0755)
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return err
+		}
+		dst, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			return err
+		}
+		src, err := f.Open()
+		if err != nil {
+			dst.Close()
+			return err
+		}
+		io.Copy(dst, src)
+		dst.Close()
+		src.Close()
+	}
+	return nil
+}
+
+func extractTarGz(body io.Reader, dest string) error {
+	gzr, err := gzip.NewReader(body)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		path := filepath.Join(dest, header.Name)
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(path, 0755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+			if err != nil {
+				return err
+			}
+			io.Copy(f, tr)
+			f.Close()
+		}
+	}
+	return nil
+}
+
+func copyDirRecursive(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+		if entry.IsDir() {
+			if err := copyDirRecursive(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			data, err := os.ReadFile(srcPath)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(dstPath, data, 0644); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func computeDirChecksum(dir string) (string, error) {
+	var files []string
+	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(dir, path)
+		files = append(files, rel)
+		return nil
+	})
+	sort.Strings(files)
+
+	hash := ""
+	for _, f := range files {
+		data, err := os.ReadFile(filepath.Join(dir, f))
+		if err != nil {
+			continue
+		}
+		h := sha256.Sum256(data)
+		hash += fmt.Sprintf("%s:%x\n", f, h)
+	}
+	h := sha256.Sum256([]byte(hash))
+	return fmt.Sprintf("%x", h), nil
+}
+
+func verifyPluginSignature(pluginDir, signature string) error {
+	manifestPath := filepath.Join(pluginDir, "plugin.json")
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		manifestPath = filepath.Join(pluginDir, "openclaw.plugin.json")
+		manifestData, err = os.ReadFile(manifestPath)
+		if err != nil {
+			return fmt.Errorf("no manifest: %w", err)
+		}
+	}
+
+	var sig Signature
+	if err := json.Unmarshal([]byte(signature), &sig); err != nil {
+		return fmt.Errorf("invalid signature: %w", err)
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(manifestData, &m); err != nil {
+		return fmt.Errorf("invalid manifest: %w", err)
+	}
+
+	ok, err := VerifySignature(&m, &sig, "")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("signature verification failed")
+	}
+	return nil
+}
+
+func deduplicateListings(listings []PluginListing) []PluginListing {
+	seen := make(map[string]int)
+	var result []PluginListing
+	for i, l := range listings {
+		if idx, ok := seen[l.PluginID]; ok {
+			if l.Downloads > result[idx].Downloads {
+				result[idx] = l
+			}
+			continue
+		}
+		seen[l.PluginID] = len(result)
+		result = append(result, listings[i])
+	}
+	return result
+}
+
+func compareVersions(a, b string) int {
+	va, errA := ParseVersion(a)
+	vb, errB := ParseVersion(b)
+	if errA != nil || errB != nil {
+		if a == b {
+			return 0
+		}
+		if a > b {
+			return 1
+		}
+		return -1
+	}
+	return va.Compare(vb)
+}

--- a/pkg/extensions/plugin/types.go
+++ b/pkg/extensions/plugin/types.go
@@ -1,0 +1,144 @@
+package plugin
+
+type PluginType string
+
+const (
+	PluginTypeTool          PluginType = "tool"
+	PluginTypeChannel       PluginType = "channel"
+	PluginTypeSkill         PluginType = "skill"
+	PluginTypeModelProvider PluginType = "model-provider"
+	PluginTypeSpeech        PluginType = "speech"
+	PluginTypeMCP           PluginType = "mcp"
+	PluginTypeContextEngine PluginType = "context-engine"
+	PluginTypeNode          PluginType = "node"
+	PluginTypeSurface       PluginType = "surface"
+	PluginTypeIngress       PluginType = "ingress"
+	PluginTypeWorkflowPack  PluginType = "workflow-pack"
+)
+
+type PluginSpec interface {
+	GetName() string
+	GetType() PluginType
+}
+
+type ModelProviderSpec struct {
+	Name         string   `json:"name"`
+	Provider     string   `json:"provider"`
+	BaseURL      string   `json:"base_url,omitempty"`
+	APIKeyEnv    string   `json:"api_key_env,omitempty"`
+	Models       []string `json:"models"`
+	Capabilities []string `json:"capabilities"`
+}
+
+func (s *ModelProviderSpec) GetName() string     { return s.Name }
+func (s *ModelProviderSpec) GetType() PluginType { return PluginTypeModelProvider }
+
+type SpeechSpec struct {
+	Name       string `json:"name"`
+	Provider   string `json:"provider"`
+	STTEnabled bool   `json:"stt_enabled"`
+	TTSEnabled bool   `json:"tts_enabled"`
+	Language   string `json:"language,omitempty"`
+	Voice      string `json:"voice,omitempty"`
+	SampleRate int    `json:"sample_rate,omitempty"`
+	APIKeyEnv  string `json:"api_key_env,omitempty"`
+	BaseURL    string `json:"base_url,omitempty"`
+}
+
+func (s *SpeechSpec) GetName() string     { return s.Name }
+func (s *SpeechSpec) GetType() PluginType { return PluginTypeSpeech }
+
+type MCPSpec struct {
+	Name         string            `json:"name"`
+	Command      string            `json:"command"`
+	Args         []string          `json:"args,omitempty"`
+	Env          map[string]string `json:"env,omitempty"`
+	Transport    string            `json:"transport"`
+	Capabilities []string          `json:"capabilities"`
+}
+
+func (s *MCPSpec) GetName() string     { return s.Name }
+func (s *MCPSpec) GetType() PluginType { return PluginTypeMCP }
+
+type ContextEngineSpec struct {
+	Name        string             `json:"name"`
+	Provider    string             `json:"provider"`
+	Type        string             `json:"type"`
+	Config      map[string]any     `json:"config,omitempty"`
+	VectorStore *VectorStoreConfig `json:"vector_store,omitempty"`
+}
+
+type VectorStoreConfig struct {
+	Provider  string `json:"provider"`
+	Dimension int    `json:"dimension"`
+	IndexType string `json:"index_type"`
+	Endpoint  string `json:"endpoint,omitempty"`
+	APIKeyEnv string `json:"api_key_env,omitempty"`
+}
+
+func (s *ContextEngineSpec) GetName() string     { return s.Name }
+func (s *ContextEngineSpec) GetType() PluginType { return PluginTypeContextEngine }
+
+func (m *Manifest) SupportsType(t PluginType) bool {
+	for _, k := range m.Kinds {
+		if string(t) == k {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manifest) GetSpec() PluginSpec {
+	if m.Tool != nil {
+		return m.Tool
+	}
+	if m.Channel != nil {
+		return m.Channel
+	}
+	if m.ModelProvider != nil {
+		return m.ModelProvider
+	}
+	if m.Speech != nil {
+		return m.Speech
+	}
+	if m.MCP != nil {
+		return m.MCP
+	}
+	if m.ContextEngine != nil {
+		return m.ContextEngine
+	}
+	if m.Node != nil {
+		return m.Node
+	}
+	if m.Surface != nil {
+		return m.Surface
+	}
+	if m.Ingress != nil {
+		return m.Ingress
+	}
+	return nil
+}
+
+func (m *Manifest) HasCapability(cap string) bool {
+	for _, tag := range m.CapabilityTags {
+		if tag == cap {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *ToolSpec) GetName() string     { return s.Name }
+func (s *ToolSpec) GetType() PluginType { return PluginTypeTool }
+
+func (s *IngressSpec) GetName() string     { return s.Name }
+func (s *IngressSpec) GetType() PluginType { return PluginTypeIngress }
+
+func (s *ChannelSpec) GetName() string     { return s.Name }
+func (s *ChannelSpec) GetType() PluginType { return PluginTypeChannel }
+
+func (s *NodeSpec) GetName() string     { return s.Name }
+func (s *NodeSpec) GetType() PluginType { return PluginTypeNode }
+
+func (s *SurfaceSpec) GetName() string     { return s.Name }
+func (s *SurfaceSpec) GetType() PluginType { return PluginTypeSurface }


### PR DESCRIPTION
## Summary
- Add webhook adapter and plugin runtime support extracted from gateway-module-wiring.
- Split out from the larger gateway-module-wiring work (the previous large gateway wiring PR).

## Merge Order
System.Object[]

## Notes
- This PR is intentionally folder-scoped to make the remaining gateway wiring upload reviewable.
- Recommended base branch for merge order is the dependency list above, even though this PR targets `main`.