### PR TITLE
feat(route): add handoff service and ingress title routing

### DIFF
--- a/pkg/route/handoff/service.go
+++ b/pkg/route/handoff/service.go
@@ -1,0 +1,197 @@
+package handoff
+
+import "strings"
+
+const (
+	ModeMain               = "main"
+	ModePersistentSubagent = "persistent_subagent"
+	ModeTemporarySubagent  = "temporary_subagent"
+)
+
+type HandoffRoutingEntry struct {
+	SessionID           string
+	UserInput           string
+	PreferredSubagentID string
+	SkipDelegation      bool
+	Metadata            map[string]string
+}
+
+type HandoffRequest struct {
+	SessionID           string
+	UserInput           string
+	PreferredSubagentID string
+	SkipDelegation      bool
+}
+
+type PlanOptions struct {
+	PersistentFirst bool
+	AllowTemporary  bool
+}
+
+type HandoffPlan struct {
+	Mode          string
+	TargetAgentID string
+	SessionID     string
+	Persistence   string
+	Reason        string
+}
+
+type PersistentMatcher interface {
+	AvailableAgentNames() []string
+}
+
+type Router struct {
+	persistent PersistentMatcher
+}
+
+func NewRouter(persistent PersistentMatcher) *Router {
+	return &Router{persistent: persistent}
+}
+
+func (r *Router) Prepare(entry HandoffRoutingEntry) HandoffRequest {
+	return HandoffRequest{
+		SessionID:           strings.TrimSpace(entry.SessionID),
+		UserInput:           strings.TrimSpace(entry.UserInput),
+		PreferredSubagentID: strings.TrimSpace(entry.PreferredSubagentID),
+		SkipDelegation:      entry.SkipDelegation,
+	}
+}
+
+func (r *Router) Plan(req HandoffRequest, options PlanOptions) HandoffPlan {
+	req = HandoffRequest{
+		SessionID:           strings.TrimSpace(req.SessionID),
+		UserInput:           strings.TrimSpace(req.UserInput),
+		PreferredSubagentID: strings.TrimSpace(req.PreferredSubagentID),
+		SkipDelegation:      req.SkipDelegation,
+	}
+
+	if req.SkipDelegation {
+		return HandoffPlan{
+			Mode:        ModeMain,
+			SessionID:   req.SessionID,
+			Persistence: "main",
+			Reason:      "skip_delegation requested",
+		}
+	}
+
+	if req.UserInput == "" {
+		return HandoffPlan{
+			Mode:        ModeMain,
+			SessionID:   req.SessionID,
+			Persistence: "main",
+			Reason:      "empty user input",
+		}
+	}
+
+	available := availablePersistentNames(r.persistent)
+	if preferred := req.PreferredSubagentID; preferred != "" {
+		if resolved, ok := resolvePersistentName(available, preferred); ok {
+			return HandoffPlan{
+				Mode:          ModePersistentSubagent,
+				TargetAgentID: resolved,
+				SessionID:     req.SessionID,
+				Persistence:   "persistent",
+				Reason:        "explicit preferred persistent subagent",
+			}
+		}
+		if options.AllowTemporary {
+			return HandoffPlan{
+				Mode:          ModeTemporarySubagent,
+				TargetAgentID: preferred,
+				SessionID:     req.SessionID,
+				Persistence:   "temporary",
+				Reason:        "preferred persistent subagent unavailable; falling back to temporary",
+			}
+		}
+		return HandoffPlan{
+			Mode:        ModeMain,
+			SessionID:   req.SessionID,
+			Persistence: "main",
+			Reason:      "preferred persistent subagent unavailable",
+		}
+	}
+
+	if len(available) == 1 {
+		return HandoffPlan{
+			Mode:          ModePersistentSubagent,
+			TargetAgentID: available[0],
+			SessionID:     req.SessionID,
+			Persistence:   "persistent",
+			Reason:        "single persistent subagent available",
+		}
+	}
+
+	if len(available) > 1 {
+		if !options.PersistentFirst && options.AllowTemporary {
+			return HandoffPlan{
+				Mode:        ModeTemporarySubagent,
+				SessionID:   req.SessionID,
+				Persistence: "temporary",
+				Reason:      "multiple persistent subagents available without an explicit preference",
+			}
+		}
+		return HandoffPlan{
+			Mode:        ModeMain,
+			SessionID:   req.SessionID,
+			Persistence: "main",
+			Reason:      "multiple persistent subagents available without an explicit preference",
+		}
+	}
+
+	if options.AllowTemporary {
+		return HandoffPlan{
+			Mode:        ModeTemporarySubagent,
+			SessionID:   req.SessionID,
+			Persistence: "temporary",
+			Reason:      "no persistent subagent available",
+		}
+	}
+
+	return HandoffPlan{
+		Mode:        ModeMain,
+		SessionID:   req.SessionID,
+		Persistence: "main",
+		Reason:      "no persistent subagent available",
+	}
+}
+
+func availablePersistentNames(matcher PersistentMatcher) []string {
+	if matcher == nil {
+		return nil
+	}
+	return normalizeNames(matcher.AvailableAgentNames())
+}
+
+func resolvePersistentName(available []string, preferred string) (string, bool) {
+	preferred = strings.TrimSpace(preferred)
+	if preferred == "" {
+		return "", false
+	}
+	for _, name := range available {
+		if strings.EqualFold(name, preferred) {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+func normalizeNames(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		name := strings.TrimSpace(item)
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, name)
+	}
+	return result
+}

--- a/pkg/route/handoff/service_test.go
+++ b/pkg/route/handoff/service_test.go
@@ -1,0 +1,118 @@
+package handoff
+
+import "testing"
+
+type stubMatcher struct {
+	names []string
+}
+
+func (s stubMatcher) AvailableAgentNames() []string {
+	return s.names
+}
+
+func TestPrepareNormalizesHandoffEntry(t *testing.T) {
+	router := NewRouter(nil)
+
+	req := router.Prepare(HandoffRoutingEntry{
+		SessionID:           " session-1 ",
+		UserInput:           " inspect repository ",
+		PreferredSubagentID: " specialist-a ",
+		SkipDelegation:      true,
+	})
+
+	if req.SessionID != "session-1" {
+		t.Fatalf("expected trimmed session id, got %q", req.SessionID)
+	}
+	if req.UserInput != "inspect repository" {
+		t.Fatalf("expected trimmed user input, got %q", req.UserInput)
+	}
+	if req.PreferredSubagentID != "specialist-a" {
+		t.Fatalf("expected trimmed preferred agent, got %q", req.PreferredSubagentID)
+	}
+	if !req.SkipDelegation {
+		t.Fatal("expected skip delegation flag to be preserved")
+	}
+}
+
+func TestPlanReturnsMainWhenSkipDelegationIsRequested(t *testing.T) {
+	router := NewRouter(stubMatcher{names: []string{"specialist-a"}})
+
+	plan := router.Plan(HandoffRequest{
+		SessionID:      "session-1",
+		UserInput:      "Inspect the repository",
+		SkipDelegation: true,
+	}, PlanOptions{PersistentFirst: true})
+
+	if plan.Mode != ModeMain {
+		t.Fatalf("expected main mode, got %q", plan.Mode)
+	}
+	if plan.TargetAgentID != "" {
+		t.Fatalf("expected no target agent, got %q", plan.TargetAgentID)
+	}
+}
+
+func TestPlanUsesPreferredPersistentSubagentWhenAvailable(t *testing.T) {
+	router := NewRouter(stubMatcher{names: []string{"specialist-a", "specialist-b"}})
+
+	plan := router.Plan(HandoffRequest{
+		SessionID:           "session-1",
+		UserInput:           "Inspect the repository",
+		PreferredSubagentID: "SPECIALIST-B",
+	}, PlanOptions{PersistentFirst: true})
+
+	if plan.Mode != ModePersistentSubagent {
+		t.Fatalf("expected persistent subagent mode, got %q", plan.Mode)
+	}
+	if plan.TargetAgentID != "specialist-b" {
+		t.Fatalf("expected resolved target agent, got %q", plan.TargetAgentID)
+	}
+}
+
+func TestPlanFallsBackToTemporaryWhenPreferredPersistentSubagentIsUnavailable(t *testing.T) {
+	router := NewRouter(stubMatcher{names: []string{"specialist-a"}})
+
+	plan := router.Plan(HandoffRequest{
+		SessionID:           "session-1",
+		UserInput:           "Inspect the repository",
+		PreferredSubagentID: "specialist-b",
+	}, PlanOptions{PersistentFirst: true, AllowTemporary: true})
+
+	if plan.Mode != ModeTemporarySubagent {
+		t.Fatalf("expected temporary subagent mode, got %q", plan.Mode)
+	}
+	if plan.TargetAgentID != "specialist-b" {
+		t.Fatalf("expected temporary target to keep requested id, got %q", plan.TargetAgentID)
+	}
+}
+
+func TestPlanUsesSingleAvailablePersistentSubagentWhenUnambiguous(t *testing.T) {
+	router := NewRouter(stubMatcher{names: []string{"specialist-a"}})
+
+	plan := router.Plan(HandoffRequest{
+		SessionID: "session-1",
+		UserInput: "Inspect the repository",
+	}, PlanOptions{PersistentFirst: true})
+
+	if plan.Mode != ModePersistentSubagent {
+		t.Fatalf("expected persistent subagent mode, got %q", plan.Mode)
+	}
+	if plan.TargetAgentID != "specialist-a" {
+		t.Fatalf("expected the single available specialist to be selected, got %q", plan.TargetAgentID)
+	}
+}
+
+func TestPlanKeepsTaskOnMainWhenMultiplePersistentSubagentsAreAvailableWithoutPreference(t *testing.T) {
+	router := NewRouter(stubMatcher{names: []string{"specialist-a", "specialist-b"}})
+
+	plan := router.Plan(HandoffRequest{
+		SessionID: "session-1",
+		UserInput: "Inspect the repository",
+	}, PlanOptions{PersistentFirst: true, AllowTemporary: true})
+
+	if plan.Mode != ModeMain {
+		t.Fatalf("expected main mode, got %q", plan.Mode)
+	}
+	if plan.TargetAgentID != "" {
+		t.Fatalf("expected no target agent, got %q", plan.TargetAgentID)
+	}
+}

--- a/pkg/route/ingress/projector.go
+++ b/pkg/route/ingress/projector.go
@@ -10,7 +10,7 @@ type IngressRouteProjector struct{}
 
 // Project converts one gateway-trusted ingress entry into the route layer contract.
 func (p IngressRouteProjector) Project(entry IngressRoutingEntry) (MainRouteRequest, error) {
-	channelID := firstNonEmpty(entry.Scope.ChannelID, entry.Delivery.ChannelID)
+	channelID := strings.TrimSpace(firstNonEmpty(entry.Scope.ChannelID, entry.Delivery.ChannelID))
 	entryPoint := strings.TrimSpace(entry.Scope.EntryPoint)
 	if channelID == "" && entryPoint == "" {
 		return MainRouteRequest{}, fmt.Errorf("ingress routing entry requires an entry point or channel id")
@@ -21,33 +21,33 @@ func (p IngressRouteProjector) Project(entry IngressRoutingEntry) (MainRouteRequ
 
 	scopeMetadata := cloneStringMap(entry.Scope.Metadata)
 	deliveryMetadata := cloneStringMap(entry.Delivery.Metadata)
-	conversationID := firstNonEmpty(
+	conversationID := strings.TrimSpace(firstNonEmpty(
 		entry.Scope.ConversationID,
 		entry.Delivery.ConversationID,
 		entry.Hint.RequestedSessionID,
 		scopeMetadata["conversation_id"],
 		scopeMetadata["chat_id"],
-	)
-	threadID := firstNonEmpty(
+	))
+	threadID := strings.TrimSpace(firstNonEmpty(
 		entry.Scope.ThreadID,
 		entry.Delivery.ThreadID,
 		scopeMetadata["thread_id"],
-	)
+	))
 
 	scope := MessageScope{
 		EntryPoint:     entryPoint,
 		ChannelID:      channelID,
 		ConversationID: conversationID,
 		ThreadID:       threadID,
-		GroupID:        firstNonEmpty(entry.Scope.GroupID, scopeMetadata["group_id"], scopeMetadata["guild_id"]),
+		GroupID:        strings.TrimSpace(firstNonEmpty(entry.Scope.GroupID, scopeMetadata["group_id"], scopeMetadata["guild_id"])),
 		IsGroup:        entry.Scope.IsGroup,
 		Metadata:       scopeMetadata,
 	}
 	delivery := DeliveryHint{
-		ChannelID:      firstNonEmpty(entry.Delivery.ChannelID, scope.ChannelID),
-		ConversationID: firstNonEmpty(entry.Delivery.ConversationID, scope.ConversationID),
+		ChannelID:      strings.TrimSpace(firstNonEmpty(entry.Delivery.ChannelID, scope.ChannelID)),
+		ConversationID: strings.TrimSpace(firstNonEmpty(entry.Delivery.ConversationID, scope.ConversationID)),
 		ReplyTo:        strings.TrimSpace(entry.Delivery.ReplyTo),
-		ThreadID:       firstNonEmpty(entry.Delivery.ThreadID, scope.ThreadID),
+		ThreadID:       strings.TrimSpace(firstNonEmpty(entry.Delivery.ThreadID, scope.ThreadID)),
 		Metadata:       deliveryMetadata,
 	}
 	if len(delivery.Metadata) == 0 {
@@ -55,16 +55,17 @@ func (p IngressRouteProjector) Project(entry IngressRoutingEntry) (MainRouteRequ
 	}
 
 	return MainRouteRequest{
-		MessageID: firstNonEmpty(entry.MessageID, scopeMetadata["message_id"]),
+		MessageID: strings.TrimSpace(firstNonEmpty(entry.MessageID, scopeMetadata["message_id"])),
 		Text:      entry.Text,
+		TitleHint: strings.TrimSpace(firstNonEmpty(entry.TitleHint, scopeMetadata["title_hint"], scopeMetadata["title"])),
 		Actor: MessageActor{
-			UserID: firstNonEmpty(entry.Actor.UserID, scopeMetadata["user_id"]),
-			DisplayName: firstNonEmpty(
+			UserID: strings.TrimSpace(firstNonEmpty(entry.Actor.UserID, scopeMetadata["user_id"])),
+			DisplayName: strings.TrimSpace(firstNonEmpty(
 				entry.Actor.DisplayName,
 				scopeMetadata["user_name"],
 				scopeMetadata["username"],
 				scopeMetadata["display_name"],
-			),
+			)),
 		},
 		Scope:        scope,
 		DeliveryHint: delivery,

--- a/pkg/route/ingress/session_resolver.go
+++ b/pkg/route/ingress/session_resolver.go
@@ -3,6 +3,9 @@ package ingress
 import (
 	"fmt"
 	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // SessionResolver implements M3 for conversation-key reuse and explicit session reuse.
@@ -167,14 +170,14 @@ func buildSessionCreateOptions(request MainRouteRequest, decision RouteDecision,
 }
 
 func sessionTitle(request MainRouteRequest, decision RouteDecision) string {
+	if title := strings.TrimSpace(request.TitleHint); title != "" {
+		return title
+	}
 	if title := strings.TrimSpace(decision.TitleHint); title != "" {
 		return title
 	}
 	source := strings.TrimSpace(firstNonEmpty(request.Scope.ChannelID, "channel"))
-	if source == "" {
-		return "Session"
-	}
-	return strings.ToUpper(source[:1]) + strings.ToLower(source[1:]) + " session"
+	return cases.Title(language.English).String(source) + " session"
 }
 
 func derivedSessionKey(request MainRouteRequest) string {

--- a/pkg/route/ingress/types.go
+++ b/pkg/route/ingress/types.go
@@ -2,7 +2,7 @@ package ingress
 
 import "time"
 
-// RouteRequest is the lightweight routing input consumed by the M2 router.
+// RouteRequest is the legacy channel session routing input used by DecideChannel.
 type RouteRequest struct {
 	Channel   string
 	Source    string
@@ -13,7 +13,8 @@ type RouteRequest struct {
 	TitleHint string
 }
 
-// SessionRoute describes where an inbound message should land for legacy gateway callers.
+// SessionRoute describes where an inbound message should land. It is limited
+// to session-scoped routing concerns and must not select agents or resources.
 type SessionRoute struct {
 	Key         string `json:"key"`
 	SessionMode string `json:"session_mode"`
@@ -43,7 +44,7 @@ type MessageScope struct {
 	Metadata       map[string]string
 }
 
-// DeliveryHint stores the inbound delivery facts observed before delivery routing.
+// DeliveryHint stores the inbound delivery facts observed before M4 resolves a final target.
 type DeliveryHint struct {
 	ChannelID      string
 	ConversationID string
@@ -63,6 +64,7 @@ type RouteHint struct {
 type IngressRoutingEntry struct {
 	MessageID  string
 	Text       string
+	TitleHint  string
 	Actor      MessageActor
 	Scope      MessageScope
 	Delivery   DeliveryHint
@@ -70,10 +72,11 @@ type IngressRoutingEntry struct {
 	ReceivedAt time.Time
 }
 
-// MainRouteRequest is the normalized request emitted by the M1 projector.
+// MainRouteRequest is the normalized request shared by M1-M4.
 type MainRouteRequest struct {
 	MessageID    string
 	Text         string
+	TitleHint    string
 	Actor        MessageActor
 	Scope        MessageScope
 	DeliveryHint DeliveryHint
@@ -99,7 +102,7 @@ type RouteDecision struct {
 	ThreadID        string
 }
 
-// SessionResolution is the M3 output for session selection.
+// SessionResolution is the current M3 output for session selection.
 type SessionResolution struct {
 	SessionID   string
 	SessionKey  string
@@ -112,6 +115,38 @@ type SessionResolution struct {
 	ThreadID    string
 	Created     bool
 	NeedsCreate bool
+}
+
+// DeliveryTarget is the future M4 output for the final outbound target.
+type DeliveryTarget struct {
+	ChannelID      string
+	ConversationID string
+	ReplyTo        string
+	ThreadID       string
+	TransportMeta  map[string]string
+}
+
+// RouteResolution groups the route decisions for one inbound message.
+type RouteResolution struct {
+	Agent    AgentResolution
+	Session  SessionResolution
+	Delivery DeliveryTarget
+}
+
+// RoutedRequest is the route service output consumed by later layers.
+type RoutedRequest struct {
+	Request MainRouteRequest
+	Route   RouteResolution
+}
+
+// RouteInput is the raw input passed to the route service.
+type RouteInput struct {
+	Entry IngressRoutingEntry
+}
+
+// RouteOutput is the result returned by the current route service stage.
+type RouteOutput struct {
+	Request RoutedRequest
 }
 
 // SessionSnapshot is the route-layer view of one persisted session.
@@ -153,38 +188,6 @@ type SessionStore interface {
 	FindByConversationKey(conversationKey string) (SessionSnapshot, bool, error)
 	BindConversationKey(sessionID string, conversationKey string) (SessionSnapshot, error)
 	Create(opts SessionCreateOptions) (SessionSnapshot, error)
-}
-
-// DeliveryTarget is the M4 output for the final outbound target.
-type DeliveryTarget struct {
-	ChannelID      string
-	ConversationID string
-	ReplyTo        string
-	ThreadID       string
-	TransportMeta  map[string]string
-}
-
-// RouteResolution groups the route decisions for one inbound message.
-type RouteResolution struct {
-	Agent    AgentResolution
-	Session  SessionResolution
-	Delivery DeliveryTarget
-}
-
-// RoutedRequest is the route service output consumed by later layers.
-type RoutedRequest struct {
-	Request MainRouteRequest
-	Route   RouteResolution
-}
-
-// RouteInput is the raw input passed to the route service.
-type RouteInput struct {
-	Entry IngressRoutingEntry
-}
-
-// RouteOutput is the result returned by the current route service stage.
-type RouteOutput struct {
-	Request RoutedRequest
 }
 
 // LegacySessionRoute converts the M3 result back into the legacy session-only contract.


### PR DESCRIPTION
## Summary
- Add the route handoff service and the ingress routing updates extracted from gateway-module-wiring.
- Split out from the larger gateway-module-wiring work (the previous large gateway wiring PR).

## Merge Order
System.Object[]

## Notes
- This PR is intentionally folder-scoped to make the remaining gateway wiring upload reviewable.
- Recommended base branch for merge order is the dependency list above, even though this PR targets `main`.