### PR TITLE
feat(isolation): add runtime isolation manager

### DIFF
--- a/pkg/isolation/isolated_engine.go
+++ b/pkg/isolation/isolated_engine.go
@@ -1,0 +1,297 @@
+package isolation
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	ctxpkg "github.com/1024XEngineer/anyclaw/pkg/runtime/context/store"
+)
+
+type IsolatedEngine struct {
+	mu         sync.RWMutex
+	scope      *ContextScope
+	boundary   *ContextBoundary
+	documents  map[string]*ctxpkg.Document
+	config     IsolationConfig
+	visibility ContextVisibility
+	closed     bool
+}
+
+func NewIsolatedEngine(scope *ContextScope, boundary *ContextBoundary, config IsolationConfig) *IsolatedEngine {
+	return &IsolatedEngine{
+		scope:      scope,
+		boundary:   boundary,
+		documents:  make(map[string]*ctxpkg.Document),
+		config:     config,
+		visibility: boundary.Visibility,
+	}
+}
+
+func (e *IsolatedEngine) Name() string {
+	return fmt.Sprintf("isolated-%s", e.scope.ID())
+}
+
+func (e *IsolatedEngine) Type() string {
+	return "isolated"
+}
+
+func (e *IsolatedEngine) Initialize(config map[string]any) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if v, ok := config["vector_size"].(float64); ok {
+		_ = int(v)
+	}
+	return nil
+}
+
+func (e *IsolatedEngine) AddDocument(ctx context.Context, doc ctxpkg.Document) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.closed {
+		return fmt.Errorf("engine is closed")
+	}
+
+	if len(e.documents) >= e.config.MaxContextSize {
+		return fmt.Errorf("context size limit reached: %d", e.config.MaxContextSize)
+	}
+
+	if doc.Metadata == nil {
+		doc.Metadata = make(map[string]any)
+	}
+	doc.Metadata["agent_id"] = e.scope.AgentID
+	doc.Metadata["session_id"] = e.scope.SessionID
+	doc.Metadata["task_id"] = e.scope.TaskID
+	doc.Metadata["namespace"] = e.scope.Namespace
+	doc.Metadata["scope_id"] = e.scope.ID()
+
+	now := time.Now()
+	doc.CreatedAt = now
+	doc.UpdatedAt = now
+
+	e.documents[doc.ID] = &doc
+	return nil
+}
+
+func (e *IsolatedEngine) Search(ctx context.Context, query string, options ctxpkg.SearchOptions) ([]ctxpkg.SearchResult, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	if e.closed {
+		return nil, fmt.Errorf("engine is closed")
+	}
+
+	var results []ctxpkg.SearchResult
+
+	for _, doc := range e.documents {
+		if len(options.Filters) > 0 {
+			if !matchesFilters(doc, options.Filters) {
+				continue
+			}
+		}
+
+		score := calculateSimilarity(query, doc.Content)
+		if score >= options.Threshold {
+			results = append(results, ctxpkg.SearchResult{
+				Document: doc,
+				Score:    score,
+			})
+		}
+	}
+
+	for i := 0; i < len(results)-1; i++ {
+		for j := i + 1; j < len(results); j++ {
+			if results[j].Score > results[i].Score {
+				results[i], results[j] = results[j], results[i]
+			}
+		}
+	}
+
+	if len(results) > options.TopK {
+		results = results[:options.TopK]
+	}
+
+	return results, nil
+}
+
+func (e *IsolatedEngine) GetDocument(ctx context.Context, id string) (*ctxpkg.Document, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	if e.closed {
+		return nil, fmt.Errorf("engine is closed")
+	}
+
+	doc, ok := e.documents[id]
+	if !ok {
+		return nil, fmt.Errorf("document not found: %s", id)
+	}
+	return doc, nil
+}
+
+func (e *IsolatedEngine) DeleteDocument(ctx context.Context, id string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.closed {
+		return fmt.Errorf("engine is closed")
+	}
+
+	if _, ok := e.documents[id]; !ok {
+		return fmt.Errorf("document not found: %s", id)
+	}
+	delete(e.documents, id)
+	return nil
+}
+
+func (e *IsolatedEngine) Close() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.closed = true
+	e.documents = make(map[string]*ctxpkg.Document)
+	return nil
+}
+
+func (e *IsolatedEngine) Scope() *ContextScope {
+	return e.scope
+}
+
+func (e *IsolatedEngine) Boundary() *ContextBoundary {
+	return e.boundary
+}
+
+func (e *IsolatedEngine) SetVisibility(visibility ContextVisibility) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.visibility = visibility
+	e.boundary.Visibility = visibility
+}
+
+func (e *IsolatedEngine) Visibility() ContextVisibility {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.visibility
+}
+
+func (e *IsolatedEngine) Clone() IsolatedContextEngine {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	newScope := &ContextScope{
+		AgentID:   e.scope.AgentID,
+		SessionID: e.scope.SessionID,
+		TaskID:    e.scope.TaskID,
+		Namespace: e.scope.Namespace,
+		Labels:    make(map[string]string),
+		CreatedAt: time.Now(),
+	}
+	for k, v := range e.scope.Labels {
+		newScope.Labels[k] = v
+	}
+
+	newBoundary := &ContextBoundary{
+		Scope:      newScope,
+		Mode:       e.boundary.Mode,
+		Visibility: e.visibility,
+		Parent:     e.boundary,
+		Children:   make([]*ContextBoundary, 0),
+	}
+
+	cloned := NewIsolatedEngine(newScope, newBoundary, e.config)
+	cloned.visibility = e.visibility
+
+	for id, doc := range e.documents {
+		clonedDoc := *doc
+		clonedDoc.Metadata = make(map[string]any)
+		for k, v := range doc.Metadata {
+			clonedDoc.Metadata[k] = v
+		}
+		cloned.documents[id] = &clonedDoc
+	}
+
+	return cloned
+}
+
+func (e *IsolatedEngine) SnapshotDocuments() []ctxpkg.Document {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	docs := make([]ctxpkg.Document, 0, len(e.documents))
+	for _, doc := range e.documents {
+		docs = append(docs, *doc)
+	}
+	return docs
+}
+
+func (e *IsolatedEngine) DocumentCount() int {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return len(e.documents)
+}
+
+func (e *IsolatedEngine) GetDocumentsByNamespace(namespace string) []ctxpkg.Document {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	var docs []ctxpkg.Document
+	for _, doc := range e.documents {
+		if ns, ok := doc.Metadata["namespace"].(string); ok && ns == namespace {
+			docs = append(docs, *doc)
+		}
+	}
+	return docs
+}
+
+func matchesFilters(doc *ctxpkg.Document, filters map[string]any) bool {
+	for key, value := range filters {
+		docValue, ok := doc.Metadata[key]
+		if !ok {
+			return false
+		}
+		if docValue != value {
+			return false
+		}
+	}
+	return true
+}
+
+func calculateSimilarity(query, content string) float64 {
+	queryWords := wordSet(query)
+	contentWords := wordSet(content)
+
+	if len(contentWords) == 0 {
+		return 0
+	}
+
+	overlap := 0
+	for word := range queryWords {
+		if contentWords[word] {
+			overlap++
+		}
+	}
+
+	return float64(overlap) / float64(len(contentWords))
+}
+
+func wordSet(s string) map[string]bool {
+	words := make(map[string]bool)
+	current := []rune{}
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			current = append(current, r)
+		} else {
+			if len(current) > 0 {
+				words[string(current)] = true
+				current = nil
+			}
+		}
+	}
+	if len(current) > 0 {
+		words[string(current)] = true
+	}
+	return words
+}

--- a/pkg/isolation/isolated_engine.go
+++ b/pkg/isolation/isolated_engine.go
@@ -59,20 +59,21 @@ func (e *IsolatedEngine) AddDocument(ctx context.Context, doc ctxpkg.Document) e
 		return fmt.Errorf("context size limit reached: %d", e.config.MaxContextSize)
 	}
 
-	if doc.Metadata == nil {
-		doc.Metadata = make(map[string]any)
+	storedDoc := cloneIsolatedDocument(&doc)
+	if storedDoc.Metadata == nil {
+		storedDoc.Metadata = make(map[string]any)
 	}
-	doc.Metadata["agent_id"] = e.scope.AgentID
-	doc.Metadata["session_id"] = e.scope.SessionID
-	doc.Metadata["task_id"] = e.scope.TaskID
-	doc.Metadata["namespace"] = e.scope.Namespace
-	doc.Metadata["scope_id"] = e.scope.ID()
+	storedDoc.Metadata["agent_id"] = e.scope.AgentID
+	storedDoc.Metadata["session_id"] = e.scope.SessionID
+	storedDoc.Metadata["task_id"] = e.scope.TaskID
+	storedDoc.Metadata["namespace"] = e.scope.Namespace
+	storedDoc.Metadata["scope_id"] = e.scope.ID()
 
 	now := time.Now()
-	doc.CreatedAt = now
-	doc.UpdatedAt = now
+	storedDoc.CreatedAt = now
+	storedDoc.UpdatedAt = now
 
-	e.documents[doc.ID] = &doc
+	e.documents[storedDoc.ID] = storedDoc
 	return nil
 }
 
@@ -96,7 +97,7 @@ func (e *IsolatedEngine) Search(ctx context.Context, query string, options ctxpk
 		score := calculateSimilarity(query, doc.Content)
 		if score >= options.Threshold {
 			results = append(results, ctxpkg.SearchResult{
-				Document: doc,
+				Document: cloneIsolatedDocument(doc),
 				Score:    score,
 			})
 		}
@@ -110,7 +111,7 @@ func (e *IsolatedEngine) Search(ctx context.Context, query string, options ctxpk
 		}
 	}
 
-	if len(results) > options.TopK {
+	if options.TopK > 0 && len(results) > options.TopK {
 		results = results[:options.TopK]
 	}
 
@@ -129,7 +130,7 @@ func (e *IsolatedEngine) GetDocument(ctx context.Context, id string) (*ctxpkg.Do
 	if !ok {
 		return nil, fmt.Errorf("document not found: %s", id)
 	}
-	return doc, nil
+	return cloneIsolatedDocument(doc), nil
 }
 
 func (e *IsolatedEngine) DeleteDocument(ctx context.Context, id string) error {
@@ -205,12 +206,7 @@ func (e *IsolatedEngine) Clone() IsolatedContextEngine {
 	cloned.visibility = e.visibility
 
 	for id, doc := range e.documents {
-		clonedDoc := *doc
-		clonedDoc.Metadata = make(map[string]any)
-		for k, v := range doc.Metadata {
-			clonedDoc.Metadata[k] = v
-		}
-		cloned.documents[id] = &clonedDoc
+		cloned.documents[id] = cloneIsolatedDocument(doc)
 	}
 
 	return cloned
@@ -222,7 +218,7 @@ func (e *IsolatedEngine) SnapshotDocuments() []ctxpkg.Document {
 
 	docs := make([]ctxpkg.Document, 0, len(e.documents))
 	for _, doc := range e.documents {
-		docs = append(docs, *doc)
+		docs = append(docs, *cloneIsolatedDocument(doc))
 	}
 	return docs
 }
@@ -240,10 +236,28 @@ func (e *IsolatedEngine) GetDocumentsByNamespace(namespace string) []ctxpkg.Docu
 	var docs []ctxpkg.Document
 	for _, doc := range e.documents {
 		if ns, ok := doc.Metadata["namespace"].(string); ok && ns == namespace {
-			docs = append(docs, *doc)
+			docs = append(docs, *cloneIsolatedDocument(doc))
 		}
 	}
 	return docs
+}
+
+func cloneIsolatedDocument(doc *ctxpkg.Document) *ctxpkg.Document {
+	if doc == nil {
+		return nil
+	}
+
+	cloned := *doc
+	if doc.Metadata != nil {
+		cloned.Metadata = make(map[string]any, len(doc.Metadata))
+		for key, value := range doc.Metadata {
+			cloned.Metadata[key] = value
+		}
+	}
+	if doc.Vector != nil {
+		cloned.Vector = append([]float64(nil), doc.Vector...)
+	}
+	return &cloned
 }
 
 func matchesFilters(doc *ctxpkg.Document, filters map[string]any) bool {

--- a/pkg/isolation/manager.go
+++ b/pkg/isolation/manager.go
@@ -1,0 +1,588 @@
+package isolation
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	ctxpkg "github.com/1024XEngineer/anyclaw/pkg/runtime/context/store"
+	ctxengine "github.com/1024XEngineer/anyclaw/pkg/runtime/context/window"
+)
+
+var snapshotCounter uint64
+
+type ContextIsolationManager struct {
+	mu            sync.RWMutex
+	boundaries    map[string]*ContextBoundary
+	engines       map[string]*IsolatedEngine
+	policies      []*SharedContextPolicy
+	snapshots     map[string]*ContextSnapshot
+	config        IsolationConfig
+	kvEngines     map[string]*ctxengine.Engine
+	globalKV      *ctxengine.Engine
+	cleanupTicker *time.Ticker
+	stopCh        chan struct{}
+}
+
+func NewContextIsolationManager(config IsolationConfig) *ContextIsolationManager {
+	mgr := &ContextIsolationManager{
+		boundaries: make(map[string]*ContextBoundary),
+		engines:    make(map[string]*IsolatedEngine),
+		policies:   make([]*SharedContextPolicy, 0),
+		snapshots:  make(map[string]*ContextSnapshot),
+		config:     config,
+		kvEngines:  make(map[string]*ctxengine.Engine),
+		globalKV: ctxengine.New(ctxengine.ContextConfig{
+			MaxAge:          config.DefaultTTL,
+			MaxSize:         config.MaxContextSize,
+			AutoExpire:      true,
+			CleanupInterval: config.CleanupInterval,
+		}),
+		stopCh: make(chan struct{}),
+	}
+
+	if config.CleanupInterval > 0 {
+		mgr.startCleanup()
+	}
+
+	return mgr
+}
+
+func (m *ContextIsolationManager) CreateBoundary(scope *ContextScope, mode IsolationMode, visibility ContextVisibility) (*ContextBoundary, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if scope == nil {
+		return nil, fmt.Errorf("scope cannot be nil")
+	}
+
+	scopeID := scope.ID()
+	if scopeID == "" {
+		return nil, fmt.Errorf("scope must have at least one of AgentID, SessionID, or TaskID")
+	}
+
+	if _, exists := m.boundaries[scopeID]; exists {
+		return nil, fmt.Errorf("boundary already exists for scope: %s", scopeID)
+	}
+
+	if mode == "" {
+		mode = m.config.DefaultMode
+	}
+	if visibility == "" {
+		visibility = m.config.DefaultVisibility
+	}
+
+	if scope.CreatedAt.IsZero() {
+		scope.CreatedAt = time.Now()
+	}
+	if !scope.ExpiresAt.IsZero() && scope.ExpiresAt.Before(time.Now()) {
+		return nil, fmt.Errorf("scope expiration must be in the future")
+	}
+
+	boundary := &ContextBoundary{
+		Scope:      scope,
+		Mode:       mode,
+		Visibility: visibility,
+		Children:   make([]*ContextBoundary, 0),
+	}
+
+	m.boundaries[scopeID] = boundary
+
+	engine := NewIsolatedEngine(scope, boundary, m.config)
+	m.engines[scopeID] = engine
+
+	if m.config.EnableSharing {
+		m.kvEngines[scopeID] = ctxengine.New(ctxengine.ContextConfig{
+			MaxAge:          m.config.DefaultTTL,
+			MaxSize:         m.config.MaxContextSize,
+			AutoExpire:      true,
+			CleanupInterval: m.config.CleanupInterval,
+		})
+	}
+
+	return boundary, nil
+}
+
+func (m *ContextIsolationManager) GetBoundary(scopeID string) (*ContextBoundary, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	boundary, ok := m.boundaries[scopeID]
+	return boundary, ok
+}
+
+func (m *ContextIsolationManager) GetEngine(scopeID string) (*IsolatedEngine, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	engine, ok := m.engines[scopeID]
+	return engine, ok
+}
+
+func (m *ContextIsolationManager) GetKVEngine(scopeID string) (*ctxengine.Engine, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	engine, ok := m.kvEngines[scopeID]
+	return engine, ok
+}
+
+func (m *ContextIsolationManager) GetGlobalKVEngine() *ctxengine.Engine {
+	return m.globalKV
+}
+
+func (m *ContextIsolationManager) CreateChildBoundary(parentScopeID string, childScope *ContextScope, mode IsolationMode, visibility ContextVisibility) (*ContextBoundary, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	parent, exists := m.boundaries[parentScopeID]
+	if !exists {
+		return nil, fmt.Errorf("parent boundary not found: %s", parentScopeID)
+	}
+
+	childScopeID := childScope.ID()
+	if childScopeID == "" {
+		return nil, fmt.Errorf("child scope must have at least one of AgentID, SessionID, or TaskID")
+	}
+
+	if _, exists := m.boundaries[childScopeID]; exists {
+		return nil, fmt.Errorf("boundary already exists for scope: %s", childScopeID)
+	}
+
+	if mode == "" {
+		mode = m.config.DefaultMode
+	}
+	if visibility == "" {
+		visibility = m.config.DefaultVisibility
+	}
+
+	if childScope.CreatedAt.IsZero() {
+		childScope.CreatedAt = time.Now()
+	}
+
+	childBoundary := &ContextBoundary{
+		Scope:      childScope,
+		Mode:       mode,
+		Visibility: visibility,
+		Parent:     parent,
+		Children:   make([]*ContextBoundary, 0),
+	}
+
+	m.boundaries[childScopeID] = childBoundary
+	parent.Children = append(parent.Children, childBoundary)
+
+	engine := NewIsolatedEngine(childScope, childBoundary, m.config)
+	m.engines[childScopeID] = engine
+
+	if m.config.EnableSharing {
+		m.kvEngines[childScopeID] = ctxengine.New(ctxengine.ContextConfig{
+			MaxAge:          m.config.DefaultTTL,
+			MaxSize:         m.config.MaxContextSize,
+			AutoExpire:      true,
+			CleanupInterval: m.config.CleanupInterval,
+		})
+	}
+
+	return childBoundary, nil
+}
+
+func (m *ContextIsolationManager) AddSharingPolicy(policy *SharedContextPolicy) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if policy.SourceAgentID == "" {
+		return fmt.Errorf("source agent ID cannot be empty")
+	}
+	if len(policy.TargetAgentIDs) == 0 {
+		return fmt.Errorf("at least one target agent ID is required")
+	}
+
+	if policy.ExpiresAt.IsZero() {
+		policy.ExpiresAt = time.Now().Add(m.config.DefaultTTL)
+	}
+
+	m.policies = append(m.policies, policy)
+	return nil
+}
+
+func (m *ContextIsolationManager) RemoveSharingPolicy(sourceAgentID string, targetAgentID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for i, policy := range m.policies {
+		if policy.SourceAgentID == sourceAgentID {
+			for j, target := range policy.TargetAgentIDs {
+				if target == targetAgentID {
+					policy.TargetAgentIDs = append(policy.TargetAgentIDs[:j], policy.TargetAgentIDs[j+1:]...)
+					if len(policy.TargetAgentIDs) == 0 {
+						m.policies = append(m.policies[:i], m.policies[i+1:]...)
+					}
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (m *ContextIsolationManager) ListSharingPolicies() []*SharedContextPolicy {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]*SharedContextPolicy, len(m.policies))
+	copy(result, m.policies)
+	return result
+}
+
+func (m *ContextIsolationManager) CanShareContext(sourceAgentID, targetAgentID, namespace string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	now := time.Now()
+	for _, policy := range m.policies {
+		if policy.ExpiresAt.Before(now) {
+			continue
+		}
+		if policy.SourceAgentID != sourceAgentID {
+			continue
+		}
+
+		targetMatch := false
+		for _, target := range policy.TargetAgentIDs {
+			if target == targetAgentID {
+				targetMatch = true
+				break
+			}
+		}
+		if !targetMatch {
+			continue
+		}
+
+		if policy.Namespace != "" && policy.Namespace != namespace {
+			continue
+		}
+
+		return true
+	}
+	return false
+}
+
+func (m *ContextIsolationManager) CreateSnapshot(agentID, sessionID, description string) (*ContextSnapshot, error) {
+	if !m.config.EnableSnapshots {
+		return nil, fmt.Errorf("snapshots are disabled")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(m.snapshots) >= m.config.MaxSnapshots {
+		oldestID := ""
+		oldestTime := time.Now()
+		for id, snap := range m.snapshots {
+			if snap.TakenAt.Before(oldestTime) {
+				oldestTime = snap.TakenAt
+				oldestID = id
+			}
+		}
+		if oldestID != "" {
+			delete(m.snapshots, oldestID)
+		}
+	}
+
+	snapshotCounter++
+	snapshotID := fmt.Sprintf("snap_%s_%d_%d", agentID, time.Now().UnixNano(), snapshotCounter)
+
+	var docs []ctxpkg.Document
+	var kvs map[string]any
+
+	for scopeID, engine := range m.engines {
+		boundary, ok := m.boundaries[scopeID]
+		if !ok {
+			continue
+		}
+		if boundary.Scope.AgentID == agentID && (sessionID == "" || boundary.Scope.SessionID == sessionID) {
+			docs = engine.SnapshotDocuments()
+			break
+		}
+	}
+	for scopeID, kvEngine := range m.kvEngines {
+		boundary, ok := m.boundaries[scopeID]
+		if !ok {
+			continue
+		}
+		if boundary.Scope.AgentID == agentID && (sessionID == "" || boundary.Scope.SessionID == sessionID) {
+			kvs = make(map[string]any)
+			for _, ctx := range kvEngine.List() {
+				kvs[ctx.Key] = ctx.Value
+			}
+			break
+		}
+	}
+
+	snapshot := &ContextSnapshot{
+		ID:          snapshotID,
+		AgentID:     agentID,
+		SessionID:   sessionID,
+		Documents:   docs,
+		KeyValues:   kvs,
+		TakenAt:     time.Now(),
+		Description: description,
+	}
+
+	m.snapshots[snapshotID] = snapshot
+	return snapshot, nil
+}
+
+func (m *ContextIsolationManager) GetSnapshot(snapshotID string) (*ContextSnapshot, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	snapshot, ok := m.snapshots[snapshotID]
+	return snapshot, ok
+}
+
+func (m *ContextIsolationManager) ListSnapshots(agentID string) []*ContextSnapshot {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var result []*ContextSnapshot
+	for _, snap := range m.snapshots {
+		if agentID == "" || snap.AgentID == agentID {
+			result = append(result, snap)
+		}
+	}
+	return result
+}
+
+func (m *ContextIsolationManager) DeleteBoundary(scopeID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	boundary, exists := m.boundaries[scopeID]
+	if !exists {
+		return fmt.Errorf("boundary not found: %s", scopeID)
+	}
+
+	if len(boundary.Children) > 0 {
+		for _, child := range boundary.Children {
+			childID := child.Scope.ID()
+			delete(m.boundaries, childID)
+			delete(m.engines, childID)
+			delete(m.kvEngines, childID)
+		}
+	}
+
+	if boundary.Parent != nil {
+		parent := boundary.Parent
+		for i, child := range parent.Children {
+			if child.Scope.ID() == scopeID {
+				parent.Children = append(parent.Children[:i], parent.Children[i+1:]...)
+				break
+			}
+		}
+	}
+
+	delete(m.boundaries, scopeID)
+
+	if engine, ok := m.engines[scopeID]; ok {
+		engine.Close()
+		delete(m.engines, scopeID)
+	}
+	delete(m.kvEngines, scopeID)
+
+	return nil
+}
+
+func (m *ContextIsolationManager) ListBoundaries() []*ContextBoundary {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]*ContextBoundary, 0, len(m.boundaries))
+	for _, boundary := range m.boundaries {
+		result = append(result, boundary)
+	}
+	return result
+}
+
+func (m *ContextIsolationManager) ListEngines() map[string]*IsolatedEngine {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make(map[string]*IsolatedEngine, len(m.engines))
+	for k, v := range m.engines {
+		result[k] = v
+	}
+	return result
+}
+
+func (m *ContextIsolationManager) SharedSearch(scopeID string, query string, namespace string) ([]SharedSearchResult, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	boundary, exists := m.boundaries[scopeID]
+	if !exists {
+		return nil, fmt.Errorf("boundary not found: %s", scopeID)
+	}
+
+	targetAgentID := boundary.Scope.AgentID
+
+	var results []SharedSearchResult
+
+	if boundary.Mode == IsolationModeShared || boundary.Mode == IsolationModeHybrid {
+		for sourceScopeID, kvEngine := range m.kvEngines {
+			if sourceScopeID == scopeID {
+				continue
+			}
+
+			sourceBoundary, exists := m.boundaries[sourceScopeID]
+			if !exists {
+				continue
+			}
+
+			sourceAgentID := sourceBoundary.Scope.AgentID
+
+			if !m.canShareContextLocked(sourceAgentID, targetAgentID, namespace) {
+				continue
+			}
+
+			if sourceBoundary.Visibility == ContextVisibilityPrivate {
+				continue
+			}
+
+			for _, ctx := range kvEngine.List() {
+				if namespace != "" && ctx.Metadata["namespace"] != namespace {
+					continue
+				}
+				results = append(results, SharedSearchResult{
+					SourceScopeID: sourceScopeID,
+					Key:           ctx.Key,
+					Value:         ctx.Value,
+					Metadata:      ctx.Metadata,
+				})
+			}
+		}
+	}
+
+	return results, nil
+}
+
+func (m *ContextIsolationManager) canShareContextLocked(sourceID, targetID, namespace string) bool {
+	now := time.Now()
+	for _, policy := range m.policies {
+		if policy.ExpiresAt.Before(now) {
+			continue
+		}
+		if policy.SourceAgentID != sourceID {
+			continue
+		}
+
+		targetMatch := false
+		for _, target := range policy.TargetAgentIDs {
+			if target == targetID {
+				targetMatch = true
+				break
+			}
+		}
+		if !targetMatch {
+			continue
+		}
+
+		if policy.Namespace != "" && policy.Namespace != namespace {
+			continue
+		}
+
+		return true
+	}
+	return false
+}
+
+func (m *ContextIsolationManager) startCleanup() {
+	m.cleanupTicker = time.NewTicker(m.config.CleanupInterval)
+	go func() {
+		for {
+			select {
+			case <-m.cleanupTicker.C:
+				m.cleanup()
+			case <-m.stopCh:
+				return
+			}
+		}
+	}()
+}
+
+func (m *ContextIsolationManager) cleanup() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	expired := make([]string, 0)
+
+	for scopeID, boundary := range m.boundaries {
+		if !boundary.Scope.ExpiresAt.IsZero() && boundary.Scope.ExpiresAt.Before(now) {
+			expired = append(expired, scopeID)
+		}
+	}
+
+	for _, scopeID := range expired {
+		boundary := m.boundaries[scopeID]
+		if len(boundary.Children) > 0 {
+			for _, child := range boundary.Children {
+				childID := child.Scope.ID()
+				delete(m.boundaries, childID)
+				delete(m.engines, childID)
+				delete(m.kvEngines, childID)
+			}
+		}
+		delete(m.boundaries, scopeID)
+		if engine, ok := m.engines[scopeID]; ok {
+			engine.Close()
+			delete(m.engines, scopeID)
+		}
+		delete(m.kvEngines, scopeID)
+	}
+
+	expiredPolicies := make([]int, 0)
+	for i, policy := range m.policies {
+		if policy.ExpiresAt.Before(now) {
+			expiredPolicies = append(expiredPolicies, i)
+		}
+	}
+	for i := len(expiredPolicies) - 1; i >= 0; i-- {
+		m.policies = append(m.policies[:expiredPolicies[i]], m.policies[expiredPolicies[i]+1:]...)
+	}
+
+	expiredSnapshots := make([]string, 0)
+	for id, snap := range m.snapshots {
+		if snap.TakenAt.Add(m.config.DefaultTTL * 2).Before(now) {
+			expiredSnapshots = append(expiredSnapshots, id)
+		}
+	}
+	for _, id := range expiredSnapshots {
+		delete(m.snapshots, id)
+	}
+}
+
+func (m *ContextIsolationManager) Close() error {
+	if m.cleanupTicker != nil {
+		m.cleanupTicker.Stop()
+	}
+	close(m.stopCh)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for scopeID, engine := range m.engines {
+		engine.Close()
+		delete(m.engines, scopeID)
+	}
+
+	m.boundaries = make(map[string]*ContextBoundary)
+	m.kvEngines = make(map[string]*ctxengine.Engine)
+	m.policies = make([]*SharedContextPolicy, 0)
+	m.snapshots = make(map[string]*ContextSnapshot)
+
+	return nil
+}
+
+type SharedSearchResult struct {
+	SourceScopeID string
+	Key           string
+	Value         any
+	Metadata      map[string]string
+}

--- a/pkg/isolation/manager.go
+++ b/pkg/isolation/manager.go
@@ -137,6 +137,10 @@ func (m *ContextIsolationManager) CreateChildBoundary(parentScopeID string, chil
 		return nil, fmt.Errorf("parent boundary not found: %s", parentScopeID)
 	}
 
+	if childScope == nil {
+		return nil, fmt.Errorf("child scope cannot be nil")
+	}
+
 	childScopeID := childScope.ID()
 	if childScopeID == "" {
 		return nil, fmt.Errorf("child scope must have at least one of AgentID, SessionID, or TaskID")
@@ -231,37 +235,18 @@ func (m *ContextIsolationManager) ListSharingPolicies() []*SharedContextPolicy {
 	return result
 }
 
+func (m *ContextIsolationManager) sharingPolicy(sourceAgentID, targetAgentID, namespace string) *SharedContextPolicy {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return cloneSharedContextPolicy(m.matchSharingPolicyLocked(sourceAgentID, targetAgentID, namespace))
+}
+
 func (m *ContextIsolationManager) CanShareContext(sourceAgentID, targetAgentID, namespace string) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	now := time.Now()
-	for _, policy := range m.policies {
-		if policy.ExpiresAt.Before(now) {
-			continue
-		}
-		if policy.SourceAgentID != sourceAgentID {
-			continue
-		}
-
-		targetMatch := false
-		for _, target := range policy.TargetAgentIDs {
-			if target == targetAgentID {
-				targetMatch = true
-				break
-			}
-		}
-		if !targetMatch {
-			continue
-		}
-
-		if policy.Namespace != "" && policy.Namespace != namespace {
-			continue
-		}
-
-		return true
-	}
-	return false
+	return m.canShareContextLocked(sourceAgentID, targetAgentID, namespace)
 }
 
 func (m *ContextIsolationManager) CreateSnapshot(agentID, sessionID, description string) (*ContextSnapshot, error) {
@@ -298,8 +283,7 @@ func (m *ContextIsolationManager) CreateSnapshot(agentID, sessionID, description
 			continue
 		}
 		if boundary.Scope.AgentID == agentID && (sessionID == "" || boundary.Scope.SessionID == sessionID) {
-			docs = engine.SnapshotDocuments()
-			break
+			docs = append(docs, engine.SnapshotDocuments()...)
 		}
 	}
 	for scopeID, kvEngine := range m.kvEngines {
@@ -308,11 +292,12 @@ func (m *ContextIsolationManager) CreateSnapshot(agentID, sessionID, description
 			continue
 		}
 		if boundary.Scope.AgentID == agentID && (sessionID == "" || boundary.Scope.SessionID == sessionID) {
-			kvs = make(map[string]any)
+			if kvs == nil {
+				kvs = make(map[string]any)
+			}
 			for _, ctx := range kvEngine.List() {
 				kvs[ctx.Key] = ctx.Value
 			}
-			break
 		}
 	}
 
@@ -437,7 +422,8 @@ func (m *ContextIsolationManager) SharedSearch(scopeID string, query string, nam
 
 			sourceAgentID := sourceBoundary.Scope.AgentID
 
-			if !m.canShareContextLocked(sourceAgentID, targetAgentID, namespace) {
+			policy := m.matchSharingPolicyLocked(sourceAgentID, targetAgentID, namespace)
+			if policy == nil || policy.RequireApproval {
 				continue
 			}
 
@@ -446,6 +432,9 @@ func (m *ContextIsolationManager) SharedSearch(scopeID string, query string, nam
 			}
 
 			for _, ctx := range kvEngine.List() {
+				if !policyAllowsContextKey(policy, ctx.Key) {
+					continue
+				}
 				if namespace != "" && ctx.Metadata["namespace"] != namespace {
 					continue
 				}
@@ -453,7 +442,7 @@ func (m *ContextIsolationManager) SharedSearch(scopeID string, query string, nam
 					SourceScopeID: sourceScopeID,
 					Key:           ctx.Key,
 					Value:         ctx.Value,
-					Metadata:      ctx.Metadata,
+					Metadata:      cloneStringMap(ctx.Metadata),
 				})
 			}
 		}
@@ -463,33 +452,79 @@ func (m *ContextIsolationManager) SharedSearch(scopeID string, query string, nam
 }
 
 func (m *ContextIsolationManager) canShareContextLocked(sourceID, targetID, namespace string) bool {
+	policy := m.matchSharingPolicyLocked(sourceID, targetID, namespace)
+	return policy != nil && !policy.RequireApproval
+}
+
+func (m *ContextIsolationManager) matchSharingPolicyLocked(sourceID, targetID, namespace string) *SharedContextPolicy {
 	now := time.Now()
 	for _, policy := range m.policies {
-		if policy.ExpiresAt.Before(now) {
+		if policy == nil {
+			continue
+		}
+		if !policy.ExpiresAt.IsZero() && policy.ExpiresAt.Before(now) {
 			continue
 		}
 		if policy.SourceAgentID != sourceID {
 			continue
 		}
-
-		targetMatch := false
-		for _, target := range policy.TargetAgentIDs {
-			if target == targetID {
-				targetMatch = true
-				break
-			}
-		}
-		if !targetMatch {
+		if !policyTargetsAgent(policy, targetID) {
 			continue
 		}
-
 		if policy.Namespace != "" && policy.Namespace != namespace {
 			continue
 		}
+		return policy
+	}
+	return nil
+}
 
-		return true
+func policyTargetsAgent(policy *SharedContextPolicy, targetID string) bool {
+	for _, target := range policy.TargetAgentIDs {
+		if target == targetID {
+			return true
+		}
 	}
 	return false
+}
+
+func policyAllowsContextKey(policy *SharedContextPolicy, key string) bool {
+	if policy == nil || len(policy.ContextKeys) == 0 {
+		return true
+	}
+	for _, allowed := range policy.ContextKeys {
+		if allowed == key {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneSharedContextPolicy(policy *SharedContextPolicy) *SharedContextPolicy {
+	if policy == nil {
+		return nil
+	}
+
+	cloned := *policy
+	if policy.TargetAgentIDs != nil {
+		cloned.TargetAgentIDs = append([]string(nil), policy.TargetAgentIDs...)
+	}
+	if policy.ContextKeys != nil {
+		cloned.ContextKeys = append([]string(nil), policy.ContextKeys...)
+	}
+	return &cloned
+}
+
+func cloneStringMap(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+
+	cloned := make(map[string]string, len(src))
+	for key, value := range src {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func (m *ContextIsolationManager) startCleanup() {

--- a/pkg/isolation/manager_test.go
+++ b/pkg/isolation/manager_test.go
@@ -1,0 +1,1268 @@
+package isolation
+
+import (
+	"context"
+	"testing"
+
+	ctxpkg "github.com/1024XEngineer/anyclaw/pkg/runtime/context/store"
+)
+
+func TestNewContextIsolationManager(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	if mgr == nil {
+		t.Fatal("expected manager to be created")
+	}
+	defer mgr.Close()
+}
+
+func TestCreateBoundary(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+		Namespace: "test",
+	}
+
+	boundary, err := mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if boundary.Scope.AgentID != "agent-1" {
+		t.Errorf("expected agent ID 'agent-1', got '%s'", boundary.Scope.AgentID)
+	}
+
+	if boundary.Mode != IsolationModeStrict {
+		t.Errorf("expected mode 'strict', got '%s'", boundary.Mode)
+	}
+
+	if boundary.Visibility != ContextVisibilityPrivate {
+		t.Errorf("expected visibility 'private', got '%s'", boundary.Visibility)
+	}
+}
+
+func TestCreateBoundaryDuplicate(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+
+	_, err := mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("first create should succeed: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err == nil {
+		t.Fatal("expected error for duplicate boundary")
+	}
+}
+
+func TestGetBoundary(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+
+	_, err := mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	boundary, ok := mgr.GetBoundary("session-1")
+	if !ok {
+		t.Fatal("expected boundary to exist")
+	}
+
+	if boundary.Scope.AgentID != "agent-1" {
+		t.Errorf("expected agent ID 'agent-1', got '%s'", boundary.Scope.AgentID)
+	}
+
+	_, ok = mgr.GetBoundary("nonexistent")
+	if ok {
+		t.Fatal("expected boundary to not exist")
+	}
+}
+
+func TestGetEngine(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+
+	_, err := mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	engine, ok := mgr.GetEngine("session-1")
+	if !ok {
+		t.Fatal("expected engine to exist")
+	}
+
+	if engine.Name() != "isolated-session-1" {
+		t.Errorf("expected engine name 'isolated-session-1', got '%s'", engine.Name())
+	}
+}
+
+func TestCreateChildBoundary(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	parentScope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+
+	_, err := mgr.CreateBoundary(parentScope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create parent boundary: %v", err)
+	}
+
+	childScope := &ContextScope{
+		AgentID:   "agent-1",
+		TaskID:    "task-1",
+		Namespace: "child",
+	}
+
+	childBoundary, err := mgr.CreateChildBoundary("session-1", childScope, IsolationModeHybrid, ContextVisibilityScoped)
+	if err != nil {
+		t.Fatalf("failed to create child boundary: %v", err)
+	}
+
+	if childBoundary.Parent == nil {
+		t.Fatal("expected child boundary to have parent")
+	}
+
+	if childBoundary.Parent.Scope.SessionID != "session-1" {
+		t.Errorf("expected parent session ID 'session-1', got '%s'", childBoundary.Parent.Scope.SessionID)
+	}
+
+	if childBoundary.Mode != IsolationModeHybrid {
+		t.Errorf("expected child mode 'hybrid', got '%s'", childBoundary.Mode)
+	}
+}
+
+func TestAddDocument(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+		Namespace: "test",
+	}
+
+	_, err := mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	engine, ok := mgr.GetEngine("session-1")
+	if !ok {
+		t.Fatal("expected engine to exist")
+	}
+
+	doc := ctxpkg.Document{
+		ID:      "doc-1",
+		Content: "This is a test document about Go programming",
+		Metadata: map[string]any{
+			"type": "test",
+		},
+	}
+
+	ctx := context.Background()
+	err = engine.AddDocument(ctx, doc)
+	if err != nil {
+		t.Fatalf("failed to add document: %v", err)
+	}
+
+	retrieved, err := engine.GetDocument(ctx, "doc-1")
+	if err != nil {
+		t.Fatalf("failed to get document: %v", err)
+	}
+
+	if retrieved.Content != doc.Content {
+		t.Errorf("expected content '%s', got '%s'", doc.Content, retrieved.Content)
+	}
+
+	if retrieved.Metadata["agent_id"] != "agent-1" {
+		t.Errorf("expected metadata agent_id 'agent-1', got '%v'", retrieved.Metadata["agent_id"])
+	}
+}
+
+func TestSearchDocuments(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+
+	_, err := mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	engine, ok := mgr.GetEngine("session-1")
+	if !ok {
+		t.Fatal("expected engine to exist")
+	}
+
+	ctx := context.Background()
+	docs := []ctxpkg.Document{
+		{ID: "doc-1", Content: "Go programming language is great for building systems"},
+		{ID: "doc-2", Content: "Python is good for data science and machine learning"},
+		{ID: "doc-3", Content: "Go concurrency model uses goroutines and channels"},
+	}
+
+	for _, doc := range docs {
+		if err := engine.AddDocument(ctx, doc); err != nil {
+			t.Fatalf("failed to add document %s: %v", doc.ID, err)
+		}
+	}
+
+	results, err := engine.Search(ctx, "Go programming", ctxpkg.SearchOptions{
+		TopK:      2,
+		Threshold: 0.0,
+	})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(results))
+	}
+
+	if len(results) > 0 && results[0].Document.ID != "doc-1" && results[0].Document.ID != "doc-3" {
+		t.Logf("first result should be Go-related, got: %s", results[0].Document.ID)
+	}
+}
+
+func TestDeleteDocument(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+
+	_, err := mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	engine, ok := mgr.GetEngine("session-1")
+	if !ok {
+		t.Fatal("expected engine to exist")
+	}
+
+	ctx := context.Background()
+	doc := ctxpkg.Document{ID: "doc-1", Content: "test content"}
+
+	if err := engine.AddDocument(ctx, doc); err != nil {
+		t.Fatalf("failed to add document: %v", err)
+	}
+
+	if err := engine.DeleteDocument(ctx, "doc-1"); err != nil {
+		t.Fatalf("failed to delete document: %v", err)
+	}
+
+	_, err = engine.GetDocument(ctx, "doc-1")
+	if err == nil {
+		t.Fatal("expected error after deletion")
+	}
+}
+
+func TestContextIsolation(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope1 := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+	scope2 := &ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}
+
+	_, err := mgr.CreateBoundary(scope1, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary 1: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(scope2, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary 2: %v", err)
+	}
+
+	engine1, _ := mgr.GetEngine("session-1")
+	engine2, _ := mgr.GetEngine("session-2")
+
+	ctx := context.Background()
+	doc := ctxpkg.Document{ID: "doc-1", Content: "isolated content"}
+
+	if err := engine1.AddDocument(ctx, doc); err != nil {
+		t.Fatalf("failed to add document to engine1: %v", err)
+	}
+
+	_, err = engine2.GetDocument(ctx, "doc-1")
+	if err == nil {
+		t.Fatal("expected document to be isolated, but it was accessible from engine2")
+	}
+}
+
+func TestSharingPolicy(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	policy := &SharedContextPolicy{
+		SourceAgentID:  "agent-1",
+		TargetAgentIDs: []string{"agent-2", "agent-3"},
+		Namespace:      "shared",
+	}
+
+	if err := mgr.AddSharingPolicy(policy); err != nil {
+		t.Fatalf("failed to add policy: %v", err)
+	}
+
+	if !mgr.CanShareContext("agent-1", "agent-2", "shared") {
+		t.Error("expected sharing to be allowed")
+	}
+
+	if !mgr.CanShareContext("agent-1", "agent-3", "shared") {
+		t.Error("expected sharing to be allowed")
+	}
+
+	if mgr.CanShareContext("agent-2", "agent-1", "shared") {
+		t.Error("expected sharing to be denied (one-way)")
+	}
+
+	if mgr.CanShareContext("agent-1", "agent-2", "other") {
+		t.Error("expected sharing to be denied (wrong namespace)")
+	}
+}
+
+func TestRemoveSharingPolicy(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	policy := &SharedContextPolicy{
+		SourceAgentID:  "agent-1",
+		TargetAgentIDs: []string{"agent-2", "agent-3"},
+	}
+
+	if err := mgr.AddSharingPolicy(policy); err != nil {
+		t.Fatalf("failed to add policy: %v", err)
+	}
+
+	removed := mgr.RemoveSharingPolicy("agent-1", "agent-2")
+	if !removed {
+		t.Fatal("expected policy to be removed")
+	}
+
+	if mgr.CanShareContext("agent-1", "agent-2", "") {
+		t.Error("expected sharing to be denied after removal")
+	}
+
+	if !mgr.CanShareContext("agent-1", "agent-3", "") {
+		t.Error("expected sharing to still be allowed for agent-3")
+	}
+}
+
+func TestCreateSnapshot(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSnapshots = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+
+	_, err := mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary: %v", err)
+	}
+
+	engine, _ := mgr.GetEngine("session-1")
+	ctx := context.Background()
+
+	doc := ctxpkg.Document{ID: "doc-1", Content: "snapshot content"}
+	if err := engine.AddDocument(ctx, doc); err != nil {
+		t.Fatalf("failed to add document: %v", err)
+	}
+
+	snapshot, err := mgr.CreateSnapshot("agent-1", "session-1", "test snapshot")
+	if err != nil {
+		t.Fatalf("failed to create snapshot: %v", err)
+	}
+
+	if len(snapshot.Documents) != 1 {
+		t.Errorf("expected 1 document in snapshot, got %d", len(snapshot.Documents))
+	}
+
+	if snapshot.AgentID != "agent-1" {
+		t.Errorf("expected agent ID 'agent-1', got '%s'", snapshot.AgentID)
+	}
+
+	retrieved, ok := mgr.GetSnapshot(snapshot.ID)
+	if !ok {
+		t.Fatal("expected snapshot to exist")
+	}
+
+	if retrieved.ID != snapshot.ID {
+		t.Errorf("expected snapshot ID '%s', got '%s'", snapshot.ID, retrieved.ID)
+	}
+}
+
+func TestListSnapshots(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSnapshots = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+
+	_, err := mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary: %v", err)
+	}
+
+	_, err = mgr.CreateSnapshot("agent-1", "session-1", "snapshot 1")
+	if err != nil {
+		t.Fatalf("failed to create snapshot 1: %v", err)
+	}
+
+	_, err = mgr.CreateSnapshot("agent-1", "session-1", "snapshot 2")
+	if err != nil {
+		t.Fatalf("failed to create snapshot 2: %v", err)
+	}
+
+	snapshots := mgr.ListSnapshots("agent-1")
+	if len(snapshots) != 2 {
+		t.Errorf("expected 2 snapshots, got %d", len(snapshots))
+	}
+
+	allSnapshots := mgr.ListSnapshots("")
+	if len(allSnapshots) != 2 {
+		t.Errorf("expected 2 total snapshots, got %d", len(allSnapshots))
+	}
+}
+
+func TestDeleteBoundary(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+
+	_, err := mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary: %v", err)
+	}
+
+	if err := mgr.DeleteBoundary("session-1"); err != nil {
+		t.Fatalf("failed to delete boundary: %v", err)
+	}
+
+	_, ok := mgr.GetBoundary("session-1")
+	if ok {
+		t.Fatal("expected boundary to be deleted")
+	}
+
+	_, ok = mgr.GetEngine("session-1")
+	if ok {
+		t.Fatal("expected engine to be deleted")
+	}
+}
+
+func TestDeleteBoundaryWithChildren(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	parentScope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+
+	_, err := mgr.CreateBoundary(parentScope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create parent boundary: %v", err)
+	}
+
+	childScope := &ContextScope{
+		AgentID: "agent-1",
+		TaskID:  "task-1",
+	}
+
+	_, err = mgr.CreateChildBoundary("session-1", childScope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create child boundary: %v", err)
+	}
+
+	if err := mgr.DeleteBoundary("session-1"); err != nil {
+		t.Fatalf("failed to delete parent boundary: %v", err)
+	}
+
+	_, ok := mgr.GetBoundary("task-1")
+	if ok {
+		t.Fatal("expected child boundary to be deleted")
+	}
+}
+
+func TestListBoundaries(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope1 := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+	scope2 := &ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}
+
+	_, err := mgr.CreateBoundary(scope1, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary 1: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(scope2, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary 2: %v", err)
+	}
+
+	boundaries := mgr.ListBoundaries()
+	if len(boundaries) != 2 {
+		t.Errorf("expected 2 boundaries, got %d", len(boundaries))
+	}
+}
+
+func TestSharedSearch(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope1 := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+	scope2 := &ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}
+
+	_, err := mgr.CreateBoundary(scope1, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create boundary 1: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(scope2, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create boundary 2: %v", err)
+	}
+
+	policy := &SharedContextPolicy{
+		SourceAgentID:  "agent-1",
+		TargetAgentIDs: []string{"agent-2"},
+	}
+	if err := mgr.AddSharingPolicy(policy); err != nil {
+		t.Fatalf("failed to add policy: %v", err)
+	}
+
+	kvEngine1, _ := mgr.GetKVEngine("session-1")
+	ctx := context.Background()
+	kvEngine1.Set(ctx, "key1", "value1")
+	kvEngine1.Set(ctx, "key2", "value2")
+
+	results, err := mgr.SharedSearch("session-2", "", "")
+	if err != nil {
+		t.Fatalf("shared search failed: %v", err)
+	}
+
+	if len(results) < 1 {
+		t.Errorf("expected at least 1 shared result, got %d", len(results))
+	}
+}
+
+func TestContextScopeMiddleware(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	middleware := NewContextScopeMiddleware(mgr)
+
+	scopeID, err := middleware.EnterScope("agent-1", "session-1", "", "test", IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to enter scope: %v", err)
+	}
+
+	if scopeID != "session-1" {
+		t.Errorf("expected scope ID 'session-1', got '%s'", scopeID)
+	}
+
+	if !middleware.IsScoped("agent-1") {
+		t.Error("expected agent to be scoped")
+	}
+
+	currentScope, err := middleware.GetCurrentScope("agent-1")
+	if err != nil {
+		t.Fatalf("failed to get current scope: %v", err)
+	}
+
+	if currentScope.AgentID != "agent-1" {
+		t.Errorf("expected agent ID 'agent-1', got '%s'", currentScope.AgentID)
+	}
+
+	engine, err := middleware.GetCurrentEngine("agent-1")
+	if err != nil {
+		t.Fatalf("failed to get current engine: %v", err)
+	}
+
+	if engine == nil {
+		t.Fatal("expected engine to be returned")
+	}
+
+	if err := middleware.ExitScope("agent-1"); err != nil {
+		t.Fatalf("failed to exit scope: %v", err)
+	}
+
+	if middleware.IsScoped("agent-1") {
+		t.Error("expected agent to no longer be scoped")
+	}
+}
+
+func TestContextScopeMiddlewareNested(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	middleware := NewContextScopeMiddleware(mgr)
+
+	_, err := middleware.EnterScope("agent-1", "session-1", "", "test", IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to enter first scope: %v", err)
+	}
+
+	_, err = middleware.EnterScope("agent-1", "session-2", "task-1", "test", IsolationModeHybrid, ContextVisibilityScoped)
+	if err != nil {
+		t.Fatalf("failed to enter nested scope: %v", err)
+	}
+
+	stack := middleware.GetScopeStack("agent-1")
+	if len(stack) != 2 {
+		t.Errorf("expected stack depth 2, got %d", len(stack))
+	}
+
+	if err := middleware.ExitScope("agent-1"); err != nil {
+		t.Fatalf("failed to exit nested scope: %v", err)
+	}
+
+	if !middleware.IsScoped("agent-1") {
+		t.Error("expected agent to still be scoped after exiting nested scope")
+	}
+
+	if err := middleware.ExitScope("agent-1"); err != nil {
+		t.Fatalf("failed to exit outer scope: %v", err)
+	}
+
+	if middleware.IsScoped("agent-1") {
+		t.Error("expected agent to no longer be scoped")
+	}
+}
+
+func TestContextEnforcer(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	middleware := NewContextScopeMiddleware(mgr)
+	enforcer := NewContextEnforcer(middleware)
+
+	enforcer.AddRule("agent-1", &EnforcementRule{
+		AgentID:            "agent-1",
+		RequiredMode:       IsolationModeStrict,
+		RequiredVisibility: ContextVisibilityPrivate,
+		MaxNestedDepth:     2,
+	})
+
+	_, err := middleware.EnterScope("agent-1", "session-1", "", "test", IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to enter scope: %v", err)
+	}
+
+	if err := enforcer.Enforce("agent-1"); err != nil {
+		t.Errorf("expected enforcement to pass: %v", err)
+	}
+
+	if err := middleware.ExitScope("agent-1"); err != nil {
+		t.Fatalf("failed to exit scope: %v", err)
+	}
+}
+
+func TestContextEnforcerViolation(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	middleware := NewContextScopeMiddleware(mgr)
+	enforcer := NewContextEnforcer(middleware)
+
+	enforcer.AddRule("agent-1", &EnforcementRule{
+		AgentID:            "agent-1",
+		RequiredMode:       IsolationModeStrict,
+		RequiredVisibility: ContextVisibilityPrivate,
+	})
+
+	_, err := middleware.EnterScope("agent-1", "session-1", "", "test", IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to enter scope: %v", err)
+	}
+
+	err = enforcer.Enforce("agent-1")
+	if err == nil {
+		t.Fatal("expected enforcement to fail due to mode violation")
+	}
+
+	if err := middleware.ExitScope("agent-1"); err != nil {
+		t.Fatalf("failed to exit scope: %v", err)
+	}
+}
+
+func TestContextBridge(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope1 := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+	scope2 := &ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}
+
+	_, err := mgr.CreateBoundary(scope1, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create boundary 1: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(scope2, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create boundary 2: %v", err)
+	}
+
+	policy := &SharedContextPolicy{
+		SourceAgentID:  "agent-1",
+		TargetAgentIDs: []string{"agent-2"},
+	}
+	if err := mgr.AddSharingPolicy(policy); err != nil {
+		t.Fatalf("failed to add policy: %v", err)
+	}
+
+	bridge := NewContextBridge(mgr)
+
+	engine1, _ := mgr.GetEngine("session-1")
+	ctx := context.Background()
+
+	docs := []ctxpkg.Document{
+		{ID: "doc-1", Content: "shared document 1"},
+		{ID: "doc-2", Content: "shared document 2"},
+	}
+
+	for _, doc := range docs {
+		if err := engine1.AddDocument(ctx, doc); err != nil {
+			t.Fatalf("failed to add document: %v", err)
+		}
+	}
+
+	transfer, err := bridge.TransferDocuments(ctx, "session-1", "session-2", []string{"doc-1", "doc-2"}, "")
+	if err != nil {
+		t.Fatalf("transfer failed: %v", err)
+	}
+
+	if transfer.Status != TransferStatusCompleted {
+		t.Errorf("expected transfer status 'completed', got '%s'", transfer.Status)
+	}
+
+	if len(transfer.Documents) != 2 {
+		t.Errorf("expected 2 transferred documents, got %d", len(transfer.Documents))
+	}
+
+	engine2, _ := mgr.GetEngine("session-2")
+	docCount := engine2.DocumentCount()
+	if docCount != 2 {
+		t.Errorf("expected 2 documents in target engine, got %d", docCount)
+	}
+}
+
+func TestContextAggregator(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope1 := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+	scope2 := &ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}
+
+	_, err := mgr.CreateBoundary(scope1, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create boundary 1: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(scope2, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create boundary 2: %v", err)
+	}
+
+	engine1, _ := mgr.GetEngine("session-1")
+	engine2, _ := mgr.GetEngine("session-2")
+	ctx := context.Background()
+
+	engine1.AddDocument(ctx, ctxpkg.Document{ID: "doc-1", Content: "agent 1 document about Go"})
+	engine2.AddDocument(ctx, ctxpkg.Document{ID: "doc-2", Content: "agent 2 document about Python"})
+
+	aggregator := NewContextAggregator(mgr)
+
+	docs, err := aggregator.AggregateDocuments([]string{"session-1", "session-2"}, "")
+	if err != nil {
+		t.Fatalf("aggregation failed: %v", err)
+	}
+
+	if len(docs) != 2 {
+		t.Errorf("expected 2 aggregated documents, got %d", len(docs))
+	}
+}
+
+func TestContextSync(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope1 := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+	scope2 := &ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}
+
+	_, err := mgr.CreateBoundary(scope1, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create boundary 1: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(scope2, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create boundary 2: %v", err)
+	}
+
+	policy := &SharedContextPolicy{
+		SourceAgentID:  "agent-1",
+		TargetAgentIDs: []string{"agent-2"},
+	}
+	if err := mgr.AddSharingPolicy(policy); err != nil {
+		t.Fatalf("failed to add policy: %v", err)
+	}
+
+	engine1, _ := mgr.GetEngine("session-1")
+	ctx := context.Background()
+	engine1.AddDocument(ctx, ctxpkg.Document{ID: "doc-1", Content: "sync document"})
+
+	sync := NewContextSync(mgr)
+
+	if err := sync.SyncContext("session-1", "session-2", ""); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	engine2, _ := mgr.GetEngine("session-2")
+	docCount := engine2.DocumentCount()
+	if docCount != 1 {
+		t.Errorf("expected 1 document after sync, got %d", docCount)
+	}
+}
+
+func TestIsolatedEngineClone(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+
+	_, err := mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary: %v", err)
+	}
+
+	engine, _ := mgr.GetEngine("session-1")
+	ctx := context.Background()
+
+	engine.AddDocument(ctx, ctxpkg.Document{ID: "doc-1", Content: "original document"})
+
+	cloned := engine.Clone()
+
+	if cloned.Scope().AgentID != "agent-1" {
+		t.Errorf("expected cloned agent ID 'agent-1', got '%s'", cloned.Scope().AgentID)
+	}
+
+	if cloned.Visibility() != engine.Visibility() {
+		t.Errorf("expected cloned visibility to match original")
+	}
+
+	docCount := cloned.(*IsolatedEngine).DocumentCount()
+	if docCount != 1 {
+		t.Errorf("expected 1 document in clone, got %d", docCount)
+	}
+}
+
+func TestIsolatedEngineMaxSize(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.MaxContextSize = 2
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+
+	_, err := mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary: %v", err)
+	}
+
+	engine, _ := mgr.GetEngine("session-1")
+	ctx := context.Background()
+
+	engine.AddDocument(ctx, ctxpkg.Document{ID: "doc-1", Content: "doc 1"})
+	engine.AddDocument(ctx, ctxpkg.Document{ID: "doc-2", Content: "doc 2"})
+
+	err = engine.AddDocument(ctx, ctxpkg.Document{ID: "doc-3", Content: "doc 3"})
+	if err == nil {
+		t.Fatal("expected error when exceeding max size")
+	}
+}
+
+func TestIsolatedEngineClosed(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+
+	_, err := mgr.CreateBoundary(scope, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary: %v", err)
+	}
+
+	engine, _ := mgr.GetEngine("session-1")
+	ctx := context.Background()
+
+	engine.Close()
+
+	err = engine.AddDocument(ctx, ctxpkg.Document{ID: "doc-1", Content: "test"})
+	if err == nil {
+		t.Fatal("expected error when adding to closed engine")
+	}
+
+	_, err = engine.GetDocument(ctx, "doc-1")
+	if err == nil {
+		t.Fatal("expected error when getting from closed engine")
+	}
+}
+
+func TestKVEngineIsolation(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope1 := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+	scope2 := &ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}
+
+	_, err := mgr.CreateBoundary(scope1, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary 1: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(scope2, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary 2: %v", err)
+	}
+
+	kvEngine1, _ := mgr.GetKVEngine("session-1")
+	kvEngine2, _ := mgr.GetKVEngine("session-2")
+	ctx := context.Background()
+
+	kvEngine1.Set(ctx, "key1", "value1")
+
+	_, err = kvEngine2.Get(ctx, "key1")
+	if err == nil {
+		t.Fatal("expected KV to be isolated")
+	}
+}
+
+func TestListSharingPolicies(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	policy1 := &SharedContextPolicy{
+		SourceAgentID:  "agent-1",
+		TargetAgentIDs: []string{"agent-2"},
+	}
+	policy2 := &SharedContextPolicy{
+		SourceAgentID:  "agent-3",
+		TargetAgentIDs: []string{"agent-4"},
+	}
+
+	mgr.AddSharingPolicy(policy1)
+	mgr.AddSharingPolicy(policy2)
+
+	policies := mgr.ListSharingPolicies()
+	if len(policies) != 2 {
+		t.Errorf("expected 2 policies, got %d", len(policies))
+	}
+}
+
+func TestContextScopeMiddlewareWithScope(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	middleware := NewContextScopeMiddleware(mgr)
+
+	var executedScopeID string
+	err := middleware.WithScope(context.Background(), "agent-1", "session-1", "", "test", IsolationModeStrict, ContextVisibilityPrivate, func(scopeID string) error {
+		executedScopeID = scopeID
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("WithScope failed: %v", err)
+	}
+
+	if executedScopeID != "session-1" {
+		t.Errorf("expected scope ID 'session-1', got '%s'", executedScopeID)
+	}
+
+	if middleware.IsScoped("agent-1") {
+		t.Error("expected agent to be unscoped after WithScope")
+	}
+}
+
+func TestContextEnforcerNoScope(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	middleware := NewContextScopeMiddleware(mgr)
+	enforcer := NewContextEnforcer(middleware)
+
+	enforcer.AddRule("agent-1", &EnforcementRule{
+		AgentID:            "agent-1",
+		RequiredMode:       IsolationModeStrict,
+		RequiredVisibility: ContextVisibilityPrivate,
+	})
+
+	err := enforcer.Enforce("agent-1")
+	if err == nil {
+		t.Fatal("expected enforcement to fail when no scope is active")
+	}
+}
+
+func TestContextBridgeTransferPrivateSource(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope1 := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+	scope2 := &ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}
+
+	_, err := mgr.CreateBoundary(scope1, IsolationModeShared, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary 1: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(scope2, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create boundary 2: %v", err)
+	}
+
+	policy := &SharedContextPolicy{
+		SourceAgentID:  "agent-1",
+		TargetAgentIDs: []string{"agent-2"},
+	}
+	mgr.AddSharingPolicy(policy)
+
+	bridge := NewContextBridge(mgr)
+	ctx := context.Background()
+
+	transfer, err := bridge.TransferDocuments(ctx, "session-1", "session-2", []string{"doc-1"}, "")
+	if err != nil {
+		t.Fatalf("transfer should not error: %v", err)
+	}
+
+	if transfer.Status != TransferStatusRejected {
+		t.Errorf("expected transfer to be rejected due to private visibility, got '%s'", transfer.Status)
+	}
+}
+
+func TestContextAggregatorCrossScopeSearch(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope1 := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+	scope2 := &ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}
+
+	_, err := mgr.CreateBoundary(scope1, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create boundary 1: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(scope2, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create boundary 2: %v", err)
+	}
+
+	engine1, _ := mgr.GetEngine("session-1")
+	engine2, _ := mgr.GetEngine("session-2")
+	ctx := context.Background()
+
+	engine1.AddDocument(ctx, ctxpkg.Document{ID: "doc-1", Content: "Go programming is great"})
+	engine2.AddDocument(ctx, ctxpkg.Document{ID: "doc-2", Content: "Python for data science"})
+
+	aggregator := NewContextAggregator(mgr)
+
+	results, err := aggregator.CrossScopeSearch([]string{"session-1", "session-2"}, "Go programming", "", 5)
+	if err != nil {
+		t.Fatalf("cross-scope search failed: %v", err)
+	}
+
+	if len(results) < 1 {
+		t.Errorf("expected at least 1 result, got %d", len(results))
+	}
+}
+
+func TestContextSyncAllPairs(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	scope1 := &ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}
+	scope2 := &ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}
+	scope3 := &ContextScope{
+		AgentID:   "agent-3",
+		SessionID: "session-3",
+	}
+
+	mgr.CreateBoundary(scope1, IsolationModeShared, ContextVisibilityPublic)
+	mgr.CreateBoundary(scope2, IsolationModeShared, ContextVisibilityPublic)
+	mgr.CreateBoundary(scope3, IsolationModeShared, ContextVisibilityPublic)
+
+	mgr.AddSharingPolicy(&SharedContextPolicy{
+		SourceAgentID:  "agent-1",
+		TargetAgentIDs: []string{"agent-2", "agent-3"},
+	})
+	mgr.AddSharingPolicy(&SharedContextPolicy{
+		SourceAgentID:  "agent-2",
+		TargetAgentIDs: []string{"agent-3"},
+	})
+
+	engine1, _ := mgr.GetEngine("session-1")
+	ctx := context.Background()
+	engine1.AddDocument(ctx, ctxpkg.Document{ID: "doc-1", Content: "sync test"})
+
+	sync := NewContextSync(mgr)
+
+	results := sync.SyncAllPairs([]string{"session-1", "session-2", "session-3"}, "")
+
+	if len(results) != 6 {
+		t.Errorf("expected 6 sync results, got %d", len(results))
+	}
+}

--- a/pkg/isolation/manager_test.go
+++ b/pkg/isolation/manager_test.go
@@ -1266,3 +1266,593 @@ func TestContextSyncAllPairs(t *testing.T) {
 		t.Errorf("expected 6 sync results, got %d", len(results))
 	}
 }
+
+func TestCreateChildBoundaryNilScope(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	_, err := mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create parent boundary: %v", err)
+	}
+
+	_, err = mgr.CreateChildBoundary("session-1", nil, IsolationModeStrict, ContextVisibilityPrivate)
+	if err == nil {
+		t.Fatal("expected error when child scope is nil")
+	}
+}
+
+func TestIsolatedEngineReturnsClones(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	_, err := mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary: %v", err)
+	}
+
+	engine, _ := mgr.GetEngine("session-1")
+	ctx := context.Background()
+
+	metadata := map[string]any{"type": "test"}
+	vector := []float64{1, 2, 3}
+	doc := ctxpkg.Document{
+		ID:       "doc-1",
+		Content:  "Go programming language",
+		Metadata: metadata,
+		Vector:   vector,
+	}
+
+	if err := engine.AddDocument(ctx, doc); err != nil {
+		t.Fatalf("failed to add document: %v", err)
+	}
+
+	metadata["type"] = "mutated"
+	vector[0] = 99
+
+	stored, err := engine.GetDocument(ctx, "doc-1")
+	if err != nil {
+		t.Fatalf("failed to get stored document: %v", err)
+	}
+	if stored.Metadata["type"] != "test" {
+		t.Fatalf("expected stored metadata to stay isolated, got %v", stored.Metadata["type"])
+	}
+	if len(stored.Vector) != 3 || stored.Vector[0] != 1 {
+		t.Fatalf("expected stored vector to stay isolated, got %#v", stored.Vector)
+	}
+
+	stored.Metadata["type"] = "changed"
+	stored.Vector[0] = 77
+
+	again, err := engine.GetDocument(ctx, "doc-1")
+	if err != nil {
+		t.Fatalf("failed to get document again: %v", err)
+	}
+	if again.Metadata["type"] != "test" {
+		t.Fatalf("expected GetDocument to return a clone, got %v", again.Metadata["type"])
+	}
+	if again.Vector[0] != 1 {
+		t.Fatalf("expected GetDocument vector clone, got %#v", again.Vector)
+	}
+
+	results, err := engine.Search(ctx, "Go programming", ctxpkg.SearchOptions{
+		TopK:      1,
+		Threshold: 0.0,
+	})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 search result, got %d", len(results))
+	}
+
+	results[0].Document.Metadata["type"] = "search"
+	postSearch, err := engine.GetDocument(ctx, "doc-1")
+	if err != nil {
+		t.Fatalf("failed to get document after search mutation: %v", err)
+	}
+	if postSearch.Metadata["type"] != "test" {
+		t.Fatalf("expected search result mutation to not leak, got %v", postSearch.Metadata["type"])
+	}
+
+	snapshot := engine.SnapshotDocuments()
+	if len(snapshot) != 1 {
+		t.Fatalf("expected 1 document in snapshot, got %d", len(snapshot))
+	}
+	snapshot[0].Metadata["type"] = "snapshot"
+	snapshot[0].Vector[0] = 55
+
+	postSnapshot, err := engine.GetDocument(ctx, "doc-1")
+	if err != nil {
+		t.Fatalf("failed to get document after snapshot mutation: %v", err)
+	}
+	if postSnapshot.Metadata["type"] != "test" {
+		t.Fatalf("expected snapshot mutation to not leak, got %v", postSnapshot.Metadata["type"])
+	}
+	if postSnapshot.Vector[0] != 1 {
+		t.Fatalf("expected snapshot vector mutation to not leak, got %#v", postSnapshot.Vector)
+	}
+}
+
+func TestSearchDocumentsTopKZeroMeansUnlimited(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	_, err := mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create boundary: %v", err)
+	}
+
+	engine, _ := mgr.GetEngine("session-1")
+	ctx := context.Background()
+
+	for _, doc := range []ctxpkg.Document{
+		{ID: "doc-1", Content: "Go programming"},
+		{ID: "doc-2", Content: "Go concurrency"},
+	} {
+		if err := engine.AddDocument(ctx, doc); err != nil {
+			t.Fatalf("failed to add document %s: %v", doc.ID, err)
+		}
+	}
+
+	results, err := engine.Search(ctx, "Go", ctxpkg.SearchOptions{
+		TopK:      0,
+		Threshold: 0.0,
+	})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected unlimited TopK to return 2 results, got %d", len(results))
+	}
+}
+
+func TestCanShareContextRequiresApproval(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	if err := mgr.AddSharingPolicy(&SharedContextPolicy{
+		SourceAgentID:   "agent-1",
+		TargetAgentIDs:  []string{"agent-2"},
+		RequireApproval: true,
+	}); err != nil {
+		t.Fatalf("failed to add sharing policy: %v", err)
+	}
+
+	if mgr.CanShareContext("agent-1", "agent-2", "") {
+		t.Fatal("expected approval-required policy to block automatic sharing")
+	}
+}
+
+func TestSharedSearchRespectsContextKeys(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	_, err := mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create source boundary: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create target boundary: %v", err)
+	}
+
+	if err := mgr.AddSharingPolicy(&SharedContextPolicy{
+		SourceAgentID:  "agent-1",
+		TargetAgentIDs: []string{"agent-2"},
+		ContextKeys:    []string{"allowed"},
+	}); err != nil {
+		t.Fatalf("failed to add sharing policy: %v", err)
+	}
+
+	kvEngine, _ := mgr.GetKVEngine("session-1")
+	ctx := context.Background()
+	if err := kvEngine.Set(ctx, "allowed", "value-1"); err != nil {
+		t.Fatalf("failed to set allowed key: %v", err)
+	}
+	if err := kvEngine.Set(ctx, "blocked", "value-2"); err != nil {
+		t.Fatalf("failed to set blocked key: %v", err)
+	}
+
+	results, err := mgr.SharedSearch("session-2", "", "")
+	if err != nil {
+		t.Fatalf("shared search failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 shared result, got %d", len(results))
+	}
+	if results[0].Key != "allowed" {
+		t.Fatalf("expected only allowed key to be shared, got %s", results[0].Key)
+	}
+}
+
+func TestContextBridgeTransferRequiresApproval(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	_, err := mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create source boundary: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create target boundary: %v", err)
+	}
+
+	if err := mgr.AddSharingPolicy(&SharedContextPolicy{
+		SourceAgentID:   "agent-1",
+		TargetAgentIDs:  []string{"agent-2"},
+		RequireApproval: true,
+	}); err != nil {
+		t.Fatalf("failed to add sharing policy: %v", err)
+	}
+
+	bridge := NewContextBridge(mgr)
+	if _, err := bridge.TransferDocuments(context.Background(), "session-1", "session-2", []string{"doc-1"}, ""); err == nil {
+		t.Fatal("expected approval-required policy to block transfer")
+	}
+}
+
+func TestContextBridgeTransferKeyValuesRespectsContextKeys(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	_, err := mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create source boundary: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create target boundary: %v", err)
+	}
+
+	if err := mgr.AddSharingPolicy(&SharedContextPolicy{
+		SourceAgentID:  "agent-1",
+		TargetAgentIDs: []string{"agent-2"},
+		ContextKeys:    []string{"allowed"},
+	}); err != nil {
+		t.Fatalf("failed to add sharing policy: %v", err)
+	}
+
+	sourceKV, _ := mgr.GetKVEngine("session-1")
+	targetKV, _ := mgr.GetKVEngine("session-2")
+	ctx := context.Background()
+	if err := sourceKV.Set(ctx, "allowed", "value-1"); err != nil {
+		t.Fatalf("failed to set allowed key: %v", err)
+	}
+	if err := sourceKV.Set(ctx, "blocked", "value-2"); err != nil {
+		t.Fatalf("failed to set blocked key: %v", err)
+	}
+
+	bridge := NewContextBridge(mgr)
+	transfer, err := bridge.TransferKeyValues("session-1", "session-2", []string{"allowed", "blocked"}, "")
+	if err != nil {
+		t.Fatalf("transfer failed: %v", err)
+	}
+	if len(transfer.KeyValues) != 1 {
+		t.Fatalf("expected only 1 allowed key to transfer, got %d", len(transfer.KeyValues))
+	}
+
+	if _, err := targetKV.Get(ctx, "shared_session-1_allowed"); err != nil {
+		t.Fatalf("expected allowed key to be transferred: %v", err)
+	}
+	if _, err := targetKV.Get(ctx, "shared_session-1_blocked"); err == nil {
+		t.Fatal("expected blocked key to stay filtered out")
+	}
+}
+
+func TestCreateSnapshotAggregatesAgentScopes(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	config.EnableSnapshots = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	_, err := mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create session boundary: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-2",
+		TaskID:    "task-1",
+	}, IsolationModeStrict, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create task boundary: %v", err)
+	}
+
+	sessionEngine, _ := mgr.GetEngine("session-1")
+	taskEngine, _ := mgr.GetEngine("task-1")
+	ctx := context.Background()
+	if err := sessionEngine.AddDocument(ctx, ctxpkg.Document{ID: "doc-1", Content: "session document"}); err != nil {
+		t.Fatalf("failed to add session document: %v", err)
+	}
+	if err := taskEngine.AddDocument(ctx, ctxpkg.Document{ID: "doc-2", Content: "task document"}); err != nil {
+		t.Fatalf("failed to add task document: %v", err)
+	}
+
+	sessionKV, _ := mgr.GetKVEngine("session-1")
+	taskKV, _ := mgr.GetKVEngine("task-1")
+	if err := sessionKV.Set(ctx, "key-1", "value-1"); err != nil {
+		t.Fatalf("failed to set session key: %v", err)
+	}
+	if err := taskKV.Set(ctx, "key-2", "value-2"); err != nil {
+		t.Fatalf("failed to set task key: %v", err)
+	}
+
+	snapshot, err := mgr.CreateSnapshot("agent-1", "", "aggregate")
+	if err != nil {
+		t.Fatalf("failed to create snapshot: %v", err)
+	}
+	if len(snapshot.Documents) != 2 {
+		t.Fatalf("expected 2 documents in aggregate snapshot, got %d", len(snapshot.Documents))
+	}
+	if len(snapshot.KeyValues) != 2 {
+		t.Fatalf("expected 2 key-values in aggregate snapshot, got %d", len(snapshot.KeyValues))
+	}
+}
+
+func TestContextScopeMiddlewareExitNestedCleansUpBoundary(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	middleware := NewContextScopeMiddleware(mgr)
+
+	if _, err := middleware.EnterScope("agent-1", "session-1", "", "outer", IsolationModeStrict, ContextVisibilityPrivate); err != nil {
+		t.Fatalf("failed to enter outer scope: %v", err)
+	}
+	if _, err := middleware.EnterScope("agent-1", "session-1", "task-1", "inner", IsolationModeHybrid, ContextVisibilityScoped); err != nil {
+		t.Fatalf("failed to enter inner scope: %v", err)
+	}
+
+	if err := middleware.ExitScope("agent-1"); err != nil {
+		t.Fatalf("failed to exit inner scope: %v", err)
+	}
+
+	if _, ok := mgr.GetBoundary("task-1"); ok {
+		t.Fatal("expected exited nested scope boundary to be deleted")
+	}
+	if _, ok := mgr.GetEngine("task-1"); ok {
+		t.Fatal("expected exited nested scope engine to be deleted")
+	}
+
+	currentScope, err := middleware.GetCurrentScope("agent-1")
+	if err != nil {
+		t.Fatalf("failed to get current scope after nested exit: %v", err)
+	}
+	if currentScope.ID() != "session-1" {
+		t.Fatalf("expected current scope to return to outer scope, got %s", currentScope.ID())
+	}
+}
+
+func TestContextScopeMiddlewareExitNestedSameScopeKeepsBoundary(t *testing.T) {
+	config := DefaultIsolationConfig()
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	middleware := NewContextScopeMiddleware(mgr)
+
+	if _, err := middleware.EnterScope("agent-1", "session-1", "", "test", IsolationModeStrict, ContextVisibilityPrivate); err != nil {
+		t.Fatalf("failed to enter first scope: %v", err)
+	}
+	if _, err := middleware.EnterScope("agent-1", "session-1", "", "test", IsolationModeStrict, ContextVisibilityPrivate); err != nil {
+		t.Fatalf("failed to enter duplicate scope: %v", err)
+	}
+
+	if err := middleware.ExitScope("agent-1"); err != nil {
+		t.Fatalf("failed to exit nested duplicate scope: %v", err)
+	}
+
+	if _, ok := mgr.GetBoundary("session-1"); !ok {
+		t.Fatal("expected boundary to remain while outer scope is still active")
+	}
+	if !middleware.IsScoped("agent-1") {
+		t.Fatal("expected agent to stay scoped after first exit")
+	}
+
+	if err := middleware.ExitScope("agent-1"); err != nil {
+		t.Fatalf("failed to exit outer scope: %v", err)
+	}
+	if _, ok := mgr.GetBoundary("session-1"); ok {
+		t.Fatal("expected boundary to be deleted after final exit")
+	}
+}
+
+func TestContextAggregatorCrossScopeSearchAllNamespaces(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	_, err := mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+		Namespace: "alpha",
+	}, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create first boundary: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+		Namespace: "beta",
+	}, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create second boundary: %v", err)
+	}
+
+	engine1, _ := mgr.GetEngine("session-1")
+	engine2, _ := mgr.GetEngine("session-2")
+	ctx := context.Background()
+	if err := engine1.AddDocument(ctx, ctxpkg.Document{ID: "doc-1", Content: "Go programming"}); err != nil {
+		t.Fatalf("failed to add first document: %v", err)
+	}
+	if err := engine2.AddDocument(ctx, ctxpkg.Document{ID: "doc-2", Content: "Go concurrency"}); err != nil {
+		t.Fatalf("failed to add second document: %v", err)
+	}
+
+	aggregator := NewContextAggregator(mgr)
+	results, err := aggregator.CrossScopeSearch([]string{"session-1", "session-2"}, "Go", "", 0)
+	if err != nil {
+		t.Fatalf("cross-scope search failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected search across all namespaces to return 2 results, got %d", len(results))
+	}
+}
+
+func TestContextSyncRejectsPrivateSource(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	_, err := mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}, IsolationModeShared, ContextVisibilityPrivate)
+	if err != nil {
+		t.Fatalf("failed to create private source boundary: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create target boundary: %v", err)
+	}
+
+	if err := mgr.AddSharingPolicy(&SharedContextPolicy{
+		SourceAgentID:  "agent-1",
+		TargetAgentIDs: []string{"agent-2"},
+	}); err != nil {
+		t.Fatalf("failed to add sharing policy: %v", err)
+	}
+
+	sync := NewContextSync(mgr)
+	if err := sync.SyncContext("session-1", "session-2", ""); err == nil {
+		t.Fatal("expected sync from private source to be rejected")
+	}
+}
+
+func TestContextSyncRespectsContextKeys(t *testing.T) {
+	config := DefaultIsolationConfig()
+	config.EnableSharing = true
+	mgr := NewContextIsolationManager(config)
+	defer mgr.Close()
+
+	_, err := mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-1",
+		SessionID: "session-1",
+	}, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create source boundary: %v", err)
+	}
+
+	_, err = mgr.CreateBoundary(&ContextScope{
+		AgentID:   "agent-2",
+		SessionID: "session-2",
+	}, IsolationModeShared, ContextVisibilityPublic)
+	if err != nil {
+		t.Fatalf("failed to create target boundary: %v", err)
+	}
+
+	if err := mgr.AddSharingPolicy(&SharedContextPolicy{
+		SourceAgentID:  "agent-1",
+		TargetAgentIDs: []string{"agent-2"},
+		ContextKeys:    []string{"doc-1", "key-1"},
+	}); err != nil {
+		t.Fatalf("failed to add sharing policy: %v", err)
+	}
+
+	sourceEngine, _ := mgr.GetEngine("session-1")
+	targetEngine, _ := mgr.GetEngine("session-2")
+	sourceKV, _ := mgr.GetKVEngine("session-1")
+	targetKV, _ := mgr.GetKVEngine("session-2")
+	ctx := context.Background()
+
+	for _, doc := range []ctxpkg.Document{
+		{ID: "doc-1", Content: "allowed document"},
+		{ID: "doc-2", Content: "blocked document"},
+	} {
+		if err := sourceEngine.AddDocument(ctx, doc); err != nil {
+			t.Fatalf("failed to add document %s: %v", doc.ID, err)
+		}
+	}
+	if err := sourceKV.Set(ctx, "key-1", "value-1"); err != nil {
+		t.Fatalf("failed to set allowed key: %v", err)
+	}
+	if err := sourceKV.Set(ctx, "key-2", "value-2"); err != nil {
+		t.Fatalf("failed to set blocked key: %v", err)
+	}
+
+	sync := NewContextSync(mgr)
+	if err := sync.SyncContext("session-1", "session-2", ""); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	if targetEngine.DocumentCount() != 1 {
+		t.Fatalf("expected only 1 allowed document to sync, got %d", targetEngine.DocumentCount())
+	}
+	if _, err := targetEngine.GetDocument(ctx, "doc-1"); err != nil {
+		t.Fatalf("expected allowed document to sync: %v", err)
+	}
+	if _, err := targetEngine.GetDocument(ctx, "doc-2"); err == nil {
+		t.Fatal("expected blocked document to stay out of sync target")
+	}
+
+	if _, err := targetKV.Get(ctx, "key-1"); err != nil {
+		t.Fatalf("expected allowed key to sync: %v", err)
+	}
+	if _, err := targetKV.Get(ctx, "key-2"); err == nil {
+		t.Fatal("expected blocked key to stay out of sync target")
+	}
+}

--- a/pkg/isolation/scope.go
+++ b/pkg/isolation/scope.go
@@ -1,0 +1,310 @@
+package isolation
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	ctxengine "github.com/1024XEngineer/anyclaw/pkg/runtime/context/window"
+)
+
+type ContextScopeMiddleware struct {
+	mu           sync.RWMutex
+	manager      *ContextIsolationManager
+	activeScopes map[string]*ActiveScope
+	scopeStack   map[string][]string
+}
+
+type ActiveScope struct {
+	ScopeID   string
+	AgentID   string
+	SessionID string
+	EnteredAt int64
+	Nested    int
+}
+
+func NewContextScopeMiddleware(manager *ContextIsolationManager) *ContextScopeMiddleware {
+	return &ContextScopeMiddleware{
+		manager:      manager,
+		activeScopes: make(map[string]*ActiveScope),
+		scopeStack:   make(map[string][]string),
+	}
+}
+
+func (m *ContextScopeMiddleware) EnterScope(agentID, sessionID, taskID, namespace string, mode IsolationMode, visibility ContextVisibility) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope := &ContextScope{
+		AgentID:   agentID,
+		SessionID: sessionID,
+		TaskID:    taskID,
+		Namespace: namespace,
+		Labels:    make(map[string]string),
+	}
+
+	boundary, err := m.manager.CreateBoundary(scope, mode, visibility)
+	if err != nil {
+		if existingBoundary, ok := m.manager.GetBoundary(scope.ID()); ok {
+			m.scopeStack[agentID] = append(m.scopeStack[agentID], scope.ID())
+
+			if activeScope, exists := m.activeScopes[agentID]; exists {
+				activeScope.Nested++
+			} else {
+				m.activeScopes[agentID] = &ActiveScope{
+					ScopeID:   scope.ID(),
+					AgentID:   agentID,
+					SessionID: sessionID,
+					Nested:    1,
+				}
+			}
+
+			return existingBoundary.Scope.ID(), nil
+		}
+		return "", fmt.Errorf("failed to create boundary: %w", err)
+	}
+
+	m.scopeStack[agentID] = append(m.scopeStack[agentID], scope.ID())
+
+	if activeScope, exists := m.activeScopes[agentID]; exists {
+		activeScope.ScopeID = scope.ID()
+		activeScope.SessionID = sessionID
+		activeScope.Nested++
+	} else {
+		m.activeScopes[agentID] = &ActiveScope{
+			ScopeID:   scope.ID(),
+			AgentID:   agentID,
+			SessionID: sessionID,
+			Nested:    1,
+		}
+	}
+
+	_ = boundary
+	return scope.ID(), nil
+}
+
+func (m *ContextScopeMiddleware) ExitScope(agentID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	activeScope, exists := m.activeScopes[agentID]
+	if !exists {
+		return fmt.Errorf("no active scope for agent: %s", agentID)
+	}
+
+	if activeScope.Nested > 1 {
+		activeScope.Nested--
+		if len(m.scopeStack[agentID]) > 1 {
+			m.scopeStack[agentID] = m.scopeStack[agentID][:len(m.scopeStack[agentID])-1]
+			activeScope.ScopeID = m.scopeStack[agentID][len(m.scopeStack[agentID])-1]
+		}
+		return nil
+	}
+
+	if len(m.scopeStack[agentID]) > 0 {
+		scopeID := m.scopeStack[agentID][len(m.scopeStack[agentID])-1]
+		m.scopeStack[agentID] = m.scopeStack[agentID][:len(m.scopeStack[agentID])-1]
+		delete(m.activeScopes, agentID)
+		return m.manager.DeleteBoundary(scopeID)
+	}
+
+	delete(m.activeScopes, agentID)
+	return nil
+}
+
+func (m *ContextScopeMiddleware) GetCurrentScope(agentID string) (*ContextScope, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	activeScope, exists := m.activeScopes[agentID]
+	if !exists {
+		return nil, fmt.Errorf("no active scope for agent: %s", agentID)
+	}
+
+	boundary, ok := m.manager.GetBoundary(activeScope.ScopeID)
+	if !ok {
+		return nil, fmt.Errorf("boundary not found for scope: %s", activeScope.ScopeID)
+	}
+
+	return boundary.Scope, nil
+}
+
+func (m *ContextScopeMiddleware) GetCurrentEngine(agentID string) (*IsolatedEngine, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	activeScope, exists := m.activeScopes[agentID]
+	if !exists {
+		return nil, fmt.Errorf("no active scope for agent: %s", agentID)
+	}
+
+	engine, ok := m.manager.GetEngine(activeScope.ScopeID)
+	if !ok {
+		return nil, fmt.Errorf("engine not found for scope: %s", activeScope.ScopeID)
+	}
+
+	return engine, nil
+}
+
+func (m *ContextScopeMiddleware) GetCurrentKVEngine(agentID string) (*ctxengine.Engine, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	activeScope, exists := m.activeScopes[agentID]
+	if !exists {
+		return nil, fmt.Errorf("no active scope for agent: %s", agentID)
+	}
+
+	kvEngine, ok := m.manager.GetKVEngine(activeScope.ScopeID)
+	if !ok {
+		return nil, fmt.Errorf("KV engine not found for scope: %s", activeScope.ScopeID)
+	}
+
+	return kvEngine, nil
+}
+
+func (m *ContextScopeMiddleware) WithScope(ctx context.Context, agentID, sessionID, taskID, namespace string, mode IsolationMode, visibility ContextVisibility, fn func(scopeID string) error) error {
+	scopeID, err := m.EnterScope(agentID, sessionID, taskID, namespace, mode, visibility)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = m.ExitScope(agentID)
+	}()
+
+	return fn(scopeID)
+}
+
+func (m *ContextScopeMiddleware) GetScopeStack(agentID string) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if stack, ok := m.scopeStack[agentID]; ok {
+		result := make([]string, len(stack))
+		copy(result, stack)
+		return result
+	}
+	return nil
+}
+
+func (m *ContextScopeMiddleware) IsScoped(agentID string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, exists := m.activeScopes[agentID]
+	return exists
+}
+
+func (m *ContextScopeMiddleware) ListActiveScopes() []*ActiveScope {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	scopes := make([]*ActiveScope, 0, len(m.activeScopes))
+	for _, scope := range m.activeScopes {
+		scopes = append(scopes, scope)
+	}
+	return scopes
+}
+
+type ContextEnforcer struct {
+	mu         sync.RWMutex
+	middleware *ContextScopeMiddleware
+	rules      map[string]*EnforcementRule
+}
+
+type EnforcementRule struct {
+	AgentID            string
+	RequiredMode       IsolationMode
+	RequiredVisibility ContextVisibility
+	AllowEscalation    bool
+	MaxNestedDepth     int
+}
+
+func NewContextEnforcer(middleware *ContextScopeMiddleware) *ContextEnforcer {
+	return &ContextEnforcer{
+		middleware: middleware,
+		rules:      make(map[string]*EnforcementRule),
+	}
+}
+
+func (e *ContextEnforcer) AddRule(agentID string, rule *EnforcementRule) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.rules[agentID] = rule
+}
+
+func (e *ContextEnforcer) RemoveRule(agentID string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	delete(e.rules, agentID)
+}
+
+func (e *ContextEnforcer) Enforce(agentID string) error {
+	e.mu.RLock()
+	rule, exists := e.rules[agentID]
+	e.mu.RUnlock()
+
+	if !exists {
+		return nil
+	}
+
+	if !e.middleware.IsScoped(agentID) {
+		return fmt.Errorf("agent %s must operate within a context scope", agentID)
+	}
+
+	currentScope, err := e.middleware.GetCurrentScope(agentID)
+	if err != nil {
+		return fmt.Errorf("failed to get current scope: %w", err)
+	}
+
+	boundary, ok := e.middleware.manager.GetBoundary(currentScope.ID())
+	if !ok {
+		return fmt.Errorf("boundary not found for scope: %s", currentScope.ID())
+	}
+
+	if rule.RequiredMode != "" && boundary.Mode != rule.RequiredMode {
+		return fmt.Errorf("agent %s requires isolation mode %s, but current mode is %s", agentID, rule.RequiredMode, boundary.Mode)
+	}
+
+	if rule.RequiredVisibility != "" && boundary.Visibility != rule.RequiredVisibility {
+		return fmt.Errorf("agent %s requires visibility %s, but current visibility is %s", agentID, rule.RequiredVisibility, boundary.Visibility)
+	}
+
+	stack := e.middleware.GetScopeStack(agentID)
+	if rule.MaxNestedDepth > 0 && len(stack) > rule.MaxNestedDepth {
+		return fmt.Errorf("agent %s exceeded max nested depth: %d > %d", agentID, len(stack), rule.MaxNestedDepth)
+	}
+
+	return nil
+}
+
+func (e *ContextEnforcer) EnforceWithFallback(agentID string, fallbackMode IsolationMode, fallbackVisibility ContextVisibility) error {
+	err := e.Enforce(agentID)
+	if err != nil {
+		rule, exists := e.rules[agentID]
+		if exists && rule.AllowEscalation {
+			currentScope, scopeErr := e.middleware.GetCurrentScope(agentID)
+			if scopeErr == nil {
+				boundary, ok := e.middleware.manager.GetBoundary(currentScope.ID())
+				if ok {
+					boundary.Mode = fallbackMode
+					boundary.Visibility = fallbackVisibility
+					return nil
+				}
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+func (e *ContextEnforcer) ListRules() map[string]*EnforcementRule {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	rules := make(map[string]*EnforcementRule)
+	for k, v := range e.rules {
+		rules[k] = v
+	}
+	return rules
+}

--- a/pkg/isolation/scope.go
+++ b/pkg/isolation/scope.go
@@ -49,6 +49,8 @@ func (m *ContextScopeMiddleware) EnterScope(agentID, sessionID, taskID, namespac
 			m.scopeStack[agentID] = append(m.scopeStack[agentID], scope.ID())
 
 			if activeScope, exists := m.activeScopes[agentID]; exists {
+				activeScope.ScopeID = scope.ID()
+				activeScope.SessionID = sessionID
 				activeScope.Nested++
 			} else {
 				m.activeScopes[agentID] = &ActiveScope{
@@ -93,10 +95,27 @@ func (m *ContextScopeMiddleware) ExitScope(agentID string) error {
 	}
 
 	if activeScope.Nested > 1 {
-		activeScope.Nested--
-		if len(m.scopeStack[agentID]) > 1 {
+		exitingScopeID := ""
+		if len(m.scopeStack[agentID]) > 0 {
+			exitingScopeID = m.scopeStack[agentID][len(m.scopeStack[agentID])-1]
 			m.scopeStack[agentID] = m.scopeStack[agentID][:len(m.scopeStack[agentID])-1]
+			if len(m.scopeStack[agentID]) == 0 {
+				delete(m.scopeStack, agentID)
+			}
+		}
+
+		activeScope.Nested--
+		if len(m.scopeStack[agentID]) > 0 {
 			activeScope.ScopeID = m.scopeStack[agentID][len(m.scopeStack[agentID])-1]
+			if boundary, ok := m.manager.GetBoundary(activeScope.ScopeID); ok {
+				activeScope.SessionID = boundary.Scope.SessionID
+			} else {
+				activeScope.SessionID = ""
+			}
+		}
+
+		if exitingScopeID != "" && !scopeStackContains(m.scopeStack[agentID], exitingScopeID) {
+			return m.manager.DeleteBoundary(exitingScopeID)
 		}
 		return nil
 	}
@@ -104,8 +123,14 @@ func (m *ContextScopeMiddleware) ExitScope(agentID string) error {
 	if len(m.scopeStack[agentID]) > 0 {
 		scopeID := m.scopeStack[agentID][len(m.scopeStack[agentID])-1]
 		m.scopeStack[agentID] = m.scopeStack[agentID][:len(m.scopeStack[agentID])-1]
+		if len(m.scopeStack[agentID]) == 0 {
+			delete(m.scopeStack, agentID)
+		}
 		delete(m.activeScopes, agentID)
-		return m.manager.DeleteBoundary(scopeID)
+		if !scopeStackContains(m.scopeStack[agentID], scopeID) {
+			return m.manager.DeleteBoundary(scopeID)
+		}
+		return nil
 	}
 
 	delete(m.activeScopes, agentID)
@@ -204,6 +229,15 @@ func (m *ContextScopeMiddleware) ListActiveScopes() []*ActiveScope {
 		scopes = append(scopes, scope)
 	}
 	return scopes
+}
+
+func scopeStackContains(stack []string, scopeID string) bool {
+	for _, existing := range stack {
+		if existing == scopeID {
+			return true
+		}
+	}
+	return false
 }
 
 type ContextEnforcer struct {

--- a/pkg/isolation/sharing.go
+++ b/pkg/isolation/sharing.go
@@ -1,0 +1,575 @@
+package isolation
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	ctxpkg "github.com/1024XEngineer/anyclaw/pkg/runtime/context/store"
+)
+
+type ContextBridge struct {
+	mu       sync.RWMutex
+	manager  *ContextIsolationManager
+	handlers map[string]BridgeHandler
+}
+
+type BridgeHandler func(sourceScopeID, targetScopeID string, data BridgeData) error
+
+type BridgeData struct {
+	Type      string
+	Payload   any
+	Metadata  map[string]string
+	Timestamp time.Time
+}
+
+type ContextTransfer struct {
+	ID            string
+	SourceScopeID string
+	TargetScopeID string
+	Documents     []ctxpkg.Document
+	KeyValues     map[string]any
+	Namespace     string
+	Status        TransferStatus
+	CreatedAt     time.Time
+	CompletedAt   time.Time
+	Error         string
+}
+
+type TransferStatus string
+
+const (
+	TransferStatusPending   TransferStatus = "pending"
+	TransferStatusApproved  TransferStatus = "approved"
+	TransferStatusRejected  TransferStatus = "rejected"
+	TransferStatusCompleted TransferStatus = "completed"
+	TransferStatusFailed    TransferStatus = "failed"
+)
+
+func NewContextBridge(manager *ContextIsolationManager) *ContextBridge {
+	return &ContextBridge{
+		manager:  manager,
+		handlers: make(map[string]BridgeHandler),
+	}
+}
+
+func (b *ContextBridge) RegisterHandler(transferType string, handler BridgeHandler) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.handlers[transferType] = handler
+}
+
+func (b *ContextBridge) TransferDocuments(ctx context.Context, sourceScopeID, targetScopeID string, docIDs []string, namespace string) (*ContextTransfer, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	sourceBoundary, sourceOk := b.manager.GetBoundary(sourceScopeID)
+	targetBoundary, targetOk := b.manager.GetBoundary(targetScopeID)
+	if !sourceOk || !targetOk {
+		return nil, fmt.Errorf("source or target boundary not found")
+	}
+
+	if !b.manager.CanShareContext(sourceBoundary.Scope.AgentID, targetBoundary.Scope.AgentID, namespace) {
+		return nil, fmt.Errorf("context sharing not allowed from %s to %s for namespace %s", sourceScopeID, targetScopeID, namespace)
+	}
+
+	sourceEngine, ok := b.manager.GetEngine(sourceScopeID)
+	if !ok {
+		return nil, fmt.Errorf("source engine not found: %s", sourceScopeID)
+	}
+
+	targetEngine, ok := b.manager.GetEngine(targetScopeID)
+	if !ok {
+		return nil, fmt.Errorf("target engine not found: %s", targetScopeID)
+	}
+
+	transfer := &ContextTransfer{
+		ID:            fmt.Sprintf("xfer_%s_%s_%d", sourceScopeID, targetScopeID, time.Now().UnixNano()),
+		SourceScopeID: sourceScopeID,
+		TargetScopeID: targetScopeID,
+		Namespace:     namespace,
+		Status:        TransferStatusPending,
+		CreatedAt:     time.Now(),
+		Documents:     make([]ctxpkg.Document, 0),
+		KeyValues:     make(map[string]any),
+	}
+
+	if sourceEngine.Visibility() == ContextVisibilityPrivate {
+		transfer.Status = TransferStatusRejected
+		transfer.Error = "source context is private"
+		return transfer, nil
+	}
+
+	for _, docID := range docIDs {
+		doc, err := sourceEngine.GetDocument(ctx, docID)
+		if err != nil {
+			continue
+		}
+
+		if ns, ok := doc.Metadata["namespace"].(string); namespace != "" && (!ok || ns != namespace) {
+			continue
+		}
+
+		newDoc := *doc
+		newDoc.ID = fmt.Sprintf("transferred_%s_%d", doc.ID, time.Now().UnixNano())
+		newDoc.Metadata = make(map[string]any)
+		for k, v := range doc.Metadata {
+			newDoc.Metadata[k] = v
+		}
+		newDoc.Metadata["transferred_from"] = sourceScopeID
+		newDoc.Metadata["transferred_at"] = time.Now().Format(time.RFC3339)
+
+		if err := targetEngine.AddDocument(ctx, newDoc); err != nil {
+			transfer.Status = TransferStatusFailed
+			transfer.Error = fmt.Sprintf("failed to add document %s: %v", docID, err)
+			return transfer, nil
+		}
+
+		transfer.Documents = append(transfer.Documents, newDoc)
+	}
+
+	transfer.Status = TransferStatusCompleted
+	transfer.CompletedAt = time.Now()
+	return transfer, nil
+}
+
+func (b *ContextBridge) TransferKeyValues(sourceScopeID, targetScopeID string, keys []string, namespace string) (*ContextTransfer, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	sourceBoundary, sourceOk := b.manager.GetBoundary(sourceScopeID)
+	targetBoundary, targetOk := b.manager.GetBoundary(targetScopeID)
+	if !sourceOk || !targetOk {
+		return nil, fmt.Errorf("source or target boundary not found")
+	}
+
+	if !b.manager.CanShareContext(sourceBoundary.Scope.AgentID, targetBoundary.Scope.AgentID, namespace) {
+		return nil, fmt.Errorf("context sharing not allowed from %s to %s for namespace %s", sourceScopeID, targetScopeID, namespace)
+	}
+
+	sourceKV, ok := b.manager.GetKVEngine(sourceScopeID)
+	if !ok {
+		return nil, fmt.Errorf("source KV engine not found: %s", sourceScopeID)
+	}
+
+	targetKV, ok := b.manager.GetKVEngine(targetScopeID)
+	if !ok {
+		return nil, fmt.Errorf("target KV engine not found: %s", targetScopeID)
+	}
+
+	transfer := &ContextTransfer{
+		ID:            fmt.Sprintf("xfer_kv_%s_%s_%d", sourceScopeID, targetScopeID, time.Now().UnixNano()),
+		SourceScopeID: sourceScopeID,
+		TargetScopeID: targetScopeID,
+		Namespace:     namespace,
+		Status:        TransferStatusPending,
+		CreatedAt:     time.Now(),
+		KeyValues:     make(map[string]any),
+	}
+
+	if sourceBoundary.Visibility == ContextVisibilityPrivate {
+		transfer.Status = TransferStatusRejected
+		transfer.Error = "source context is private"
+		return transfer, nil
+	}
+
+	ctx := context.Background()
+	for _, key := range keys {
+		value, err := sourceKV.Get(ctx, key)
+		if err != nil {
+			continue
+		}
+
+		newKey := fmt.Sprintf("shared_%s_%s", sourceScopeID, key)
+		if err := targetKV.Set(ctx, newKey, value); err != nil {
+			transfer.Status = TransferStatusFailed
+			transfer.Error = fmt.Sprintf("failed to set key %s: %v", key, err)
+			return transfer, nil
+		}
+
+		transfer.KeyValues[newKey] = value
+	}
+
+	transfer.Status = TransferStatusCompleted
+	transfer.CompletedAt = time.Now()
+	return transfer, nil
+}
+
+func (b *ContextBridge) ShareAllContext(sourceScopeID, targetScopeID string, namespace string) (*ContextTransfer, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	sourceBoundary, sourceOk := b.manager.GetBoundary(sourceScopeID)
+	targetBoundary, targetOk := b.manager.GetBoundary(targetScopeID)
+	if !sourceOk || !targetOk {
+		return nil, fmt.Errorf("source or target boundary not found")
+	}
+
+	if !b.manager.CanShareContext(sourceBoundary.Scope.AgentID, targetBoundary.Scope.AgentID, namespace) {
+		return nil, fmt.Errorf("context sharing not allowed from %s to %s for namespace %s", sourceScopeID, targetScopeID, namespace)
+	}
+
+	sourceEngine, ok := b.manager.GetEngine(sourceScopeID)
+	if !ok {
+		return nil, fmt.Errorf("source engine not found: %s", sourceScopeID)
+	}
+
+	targetEngine, ok := b.manager.GetEngine(targetScopeID)
+	if !ok {
+		return nil, fmt.Errorf("target engine not found: %s", targetScopeID)
+	}
+
+	transfer := &ContextTransfer{
+		ID:            fmt.Sprintf("xfer_all_%s_%s_%d", sourceScopeID, targetScopeID, time.Now().UnixNano()),
+		SourceScopeID: sourceScopeID,
+		TargetScopeID: targetScopeID,
+		Namespace:     namespace,
+		Status:        TransferStatusPending,
+		CreatedAt:     time.Now(),
+		Documents:     make([]ctxpkg.Document, 0),
+		KeyValues:     make(map[string]any),
+	}
+
+	if sourceBoundary.Visibility == ContextVisibilityPrivate {
+		transfer.Status = TransferStatusRejected
+		transfer.Error = "source context is private"
+		return transfer, nil
+	}
+
+	docs := sourceEngine.SnapshotDocuments()
+	ctx := context.Background()
+
+	for _, doc := range docs {
+		if namespace != "" {
+			if ns, ok := doc.Metadata["namespace"].(string); !ok || ns != namespace {
+				continue
+			}
+		}
+
+		newDoc := doc
+		newDoc.ID = fmt.Sprintf("shared_%s_%d", doc.ID, time.Now().UnixNano())
+		newDoc.Metadata = make(map[string]any)
+		for k, v := range doc.Metadata {
+			newDoc.Metadata[k] = v
+		}
+		newDoc.Metadata["shared_from"] = sourceScopeID
+		newDoc.Metadata["shared_at"] = time.Now().Format(time.RFC3339)
+
+		if err := targetEngine.AddDocument(ctx, newDoc); err != nil {
+			transfer.Status = TransferStatusFailed
+			transfer.Error = fmt.Sprintf("failed to add document: %v", err)
+			return transfer, nil
+		}
+
+		transfer.Documents = append(transfer.Documents, newDoc)
+	}
+
+	if sourceKV, ok := b.manager.GetKVEngine(sourceScopeID); ok {
+		if targetKV, ok := b.manager.GetKVEngine(targetScopeID); ok {
+			for _, kvCtx := range sourceKV.List() {
+				if namespace != "" && kvCtx.Metadata["namespace"] != namespace {
+					continue
+				}
+				newKey := fmt.Sprintf("shared_%s_%s", sourceScopeID, kvCtx.Key)
+				targetKV.Set(ctx, newKey, kvCtx.Value)
+				transfer.KeyValues[newKey] = kvCtx.Value
+			}
+		}
+	}
+
+	transfer.Status = TransferStatusCompleted
+	transfer.CompletedAt = time.Now()
+	return transfer, nil
+}
+
+func (b *ContextBridge) GetTransferHistory(sourceScopeID, targetScopeID string) []*ContextTransfer {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	var transfers []*ContextTransfer
+	for _, engine := range b.manager.ListEngines() {
+		_ = engine
+	}
+	return transfers
+}
+
+func (b *ContextBridge) NotifyTransfer(sourceScopeID, targetScopeID string, data BridgeData) error {
+	b.mu.RLock()
+	handler, ok := b.handlers[data.Type]
+	b.mu.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("no handler registered for transfer type: %s", data.Type)
+	}
+
+	return handler(sourceScopeID, targetScopeID, data)
+}
+
+type ContextAggregator struct {
+	mu      sync.RWMutex
+	manager *ContextIsolationManager
+}
+
+func NewContextAggregator(manager *ContextIsolationManager) *ContextAggregator {
+	return &ContextAggregator{
+		manager: manager,
+	}
+}
+
+func (a *ContextAggregator) AggregateDocuments(scopeIDs []string, namespace string) ([]ctxpkg.Document, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	var allDocs []ctxpkg.Document
+
+	for _, scopeID := range scopeIDs {
+		engine, ok := a.manager.GetEngine(scopeID)
+		if !ok {
+			continue
+		}
+
+		boundary, ok := a.manager.GetBoundary(scopeID)
+		if !ok {
+			continue
+		}
+
+		if boundary.Visibility == ContextVisibilityPrivate {
+			continue
+		}
+
+		if boundary.Mode == IsolationModeStrict {
+			continue
+		}
+
+		docs := engine.GetDocumentsByNamespace(namespace)
+		allDocs = append(allDocs, docs...)
+
+		if namespace == "" {
+			docs = engine.SnapshotDocuments()
+			for _, doc := range docs {
+				alreadyExists := false
+				for _, existing := range allDocs {
+					if existing.ID == doc.ID {
+						alreadyExists = true
+						break
+					}
+				}
+				if !alreadyExists {
+					allDocs = append(allDocs, doc)
+				}
+			}
+		}
+	}
+
+	return allDocs, nil
+}
+
+func (a *ContextAggregator) AggregateKeyValues(scopeIDs []string, namespace string) (map[string]any, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	aggregated := make(map[string]any)
+
+	for _, scopeID := range scopeIDs {
+		kvEngine, ok := a.manager.GetKVEngine(scopeID)
+		if !ok {
+			continue
+		}
+
+		boundary, ok := a.manager.GetBoundary(scopeID)
+		if !ok {
+			continue
+		}
+
+		if boundary.Visibility == ContextVisibilityPrivate {
+			continue
+		}
+
+		if boundary.Mode == IsolationModeStrict {
+			continue
+		}
+
+		for _, kvCtx := range kvEngine.List() {
+			if namespace != "" && kvCtx.Metadata["namespace"] != namespace {
+				continue
+			}
+
+			aggregatedKey := fmt.Sprintf("%s:%s", scopeID, kvCtx.Key)
+			aggregated[aggregatedKey] = kvCtx.Value
+		}
+	}
+
+	return aggregated, nil
+}
+
+func (a *ContextAggregator) CrossScopeSearch(scopeIDs []string, query string, namespace string, topK int) ([]ctxpkg.SearchResult, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	var allResults []ctxpkg.SearchResult
+	ctx := context.Background()
+
+	for _, scopeID := range scopeIDs {
+		engine, ok := a.manager.GetEngine(scopeID)
+		if !ok {
+			continue
+		}
+
+		boundary, ok := a.manager.GetBoundary(scopeID)
+		if !ok {
+			continue
+		}
+
+		if boundary.Visibility == ContextVisibilityPrivate {
+			continue
+		}
+
+		results, err := engine.Search(ctx, query, ctxpkg.SearchOptions{
+			TopK:      topK,
+			Threshold: 0.1,
+			Filters:   map[string]any{"namespace": namespace},
+		})
+		if err != nil {
+			continue
+		}
+
+		allResults = append(allResults, results...)
+	}
+
+	for i := 0; i < len(allResults)-1; i++ {
+		for j := i + 1; j < len(allResults); j++ {
+			if allResults[j].Score > allResults[i].Score {
+				allResults[i], allResults[j] = allResults[j], allResults[i]
+			}
+		}
+	}
+
+	if len(allResults) > topK {
+		allResults = allResults[:topK]
+	}
+
+	return allResults, nil
+}
+
+type ContextSync struct {
+	mu      sync.RWMutex
+	manager *ContextIsolationManager
+	syncing map[string]bool
+}
+
+func NewContextSync(manager *ContextIsolationManager) *ContextSync {
+	return &ContextSync{
+		manager: manager,
+		syncing: make(map[string]bool),
+	}
+}
+
+func (s *ContextSync) SyncContext(sourceScopeID, targetScopeID string, namespace string) error {
+	s.mu.Lock()
+	syncKey := fmt.Sprintf("%s:%s:%s", sourceScopeID, targetScopeID, namespace)
+	if s.syncing[syncKey] {
+		s.mu.Unlock()
+		return fmt.Errorf("sync already in progress for %s", syncKey)
+	}
+	s.syncing[syncKey] = true
+	s.mu.Unlock()
+
+	defer func() {
+		s.mu.Lock()
+		delete(s.syncing, syncKey)
+		s.mu.Unlock()
+	}()
+
+	sourceBoundary, sourceOk := s.manager.GetBoundary(sourceScopeID)
+	targetBoundary, targetOk := s.manager.GetBoundary(targetScopeID)
+	if !sourceOk || !targetOk {
+		return fmt.Errorf("source or target boundary not found")
+	}
+
+	if !s.manager.CanShareContext(sourceBoundary.Scope.AgentID, targetBoundary.Scope.AgentID, namespace) {
+		return fmt.Errorf("context sharing not allowed from %s to %s for namespace %s", sourceScopeID, targetScopeID, namespace)
+	}
+
+	sourceEngine, ok := s.manager.GetEngine(sourceScopeID)
+	if !ok {
+		return fmt.Errorf("source engine not found: %s", sourceScopeID)
+	}
+
+	targetEngine, ok := s.manager.GetEngine(targetScopeID)
+	if !ok {
+		return fmt.Errorf("target engine not found: %s", targetScopeID)
+	}
+
+	docs := sourceEngine.SnapshotDocuments()
+	ctx := context.Background()
+
+	for _, doc := range docs {
+		if namespace != "" {
+			if ns, ok := doc.Metadata["namespace"].(string); !ok || ns != namespace {
+				continue
+			}
+		}
+
+		if _, err := targetEngine.GetDocument(ctx, doc.ID); err == nil {
+			continue
+		}
+
+		newDoc := doc
+		newDoc.Metadata = make(map[string]any)
+		for k, v := range doc.Metadata {
+			newDoc.Metadata[k] = v
+		}
+		newDoc.Metadata["synced_from"] = sourceScopeID
+		newDoc.Metadata["synced_at"] = time.Now().Format(time.RFC3339)
+
+		targetEngine.AddDocument(ctx, newDoc)
+	}
+
+	if sourceKV, ok := s.manager.GetKVEngine(sourceScopeID); ok {
+		if targetKV, ok := s.manager.GetKVEngine(targetScopeID); ok {
+			for _, kvCtx := range sourceKV.List() {
+				if namespace != "" && kvCtx.Metadata["namespace"] != namespace {
+					continue
+				}
+
+				_, err := targetKV.Get(ctx, kvCtx.Key)
+				if err == nil {
+					continue
+				}
+
+				targetKV.Set(ctx, kvCtx.Key, kvCtx.Value)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *ContextSync) IsSyncing(sourceScopeID, targetScopeID, namespace string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	syncKey := fmt.Sprintf("%s:%s:%s", sourceScopeID, targetScopeID, namespace)
+	return s.syncing[syncKey]
+}
+
+func (s *ContextSync) SyncAllPairs(scopeIDs []string, namespace string) map[string]error {
+	results := make(map[string]error)
+
+	for i, sourceID := range scopeIDs {
+		for j, targetID := range scopeIDs {
+			if i == j {
+				continue
+			}
+
+			pairKey := fmt.Sprintf("%s->%s", sourceID, targetID)
+			if err := s.SyncContext(sourceID, targetID, namespace); err != nil {
+				results[pairKey] = err
+			} else {
+				results[pairKey] = nil
+			}
+		}
+	}
+
+	return results
+}

--- a/pkg/isolation/sharing.go
+++ b/pkg/isolation/sharing.go
@@ -70,8 +70,12 @@ func (b *ContextBridge) TransferDocuments(ctx context.Context, sourceScopeID, ta
 		return nil, fmt.Errorf("source or target boundary not found")
 	}
 
-	if !b.manager.CanShareContext(sourceBoundary.Scope.AgentID, targetBoundary.Scope.AgentID, namespace) {
+	policy := b.manager.sharingPolicy(sourceBoundary.Scope.AgentID, targetBoundary.Scope.AgentID, namespace)
+	if policy == nil {
 		return nil, fmt.Errorf("context sharing not allowed from %s to %s for namespace %s", sourceScopeID, targetScopeID, namespace)
+	}
+	if policy.RequireApproval {
+		return nil, fmt.Errorf("context sharing from %s to %s for namespace %s requires approval", sourceScopeID, targetScopeID, namespace)
 	}
 
 	sourceEngine, ok := b.manager.GetEngine(sourceScopeID)
@@ -102,6 +106,10 @@ func (b *ContextBridge) TransferDocuments(ctx context.Context, sourceScopeID, ta
 	}
 
 	for _, docID := range docIDs {
+		if !policyAllowsContextKey(policy, docID) {
+			continue
+		}
+
 		doc, err := sourceEngine.GetDocument(ctx, docID)
 		if err != nil {
 			continue
@@ -144,8 +152,12 @@ func (b *ContextBridge) TransferKeyValues(sourceScopeID, targetScopeID string, k
 		return nil, fmt.Errorf("source or target boundary not found")
 	}
 
-	if !b.manager.CanShareContext(sourceBoundary.Scope.AgentID, targetBoundary.Scope.AgentID, namespace) {
+	policy := b.manager.sharingPolicy(sourceBoundary.Scope.AgentID, targetBoundary.Scope.AgentID, namespace)
+	if policy == nil {
 		return nil, fmt.Errorf("context sharing not allowed from %s to %s for namespace %s", sourceScopeID, targetScopeID, namespace)
+	}
+	if policy.RequireApproval {
+		return nil, fmt.Errorf("context sharing from %s to %s for namespace %s requires approval", sourceScopeID, targetScopeID, namespace)
 	}
 
 	sourceKV, ok := b.manager.GetKVEngine(sourceScopeID)
@@ -176,6 +188,10 @@ func (b *ContextBridge) TransferKeyValues(sourceScopeID, targetScopeID string, k
 
 	ctx := context.Background()
 	for _, key := range keys {
+		if !policyAllowsContextKey(policy, key) {
+			continue
+		}
+
 		value, err := sourceKV.Get(ctx, key)
 		if err != nil {
 			continue
@@ -206,8 +222,12 @@ func (b *ContextBridge) ShareAllContext(sourceScopeID, targetScopeID string, nam
 		return nil, fmt.Errorf("source or target boundary not found")
 	}
 
-	if !b.manager.CanShareContext(sourceBoundary.Scope.AgentID, targetBoundary.Scope.AgentID, namespace) {
+	policy := b.manager.sharingPolicy(sourceBoundary.Scope.AgentID, targetBoundary.Scope.AgentID, namespace)
+	if policy == nil {
 		return nil, fmt.Errorf("context sharing not allowed from %s to %s for namespace %s", sourceScopeID, targetScopeID, namespace)
+	}
+	if policy.RequireApproval {
+		return nil, fmt.Errorf("context sharing from %s to %s for namespace %s requires approval", sourceScopeID, targetScopeID, namespace)
 	}
 
 	sourceEngine, ok := b.manager.GetEngine(sourceScopeID)
@@ -241,6 +261,10 @@ func (b *ContextBridge) ShareAllContext(sourceScopeID, targetScopeID string, nam
 	ctx := context.Background()
 
 	for _, doc := range docs {
+		if !policyAllowsContextKey(policy, doc.ID) {
+			continue
+		}
+
 		if namespace != "" {
 			if ns, ok := doc.Metadata["namespace"].(string); !ok || ns != namespace {
 				continue
@@ -268,11 +292,18 @@ func (b *ContextBridge) ShareAllContext(sourceScopeID, targetScopeID string, nam
 	if sourceKV, ok := b.manager.GetKVEngine(sourceScopeID); ok {
 		if targetKV, ok := b.manager.GetKVEngine(targetScopeID); ok {
 			for _, kvCtx := range sourceKV.List() {
+				if !policyAllowsContextKey(policy, kvCtx.Key) {
+					continue
+				}
 				if namespace != "" && kvCtx.Metadata["namespace"] != namespace {
 					continue
 				}
 				newKey := fmt.Sprintf("shared_%s_%s", sourceScopeID, kvCtx.Key)
-				targetKV.Set(ctx, newKey, kvCtx.Value)
+				if err := targetKV.Set(ctx, newKey, kvCtx.Value); err != nil {
+					transfer.Status = TransferStatusFailed
+					transfer.Error = fmt.Sprintf("failed to set key %s: %v", kvCtx.Key, err)
+					return transfer, nil
+				}
 				transfer.KeyValues[newKey] = kvCtx.Value
 			}
 		}
@@ -425,10 +456,15 @@ func (a *ContextAggregator) CrossScopeSearch(scopeIDs []string, query string, na
 			continue
 		}
 
+		filters := map[string]any(nil)
+		if namespace != "" {
+			filters = map[string]any{"namespace": namespace}
+		}
+
 		results, err := engine.Search(ctx, query, ctxpkg.SearchOptions{
 			TopK:      topK,
 			Threshold: 0.1,
-			Filters:   map[string]any{"namespace": namespace},
+			Filters:   filters,
 		})
 		if err != nil {
 			continue
@@ -445,7 +481,7 @@ func (a *ContextAggregator) CrossScopeSearch(scopeIDs []string, query string, na
 		}
 	}
 
-	if len(allResults) > topK {
+	if topK > 0 && len(allResults) > topK {
 		allResults = allResults[:topK]
 	}
 
@@ -487,8 +523,15 @@ func (s *ContextSync) SyncContext(sourceScopeID, targetScopeID string, namespace
 		return fmt.Errorf("source or target boundary not found")
 	}
 
-	if !s.manager.CanShareContext(sourceBoundary.Scope.AgentID, targetBoundary.Scope.AgentID, namespace) {
+	policy := s.manager.sharingPolicy(sourceBoundary.Scope.AgentID, targetBoundary.Scope.AgentID, namespace)
+	if policy == nil {
 		return fmt.Errorf("context sharing not allowed from %s to %s for namespace %s", sourceScopeID, targetScopeID, namespace)
+	}
+	if policy.RequireApproval {
+		return fmt.Errorf("context sharing from %s to %s for namespace %s requires approval", sourceScopeID, targetScopeID, namespace)
+	}
+	if sourceBoundary.Visibility == ContextVisibilityPrivate {
+		return fmt.Errorf("source context is private")
 	}
 
 	sourceEngine, ok := s.manager.GetEngine(sourceScopeID)
@@ -505,6 +548,10 @@ func (s *ContextSync) SyncContext(sourceScopeID, targetScopeID string, namespace
 	ctx := context.Background()
 
 	for _, doc := range docs {
+		if !policyAllowsContextKey(policy, doc.ID) {
+			continue
+		}
+
 		if namespace != "" {
 			if ns, ok := doc.Metadata["namespace"].(string); !ok || ns != namespace {
 				continue
@@ -523,12 +570,17 @@ func (s *ContextSync) SyncContext(sourceScopeID, targetScopeID string, namespace
 		newDoc.Metadata["synced_from"] = sourceScopeID
 		newDoc.Metadata["synced_at"] = time.Now().Format(time.RFC3339)
 
-		targetEngine.AddDocument(ctx, newDoc)
+		if err := targetEngine.AddDocument(ctx, newDoc); err != nil {
+			return fmt.Errorf("failed to add synced document %s: %w", doc.ID, err)
+		}
 	}
 
 	if sourceKV, ok := s.manager.GetKVEngine(sourceScopeID); ok {
 		if targetKV, ok := s.manager.GetKVEngine(targetScopeID); ok {
 			for _, kvCtx := range sourceKV.List() {
+				if !policyAllowsContextKey(policy, kvCtx.Key) {
+					continue
+				}
 				if namespace != "" && kvCtx.Metadata["namespace"] != namespace {
 					continue
 				}
@@ -538,7 +590,9 @@ func (s *ContextSync) SyncContext(sourceScopeID, targetScopeID string, namespace
 					continue
 				}
 
-				targetKV.Set(ctx, kvCtx.Key, kvCtx.Value)
+				if err := targetKV.Set(ctx, kvCtx.Key, kvCtx.Value); err != nil {
+					return fmt.Errorf("failed to set synced key %s: %w", kvCtx.Key, err)
+				}
 			}
 		}
 	}

--- a/pkg/isolation/types.go
+++ b/pkg/isolation/types.go
@@ -1,0 +1,105 @@
+package isolation
+
+import (
+	"time"
+
+	ctxpkg "github.com/1024XEngineer/anyclaw/pkg/runtime/context/store"
+)
+
+type IsolationMode string
+
+const (
+	IsolationModeStrict  IsolationMode = "strict"
+	IsolationModeShared  IsolationMode = "shared"
+	IsolationModeHybrid  IsolationMode = "hybrid"
+	IsolationModeInherit IsolationMode = "inherit"
+)
+
+type ContextVisibility string
+
+const (
+	ContextVisibilityPrivate ContextVisibility = "private"
+	ContextVisibilityPublic  ContextVisibility = "public"
+	ContextVisibilityScoped  ContextVisibility = "scoped"
+)
+
+type ContextScope struct {
+	AgentID   string
+	SessionID string
+	TaskID    string
+	Namespace string
+	Labels    map[string]string
+	CreatedAt time.Time
+	ExpiresAt time.Time
+}
+
+func (s *ContextScope) ID() string {
+	if s.TaskID != "" {
+		return s.TaskID
+	}
+	if s.SessionID != "" {
+		return s.SessionID
+	}
+	return s.AgentID
+}
+
+type ContextBoundary struct {
+	Scope      *ContextScope
+	Mode       IsolationMode
+	Visibility ContextVisibility
+	Parent     *ContextBoundary
+	Children   []*ContextBoundary
+}
+
+type SharedContextPolicy struct {
+	SourceAgentID   string
+	TargetAgentIDs  []string
+	ContextKeys     []string
+	Namespace       string
+	ExpiresAt       time.Time
+	OneWay          bool
+	RequireApproval bool
+}
+
+type ContextSnapshot struct {
+	ID          string
+	AgentID     string
+	SessionID   string
+	Documents   []ctxpkg.Document
+	KeyValues   map[string]any
+	TakenAt     time.Time
+	Description string
+}
+
+type IsolationConfig struct {
+	DefaultMode       IsolationMode
+	DefaultVisibility ContextVisibility
+	MaxContextSize    int
+	DefaultTTL        time.Duration
+	EnableSharing     bool
+	EnableSnapshots   bool
+	MaxSnapshots      int
+	CleanupInterval   time.Duration
+}
+
+func DefaultIsolationConfig() IsolationConfig {
+	return IsolationConfig{
+		DefaultMode:       IsolationModeStrict,
+		DefaultVisibility: ContextVisibilityPrivate,
+		MaxContextSize:    1000,
+		DefaultTTL:        30 * time.Minute,
+		EnableSharing:     true,
+		EnableSnapshots:   true,
+		MaxSnapshots:      50,
+		CleanupInterval:   5 * time.Minute,
+	}
+}
+
+type IsolatedContextEngine interface {
+	ctxpkg.ContextEngine
+	Scope() *ContextScope
+	Boundary() *ContextBoundary
+	SetVisibility(visibility ContextVisibility)
+	Visibility() ContextVisibility
+	Clone() IsolatedContextEngine
+}


### PR DESCRIPTION
## Summary
- Add the runtime isolation manager package extracted from gateway-module-wiring.
- Split out from the larger gateway-module-wiring work (the previous large gateway wiring PR).

## Merge Order
System.Object[]

## Notes
- This PR is intentionally folder-scoped to make the remaining gateway wiring upload reviewable.
- Recommended base branch for merge order is the dependency list above, even though this PR targets `main`.