### PR TITLE
feat(speech): add speech synthesis core

### DIFF
--- a/pkg/gateway/transport/reply/dispatch.go
+++ b/pkg/gateway/transport/reply/dispatch.go
@@ -1,0 +1,201 @@
+package reply
+
+import (
+	"context"
+	"sync"
+
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+	"github.com/1024XEngineer/anyclaw/pkg/capability/tools"
+)
+
+type Dispatcher struct {
+	mu         sync.RWMutex
+	agents     map[string]*AgentHandler
+	commands   map[string]CommandHandler
+	hooks      []Hook
+	toolReg    *tools.Registry
+	llmClients map[string]llm.Client
+}
+
+type AgentHandler struct {
+	Name        string
+	Description string
+	Model       string
+	Provider    string
+}
+
+type CommandHandler struct {
+	Name        string
+	Description string
+	Handler     func(ctx context.Context, args map[string]string) (string, error)
+	Auth        string
+}
+
+type Hook interface {
+	OnMessage(ctx context.Context, msg *Message) error
+	OnResponse(ctx context.Context, resp *Response) error
+}
+
+type Message struct {
+	ID        string
+	Channel   string
+	From      string
+	Text      string
+	Timestamp int64
+	Metadata  map[string]any
+}
+
+type Response struct {
+	MessageID string
+	Text      string
+	Tools     []ToolCall
+	Metadata  map[string]any
+}
+
+type ToolCall struct {
+	Name      string
+	Arguments map[string]any
+	ID        string
+}
+
+func NewDispatcher(toolReg *tools.Registry) *Dispatcher {
+	return &Dispatcher{
+		agents:     make(map[string]*AgentHandler),
+		commands:   make(map[string]CommandHandler),
+		hooks:      make([]Hook, 0),
+		toolReg:    toolReg,
+		llmClients: make(map[string]llm.Client),
+	}
+}
+
+func (d *Dispatcher) RegisterAgent(agent *AgentHandler) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.agents[agent.Name] = agent
+}
+
+func (d *Dispatcher) RegisterCommand(cmd CommandHandler) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.commands[cmd.Name] = cmd
+}
+
+func (d *Dispatcher) RegisterHook(hook Hook) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.hooks = append(d.hooks, hook)
+}
+
+func (d *Dispatcher) RegisterLLM(name string, client llm.Client) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.llmClients[name] = client
+}
+
+func (d *Dispatcher) Dispatch(ctx context.Context, msg *Message) (*Response, error) {
+	for _, hook := range d.hooks {
+		if err := hook.OnMessage(ctx, msg); err != nil {
+			return nil, err
+		}
+	}
+
+	if cmd, ok := d.parseCommand(msg.Text); ok {
+		if handler, exists := d.commands[cmd.Name]; exists {
+			result, err := handler.Handler(ctx, cmd.Args)
+			if err != nil {
+				return nil, err
+			}
+			return &Response{
+				MessageID: msg.ID,
+				Text:      result,
+			}, nil
+		}
+	}
+
+	agentName := d.resolveAgent(msg)
+	if agent, ok := d.agents[agentName]; ok {
+		return d.callAgent(ctx, msg, agent)
+	}
+
+	return &Response{
+		MessageID: msg.ID,
+		Text:      "No agent available",
+	}, nil
+}
+
+func (d *Dispatcher) parseCommand(text string) (cmd Command, ok bool) {
+	if len(text) > 1 && text[0] == '/' {
+		parts := splitArgs(text[1:])
+		if len(parts) > 0 {
+			cmd.Name = parts[0]
+			cmd.Args = make(map[string]string)
+			for i := 1; i < len(parts); i++ {
+				cmd.Args[parts[i]] = ""
+			}
+			return cmd, true
+		}
+	}
+	return
+}
+
+type Command struct {
+	Name string
+	Args map[string]string
+}
+
+func splitArgs(s string) []string {
+	var args []string
+	var current string
+	inQuote := false
+
+	for _, c := range s {
+		if c == '"' {
+			inQuote = !inQuote
+		} else if c == ' ' && !inQuote {
+			if current != "" {
+				args = append(args, current)
+				current = ""
+			}
+		} else {
+			current += string(c)
+		}
+	}
+	if current != "" {
+		args = append(args, current)
+	}
+	return args
+}
+
+func (d *Dispatcher) resolveAgent(msg *Message) string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	for name := range d.agents {
+		return name
+	}
+	return ""
+}
+
+func (d *Dispatcher) callAgent(ctx context.Context, msg *Message, agent *AgentHandler) (*Response, error) {
+	d.mu.RLock()
+	client, ok := d.llmClients[agent.Provider]
+	d.mu.RUnlock()
+
+	if !ok || client == nil {
+		return &Response{MessageID: msg.ID, Text: "Provider not available"}, nil
+	}
+
+	messages := []llm.Message{
+		{Role: "user", Content: msg.Text},
+	}
+
+	resp, err := client.Chat(ctx, messages, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Response{
+		MessageID: msg.ID,
+		Text:      resp.Content,
+	}, nil
+}

--- a/pkg/gateway/transport/reply/dispatch_test.go
+++ b/pkg/gateway/transport/reply/dispatch_test.go
@@ -1,0 +1,127 @@
+package reply
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+	"github.com/1024XEngineer/anyclaw/pkg/capability/tools"
+)
+
+type stubHook struct {
+	messageCalls int
+	err          error
+}
+
+func (h *stubHook) OnMessage(ctx context.Context, msg *Message) error {
+	_, _ = ctx, msg
+	h.messageCalls++
+	return h.err
+}
+
+func (h *stubHook) OnResponse(ctx context.Context, resp *Response) error {
+	_, _ = ctx, resp
+	return nil
+}
+
+type stubLLMClient struct {
+	resp *llm.Response
+	err  error
+}
+
+func (c *stubLLMClient) Chat(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition) (*llm.Response, error) {
+	_, _, _ = ctx, messages, tools
+	return c.resp, c.err
+}
+
+func (c *stubLLMClient) StreamChat(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition, onChunk func(string)) error {
+	_, _, _, _ = ctx, messages, tools, onChunk
+	return nil
+}
+
+func (c *stubLLMClient) Name() string {
+	return "stub"
+}
+
+func TestDispatcherCommandAndParsing(t *testing.T) {
+	dispatcher := NewDispatcher(tools.NewRegistry())
+	hook := &stubHook{}
+	dispatcher.RegisterHook(hook)
+	dispatcher.RegisterCommand(CommandHandler{
+		Name: "echo",
+		Handler: func(ctx context.Context, args map[string]string) (string, error) {
+			_ = ctx
+			if _, ok := args["hello world"]; !ok {
+				t.Fatalf("expected parsed arg 'hello world', got %#v", args)
+			}
+			return "ok", nil
+		},
+	})
+
+	resp, err := dispatcher.Dispatch(context.Background(), &Message{
+		ID:   "msg-1",
+		Text: `/echo "hello world"`,
+	})
+	if err != nil {
+		t.Fatalf("Dispatch(command): %v", err)
+	}
+	if resp.Text != "ok" {
+		t.Fatalf("unexpected response text: %q", resp.Text)
+	}
+	if hook.messageCalls != 1 {
+		t.Fatalf("expected hook message calls = 1, got %d", hook.messageCalls)
+	}
+
+	args := splitArgs(`one "two words" three`)
+	if len(args) != 3 || args[1] != "two words" {
+		t.Fatalf("splitArgs() = %#v, want quoted token preserved", args)
+	}
+}
+
+func TestDispatcherAgentFallbacks(t *testing.T) {
+	dispatcher := NewDispatcher(nil)
+	dispatcher.RegisterAgent(&AgentHandler{
+		Name:     "assistant",
+		Provider: "provider-a",
+	})
+
+	resp, err := dispatcher.Dispatch(context.Background(), &Message{ID: "msg-2", Text: "hello"})
+	if err != nil {
+		t.Fatalf("Dispatch(no provider): %v", err)
+	}
+	if resp.Text != "Provider not available" {
+		t.Fatalf("unexpected missing-provider response: %q", resp.Text)
+	}
+
+	dispatcher.RegisterLLM("provider-a", &stubLLMClient{resp: &llm.Response{Content: "agent-reply"}})
+	resp, err = dispatcher.Dispatch(context.Background(), &Message{ID: "msg-3", Text: "hello"})
+	if err != nil {
+		t.Fatalf("Dispatch(agent): %v", err)
+	}
+	if resp.Text != "agent-reply" {
+		t.Fatalf("unexpected agent response: %q", resp.Text)
+	}
+
+	dispatcher.RegisterLLM("provider-a", &stubLLMClient{err: errors.New("llm-failed")})
+	if _, err := dispatcher.Dispatch(context.Background(), &Message{ID: "msg-4", Text: "hello"}); err == nil {
+		t.Fatal("expected llm error to be returned")
+	}
+}
+
+func TestDispatcherNoAgentAndHookError(t *testing.T) {
+	dispatcher := NewDispatcher(nil)
+
+	resp, err := dispatcher.Dispatch(context.Background(), &Message{ID: "msg-5", Text: "hello"})
+	if err != nil {
+		t.Fatalf("Dispatch(no agent): %v", err)
+	}
+	if resp.Text != "No agent available" {
+		t.Fatalf("unexpected no-agent response: %q", resp.Text)
+	}
+
+	dispatcher.RegisterHook(&stubHook{err: errors.New("hook-failed")})
+	if _, err := dispatcher.Dispatch(context.Background(), &Message{ID: "msg-6", Text: "hello"}); err == nil {
+		t.Fatal("expected hook error to abort dispatch")
+	}
+}

--- a/pkg/speech/audio_player.go
+++ b/pkg/speech/audio_player.go
@@ -1,0 +1,417 @@
+package speech
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync"
+)
+
+type AudioPlayer interface {
+	Play(ctx context.Context, audio []byte, format AudioFormat) error
+	Stop() error
+	IsPlaying() bool
+}
+
+type LocalAudioPlayer struct {
+	mu         sync.Mutex
+	isPlaying  bool
+	currentCmd *exec.Cmd
+	tempDir    string
+	playerCmd  string
+	volume     float64
+}
+
+type LocalAudioPlayerConfig struct {
+	TempDir   string
+	PlayerCmd string
+	Volume    float64
+}
+
+func DefaultLocalAudioPlayerConfig() LocalAudioPlayerConfig {
+	return LocalAudioPlayerConfig{
+		Volume: 1.0,
+	}
+}
+
+func NewLocalAudioPlayer(cfg LocalAudioPlayerConfig) *LocalAudioPlayer {
+	if cfg.Volume <= 0 || cfg.Volume > 2.0 {
+		cfg.Volume = 1.0
+	}
+
+	if cfg.TempDir == "" {
+		cfg.TempDir = os.TempDir()
+	}
+
+	if cfg.PlayerCmd == "" {
+		cfg.PlayerCmd = detectPlayer()
+	}
+
+	return &LocalAudioPlayer{
+		tempDir:   cfg.TempDir,
+		playerCmd: cfg.PlayerCmd,
+		volume:    cfg.Volume,
+	}
+}
+
+func detectPlayer() string {
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := exec.LookPath("afplay"); err == nil {
+			return "afplay"
+		}
+	case "linux":
+		players := []string{"aplay", "paplay", "ffplay", "vlc", "mplayer"}
+		for _, p := range players {
+			if _, err := exec.LookPath(p); err == nil {
+				return p
+			}
+		}
+	case "windows":
+		if _, err := exec.LookPath("powershell"); err == nil {
+			return "powershell"
+		}
+	}
+	return ""
+}
+
+func (p *LocalAudioPlayer) Play(ctx context.Context, audio []byte, format AudioFormat) error {
+	p.mu.Lock()
+	if p.isPlaying {
+		p.mu.Unlock()
+		p.Stop()
+		p.mu.Lock()
+	}
+
+	playerCmd := p.playerCmd
+	if playerCmd == "" {
+		p.mu.Unlock()
+		return fmt.Errorf("audio-player: no player available, install aplay/afplay/ffplay")
+	}
+	p.mu.Unlock()
+
+	tmpPath, err := p.writeTempFile(audio, format)
+	if err != nil {
+		return fmt.Errorf("audio-player: failed to write temp file: %w", err)
+	}
+	defer os.Remove(tmpPath)
+
+	return p.playFile(ctx, tmpPath, format)
+}
+
+func (p *LocalAudioPlayer) writeTempFile(audio []byte, format AudioFormat) (string, error) {
+	ext := string(format)
+	if ext == "" {
+		ext = "wav"
+	}
+
+	f, err := os.CreateTemp(p.tempDir, fmt.Sprintf("voicewake-*.%s", ext))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	if _, err := f.Write(audio); err != nil {
+		return "", err
+	}
+
+	return f.Name(), nil
+}
+
+func (p *LocalAudioPlayer) playFile(ctx context.Context, filePath string, format AudioFormat) error {
+	p.mu.Lock()
+	p.isPlaying = true
+	p.mu.Unlock()
+
+	defer func() {
+		p.mu.Lock()
+		p.isPlaying = false
+		p.mu.Unlock()
+	}()
+
+	var cmd *exec.Cmd
+
+	switch p.playerCmd {
+	case "afplay":
+		cmd = exec.CommandContext(ctx, "afplay", filePath)
+
+	case "aplay":
+		cmd = exec.CommandContext(ctx, "aplay", "-q", filePath)
+
+	case "paplay":
+		cmd = exec.CommandContext(ctx, "paplay", filePath)
+
+	case "ffplay":
+		cmd = exec.CommandContext(ctx, "ffplay", "-nodisp", "-autoexit", "-loglevel", "quiet", filePath)
+
+	case "vlc":
+		cmd = exec.CommandContext(ctx, "vlc", "--play-and-exit", "--intf", "dummy", filePath)
+
+	case "mplayer":
+		cmd = exec.CommandContext(ctx, "mplayer", "-noconsolecontrols", filePath)
+
+	case "powershell":
+		psScript := fmt.Sprintf(`
+			Add-Type -AssemblyName presentationCore
+			$media = New-Object system.windows.media.mediaplayer
+			$media.open('%s')
+			$media.Play()
+			Start-Sleep -Seconds $media.NaturalDuration.TimeSpan.TotalSeconds
+			$media.Stop()
+			$media.Close()
+		`, filePath)
+		cmd = exec.CommandContext(ctx, "powershell", "-Command", psScript)
+
+	default:
+		return fmt.Errorf("audio-player: unsupported player: %s", p.playerCmd)
+	}
+
+	p.mu.Lock()
+	p.currentCmd = cmd
+	p.mu.Unlock()
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.Canceled {
+			return nil
+		}
+		return fmt.Errorf("audio-player: playback failed: %w (stderr: %s)", err, stderr.String())
+	}
+
+	return nil
+}
+
+func (p *LocalAudioPlayer) Stop() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.currentCmd != nil && p.currentCmd.Process != nil {
+		p.currentCmd.Process.Kill()
+	}
+	p.isPlaying = false
+	return nil
+}
+
+func (p *LocalAudioPlayer) IsPlaying() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.isPlaying
+}
+
+func (p *LocalAudioPlayer) SetVolume(vol float64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if vol >= 0 && vol <= 2.0 {
+		p.volume = vol
+	}
+}
+
+func (p *LocalAudioPlayer) Volume() float64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.volume
+}
+
+func (p *LocalAudioPlayer) SetPlayer(cmd string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.playerCmd = cmd
+}
+
+func (p *LocalAudioPlayer) Player() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.playerCmd
+}
+
+func (p *LocalAudioPlayer) AvailablePlayers() []string {
+	players := []string{}
+
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := exec.LookPath("afplay"); err == nil {
+			players = append(players, "afplay")
+		}
+
+	case "linux":
+		for _, p := range []string{"aplay", "paplay", "ffplay", "vlc", "mplayer"} {
+			if _, err := exec.LookPath(p); err == nil {
+				players = append(players, p)
+			}
+		}
+
+	case "windows":
+		if _, err := exec.LookPath("powershell"); err == nil {
+			players = append(players, "powershell")
+		}
+	}
+
+	return players
+}
+
+type BufferAudioPlayer struct {
+	mu        sync.Mutex
+	isPlaying bool
+	buffer    []byte
+	format    AudioFormat
+	playCh    chan struct{}
+	stopCh    chan struct{}
+}
+
+func NewBufferAudioPlayer() *BufferAudioPlayer {
+	return &BufferAudioPlayer{
+		playCh: make(chan struct{}, 1),
+		stopCh: make(chan struct{}),
+	}
+}
+
+func (p *BufferAudioPlayer) Play(ctx context.Context, audio []byte, format AudioFormat) error {
+	p.mu.Lock()
+	if p.isPlaying {
+		select {
+		case <-p.stopCh:
+		default:
+		}
+	}
+
+	p.buffer = audio
+	p.format = format
+	p.isPlaying = true
+	p.mu.Unlock()
+
+	select {
+	case p.playCh <- struct{}{}:
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		p.Stop()
+		return ctx.Err()
+	case <-p.stopCh:
+		return nil
+	}
+}
+
+func (p *BufferAudioPlayer) Stop() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.isPlaying = false
+	select {
+	case p.stopCh <- struct{}{}:
+	default:
+	}
+
+	return nil
+}
+
+func (p *BufferAudioPlayer) IsPlaying() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.isPlaying
+}
+
+func (p *BufferAudioPlayer) Buffer() []byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]byte(nil), p.buffer...)
+}
+
+func (p *BufferAudioPlayer) Format() AudioFormat {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.format
+}
+
+type MultiAudioPlayer struct {
+	mu      sync.Mutex
+	players []AudioPlayer
+	current AudioPlayer
+}
+
+func NewMultiAudioPlayer(players ...AudioPlayer) *MultiAudioPlayer {
+	return &MultiAudioPlayer{
+		players: players,
+	}
+}
+
+func (p *MultiAudioPlayer) Play(ctx context.Context, audio []byte, format AudioFormat) error {
+	p.mu.Lock()
+
+	if p.current == nil && len(p.players) > 0 {
+		p.current = p.players[0]
+	}
+
+	player := p.current
+	p.mu.Unlock()
+
+	if player == nil {
+		return fmt.Errorf("audio-player: no players available")
+	}
+
+	return player.Play(ctx, audio, format)
+}
+
+func (p *MultiAudioPlayer) Stop() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.current != nil {
+		return p.current.Stop()
+	}
+	return nil
+}
+
+func (p *MultiAudioPlayer) IsPlaying() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.current != nil {
+		return p.current.IsPlaying()
+	}
+	return false
+}
+
+func (p *MultiAudioPlayer) AddPlayer(player AudioPlayer) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.players = append(p.players, player)
+}
+
+func (p *MultiAudioPlayer) SetPlayer(index int) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if index < 0 || index >= len(p.players) {
+		return fmt.Errorf("audio-player: player index %d out of range", index)
+	}
+
+	p.current = p.players[index]
+	return nil
+}
+
+func (p *MultiAudioPlayer) Players() []AudioPlayer {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]AudioPlayer(nil), p.players...)
+}
+
+type NopAudioPlayer struct{}
+
+func (NopAudioPlayer) Play(ctx context.Context, audio []byte, format AudioFormat) error {
+	return nil
+}
+
+func (NopAudioPlayer) Stop() error {
+	return nil
+}
+
+func (NopAudioPlayer) IsPlaying() bool {
+	return false
+}

--- a/pkg/speech/audio_player_test.go
+++ b/pkg/speech/audio_player_test.go
@@ -1,0 +1,186 @@
+package speech
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+type testAudioPlayer struct {
+	playing bool
+	audio   []byte
+	format  AudioFormat
+}
+
+func (p *testAudioPlayer) Play(ctx context.Context, audio []byte, format AudioFormat) error {
+	_ = ctx
+	p.playing = true
+	p.audio = append([]byte(nil), audio...)
+	p.format = format
+	return nil
+}
+
+func (p *testAudioPlayer) Stop() error {
+	p.playing = false
+	return nil
+}
+
+func (p *testAudioPlayer) IsPlaying() bool {
+	return p.playing
+}
+
+func TestLocalAudioPlayerHelpers(t *testing.T) {
+	tempDir := t.TempDir()
+	defaultCfg := DefaultLocalAudioPlayerConfig()
+	if defaultCfg.Volume != 1.0 {
+		t.Fatalf("DefaultLocalAudioPlayerConfig() = %+v, want Volume=1.0", defaultCfg)
+	}
+
+	player := NewLocalAudioPlayer(LocalAudioPlayerConfig{
+		TempDir:   tempDir,
+		PlayerCmd: "custom-player",
+		Volume:    5,
+	})
+
+	if player.Player() != "custom-player" {
+		t.Fatalf("Player() = %q, want custom-player", player.Player())
+	}
+	if player.Volume() != 1.0 {
+		t.Fatalf("Volume() = %v, want 1.0", player.Volume())
+	}
+
+	tmpPath, err := player.writeTempFile([]byte("audio"), FormatWAV)
+	if err != nil {
+		t.Fatalf("writeTempFile: %v", err)
+	}
+	defer os.Remove(tmpPath)
+
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		t.Fatalf("ReadFile(temp): %v", err)
+	}
+	if string(data) != "audio" {
+		t.Fatalf("unexpected temp file contents: %q", data)
+	}
+
+	player.SetVolume(1.5)
+	player.SetVolume(9)
+	if player.Volume() != 1.5 {
+		t.Fatalf("Volume() after updates = %v, want 1.5", player.Volume())
+	}
+
+	player.SetPlayer("")
+	if err := player.Play(context.Background(), []byte("audio"), FormatMP3); err == nil {
+		t.Fatal("expected Play without player command to fail")
+	}
+
+	player.SetPlayer("unsupported")
+	if err := player.playFile(context.Background(), tmpPath, FormatMP3); err == nil {
+		t.Fatal("expected playFile with unsupported player to fail")
+	}
+	if player.IsPlaying() {
+		t.Fatal("expected unsupported playback to reset playing state")
+	}
+
+	player.isPlaying = true
+	if err := player.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if player.IsPlaying() {
+		t.Fatal("expected Stop to clear playing state")
+	}
+
+	_ = detectPlayer()
+
+	if players := player.AvailablePlayers(); players == nil {
+		t.Fatal("AvailablePlayers() should not return nil")
+	}
+}
+
+func TestBufferAndMultiAudioPlayers(t *testing.T) {
+	buffer := NewBufferAudioPlayer()
+
+	ctx, cancelRunning := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- buffer.Play(ctx, []byte("stream"), FormatWAV)
+	}()
+
+	select {
+	case <-buffer.playCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for buffer player to start")
+	}
+
+	if !buffer.IsPlaying() {
+		t.Fatal("expected buffer player to be playing")
+	}
+
+	cancelRunning()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Buffer Play returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for buffer player to return")
+	}
+
+	if buffer.IsPlaying() {
+		t.Fatal("expected buffer player to stop")
+	}
+	if string(buffer.Buffer()) != "stream" || buffer.Format() != FormatWAV {
+		t.Fatalf("unexpected buffer state: %q / %s", buffer.Buffer(), buffer.Format())
+	}
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := buffer.Play(cancelCtx, []byte("cancel"), FormatMP3); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+	if err := buffer.Stop(); err != nil {
+		t.Fatalf("Buffer Stop: %v", err)
+	}
+
+	multi := NewMultiAudioPlayer()
+	if err := multi.Play(context.Background(), []byte("x"), FormatPCM); err == nil {
+		t.Fatal("expected empty multi player to fail")
+	}
+
+	player := &testAudioPlayer{}
+	multi.AddPlayer(player)
+	if err := multi.SetPlayer(1); err == nil {
+		t.Fatal("expected invalid player index to fail")
+	}
+	if err := multi.SetPlayer(0); err != nil {
+		t.Fatalf("SetPlayer(0): %v", err)
+	}
+	if err := multi.Play(context.Background(), []byte("abc"), FormatPCM); err != nil {
+		t.Fatalf("Multi Play: %v", err)
+	}
+	if !multi.IsPlaying() {
+		t.Fatal("expected multi player to report playing")
+	}
+	if err := multi.Stop(); err != nil {
+		t.Fatalf("Multi Stop: %v", err)
+	}
+	if multi.IsPlaying() {
+		t.Fatal("expected multi player to stop")
+	}
+	if got := multi.Players(); len(got) != 1 {
+		t.Fatalf("Players() len = %d, want 1", len(got))
+	}
+
+	var nop NopAudioPlayer
+	if err := nop.Play(context.Background(), []byte("abc"), FormatMP3); err != nil {
+		t.Fatalf("Nop Play: %v", err)
+	}
+	if nop.IsPlaying() {
+		t.Fatal("expected nop player to never report playing")
+	}
+	if err := nop.Stop(); err != nil {
+		t.Fatalf("Nop Stop: %v", err)
+	}
+}

--- a/pkg/speech/cache.go
+++ b/pkg/speech/cache.go
@@ -1,0 +1,211 @@
+package speech
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type AudioCache struct {
+	mu           sync.RWMutex
+	items        map[string]audioCacheItem
+	maxSize      int
+	maxBytes     int64
+	currentBytes int64
+	ttl          time.Duration
+}
+
+type audioCacheItem struct {
+	result    *AudioResult
+	expiresAt time.Time
+	sizeBytes int64
+}
+
+type CacheConfig struct {
+	MaxSize  int
+	MaxBytes int64
+	TTL      time.Duration
+}
+
+func DefaultCacheConfig() CacheConfig {
+	return CacheConfig{
+		MaxSize:  1000,
+		MaxBytes: 500 * 1024 * 1024,
+		TTL:      24 * time.Hour,
+	}
+}
+
+func NewAudioCache(cfg CacheConfig) *AudioCache {
+	if cfg.MaxSize <= 0 {
+		cfg.MaxSize = 1000
+	}
+	if cfg.MaxBytes <= 0 {
+		cfg.MaxBytes = 500 * 1024 * 1024
+	}
+	if cfg.TTL <= 0 {
+		cfg.TTL = 24 * time.Hour
+	}
+
+	return &AudioCache{
+		items:    make(map[string]audioCacheItem),
+		maxSize:  cfg.MaxSize,
+		maxBytes: cfg.MaxBytes,
+		ttl:      cfg.TTL,
+	}
+}
+
+func (c *AudioCache) Get(key string) (*AudioResult, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	item, ok := c.items[key]
+	if !ok {
+		return nil, false
+	}
+
+	if time.Now().After(item.expiresAt) {
+		return nil, false
+	}
+
+	return item.result, true
+}
+
+func (c *AudioCache) Set(key string, result *AudioResult) {
+	if result == nil || len(result.Data) == 0 {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	sizeBytes := int64(len(result.Data))
+
+	if sizeBytes > c.maxBytes {
+		return
+	}
+
+	if len(c.items) >= c.maxSize || c.currentBytes+sizeBytes > c.maxBytes {
+		c.evict(sizeBytes)
+	}
+
+	c.items[key] = audioCacheItem{
+		result:    result,
+		expiresAt: time.Now().Add(c.ttl),
+		sizeBytes: sizeBytes,
+	}
+	c.currentBytes += sizeBytes
+}
+
+func (c *AudioCache) evict(neededBytes int64) {
+	now := time.Now()
+
+	for k, v := range c.items {
+		if now.After(v.expiresAt) {
+			c.currentBytes -= v.sizeBytes
+			delete(c.items, k)
+		}
+	}
+
+	if len(c.items) >= c.maxSize || c.currentBytes+neededBytes > c.maxBytes {
+		oldestKey := ""
+		oldestTime := time.Now().Add(c.ttl)
+
+		for k, v := range c.items {
+			if v.expiresAt.Before(oldestTime) {
+				oldestTime = v.expiresAt
+				oldestKey = k
+			}
+		}
+
+		if oldestKey != "" {
+			item := c.items[oldestKey]
+			c.currentBytes -= item.sizeBytes
+			delete(c.items, oldestKey)
+		}
+	}
+
+	if len(c.items) >= c.maxSize {
+		count := 0
+		half := c.maxSize / 2
+		for k, v := range c.items {
+			c.currentBytes -= v.sizeBytes
+			delete(c.items, k)
+			count++
+			if count >= half {
+				break
+			}
+		}
+	}
+}
+
+func (c *AudioCache) Remove(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if item, ok := c.items[key]; ok {
+		c.currentBytes -= item.sizeBytes
+		delete(c.items, key)
+	}
+}
+
+func (c *AudioCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.items)
+}
+
+func (c *AudioCache) SizeBytes() int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.currentBytes
+}
+
+func (c *AudioCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items = make(map[string]audioCacheItem)
+	c.currentBytes = 0
+}
+
+func (c *AudioCache) Cleanup() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	count := 0
+
+	for k, v := range c.items {
+		if now.After(v.expiresAt) {
+			c.currentBytes -= v.sizeBytes
+			delete(c.items, k)
+			count++
+		}
+	}
+
+	return count
+}
+
+func MakeCacheKey(text string, provider string, opts ...SynthesizeOption) string {
+	options := SynthesizeOptions{
+		Voice:  "default",
+		Speed:  1.0,
+		Format: FormatMP3,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	raw := fmt.Sprintf("%s|%s|%s|%.2f|%s|%s",
+		provider,
+		options.Voice,
+		text,
+		options.Speed,
+		options.Format,
+		options.Language,
+	)
+
+	hash := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(hash[:])
+}

--- a/pkg/speech/implementations.go
+++ b/pkg/speech/implementations.go
@@ -1,0 +1,1308 @@
+package speech
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type OpenAIModel string
+
+const (
+	OpenAITTS1   OpenAIModel = "tts-1"
+	OpenAITTS1HD OpenAIModel = "tts-1-hd"
+)
+
+type OpenAIProvider struct {
+	apiKey  string
+	baseURL string
+	voice   string
+	model   OpenAIModel
+	timeout time.Duration
+	retries int
+	client  *http.Client
+}
+
+type OpenAIOption func(*OpenAIProvider)
+
+func WithOpenAIBaseURL(url string) OpenAIOption {
+	return func(p *OpenAIProvider) {
+		p.baseURL = url
+	}
+}
+
+func WithOpenAIVoice(voice string) OpenAIOption {
+	return func(p *OpenAIProvider) {
+		p.voice = voice
+	}
+}
+
+func WithOpenAIModel(model OpenAIModel) OpenAIOption {
+	return func(p *OpenAIProvider) {
+		p.model = model
+	}
+}
+
+func WithOpenAITimeout(timeout time.Duration) OpenAIOption {
+	return func(p *OpenAIProvider) {
+		p.timeout = timeout
+	}
+}
+
+func WithOpenAIRetries(retries int) OpenAIOption {
+	return func(p *OpenAIProvider) {
+		p.retries = retries
+	}
+}
+
+func NewOpenAIProvider(apiKey string, opts ...OpenAIOption) (*OpenAIProvider, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("openai: API key is required")
+	}
+
+	p := &OpenAIProvider{
+		apiKey:  apiKey,
+		baseURL: "https://api.openai.com",
+		voice:   "alloy",
+		model:   OpenAITTS1,
+		timeout: 60 * time.Second,
+		retries: 2,
+		client:  &http.Client{Timeout: 60 * time.Second},
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	p.client.Timeout = p.timeout
+
+	return p, nil
+}
+
+func (p *OpenAIProvider) Name() string {
+	return "openai"
+}
+
+func (p *OpenAIProvider) Type() ProviderType {
+	return ProviderOpenAI
+}
+
+func (p *OpenAIProvider) Synthesize(ctx context.Context, text string, opts ...SynthesizeOption) (*AudioResult, error) {
+	options := SynthesizeOptions{
+		Voice:      p.voice,
+		Speed:      1.0,
+		Format:     FormatMP3,
+		SampleRate: 24000,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	payload := map[string]any{
+		"model":  string(p.model),
+		"input":  text,
+		"voice":  options.Voice,
+		"speed":  options.Speed,
+		"format": string(options.Format),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("openai: failed to marshal request: %w", err)
+	}
+
+	url := p.baseURL + "/v1/audio/speech"
+
+	var lastErr error
+	for attempt := 0; attempt <= p.retries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(attempt) * 500 * time.Millisecond
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("openai: context cancelled during retry: %w", ctx.Err())
+			case <-time.After(backoff):
+			}
+		}
+
+		result, err := p.doSynthesize(ctx, url, body, options)
+		if err == nil {
+			return result, nil
+		}
+
+		lastErr = err
+	}
+
+	return nil, fmt.Errorf("openai: all %d retries failed, last error: %w", p.retries, lastErr)
+}
+
+func (p *OpenAIProvider) doSynthesize(ctx context.Context, url string, body []byte, options SynthesizeOptions) (*AudioResult, error) {
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("openai: failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("openai: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("openai: API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	audioData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("openai: failed to read response: %w", err)
+	}
+
+	return &AudioResult{
+		Data:        audioData,
+		Format:      options.Format,
+		SampleRate:  options.SampleRate,
+		ContentType: "audio/mpeg",
+	}, nil
+}
+
+func (p *OpenAIProvider) ListVoices(ctx context.Context) ([]Voice, error) {
+	_ = ctx
+	return []Voice{
+		{ID: "alloy", Name: "Alloy", Language: "en", LanguageTag: "en-US", Gender: GenderNeutral, Provider: "openai", Description: "Balanced and versatile voice"},
+		{ID: "echo", Name: "Echo", Language: "en", LanguageTag: "en-US", Gender: GenderMale, Provider: "openai", Description: "Warm and friendly voice"},
+		{ID: "fable", Name: "Fable", Language: "en", LanguageTag: "en-GB", Gender: GenderNeutral, Provider: "openai", Description: "British accent, storytelling voice"},
+		{ID: "onyx", Name: "Onyx", Language: "en", LanguageTag: "en-US", Gender: GenderMale, Provider: "openai", Description: "Deep and authoritative voice"},
+		{ID: "nova", Name: "Nova", Language: "en", LanguageTag: "en-US", Gender: GenderFemale, Provider: "openai", Description: "Clear and professional voice"},
+		{ID: "shimmer", Name: "Shimmer", Language: "en", LanguageTag: "en-US", Gender: GenderFemale, Provider: "openai", Description: "Light and cheerful voice"},
+	}, nil
+}
+
+func (p *OpenAIProvider) GetVoice(ctx context.Context, voiceID string) (*Voice, error) {
+	voices, err := p.ListVoices(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range voices {
+		if v.ID == voiceID {
+			return &v, nil
+		}
+	}
+
+	return nil, fmt.Errorf("openai: voice not found: %s", voiceID)
+}
+
+func (p *OpenAIProvider) ValidateVoice(voiceID string) error {
+	validVoices := map[string]bool{
+		"alloy":   true,
+		"echo":    true,
+		"fable":   true,
+		"onyx":    true,
+		"nova":    true,
+		"shimmer": true,
+	}
+
+	if !validVoices[voiceID] {
+		return fmt.Errorf("openai: invalid voice: %s", voiceID)
+	}
+
+	return nil
+}
+
+func (p *OpenAIProvider) SynthesizeStream(ctx context.Context, text string, opts ...SynthesizeOption) (chan []byte, error) {
+	options := SynthesizeOptions{
+		Voice:      p.voice,
+		Speed:      1.0,
+		Format:     FormatMP3,
+		SampleRate: 24000,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	payload := map[string]any{
+		"model":  string(p.model),
+		"input":  text,
+		"voice":  options.Voice,
+		"speed":  options.Speed,
+		"format": string(options.Format),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("openai: failed to marshal request: %w", err)
+	}
+
+	url := p.baseURL + "/v1/audio/speech"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("openai: failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("openai: request failed: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("openai: API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	ch := make(chan []byte, 16)
+
+	go func() {
+		defer close(ch)
+		defer resp.Body.Close()
+
+		buf := make([]byte, 4096)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			n, err := resp.Body.Read(buf)
+			if n > 0 {
+				chunk := make([]byte, n)
+				copy(chunk, buf[:n])
+				ch <- chunk
+			}
+			if err != nil {
+				if err != io.EOF {
+					return
+				}
+				return
+			}
+		}
+	}()
+
+	return ch, nil
+}
+
+func (p *OpenAIProvider) SetModel(model OpenAIModel) {
+	p.model = model
+}
+
+func (p *OpenAIProvider) SetVoice(voice string) {
+	p.voice = voice
+}
+
+type ElevenLabsModel string
+
+const (
+	ElevenLabsMultilingualV2    ElevenLabsModel = "eleven_multilingual_v2"
+	ElevenLabsTurboV2           ElevenLabsModel = "eleven_turbo_v2"
+	ElevenLabsTurboV25          ElevenLabsModel = "eleven_turbo_v2_5"
+	ElevenLabsMultilingualSTSV1 ElevenLabsModel = "eleven_multilingual_sts_v1"
+	ElevenLabsTurboSTSV1        ElevenLabsModel = "eleven_turbo_sts_v1"
+)
+
+type ElevenLabsVoiceSettings struct {
+	Stability       float64
+	SimilarityBoost float64
+	Style           float64
+	UseSpeakerBoost bool
+}
+
+type ElevenLabsProvider struct {
+	apiKey        string
+	baseURL       string
+	voice         string
+	model         ElevenLabsModel
+	voiceSettings ElevenLabsVoiceSettings
+	timeout       time.Duration
+	retries       int
+	client        *http.Client
+}
+
+type ElevenLabsOption func(*ElevenLabsProvider)
+
+func WithElevenLabsBaseURL(url string) ElevenLabsOption {
+	return func(p *ElevenLabsProvider) {
+		p.baseURL = url
+	}
+}
+
+func WithElevenLabsVoice(voice string) ElevenLabsOption {
+	return func(p *ElevenLabsProvider) {
+		p.voice = voice
+	}
+}
+
+func WithElevenLabsModel(model ElevenLabsModel) ElevenLabsOption {
+	return func(p *ElevenLabsProvider) {
+		p.model = model
+	}
+}
+
+func WithElevenLabsVoiceSettings(settings ElevenLabsVoiceSettings) ElevenLabsOption {
+	return func(p *ElevenLabsProvider) {
+		p.voiceSettings = settings
+	}
+}
+
+func WithElevenLabsTimeout(timeout time.Duration) ElevenLabsOption {
+	return func(p *ElevenLabsProvider) {
+		p.timeout = timeout
+	}
+}
+
+func WithElevenLabsRetries(retries int) ElevenLabsOption {
+	return func(p *ElevenLabsProvider) {
+		p.retries = retries
+	}
+}
+
+func NewElevenLabsProvider(apiKey string, opts ...ElevenLabsOption) (*ElevenLabsProvider, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("elevenlabs: API key is required")
+	}
+
+	p := &ElevenLabsProvider{
+		apiKey:  apiKey,
+		baseURL: "https://api.elevenlabs.io/v1",
+		voice:   "21m00Tcm4TlvDq8ikWAM",
+		model:   ElevenLabsMultilingualV2,
+		voiceSettings: ElevenLabsVoiceSettings{
+			Stability:       0.5,
+			SimilarityBoost: 0.75,
+			Style:           0.0,
+			UseSpeakerBoost: true,
+		},
+		timeout: 60 * time.Second,
+		retries: 2,
+		client:  &http.Client{Timeout: 60 * time.Second},
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	p.client.Timeout = p.timeout
+
+	return p, nil
+}
+
+func (p *ElevenLabsProvider) Name() string {
+	return "elevenlabs"
+}
+
+func (p *ElevenLabsProvider) Type() ProviderType {
+	return ProviderElevenLabs
+}
+
+func (p *ElevenLabsProvider) Synthesize(ctx context.Context, text string, opts ...SynthesizeOption) (*AudioResult, error) {
+	options := SynthesizeOptions{
+		Voice:  p.voice,
+		Format: FormatMP3,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	payload := map[string]any{
+		"text":     text,
+		"model_id": string(p.model),
+		"voice_settings": map[string]any{
+			"stability":         p.voiceSettings.Stability,
+			"similarity_boost":  p.voiceSettings.SimilarityBoost,
+			"style":             p.voiceSettings.Style,
+			"use_speaker_boost": p.voiceSettings.UseSpeakerBoost,
+		},
+	}
+
+	if options.Format == FormatPCM {
+		payload["output_format"] = "pcm_16000"
+	} else if options.Format == FormatWAV {
+		payload["output_format"] = "wav_16000"
+	} else if options.Format == FormatOGG {
+		payload["output_format"] = "ogg_16000"
+	} else if options.Format == FormatFLAC {
+		payload["output_format"] = "flac_16000"
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("elevenlabs: failed to marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/text-to-speech/%s", p.baseURL, options.Voice)
+
+	var lastErr error
+	for attempt := 0; attempt <= p.retries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(attempt) * 500 * time.Millisecond
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("elevenlabs: context cancelled during retry: %w", ctx.Err())
+			case <-time.After(backoff):
+			}
+		}
+
+		result, err := p.doSynthesize(ctx, url, body, options)
+		if err == nil {
+			return result, nil
+		}
+
+		lastErr = err
+	}
+
+	return nil, fmt.Errorf("elevenlabs: all %d retries failed, last error: %w", p.retries, lastErr)
+}
+
+func (p *ElevenLabsProvider) doSynthesize(ctx context.Context, url string, body []byte, options SynthesizeOptions) (*AudioResult, error) {
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("elevenlabs: failed to create request: %w", err)
+	}
+	req.Header.Set("xi-api-key", p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "audio/mpeg")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("elevenlabs: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("elevenlabs: API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	audioData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("elevenlabs: failed to read response: %w", err)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "audio/mpeg"
+	}
+
+	return &AudioResult{
+		Data:        audioData,
+		Format:      options.Format,
+		ContentType: contentType,
+	}, nil
+}
+
+func (p *ElevenLabsProvider) SynthesizeStream(ctx context.Context, text string, opts ...SynthesizeOption) (chan []byte, error) {
+	options := SynthesizeOptions{
+		Voice:  p.voice,
+		Format: FormatMP3,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	payload := map[string]any{
+		"text":     text,
+		"model_id": string(p.model),
+		"voice_settings": map[string]any{
+			"stability":         p.voiceSettings.Stability,
+			"similarity_boost":  p.voiceSettings.SimilarityBoost,
+			"style":             p.voiceSettings.Style,
+			"use_speaker_boost": p.voiceSettings.UseSpeakerBoost,
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("elevenlabs: failed to marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/text-to-speech/%s/stream", p.baseURL, options.Voice)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("elevenlabs: failed to create request: %w", err)
+	}
+	req.Header.Set("xi-api-key", p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "audio/mpeg")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("elevenlabs: request failed: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("elevenlabs: API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	ch := make(chan []byte, 16)
+
+	go func() {
+		defer close(ch)
+		defer resp.Body.Close()
+
+		buf := make([]byte, 4096)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			n, err := resp.Body.Read(buf)
+			if n > 0 {
+				chunk := make([]byte, n)
+				copy(chunk, buf[:n])
+				ch <- chunk
+			}
+			if err != nil {
+				if err != io.EOF {
+					return
+				}
+				return
+			}
+		}
+	}()
+
+	return ch, nil
+}
+
+func (p *ElevenLabsProvider) ListVoices(ctx context.Context) ([]Voice, error) {
+	_ = ctx
+	return []Voice{
+		{ID: "21m00Tcm4TlvDq8ikWAM", Name: "Rachel", Language: "en", LanguageTag: "en-US", Gender: GenderFemale, Provider: "elevenlabs", Description: "Calm and well-balanced voice"},
+		{ID: "EXAVITQu4vr4xnSDxMaL", Name: "Bella", Language: "en", LanguageTag: "en-US", Gender: GenderFemale, Provider: "elevenlabs", Description: "Soft and gentle voice"},
+		{ID: "ErXwobaYiN019PkySvjV", Name: "Antoni", Language: "en", LanguageTag: "en-US", Gender: GenderMale, Provider: "elevenlabs", Description: "Well-balanced and moderately deep voice"},
+		{ID: "VR6AewLTigWG4xSOukaG", Name: "Arnold", Language: "en", LanguageTag: "en-US", Gender: GenderMale, Provider: "elevenlabs", Description: "Deep and authoritative voice"},
+		{ID: "pNInz6obpgDQGcFmaJgB", Name: "Adam", Language: "en", LanguageTag: "en-US", Gender: GenderMale, Provider: "elevenlabs", Description: "Deep and resonant voice"},
+		{ID: "yoZ06aMxZJJ28mfd3POQ", Name: "Sam", Language: "en", LanguageTag: "en-US", Gender: GenderMale, Provider: "elevenlabs", Description: "Calm and natural voice"},
+		{ID: "jBpfuIE2acCO8z3wKNLl", Name: "Gigi", Language: "en", LanguageTag: "en-US", Gender: GenderFemale, Provider: "elevenlabs", Description: "Child-like and cute voice"},
+	}, nil
+}
+
+func (p *ElevenLabsProvider) GetVoice(ctx context.Context, voiceID string) (*Voice, error) {
+	voices, err := p.ListVoices(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range voices {
+		if v.ID == voiceID {
+			return &v, nil
+		}
+	}
+
+	return nil, fmt.Errorf("elevenlabs: voice not found: %s", voiceID)
+}
+
+func (p *ElevenLabsProvider) SetModel(model ElevenLabsModel) {
+	p.model = model
+}
+
+func (p *ElevenLabsProvider) SetVoice(voice string) {
+	p.voice = voice
+}
+
+func (p *ElevenLabsProvider) SetVoiceSettings(settings ElevenLabsVoiceSettings) {
+	p.voiceSettings = settings
+}
+
+func (p *ElevenLabsProvider) GetUsage(ctx context.Context) (int, int, error) {
+	_ = ctx
+	url := p.baseURL + "/user"
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return 0, 0, fmt.Errorf("elevenlabs: failed to create request: %w", err)
+	}
+	req.Header.Set("xi-api-key", p.apiKey)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return 0, 0, fmt.Errorf("elevenlabs: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return 0, 0, fmt.Errorf("elevenlabs: API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Subscription struct {
+			CharacterCount int `json:"character_count"`
+			CharacterLimit int `json:"character_limit"`
+		} `json:"subscription"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, 0, fmt.Errorf("elevenlabs: failed to decode response: %w", err)
+	}
+
+	return result.Subscription.CharacterCount, result.Subscription.CharacterLimit, nil
+}
+
+type EdgeProvider struct {
+	baseURL  string
+	voice    string
+	language string
+	timeout  time.Duration
+	client   *http.Client
+}
+
+type EdgeOption func(*EdgeProvider)
+
+func WithEdgeBaseURL(url string) EdgeOption {
+	return func(p *EdgeProvider) {
+		p.baseURL = url
+	}
+}
+
+func WithEdgeVoice(voice string) EdgeOption {
+	return func(p *EdgeProvider) {
+		p.voice = voice
+	}
+}
+
+func WithEdgeLanguage(lang string) EdgeOption {
+	return func(p *EdgeProvider) {
+		p.language = lang
+	}
+}
+
+func WithEdgeTimeout(timeout time.Duration) EdgeOption {
+	return func(p *EdgeProvider) {
+		p.timeout = timeout
+	}
+}
+
+func NewEdgeProvider(opts ...EdgeOption) (*EdgeProvider, error) {
+	p := &EdgeProvider{
+		baseURL:  "https://speech.platform.bing.com",
+		voice:    "en-US-AriaNeural",
+		language: "en-US",
+		timeout:  30 * time.Second,
+		client:   &http.Client{Timeout: 30 * time.Second},
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	p.client.Timeout = p.timeout
+
+	return p, nil
+}
+
+func (p *EdgeProvider) Name() string {
+	return "edge"
+}
+
+func (p *EdgeProvider) Type() ProviderType {
+	return ProviderEdge
+}
+
+func (p *EdgeProvider) Synthesize(ctx context.Context, text string, opts ...SynthesizeOption) (*AudioResult, error) {
+	options := SynthesizeOptions{
+		Voice:    p.voice,
+		Language: p.language,
+		Format:   FormatMP3,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	if options.Voice == "" {
+		options.Voice = p.voice
+	}
+
+	ssml := fmt.Sprintf(`<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="%s">
+		<voice name="%s">%s</voice>
+	</speak>`, options.Language, options.Voice, text)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/synthesize", bytes.NewReader([]byte(ssml)))
+	if err != nil {
+		return nil, fmt.Errorf("edge: failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/ssml+xml")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("edge: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("edge: API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	audioData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("edge: failed to read response: %w", err)
+	}
+
+	return &AudioResult{
+		Data:        audioData,
+		Format:      options.Format,
+		ContentType: "audio/mpeg",
+	}, nil
+}
+
+func (p *EdgeProvider) ListVoices(ctx context.Context) ([]Voice, error) {
+	_ = ctx
+	return []Voice{
+		{ID: "en-US-AriaNeural", Name: "Aria", Language: "en-US", LanguageTag: "en-US", Gender: GenderFemale, Provider: "edge"},
+		{ID: "en-US-GuyNeural", Name: "Guy", Language: "en-US", LanguageTag: "en-US", Gender: GenderMale, Provider: "edge"},
+		{ID: "zh-CN-XiaoxiaoNeural", Name: "Xiaoxiao", Language: "zh-CN", LanguageTag: "zh-CN", Gender: GenderFemale, Provider: "edge"},
+		{ID: "zh-CN-YunxiNeural", Name: "Yunxi", Language: "zh-CN", LanguageTag: "zh-CN", Gender: GenderMale, Provider: "edge"},
+		{ID: "ja-JP-NanamiNeural", Name: "Nanami", Language: "ja-JP", LanguageTag: "ja-JP", Gender: GenderFemale, Provider: "edge"},
+		{ID: "ko-KR-SunHiNeural", Name: "SunHi", Language: "ko-KR", LanguageTag: "ko-KR", Gender: GenderFemale, Provider: "edge"},
+	}, nil
+}
+
+type PiperQuality string
+
+const (
+	PiperQualityXLow   PiperQuality = "x_low"
+	PiperQualityLow    PiperQuality = "low"
+	PiperQualityMedium PiperQuality = "medium"
+	PiperQualityHigh   PiperQuality = "high"
+)
+
+type PiperProvider struct {
+	modelPath       string
+	modelFile       string
+	configFile      string
+	voiceDir        string
+	pythonCmd       string
+	useGPU          bool
+	volume          float64
+	sentenceSilence float64
+	defaultVoice    string
+	defaultLang     string
+	sampleRate      int
+}
+
+type PiperOption func(*PiperProvider)
+
+func WithPiperModelPath(path string) PiperOption {
+	return func(p *PiperProvider) {
+		p.modelPath = path
+	}
+}
+
+func WithPiperVoiceDir(dir string) PiperOption {
+	return func(p *PiperProvider) {
+		p.voiceDir = dir
+	}
+}
+
+func WithPiperDefaultVoice(voice string) PiperOption {
+	return func(p *PiperProvider) {
+		p.defaultVoice = voice
+	}
+}
+
+func WithPiperDefaultLanguage(lang string) PiperOption {
+	return func(p *PiperProvider) {
+		p.defaultLang = lang
+	}
+}
+
+func WithPiperUseGPU(use bool) PiperOption {
+	return func(p *PiperProvider) {
+		p.useGPU = use
+	}
+}
+
+func WithPiperVolume(vol float64) PiperOption {
+	return func(p *PiperProvider) {
+		p.volume = vol
+	}
+}
+
+func WithPiperSentenceSilence(seconds float64) PiperOption {
+	return func(p *PiperProvider) {
+		p.sentenceSilence = seconds
+	}
+}
+
+func WithPiperPythonCmd(cmd string) PiperOption {
+	return func(p *PiperProvider) {
+		p.pythonCmd = cmd
+	}
+}
+
+func NewPiperProvider(opts ...PiperOption) (*PiperProvider, error) {
+	p := &PiperProvider{
+		voiceDir:        "",
+		pythonCmd:       "python3",
+		useGPU:          false,
+		volume:          1.0,
+		sentenceSilence: 0.0,
+		defaultVoice:    "en_US-lessac-medium",
+		defaultLang:     "en-US",
+		sampleRate:      22050,
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	if p.voiceDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err == nil {
+			p.voiceDir = filepath.Join(homeDir, ".local", "share", "piper-voices")
+		} else {
+			p.voiceDir = filepath.Join("data", "piper-voices")
+		}
+	}
+
+	if err := p.findModel(); err != nil {
+		return nil, fmt.Errorf("piper: %w", err)
+	}
+
+	return p, nil
+}
+
+func (p *PiperProvider) findModel() error {
+	voice := p.defaultVoice
+	if !strings.HasSuffix(voice, ".onnx") {
+		voice = voice + ".onnx"
+	}
+
+	modelPath := filepath.Join(p.voiceDir, voice)
+	if _, err := os.Stat(modelPath); err == nil {
+		p.modelPath = modelPath
+		p.modelFile = voice
+		configFile := strings.TrimSuffix(modelPath, ".onnx") + ".onnx.json"
+		if _, err := os.Stat(configFile); err == nil {
+			p.configFile = configFile
+		}
+		return nil
+	}
+
+	if _, err := os.Stat(p.defaultVoice); err == nil {
+		p.modelPath = p.defaultVoice
+		p.modelFile = filepath.Base(p.defaultVoice)
+		configFile := strings.TrimSuffix(p.defaultVoice, ".onnx") + ".onnx.json"
+		if _, err := os.Stat(configFile); err == nil {
+			p.configFile = configFile
+		}
+		return nil
+	}
+
+	return fmt.Errorf("model not found: %s (searched in %s)", p.defaultVoice, p.voiceDir)
+}
+
+func (p *PiperProvider) Name() string {
+	return "piper"
+}
+
+func (p *PiperProvider) Type() ProviderType {
+	return ProviderType("piper")
+}
+
+func (p *PiperProvider) Synthesize(ctx context.Context, text string, opts ...SynthesizeOption) (*AudioResult, error) {
+	options := SynthesizeOptions{
+		Voice:      p.defaultVoice,
+		Format:     FormatWAV,
+		SampleRate: p.sampleRate,
+		Volume:     p.volume,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	modelPath := p.modelPath
+	if options.Voice != "" && options.Voice != p.defaultVoice {
+		voiceFile := options.Voice
+		if !strings.HasSuffix(voiceFile, ".onnx") {
+			voiceFile = voiceFile + ".onnx"
+		}
+
+		candidate := filepath.Join(p.voiceDir, voiceFile)
+		if _, err := os.Stat(candidate); err == nil {
+			modelPath = candidate
+		} else if _, err := os.Stat(options.Voice); err == nil {
+			modelPath = options.Voice
+		}
+	}
+
+	tmpFile, err := os.CreateTemp("", "piper-*.wav")
+	if err != nil {
+		return nil, fmt.Errorf("piper: failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+
+	args := []string{"-m", "piper", "-m", modelPath, "-f", tmpPath}
+
+	if p.useGPU {
+		args = append(args, "--cuda")
+	}
+
+	if options.Volume > 0 && options.Volume != 1.0 {
+		args = append(args, "--volume", fmt.Sprintf("%.2f", options.Volume))
+	} else if p.volume > 0 && p.volume != 1.0 {
+		args = append(args, "--volume", fmt.Sprintf("%.2f", p.volume))
+	}
+
+	if p.sentenceSilence > 0 {
+		args = append(args, "--sentence-silence", fmt.Sprintf("%.2f", p.sentenceSilence))
+	}
+
+	args = append(args, "--")
+	args = append(args, text)
+
+	cmd := exec.CommandContext(ctx, p.pythonCmd, args...)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("piper: synthesis failed: %w, stderr: %s", err, stderr.String())
+	}
+
+	audioData, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return nil, fmt.Errorf("piper: failed to read output file: %w", err)
+	}
+
+	if len(audioData) == 0 {
+		return nil, fmt.Errorf("piper: synthesis produced no audio data")
+	}
+
+	sampleRate := options.SampleRate
+	if sampleRate == 0 {
+		sampleRate = p.sampleRate
+	}
+
+	return &AudioResult{
+		Data:        audioData,
+		Format:      FormatWAV,
+		SampleRate:  sampleRate,
+		Channels:    1,
+		BitDepth:    16,
+		ContentType: "audio/wav",
+	}, nil
+}
+
+func (p *PiperProvider) ListVoices(ctx context.Context) ([]Voice, error) {
+	_ = ctx
+
+	var voices []Voice
+
+	entries, err := os.ReadDir(p.voiceDir)
+	if err != nil {
+		return voices, nil
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".onnx") {
+			continue
+		}
+
+		voiceID := strings.TrimSuffix(name, ".onnx")
+		parts := strings.SplitN(voiceID, "-", 3)
+		if len(parts) < 2 {
+			continue
+		}
+
+		langCode := parts[0] + "_" + parts[1]
+		voiceName := parts[len(parts)-1]
+
+		quality := PiperQualityMedium
+		if strings.Contains(voiceID, "x_low") {
+			quality = PiperQualityXLow
+		} else if strings.Contains(voiceID, "_low") {
+			quality = PiperQualityLow
+		} else if strings.Contains(voiceID, "_high") {
+			quality = PiperQualityHigh
+		}
+
+		voices = append(voices, Voice{
+			ID:          voiceID,
+			Name:        voiceName,
+			Language:    langCode,
+			LanguageTag: strings.Replace(langCode, "_", "-", 1),
+			Gender:      GenderNeutral,
+			Provider:    "piper",
+			Description: fmt.Sprintf("Piper %s quality voice", quality),
+		})
+	}
+
+	if len(voices) == 0 {
+		voices = []Voice{
+			{ID: "en_US-lessac-medium", Name: "Lessac", Language: "en_US", LanguageTag: "en-US", Gender: GenderFemale, Provider: "piper", Description: "Default English voice"},
+			{ID: "zh_CN-huayan-medium", Name: "Huayan", Language: "zh_CN", LanguageTag: "zh-CN", Gender: GenderNeutral, Provider: "piper", Description: "Chinese voice"},
+			{ID: "ja_JP-tomoko-medium", Name: "Tomoko", Language: "ja_JP", LanguageTag: "ja-JP", Gender: GenderFemale, Provider: "piper", Description: "Japanese voice"},
+		}
+	}
+
+	return voices, nil
+}
+
+func (p *PiperProvider) SetVoice(voice string) {
+	p.defaultVoice = voice
+	if err := p.findModel(); err == nil {
+		p.defaultVoice = voice
+	}
+}
+
+func (p *PiperProvider) SetVoiceDir(dir string) {
+	p.voiceDir = dir
+}
+
+type CoquiModel string
+
+const (
+	CoquiModelTacotron2    CoquiModel = "tacotron2"
+	CoquiModelVits         CoquiModel = "vits"
+	CoquiModelXTTSv2       CoquiModel = "xtts_v2"
+	CoquiModelYourTTS      CoquiModel = "your_tts"
+	CoquiModelGlowTTS      CoquiModel = "glow_tts"
+	CoquiModelSpeedySpeech CoquiModel = "speedy_speech"
+)
+
+type CoquiProvider struct {
+	modelName    CoquiModel
+	speakerName  string
+	language     string
+	useGPU       bool
+	pythonCmd    string
+	voiceDir     string
+	defaultLang  string
+	outputFormat string
+}
+
+type CoquiOption func(*CoquiProvider)
+
+func WithCoquiModel(model CoquiModel) CoquiOption {
+	return func(p *CoquiProvider) {
+		p.modelName = model
+	}
+}
+
+func WithCoquiSpeaker(speaker string) CoquiOption {
+	return func(p *CoquiProvider) {
+		p.speakerName = speaker
+	}
+}
+
+func WithCoquiLanguage(lang string) CoquiOption {
+	return func(p *CoquiProvider) {
+		p.language = lang
+	}
+}
+
+func WithCoquiDefaultLanguage(lang string) CoquiOption {
+	return func(p *CoquiProvider) {
+		p.defaultLang = lang
+	}
+}
+
+func WithCoquiUseGPU(use bool) CoquiOption {
+	return func(p *CoquiProvider) {
+		p.useGPU = use
+	}
+}
+
+func WithCoquiPythonCmd(cmd string) CoquiOption {
+	return func(p *CoquiProvider) {
+		p.pythonCmd = cmd
+	}
+}
+
+func WithCoquiVoiceDir(dir string) CoquiOption {
+	return func(p *CoquiProvider) {
+		p.voiceDir = dir
+	}
+}
+
+func WithCoquiOutputFormat(format string) CoquiOption {
+	return func(p *CoquiProvider) {
+		p.outputFormat = format
+	}
+}
+
+func NewCoquiProvider(opts ...CoquiOption) (*CoquiProvider, error) {
+	p := &CoquiProvider{
+		modelName:    CoquiModelVits,
+		speakerName:  "",
+		language:     "",
+		useGPU:       false,
+		pythonCmd:    "python3",
+		voiceDir:     "",
+		defaultLang:  "en",
+		outputFormat: "wav",
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	if p.voiceDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err == nil {
+			p.voiceDir = filepath.Join(homeDir, ".local", "share", "tts")
+		} else {
+			p.voiceDir = filepath.Join("data", "tts")
+		}
+	}
+
+	return p, nil
+}
+
+func (p *CoquiProvider) Name() string {
+	return "coqui"
+}
+
+func (p *CoquiProvider) Type() ProviderType {
+	return ProviderType("coqui")
+}
+
+func (p *CoquiProvider) Synthesize(ctx context.Context, text string, opts ...SynthesizeOption) (*AudioResult, error) {
+	options := SynthesizeOptions{
+		Voice:    p.speakerName,
+		Format:   FormatWAV,
+		Language: p.defaultLang,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	tmpFile, err := os.CreateTemp("", "coqui-*.wav")
+	if err != nil {
+		return nil, fmt.Errorf("coqui: failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+
+	modelStr := string(p.modelName)
+	if p.modelName == CoquiModelXTTSv2 {
+		modelStr = "tts_models/multilingual/multi-dataset/xtts_v2"
+	} else if p.modelName == CoquiModelVits {
+		modelStr = "tts_models/" + options.Language + "/vits"
+	}
+
+	args := []string{"-m", "TTS", "--model_name", modelStr, "--text", text, "--out_path", tmpPath}
+
+	if options.Voice != "" {
+		args = append(args, "--speaker_idx", options.Voice)
+	}
+
+	if options.Language != "" {
+		args = append(args, "--language_idx", options.Language)
+	}
+
+	if p.useGPU {
+		args = append(args, "--use_cuda", "true")
+	}
+
+	if p.voiceDir != "" {
+		args = append(args, "--config_path", filepath.Join(p.voiceDir, "config.json"))
+	}
+
+	cmd := exec.CommandContext(ctx, p.pythonCmd, args...)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("coqui: synthesis failed: %w, stderr: %s", err, stderr.String())
+	}
+
+	audioData, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return nil, fmt.Errorf("coqui: failed to read output file: %w", err)
+	}
+
+	if len(audioData) == 0 {
+		return nil, fmt.Errorf("coqui: synthesis produced no audio data")
+	}
+
+	return &AudioResult{
+		Data:        audioData,
+		Format:      FormatWAV,
+		SampleRate:  22050,
+		Channels:    1,
+		BitDepth:    16,
+		ContentType: "audio/wav",
+	}, nil
+}
+
+func (p *CoquiProvider) ListVoices(ctx context.Context) ([]Voice, error) {
+	_ = ctx
+
+	switch p.modelName {
+	case CoquiModelXTTSv2:
+		return []Voice{
+			{ID: "Ana Florence", Name: "Ana Florence", Language: "en", LanguageTag: "en", Gender: GenderFemale, Provider: "coqui", Description: "XTTS v2 reference voice"},
+			{ID: "Claribel Dervla", Name: "Claribel Dervla", Language: "en", LanguageTag: "en", Gender: GenderFemale, Provider: "coqui", Description: "XTTS v2 reference voice"},
+			{ID: "Daisy Studious", Name: "Daisy Studious", Language: "en", LanguageTag: "en", Gender: GenderFemale, Provider: "coqui", Description: "XTTS v2 reference voice"},
+			{ID: "Gracie Wise", Name: "Gracie Wise", Language: "en", LanguageTag: "en", Gender: GenderFemale, Provider: "coqui", Description: "XTTS v2 reference voice"},
+			{ID: "Tammie Ema", Name: "Tammie Ema", Language: "en", LanguageTag: "en", Gender: GenderFemale, Provider: "coqui", Description: "XTTS v2 reference voice"},
+			{ID: "Alison Dietlinde", Name: "Alison Dietlinde", Language: "en", LanguageTag: "en", Gender: GenderFemale, Provider: "coqui", Description: "XTTS v2 reference voice"},
+		}, nil
+	case CoquiModelVits:
+		return []Voice{
+			{ID: "vits-en", Name: "VITS English", Language: "en", LanguageTag: "en-US", Gender: GenderNeutral, Provider: "coqui", Description: "VITS English model"},
+			{ID: "vits-zh", Name: "VITS Chinese", Language: "zh", LanguageTag: "zh-CN", Gender: GenderNeutral, Provider: "coqui", Description: "VITS Chinese model"},
+			{ID: "vits-ja", Name: "VITS Japanese", Language: "ja", LanguageTag: "ja-JP", Gender: GenderNeutral, Provider: "coqui", Description: "VITS Japanese model"},
+		}, nil
+	default:
+		return []Voice{
+			{ID: string(p.modelName), Name: string(p.modelName), Language: p.defaultLang, LanguageTag: p.defaultLang, Gender: GenderNeutral, Provider: "coqui", Description: fmt.Sprintf("Coqui %s model", p.modelName)},
+		}, nil
+	}
+}
+
+func (p *CoquiProvider) SetModel(model CoquiModel) {
+	p.modelName = model
+}
+
+func (p *CoquiProvider) SetSpeaker(speaker string) {
+	p.speakerName = speaker
+}
+
+func (p *CoquiProvider) SetLanguage(lang string) {
+	p.language = lang
+}
+
+func detectPythonCmd() string {
+	if runtime.GOOS == "windows" {
+		if _, err := exec.LookPath("python"); err == nil {
+			return "python"
+		}
+		if _, err := exec.LookPath("python3"); err == nil {
+			return "python3"
+		}
+		return "python"
+	}
+
+	if _, err := exec.LookPath("python3"); err == nil {
+		return "python3"
+	}
+	if _, err := exec.LookPath("python"); err == nil {
+		return "python"
+	}
+	return "python3"
+}

--- a/pkg/speech/implementations_test.go
+++ b/pkg/speech/implementations_test.go
@@ -1,0 +1,332 @@
+package speech
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOpenAIProviderHTTPAndHelpers(t *testing.T) {
+	var payloads []map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/audio/speech" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer openai-key" {
+			t.Fatalf("unexpected auth header: %s", got)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll(request): %v", err)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("Unmarshal(request): %v", err)
+		}
+		payloads = append(payloads, payload)
+
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("openai-audio"))
+	}))
+	defer server.Close()
+
+	provider, err := NewOpenAIProvider(
+		"openai-key",
+		WithOpenAIBaseURL(server.URL),
+		WithOpenAITimeout(time.Second),
+		WithOpenAIRetries(0),
+		WithOpenAIVoice("alloy"),
+		WithOpenAIModel(OpenAITTS1HD),
+	)
+	if err != nil {
+		t.Fatalf("NewOpenAIProvider: %v", err)
+	}
+
+	if provider.Name() != "openai" || provider.Type() != ProviderOpenAI {
+		t.Fatalf("unexpected provider identity: %s/%s", provider.Name(), provider.Type())
+	}
+
+	voices, err := provider.ListVoices(context.Background())
+	if err != nil {
+		t.Fatalf("ListVoices: %v", err)
+	}
+	if len(voices) == 0 {
+		t.Fatal("expected built-in openai voices")
+	}
+
+	voice, err := provider.GetVoice(context.Background(), "nova")
+	if err != nil {
+		t.Fatalf("GetVoice(nova): %v", err)
+	}
+	if voice.ID != "nova" {
+		t.Fatalf("unexpected voice lookup result: %+v", voice)
+	}
+	if err := provider.ValidateVoice("invalid"); err == nil {
+		t.Fatal("expected invalid voice validation to fail")
+	}
+
+	provider.SetModel(OpenAITTS1)
+	provider.SetVoice("echo")
+
+	result, err := provider.Synthesize(context.Background(), "hello", WithSpeed(1.25), WithFormat(FormatWAV))
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	if string(result.Data) != "openai-audio" || result.Format != FormatWAV {
+		t.Fatalf("unexpected synth result: %+v", result)
+	}
+
+	stream, err := provider.SynthesizeStream(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("SynthesizeStream: %v", err)
+	}
+
+	var streamed []byte
+	for chunk := range stream {
+		streamed = append(streamed, chunk...)
+	}
+	if string(streamed) != "openai-audio" {
+		t.Fatalf("unexpected streamed audio: %q", streamed)
+	}
+
+	if len(payloads) < 2 {
+		t.Fatalf("expected synth and stream requests, got %d", len(payloads))
+	}
+	if payloads[0]["model"] != string(OpenAITTS1) {
+		t.Fatalf("unexpected model payload: %#v", payloads[0]["model"])
+	}
+	if payloads[0]["voice"] != "echo" {
+		t.Fatalf("unexpected voice payload: %#v", payloads[0]["voice"])
+	}
+}
+
+func TestElevenLabsProviderHTTPAndHelpers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("xi-api-key"); got != "eleven-key" {
+			t.Fatalf("unexpected xi-api-key: %s", got)
+		}
+
+		switch {
+		case r.URL.Path == "/v1/user":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"subscription":{"character_count":12,"character_limit":1000}}`))
+		case strings.HasSuffix(r.URL.Path, "/stream"):
+			w.Header().Set("Content-Type", "audio/mpeg")
+			_, _ = w.Write([]byte("eleven-stream"))
+		case strings.HasPrefix(r.URL.Path, "/v1/text-to-speech/"):
+			w.Header().Set("Content-Type", "audio/ogg")
+			_, _ = w.Write([]byte("eleven-audio"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	settings := ElevenLabsVoiceSettings{
+		Stability:       0.8,
+		SimilarityBoost: 0.9,
+		Style:           0.2,
+		UseSpeakerBoost: false,
+	}
+
+	provider, err := NewElevenLabsProvider(
+		"eleven-key",
+		WithElevenLabsBaseURL(server.URL+"/v1"),
+		WithElevenLabsTimeout(time.Second),
+		WithElevenLabsRetries(0),
+		WithElevenLabsVoice("voice-a"),
+		WithElevenLabsModel(ElevenLabsTurboV2),
+		WithElevenLabsVoiceSettings(settings),
+	)
+	if err != nil {
+		t.Fatalf("NewElevenLabsProvider: %v", err)
+	}
+
+	if provider.Name() != "elevenlabs" || provider.Type() != ProviderElevenLabs {
+		t.Fatalf("unexpected provider identity: %s/%s", provider.Name(), provider.Type())
+	}
+
+	voices, err := provider.ListVoices(context.Background())
+	if err != nil {
+		t.Fatalf("ListVoices: %v", err)
+	}
+	if len(voices) == 0 {
+		t.Fatal("expected built-in elevenlabs voices")
+	}
+
+	voice, err := provider.GetVoice(context.Background(), "21m00Tcm4TlvDq8ikWAM")
+	if err != nil {
+		t.Fatalf("GetVoice: %v", err)
+	}
+	if voice.ID == "" {
+		t.Fatalf("unexpected voice lookup result: %+v", voice)
+	}
+
+	provider.SetModel(ElevenLabsTurboV25)
+	provider.SetVoice("voice-b")
+	provider.SetVoiceSettings(ElevenLabsVoiceSettings{Stability: 0.5})
+
+	result, err := provider.Synthesize(context.Background(), "hello", WithFormat(FormatOGG))
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	if string(result.Data) != "eleven-audio" || result.ContentType != "audio/ogg" {
+		t.Fatalf("unexpected synth result: %+v", result)
+	}
+
+	stream, err := provider.SynthesizeStream(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("SynthesizeStream: %v", err)
+	}
+	var streamed []byte
+	for chunk := range stream {
+		streamed = append(streamed, chunk...)
+	}
+	if string(streamed) != "eleven-stream" {
+		t.Fatalf("unexpected streamed audio: %q", streamed)
+	}
+
+	count, limit, err := provider.GetUsage(context.Background())
+	if err != nil {
+		t.Fatalf("GetUsage: %v", err)
+	}
+	if count != 12 || limit != 1000 {
+		t.Fatalf("GetUsage() = (%d, %d), want (12, 1000)", count, limit)
+	}
+}
+
+func TestEdgePiperAndCoquiProviders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/synthesize" {
+			t.Fatalf("unexpected edge path: %s", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll(edge request): %v", err)
+		}
+		text := string(body)
+		if !strings.Contains(text, `xml:lang="ja-JP"`) || !strings.Contains(text, `voice name="ja-JP-NanamiNeural"`) {
+			t.Fatalf("unexpected edge SSML: %s", text)
+		}
+		_, _ = w.Write([]byte("edge-audio"))
+	}))
+	defer server.Close()
+
+	edge, err := NewEdgeProvider(
+		WithEdgeBaseURL(server.URL),
+		WithEdgeVoice("ja-JP-NanamiNeural"),
+		WithEdgeLanguage("ja-JP"),
+		WithEdgeTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewEdgeProvider: %v", err)
+	}
+	if edge.Name() != "edge" || edge.Type() != ProviderEdge {
+		t.Fatalf("unexpected edge identity: %s/%s", edge.Name(), edge.Type())
+	}
+
+	result, err := edge.Synthesize(context.Background(), "hello", WithFormat(FormatWAV))
+	if err != nil {
+		t.Fatalf("Edge Synthesize: %v", err)
+	}
+	if string(result.Data) != "edge-audio" || result.Format != FormatWAV {
+		t.Fatalf("unexpected edge synth result: %+v", result)
+	}
+
+	edgeVoices, err := edge.ListVoices(context.Background())
+	if err != nil {
+		t.Fatalf("Edge ListVoices: %v", err)
+	}
+	if len(edgeVoices) == 0 {
+		t.Fatal("expected edge voices")
+	}
+
+	tmpDir := t.TempDir()
+	modelA := filepath.Join(tmpDir, "en_US-lessac-high.onnx")
+	modelB := filepath.Join(tmpDir, "zh_CN-huayan-medium.onnx")
+	for _, path := range []string{modelA, modelB} {
+		if err := os.WriteFile(path, []byte("model"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+		configPath := strings.TrimSuffix(path, ".onnx") + ".onnx.json"
+		if err := os.WriteFile(configPath, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", configPath, err)
+		}
+	}
+
+	piper, err := NewPiperProvider(
+		WithPiperModelPath(modelA),
+		WithPiperVoiceDir(tmpDir),
+		WithPiperDefaultVoice("en_US-lessac-high"),
+		WithPiperDefaultLanguage("en-US"),
+		WithPiperUseGPU(true),
+		WithPiperVolume(1.4),
+		WithPiperSentenceSilence(0.3),
+		WithPiperPythonCmd("python-test"),
+	)
+	if err != nil {
+		t.Fatalf("NewPiperProvider: %v", err)
+	}
+	if piper.Name() != "piper" || piper.Type() != ProviderPiper {
+		t.Fatalf("unexpected piper identity: %s/%s", piper.Name(), piper.Type())
+	}
+
+	piperVoices, err := piper.ListVoices(context.Background())
+	if err != nil {
+		t.Fatalf("Piper ListVoices: %v", err)
+	}
+	if len(piperVoices) == 0 {
+		t.Fatal("expected piper voices")
+	}
+
+	piper.SetVoice("zh_CN-huayan-medium")
+	if !strings.Contains(filepath.Base(piper.modelPath), "zh_CN-huayan-medium") {
+		t.Fatalf("expected modelPath to switch, got %s", piper.modelPath)
+	}
+	piper.SetVoiceDir(tmpDir)
+
+	coqui, err := NewCoquiProvider(
+		WithCoquiModel(CoquiModelXTTSv2),
+		WithCoquiSpeaker("speaker-a"),
+		WithCoquiLanguage("fr"),
+		WithCoquiDefaultLanguage("en"),
+		WithCoquiUseGPU(true),
+		WithCoquiPythonCmd("python-test"),
+		WithCoquiVoiceDir(tmpDir),
+		WithCoquiOutputFormat("wav"),
+	)
+	if err != nil {
+		t.Fatalf("NewCoquiProvider: %v", err)
+	}
+	if coqui.Name() != "coqui" || coqui.Type() != ProviderType("coqui") {
+		t.Fatalf("unexpected coqui identity: %s/%s", coqui.Name(), coqui.Type())
+	}
+
+	coquiVoices, err := coqui.ListVoices(context.Background())
+	if err != nil {
+		t.Fatalf("Coqui ListVoices (xtts): %v", err)
+	}
+	if len(coquiVoices) == 0 {
+		t.Fatal("expected xtts voices")
+	}
+
+	coqui.SetModel(CoquiModelVits)
+	coqui.SetSpeaker("speaker-b")
+	coqui.SetLanguage("ja")
+	coquiVoices, err = coqui.ListVoices(context.Background())
+	if err != nil {
+		t.Fatalf("Coqui ListVoices (vits): %v", err)
+	}
+	if len(coquiVoices) == 0 {
+		t.Fatal("expected vits voices")
+	}
+}

--- a/pkg/speech/integration.go
+++ b/pkg/speech/integration.go
@@ -1,0 +1,391 @@
+package speech
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	transportreply "github.com/1024XEngineer/anyclaw/pkg/gateway/transport/reply"
+)
+
+type Integration struct {
+	mu         sync.RWMutex
+	pipeline   *TTSPipeline
+	dispatcher *transportreply.Dispatcher
+	channelMgr ChannelManager
+	config     IntegrationConfig
+	hooks      []IntegrationHook
+}
+
+type IntegrationConfig struct {
+	Enabled          bool
+	AutoTTS          bool
+	TTSTriggerPrefix string
+	VoiceProvider    string
+	Voice            string
+	Speed            float64
+	Format           AudioFormat
+	FallbackToText   bool
+	MaxTextLength    int
+	Timeout          time.Duration
+	Channels         map[string]bool
+	ExcludeChannels  map[string]bool
+}
+
+func DefaultIntegrationConfig() IntegrationConfig {
+	return IntegrationConfig{
+		Enabled:          true,
+		AutoTTS:          false,
+		TTSTriggerPrefix: "/speak",
+		VoiceProvider:    "openai",
+		Voice:            "",
+		Speed:            1.0,
+		Format:           FormatMP3,
+		FallbackToText:   true,
+		MaxTextLength:    5000,
+		Timeout:          30 * time.Second,
+		Channels:         map[string]bool{},
+		ExcludeChannels:  map[string]bool{},
+	}
+}
+
+type ChannelManager interface {
+	SendMessage(ctx context.Context, channelID string, message *ChannelMessage) error
+}
+
+type ChannelMessage struct {
+	Channel   string
+	Recipient string
+	Content   string
+	Type      string
+	Metadata  map[string]any
+}
+
+type IntegrationHook interface {
+	OnBeforeTTS(ctx context.Context, req *TTSRequest) error
+	OnAfterTTS(ctx context.Context, resp *TTSResponse) error
+	OnFallbackText(ctx context.Context, channel string, recipient string, text string) error
+}
+
+func NewIntegration(pipeline *TTSPipeline, dispatcher *transportreply.Dispatcher, channelMgr ChannelManager, cfg IntegrationConfig) *Integration {
+	return &Integration{
+		pipeline:   pipeline,
+		dispatcher: dispatcher,
+		channelMgr: channelMgr,
+		config:     cfg,
+	}
+}
+
+func (i *Integration) RegisterHook(hook IntegrationHook) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.hooks = append(i.hooks, hook)
+}
+
+func (i *Integration) ProcessMessage(ctx context.Context, channel string, recipient string, text string, metadata map[string]any) error {
+	i.mu.RLock()
+	enabled := i.config.Enabled
+	channels := i.config.Channels
+	excludeChannels := i.config.ExcludeChannels
+	triggerPrefix := i.config.TTSTriggerPrefix
+	autoTTS := i.config.AutoTTS
+	i.mu.RUnlock()
+
+	if !enabled {
+		return nil
+	}
+
+	if len(channels) > 0 && !channels[channel] {
+		return nil
+	}
+
+	if excludeChannels[channel] {
+		return nil
+	}
+
+	needsTTS := false
+	cleanText := text
+
+	if strings.HasPrefix(text, triggerPrefix) {
+		needsTTS = true
+		cleanText = strings.TrimSpace(text[len(triggerPrefix):])
+		if cleanText == "" {
+			return nil
+		}
+	}
+
+	if autoTTS {
+		needsTTS = true
+	}
+
+	if !needsTTS {
+		return i.processTextOnly(ctx, channel, recipient, text, metadata)
+	}
+
+	return i.processWithTTS(ctx, channel, recipient, cleanText, metadata)
+}
+
+func (i *Integration) processTextOnly(ctx context.Context, channel string, recipient string, text string, metadata map[string]any) error {
+	if i.dispatcher != nil {
+		msg := &transportreply.Message{
+			ID:        fmt.Sprintf("msg-%d", time.Now().UnixNano()),
+			Channel:   channel,
+			From:      recipient,
+			Text:      text,
+			Timestamp: time.Now().Unix(),
+			Metadata:  metadata,
+		}
+
+		resp, err := i.dispatcher.Dispatch(ctx, msg)
+		if err != nil {
+			return fmt.Errorf("integration: dispatch failed: %w", err)
+		}
+
+		if resp.Text != "" {
+			return i.sendTextResponse(ctx, channel, recipient, resp.Text)
+		}
+	}
+
+	return nil
+}
+
+func (i *Integration) processWithTTS(ctx context.Context, channel string, recipient string, text string, metadata map[string]any) error {
+	i.mu.RLock()
+	provider := i.config.VoiceProvider
+	voice := i.config.Voice
+	speed := i.config.Speed
+	format := i.config.Format
+	maxLen := i.config.MaxTextLength
+	timeout := i.config.Timeout
+	fallback := i.config.FallbackToText
+	i.mu.RUnlock()
+
+	if len(text) > maxLen {
+		text = text[:maxLen]
+	}
+
+	if i.dispatcher != nil {
+		msg := &transportreply.Message{
+			ID:        fmt.Sprintf("tts-%d", time.Now().UnixNano()),
+			Channel:   channel,
+			From:      recipient,
+			Text:      text,
+			Timestamp: time.Now().Unix(),
+			Metadata:  metadata,
+		}
+
+		resp, err := i.dispatcher.Dispatch(ctx, msg)
+		if err != nil {
+			if fallback {
+				return i.sendTextResponse(ctx, channel, recipient, text)
+			}
+			return fmt.Errorf("integration: dispatch failed: %w", err)
+		}
+
+		if resp.Text == "" {
+			return nil
+		}
+
+		text = resp.Text
+	}
+
+	for _, hook := range i.hooks {
+		req := &TTSRequest{
+			Text:      text,
+			Channel:   channel,
+			Recipient: recipient,
+		}
+		if err := hook.OnBeforeTTS(ctx, req); err != nil {
+			if fallback {
+				return i.sendTextResponse(ctx, channel, recipient, text)
+			}
+			return fmt.Errorf("integration: before hook failed: %w", err)
+		}
+	}
+
+	ttsCtx := ctx
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ttsCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	ttsReq := &TTSRequest{
+		Text:      text,
+		Channel:   channel,
+		Recipient: recipient,
+		Provider:  provider,
+		Voice:     voice,
+		Speed:     speed,
+		Format:    format,
+		Metadata:  metadata,
+	}
+
+	ttsResp, err := i.pipeline.Process(ttsCtx, ttsReq)
+	if err != nil {
+		if fallback {
+			return i.sendTextResponse(ctx, channel, recipient, text)
+		}
+		return fmt.Errorf("integration: TTS failed: %w", err)
+	}
+
+	for _, hook := range i.hooks {
+		_ = hook.OnAfterTTS(ctx, ttsResp)
+	}
+
+	return nil
+}
+
+func (i *Integration) sendTextResponse(ctx context.Context, channel string, recipient string, text string) error {
+	for _, hook := range i.hooks {
+		if err := hook.OnFallbackText(ctx, channel, recipient, text); err != nil {
+			return err
+		}
+	}
+
+	if i.channelMgr != nil {
+		msg := &ChannelMessage{
+			Channel:   channel,
+			Recipient: recipient,
+			Content:   text,
+			Type:      "text",
+		}
+		return i.channelMgr.SendMessage(ctx, channel, msg)
+	}
+
+	return nil
+}
+
+func (i *Integration) UpdateConfig(cfg IntegrationConfig) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.config = cfg
+}
+
+func (i *Integration) Config() IntegrationConfig {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.config
+}
+
+func (i *Integration) EnableAutoTTS() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.config.AutoTTS = true
+}
+
+func (i *Integration) DisableAutoTTS() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.config.AutoTTS = false
+}
+
+func (i *Integration) SetTriggerPrefix(prefix string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.config.TTSTriggerPrefix = prefix
+}
+
+func (i *Integration) AllowChannel(channel string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.config.Channels == nil {
+		i.config.Channels = make(map[string]bool)
+	}
+	i.config.Channels[channel] = true
+}
+
+func (i *Integration) ExcludeChannel(channel string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.config.ExcludeChannels == nil {
+		i.config.ExcludeChannels = make(map[string]bool)
+	}
+	i.config.ExcludeChannels[channel] = true
+}
+
+type ReplyDispatcherAdapter struct {
+	integration *Integration
+}
+
+func NewReplyDispatcherAdapter(integration *Integration) *ReplyDispatcherAdapter {
+	return &ReplyDispatcherAdapter{integration: integration}
+}
+
+func (a *ReplyDispatcherAdapter) OnMessage(ctx context.Context, msg *transportreply.Message) error {
+	_ = ctx
+	_ = msg
+	return nil
+}
+
+func (a *ReplyDispatcherAdapter) OnResponse(ctx context.Context, resp *transportreply.Response) error {
+	a.integration.mu.RLock()
+	enabled := a.integration.config.Enabled
+	autoTTS := a.integration.config.AutoTTS
+	channels := a.integration.config.Channels
+	excludeChannels := a.integration.config.ExcludeChannels
+	a.integration.mu.RUnlock()
+
+	if !enabled {
+		return nil
+	}
+
+	channel := ""
+	recipient := ""
+	if resp.Metadata != nil {
+		if ch, ok := resp.Metadata["channel"].(string); ok {
+			channel = ch
+		}
+		if rc, ok := resp.Metadata["recipient"].(string); ok {
+			recipient = rc
+		}
+	}
+
+	if channel == "" || recipient == "" {
+		return nil
+	}
+
+	if !autoTTS {
+		return nil
+	}
+
+	if len(channels) > 0 && !channels[channel] {
+		return nil
+	}
+
+	if excludeChannels[channel] {
+		return nil
+	}
+
+	return a.integration.processWithTTS(ctx, channel, recipient, resp.Text, resp.Metadata)
+}
+
+func (i *Integration) WrapInboundHandler(handler InboundHandler) InboundHandler {
+	return func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		channel := ""
+		recipient := ""
+		if meta != nil {
+			if ch, ok := meta["channel"]; ok {
+				channel = ch
+			}
+			if rc, ok := meta["recipient"]; ok {
+				recipient = rc
+			}
+		}
+
+		metadata := make(map[string]any)
+		for k, v := range meta {
+			metadata[k] = v
+		}
+
+		if err := i.ProcessMessage(ctx, channel, recipient, message, metadata); err != nil {
+			return sessionID, "", err
+		}
+
+		return handler(ctx, sessionID, message, meta)
+	}
+}
+
+type InboundHandler func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error)

--- a/pkg/speech/manager.go
+++ b/pkg/speech/manager.go
@@ -1,0 +1,228 @@
+package speech
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type Manager struct {
+	mu          sync.RWMutex
+	providers   map[string]Provider
+	defaultName string
+	cache       *AudioCache
+	cacheConfig CacheConfig
+}
+
+type ManagerOption func(*Manager)
+
+func WithManagerCache(cfg CacheConfig) ManagerOption {
+	return func(m *Manager) {
+		m.cacheConfig = cfg
+		m.cache = NewAudioCache(cfg)
+	}
+}
+
+func WithManagerProvider(name string, provider Provider) ManagerOption {
+	return func(m *Manager) {
+		m.providers[name] = provider
+		if m.defaultName == "" {
+			m.defaultName = name
+		}
+	}
+}
+
+func WithManagerDefault(name string) ManagerOption {
+	return func(m *Manager) {
+		m.defaultName = name
+	}
+}
+
+func NewManager(opts ...ManagerOption) *Manager {
+	m := &Manager{
+		providers:   make(map[string]Provider),
+		cacheConfig: DefaultCacheConfig(),
+	}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}
+
+func (m *Manager) Register(name string, provider Provider) error {
+	if name == "" {
+		return fmt.Errorf("tts: provider name cannot be empty")
+	}
+	if provider == nil {
+		return fmt.Errorf("tts: provider cannot be nil")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.providers[name]; exists {
+		return fmt.Errorf("tts: provider already registered: %s", name)
+	}
+
+	m.providers[name] = provider
+
+	if m.defaultName == "" {
+		m.defaultName = name
+	}
+
+	return nil
+}
+
+func (m *Manager) Get(name string) (Provider, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	provider, ok := m.providers[name]
+	if !ok {
+		return nil, fmt.Errorf("tts: provider not found: %s", name)
+	}
+
+	return provider, nil
+}
+
+func (m *Manager) GetDefault() (Provider, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.defaultName == "" {
+		return nil, fmt.Errorf("tts: no default provider configured")
+	}
+
+	provider, ok := m.providers[m.defaultName]
+	if !ok {
+		return nil, fmt.Errorf("tts: default provider not found: %s", m.defaultName)
+	}
+
+	return provider, nil
+}
+
+func (m *Manager) SetDefault(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.providers[name]; !ok {
+		return fmt.Errorf("tts: provider not found: %s", name)
+	}
+
+	m.defaultName = name
+	return nil
+}
+
+func (m *Manager) Synthesize(ctx context.Context, text string, provider string, opts ...SynthesizeOption) (*AudioResult, error) {
+	var p Provider
+	var err error
+
+	if provider != "" {
+		p, err = m.Get(provider)
+	} else {
+		p, err = m.GetDefault()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if m.cache != nil {
+		cacheKey := MakeCacheKey(text, provider, opts...)
+		if cached, ok := m.cache.Get(cacheKey); ok {
+			return cached, nil
+		}
+
+		result, err := p.Synthesize(ctx, text, opts...)
+		if err == nil && result != nil {
+			m.cache.Set(cacheKey, result)
+		}
+		return result, err
+	}
+
+	return p.Synthesize(ctx, text, opts...)
+}
+
+func (m *Manager) ListVoices(ctx context.Context, provider string) ([]Voice, error) {
+	var p Provider
+	var err error
+
+	if provider != "" {
+		p, err = m.Get(provider)
+	} else {
+		p, err = m.GetDefault()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return p.ListVoices(ctx)
+}
+
+func (m *Manager) ListProviders() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	names := make([]string, 0, len(m.providers))
+	for name := range m.providers {
+		names = append(names, name)
+	}
+
+	return names
+}
+
+func (m *Manager) Remove(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.providers[name]; !ok {
+		return fmt.Errorf("tts: provider not found: %s", name)
+	}
+
+	delete(m.providers, name)
+
+	if m.defaultName == name {
+		m.defaultName = ""
+		if len(m.providers) > 0 {
+			for n := range m.providers {
+				m.defaultName = n
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+func (m *Manager) Cache() *AudioCache {
+	return m.cache
+}
+
+func (m *Manager) EnableCache(cfg CacheConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cacheConfig = cfg
+	m.cache = NewAudioCache(cfg)
+}
+
+func (m *Manager) DisableCache() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cache = nil
+}
+
+func (m *Manager) ClearCache() {
+	if m.cache != nil {
+		m.cache.Clear()
+	}
+}
+
+func (m *Manager) CacheStats() (int, int64) {
+	if m.cache == nil {
+		return 0, 0
+	}
+	return m.cache.Len(), m.cache.SizeBytes()
+}

--- a/pkg/speech/manager_cache_provider_test.go
+++ b/pkg/speech/manager_cache_provider_test.go
@@ -1,0 +1,329 @@
+package speech
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testSpeechProvider struct {
+	name       string
+	typ        ProviderType
+	voices     []Voice
+	synthErr   error
+	synthCalls int
+	lastText   string
+	lastOpts   SynthesizeOptions
+}
+
+func (p *testSpeechProvider) Name() string {
+	if p.name == "" {
+		return "test"
+	}
+	return p.name
+}
+
+func (p *testSpeechProvider) Type() ProviderType {
+	if p.typ == "" {
+		return ProviderCustom
+	}
+	return p.typ
+}
+
+func (p *testSpeechProvider) Synthesize(ctx context.Context, text string, opts ...SynthesizeOption) (*AudioResult, error) {
+	_ = ctx
+	p.synthCalls++
+
+	options := SynthesizeOptions{
+		Voice:  "default",
+		Speed:  1.0,
+		Format: FormatMP3,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	p.lastText = text
+	p.lastOpts = options
+	if p.synthErr != nil {
+		return nil, p.synthErr
+	}
+
+	return &AudioResult{
+		Data:       []byte(text + "|" + options.Voice),
+		Format:     options.Format,
+		SampleRate: 24000,
+	}, nil
+}
+
+func (p *testSpeechProvider) ListVoices(ctx context.Context) ([]Voice, error) {
+	_ = ctx
+	return append([]Voice(nil), p.voices...), nil
+}
+
+func TestManagerLifecycleAndCache(t *testing.T) {
+	primary := &testSpeechProvider{
+		name:   "primary",
+		voices: []Voice{{ID: "primary-voice", Name: "Primary"}},
+	}
+	secondary := &testSpeechProvider{
+		name:   "secondary",
+		voices: []Voice{{ID: "secondary-voice", Name: "Secondary"}},
+	}
+
+	manager := NewManager(
+		WithManagerCache(CacheConfig{MaxSize: 2, MaxBytes: 64, TTL: time.Minute}),
+		WithManagerProvider("primary", primary),
+		WithManagerDefault("primary"),
+	)
+
+	if manager.Cache() == nil {
+		t.Fatal("expected cache to be enabled")
+	}
+
+	if got, err := manager.GetDefault(); err != nil || got != primary {
+		t.Fatalf("GetDefault() = (%v, %v), want primary provider", got, err)
+	}
+
+	if err := manager.Register("", primary); err == nil {
+		t.Fatal("expected empty provider name to fail")
+	}
+	if err := manager.Register("nil", nil); err == nil {
+		t.Fatal("expected nil provider to fail")
+	}
+	if err := manager.Register("primary", primary); err == nil {
+		t.Fatal("expected duplicate provider registration to fail")
+	}
+	if err := manager.Register("secondary", secondary); err != nil {
+		t.Fatalf("Register secondary: %v", err)
+	}
+	if _, err := manager.Get("missing"); err == nil {
+		t.Fatal("expected missing provider lookup to fail")
+	}
+	if err := manager.SetDefault("missing"); err == nil {
+		t.Fatal("expected SetDefault on missing provider to fail")
+	}
+	if err := manager.SetDefault("secondary"); err != nil {
+		t.Fatalf("SetDefault secondary: %v", err)
+	}
+
+	if got, err := manager.GetDefault(); err != nil || got != secondary {
+		t.Fatalf("GetDefault() = (%v, %v), want secondary provider", got, err)
+	}
+
+	names := manager.ListProviders()
+	sort.Strings(names)
+	if len(names) != 2 || names[0] != "primary" || names[1] != "secondary" {
+		t.Fatalf("ListProviders() = %v, want [primary secondary]", names)
+	}
+
+	result1, err := manager.Synthesize(context.Background(), "hello", "secondary", WithVoice("nova"))
+	if err != nil {
+		t.Fatalf("Synthesize first call: %v", err)
+	}
+	result2, err := manager.Synthesize(context.Background(), "hello", "secondary", WithVoice("nova"))
+	if err != nil {
+		t.Fatalf("Synthesize second call: %v", err)
+	}
+
+	if secondary.synthCalls != 1 {
+		t.Fatalf("expected cached synthesize call count 1, got %d", secondary.synthCalls)
+	}
+	if string(result1.Data) != string(result2.Data) {
+		t.Fatalf("cached audio mismatch: %q != %q", result1.Data, result2.Data)
+	}
+
+	voices, err := manager.ListVoices(context.Background(), "secondary")
+	if err != nil {
+		t.Fatalf("ListVoices: %v", err)
+	}
+	if len(voices) != 1 || voices[0].ID != "secondary-voice" {
+		t.Fatalf("ListVoices() = %+v, want secondary voice", voices)
+	}
+
+	if err := manager.Remove("missing"); err == nil {
+		t.Fatal("expected Remove on missing provider to fail")
+	}
+	if err := manager.Remove("secondary"); err != nil {
+		t.Fatalf("Remove secondary: %v", err)
+	}
+	if got, err := manager.GetDefault(); err != nil || got != primary {
+		t.Fatalf("GetDefault() after remove = (%v, %v), want primary provider", got, err)
+	}
+
+	manager.ClearCache()
+	if size, bytes := manager.CacheStats(); size != 0 || bytes != 0 {
+		t.Fatalf("CacheStats() = (%d, %d), want (0, 0)", size, bytes)
+	}
+
+	manager.DisableCache()
+	if manager.Cache() != nil {
+		t.Fatal("expected cache to be disabled")
+	}
+	if _, err := manager.Synthesize(context.Background(), "uncached", "primary"); err != nil {
+		t.Fatalf("uncached synthesize: %v", err)
+	}
+	if primary.synthCalls != 1 {
+		t.Fatalf("expected primary synth calls = 1, got %d", primary.synthCalls)
+	}
+
+	manager.EnableCache(DefaultCacheConfig())
+	if manager.Cache() == nil {
+		t.Fatal("expected cache to be re-enabled")
+	}
+}
+
+func TestAudioCacheLifecycle(t *testing.T) {
+	cache := NewAudioCache(CacheConfig{MaxSize: 2, MaxBytes: 5, TTL: time.Minute})
+
+	cache.Set("nil", nil)
+	cache.Set("empty", &AudioResult{})
+	if cache.Len() != 0 || cache.SizeBytes() != 0 {
+		t.Fatalf("empty cache writes should be ignored, got len=%d bytes=%d", cache.Len(), cache.SizeBytes())
+	}
+
+	cache.Set("a", &AudioResult{Data: []byte("aa")})
+	cache.Set("b", &AudioResult{Data: []byte("bb")})
+	if cache.Len() != 2 || cache.SizeBytes() != 4 {
+		t.Fatalf("after Set() len=%d bytes=%d, want len=2 bytes=4", cache.Len(), cache.SizeBytes())
+	}
+
+	if got, ok := cache.Get("a"); !ok || string(got.Data) != "aa" {
+		t.Fatalf("Get(a) = (%v, %v), want audio 'aa'", got, ok)
+	}
+
+	cache.Set("oversize", &AudioResult{Data: []byte("123456")})
+	if _, ok := cache.Get("oversize"); ok {
+		t.Fatal("expected oversize entry to be ignored")
+	}
+
+	cache.Set("c", &AudioResult{Data: []byte("c")})
+	if cache.Len() > 2 || cache.SizeBytes() > 5 {
+		t.Fatalf("cache limits exceeded: len=%d bytes=%d", cache.Len(), cache.SizeBytes())
+	}
+
+	cache.items["expired"] = audioCacheItem{
+		result:    &AudioResult{Data: []byte("z")},
+		expiresAt: time.Now().Add(-time.Second),
+		sizeBytes: 1,
+	}
+	cache.currentBytes++
+
+	if got, ok := cache.Get("expired"); ok || got != nil {
+		t.Fatalf("Get(expired) = (%v, %v), want (nil, false)", got, ok)
+	}
+	if removed := cache.Cleanup(); removed != 1 {
+		t.Fatalf("Cleanup() = %d, want 1", removed)
+	}
+
+	cache.Remove("a")
+	cache.Clear()
+	if cache.Len() != 0 || cache.SizeBytes() != 0 {
+		t.Fatalf("after Clear() len=%d bytes=%d, want 0/0", cache.Len(), cache.SizeBytes())
+	}
+
+	key1 := MakeCacheKey("hello", "provider", WithVoice("nova"), WithSpeed(1.25), WithFormat(FormatWAV), WithLanguage("en-US"))
+	key2 := MakeCacheKey("hello", "provider", WithVoice("nova"), WithSpeed(1.25), WithFormat(FormatWAV), WithLanguage("en-US"))
+	key3 := MakeCacheKey("hello", "provider", WithVoice("echo"))
+
+	if key1 != key2 {
+		t.Fatalf("expected identical cache keys, got %q != %q", key1, key2)
+	}
+	if key1 == key3 {
+		t.Fatalf("expected different cache keys, got identical key %q", key1)
+	}
+}
+
+func TestProviderHelpersAndFactory(t *testing.T) {
+	opts := SynthesizeOptions{}
+	WithVoice("voice-a")(&opts)
+	WithSpeed(1.5)(&opts)
+	WithPitch(0.2)(&opts)
+	WithVolume(0.8)(&opts)
+	WithFormat(FormatWAV)(&opts)
+	WithLanguage("ja-JP")(&opts)
+	WithSampleRate(44100)(&opts)
+
+	if opts.Voice != "voice-a" || opts.Speed != 1.5 || opts.Pitch != 0.2 || opts.Volume != 0.8 || opts.Format != FormatWAV || opts.Language != "ja-JP" || opts.SampleRate != 44100 {
+		t.Fatalf("unexpected synth options: %+v", opts)
+	}
+
+	audio := []byte("audio-data")
+	encoded := AudioToBase64(audio)
+	decoded, err := Base64ToAudio(encoded)
+	if err != nil {
+		t.Fatalf("Base64ToAudio(valid): %v", err)
+	}
+	if string(decoded) != string(audio) {
+		t.Fatalf("decoded audio mismatch: %q != %q", decoded, audio)
+	}
+	if _, err := Base64ToAudio("%%%"); err == nil {
+		t.Fatal("expected invalid base64 to fail")
+	}
+
+	if _, err := NewProvider(Config{Type: ProviderOpenAI}); err == nil {
+		t.Fatal("expected openai provider without API key to fail")
+	}
+	if _, err := NewProvider(Config{Type: ProviderElevenLabs}); err == nil {
+		t.Fatal("expected elevenlabs provider without API key to fail")
+	}
+
+	edgeProvider, err := NewProvider(Config{
+		Type:     ProviderEdge,
+		BaseURL:  "http://edge.local",
+		Voice:    "edge-voice",
+		Language: "zh-CN",
+		Timeout:  2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewProvider(edge): %v", err)
+	}
+	edge := edgeProvider.(*EdgeProvider)
+	if edge.baseURL != "http://edge.local" || edge.voice != "edge-voice" || edge.language != "zh-CN" || edge.client.Timeout != 2*time.Second {
+		t.Fatalf("unexpected edge provider config: %+v", edge)
+	}
+
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "test-model.onnx")
+	configPath := strings.TrimSuffix(modelPath, ".onnx") + ".onnx.json"
+	if err := os.WriteFile(modelPath, []byte("model"), 0o644); err != nil {
+		t.Fatalf("WriteFile(model): %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("WriteFile(config): %v", err)
+	}
+
+	piperProvider, err := NewProvider(Config{
+		Type:     ProviderPiper,
+		Voice:    modelPath,
+		Language: "ja-JP",
+	})
+	if err != nil {
+		t.Fatalf("NewProvider(piper): %v", err)
+	}
+	piper := piperProvider.(*PiperProvider)
+	if piper.modelPath != modelPath || piper.configFile != configPath || piper.defaultLang != "ja-JP" {
+		t.Fatalf("unexpected piper provider config: %+v", piper)
+	}
+
+	coquiProvider, err := NewProvider(Config{
+		Type:     ProviderCoqui,
+		Voice:    "speaker-a",
+		Language: "fr",
+	})
+	if err != nil {
+		t.Fatalf("NewProvider(coqui): %v", err)
+	}
+	coqui := coquiProvider.(*CoquiProvider)
+	if coqui.speakerName != "speaker-a" || coqui.defaultLang != "fr" {
+		t.Fatalf("unexpected coqui provider config: %+v", coqui)
+	}
+
+	if _, err := NewProvider(Config{Type: ProviderCustom}); err == nil {
+		t.Fatal("expected unknown provider type to fail")
+	}
+}

--- a/pkg/speech/pipeline.go
+++ b/pkg/speech/pipeline.go
@@ -1,0 +1,353 @@
+package speech
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type TTSPipeline struct {
+	mu            sync.RWMutex
+	manager       *Manager
+	config        PipelineConfig
+	hooks         []PipelineHook
+	audioSenders  map[string]AudioSender
+	defaultSender AudioSender
+}
+
+type PipelineConfig struct {
+	Enabled         bool
+	AutoTrigger     bool
+	TriggerKeywords []string
+	MaxTextLength   int
+	DefaultProvider string
+	DefaultVoice    string
+	DefaultSpeed    float64
+	DefaultFormat   AudioFormat
+	Timeout         time.Duration
+	RetryOnFail     bool
+	FallbackToText  bool
+}
+
+func DefaultPipelineConfig() PipelineConfig {
+	return PipelineConfig{
+		Enabled:         true,
+		AutoTrigger:     false,
+		TriggerKeywords: []string{"/speak", "/voice", "/tts"},
+		MaxTextLength:   5000,
+		DefaultProvider: "openai",
+		DefaultVoice:    "",
+		DefaultSpeed:    1.0,
+		DefaultFormat:   FormatMP3,
+		Timeout:         30 * time.Second,
+		RetryOnFail:     true,
+		FallbackToText:  true,
+	}
+}
+
+type PipelineHook interface {
+	OnBeforeSynthesize(ctx context.Context, text string, opts *SynthesizeOptions) error
+	OnAfterSynthesize(ctx context.Context, result *AudioResult) error
+	OnSendComplete(ctx context.Context, channel string, audioID string) error
+}
+
+type AudioSender interface {
+	SendAudio(ctx context.Context, channel string, recipient string, audio *AudioResult, caption string) (string, error)
+	CanSend(channel string) bool
+}
+
+type TTSRequest struct {
+	Text      string
+	Channel   string
+	Recipient string
+	Provider  string
+	Voice     string
+	Speed     float64
+	Format    AudioFormat
+	Caption   string
+	Metadata  map[string]any
+}
+
+type TTSResponse struct {
+	AudioID   string
+	Audio     *AudioResult
+	Text      string
+	Channel   string
+	Recipient string
+	Cached    bool
+	Duration  time.Duration
+}
+
+func NewTTSPipeline(manager *Manager, cfg PipelineConfig) *TTSPipeline {
+	if manager == nil {
+		manager = NewManager()
+	}
+
+	p := &TTSPipeline{
+		manager:      manager,
+		config:       cfg,
+		audioSenders: make(map[string]AudioSender),
+	}
+
+	if p.manager.Cache() == nil {
+		p.manager.EnableCache(DefaultCacheConfig())
+	}
+
+	return p
+}
+
+func (p *TTSPipeline) RegisterAudioSender(channel string, sender AudioSender) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.audioSenders[channel] = sender
+	if p.defaultSender == nil {
+		p.defaultSender = sender
+	}
+}
+
+func (p *TTSPipeline) RegisterHook(hook PipelineHook) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.hooks = append(p.hooks, hook)
+}
+
+func (p *TTSPipeline) SetDefaultSender(sender AudioSender) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.defaultSender = sender
+}
+
+func (p *TTSPipeline) Process(ctx context.Context, req *TTSRequest) (*TTSResponse, error) {
+	p.mu.RLock()
+	enabled := p.config.Enabled
+	provider := p.config.DefaultProvider
+	voice := p.config.DefaultVoice
+	speed := p.config.DefaultSpeed
+	format := p.config.DefaultFormat
+	maxLen := p.config.MaxTextLength
+	timeout := p.config.Timeout
+	p.mu.RUnlock()
+
+	if !enabled {
+		return nil, fmt.Errorf("tts pipeline is disabled")
+	}
+
+	if req.Provider != "" {
+		provider = req.Provider
+	}
+	if req.Voice != "" {
+		voice = req.Voice
+	}
+	if req.Speed > 0 {
+		speed = req.Speed
+	}
+	if req.Format != "" {
+		format = req.Format
+	}
+
+	if len(req.Text) > maxLen {
+		req.Text = req.Text[:maxLen]
+	}
+
+	opts := []SynthesizeOption{
+		WithVoice(voice),
+		WithSpeed(speed),
+		WithFormat(format),
+	}
+
+	for _, hook := range p.hooks {
+		synthOpts := SynthesizeOptions{
+			Voice:  voice,
+			Speed:  speed,
+			Format: format,
+		}
+		if err := hook.OnBeforeSynthesize(ctx, req.Text, &synthOpts); err != nil {
+			return nil, fmt.Errorf("tts pipeline: before hook failed: %w", err)
+		}
+	}
+
+	synthCtx := ctx
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		synthCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	audio, err := p.manager.Synthesize(synthCtx, req.Text, provider, opts...)
+	if err != nil {
+		if p.config.FallbackToText {
+			return &TTSResponse{
+				Text:    req.Text,
+				Channel: req.Channel,
+			}, nil
+		}
+		return nil, fmt.Errorf("tts pipeline: synthesis failed: %w", err)
+	}
+
+	for _, hook := range p.hooks {
+		if err := hook.OnAfterSynthesize(ctx, audio); err != nil {
+			return nil, fmt.Errorf("tts pipeline: after hook failed: %w", err)
+		}
+	}
+
+	sender := p.resolveSender(req.Channel)
+	if sender == nil {
+		sender = p.defaultSender
+	}
+
+	var audioID string
+	if sender != nil {
+		caption := req.Caption
+		if caption == "" {
+			caption = req.Text
+		}
+
+		id, err := sender.SendAudio(ctx, req.Channel, req.Recipient, audio, caption)
+		if err != nil {
+			if p.config.FallbackToText {
+				return &TTSResponse{
+					Text:    req.Text,
+					Channel: req.Channel,
+				}, nil
+			}
+			return nil, fmt.Errorf("tts pipeline: failed to send audio: %w", err)
+		}
+		audioID = id
+
+		for _, hook := range p.hooks {
+			_ = hook.OnSendComplete(ctx, req.Channel, id)
+		}
+	}
+
+	return &TTSResponse{
+		AudioID:   audioID,
+		Audio:     audio,
+		Text:      req.Text,
+		Channel:   req.Channel,
+		Recipient: req.Recipient,
+		Cached:    false,
+	}, nil
+}
+
+func (p *TTSPipeline) ShouldAutoTrigger(text string) bool {
+	p.mu.RLock()
+	autoTrigger := p.config.AutoTrigger
+	keywords := p.config.TriggerKeywords
+	p.mu.RUnlock()
+
+	if !autoTrigger {
+		for _, kw := range keywords {
+			if len(text) >= len(kw) && text[:len(kw)] == kw {
+				return true
+			}
+		}
+		return false
+	}
+
+	return true
+}
+
+func (p *TTSPipeline) resolveSender(channel string) AudioSender {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if sender, ok := p.audioSenders[channel]; ok {
+		return sender
+	}
+	return nil
+}
+
+func (p *TTSPipeline) UpdateConfig(cfg PipelineConfig) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.config = cfg
+}
+
+func (p *TTSPipeline) Config() PipelineConfig {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.config
+}
+
+func (p *TTSPipeline) Enabled() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.config.Enabled
+}
+
+func (p *TTSPipeline) SetEnabled(enabled bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.config.Enabled = enabled
+}
+
+type ReplyHook struct {
+	pipeline *TTSPipeline
+}
+
+func NewReplyHook(pipeline *TTSPipeline) *ReplyHook {
+	return &ReplyHook{pipeline: pipeline}
+}
+
+func (h *ReplyHook) OnMessage(ctx context.Context, msg *Message) error {
+	_ = ctx
+	_ = msg
+	return nil
+}
+
+func (h *ReplyHook) OnResponse(ctx context.Context, resp *Response) error {
+	if !h.pipeline.Enabled() {
+		return nil
+	}
+
+	if resp.Text == "" {
+		return nil
+	}
+
+	channel := ""
+	recipient := ""
+	if resp.Metadata != nil {
+		if ch, ok := resp.Metadata["channel"].(string); ok {
+			channel = ch
+		}
+		if rc, ok := resp.Metadata["recipient"].(string); ok {
+			recipient = rc
+		}
+	}
+
+	if !h.pipeline.ShouldAutoTrigger(resp.Text) {
+		return nil
+	}
+
+	req := &TTSRequest{
+		Text:      resp.Text,
+		Channel:   channel,
+		Recipient: recipient,
+	}
+
+	_, err := h.pipeline.Process(ctx, req)
+	return err
+}
+
+type Message struct {
+	ID        string
+	Channel   string
+	From      string
+	Text      string
+	Timestamp int64
+	Metadata  map[string]any
+}
+
+type Response struct {
+	MessageID string
+	Text      string
+	Tools     []ToolCall
+	Metadata  map[string]any
+}
+
+type ToolCall struct {
+	Name      string
+	Arguments map[string]any
+	ID        string
+}

--- a/pkg/speech/pipeline_integration_test.go
+++ b/pkg/speech/pipeline_integration_test.go
@@ -1,0 +1,324 @@
+package speech
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/capability/tools"
+	transportreply "github.com/1024XEngineer/anyclaw/pkg/gateway/transport/reply"
+)
+
+type testAudioSenderImpl struct {
+	id         string
+	sendErr    error
+	sendCalls  int
+	captions   []string
+	channels   []string
+	recipients []string
+}
+
+func (s *testAudioSenderImpl) SendAudio(ctx context.Context, channel string, recipient string, audio *AudioResult, caption string) (string, error) {
+	_ = ctx
+	_ = audio
+	s.sendCalls++
+	s.channels = append(s.channels, channel)
+	s.recipients = append(s.recipients, recipient)
+	s.captions = append(s.captions, caption)
+	if s.sendErr != nil {
+		return "", s.sendErr
+	}
+	if s.id == "" {
+		return "audio-id", nil
+	}
+	return s.id, nil
+}
+
+func (s *testAudioSenderImpl) CanSend(channel string) bool {
+	return channel != ""
+}
+
+type testPipelineHook struct {
+	beforeCalls int
+	afterCalls  int
+	sendCalls   int
+	beforeErr   error
+	afterErr    error
+}
+
+func (h *testPipelineHook) OnBeforeSynthesize(ctx context.Context, text string, opts *SynthesizeOptions) error {
+	_, _, _ = ctx, text, opts
+	h.beforeCalls++
+	return h.beforeErr
+}
+
+func (h *testPipelineHook) OnAfterSynthesize(ctx context.Context, result *AudioResult) error {
+	_, _ = ctx, result
+	h.afterCalls++
+	return h.afterErr
+}
+
+func (h *testPipelineHook) OnSendComplete(ctx context.Context, channel string, audioID string) error {
+	_, _, _ = ctx, channel, audioID
+	h.sendCalls++
+	return nil
+}
+
+type testChannelManager struct {
+	messages []*ChannelMessage
+}
+
+func (m *testChannelManager) SendMessage(ctx context.Context, channelID string, message *ChannelMessage) error {
+	_ = ctx
+	_ = channelID
+	copyMsg := *message
+	m.messages = append(m.messages, &copyMsg)
+	return nil
+}
+
+type testIntegrationHook struct {
+	beforeCalls   int
+	afterCalls    int
+	fallbackCalls int
+	beforeErr     error
+}
+
+func (h *testIntegrationHook) OnBeforeTTS(ctx context.Context, req *TTSRequest) error {
+	_, _ = ctx, req
+	h.beforeCalls++
+	return h.beforeErr
+}
+
+func (h *testIntegrationHook) OnAfterTTS(ctx context.Context, resp *TTSResponse) error {
+	_, _ = ctx, resp
+	h.afterCalls++
+	return nil
+}
+
+func (h *testIntegrationHook) OnFallbackText(ctx context.Context, channel string, recipient string, text string) error {
+	_, _, _, _ = ctx, channel, recipient, text
+	h.fallbackCalls++
+	return nil
+}
+
+func TestTTSPipelineProcessAndReplyHook(t *testing.T) {
+	provider := &testSpeechProvider{name: "openai"}
+	manager := NewManager(WithManagerProvider("openai", provider))
+
+	cfg := DefaultPipelineConfig()
+	cfg.DefaultProvider = "openai"
+	cfg.Timeout = time.Second
+
+	pipeline := NewTTSPipeline(manager, cfg)
+	hook := &testPipelineHook{}
+	sender := &testAudioSenderImpl{id: "audio-1"}
+	pipeline.RegisterHook(hook)
+	pipeline.RegisterAudioSender("telegram", sender)
+	pipeline.SetDefaultSender(sender)
+
+	resp, err := pipeline.Process(context.Background(), &TTSRequest{
+		Text:      "hello there",
+		Channel:   "telegram",
+		Recipient: "user-1",
+		Provider:  "openai",
+		Voice:     "nova",
+		Speed:     1.2,
+		Format:    FormatWAV,
+	})
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if resp.AudioID != "audio-1" || resp.Audio == nil {
+		t.Fatalf("unexpected pipeline response: %+v", resp)
+	}
+	if hook.beforeCalls != 1 || hook.afterCalls != 1 || hook.sendCalls != 1 {
+		t.Fatalf("unexpected hook counts: before=%d after=%d send=%d", hook.beforeCalls, hook.afterCalls, hook.sendCalls)
+	}
+	if provider.lastOpts.Voice != "nova" || provider.lastOpts.Format != FormatWAV {
+		t.Fatalf("unexpected synth options: %+v", provider.lastOpts)
+	}
+	if sender.sendCalls != 1 || sender.captions[0] != "hello there" {
+		t.Fatalf("unexpected sender state: %+v", sender)
+	}
+
+	if !pipeline.ShouldAutoTrigger("/speak hello") {
+		t.Fatal("expected trigger keyword to auto trigger")
+	}
+	if pipeline.ShouldAutoTrigger("plain text") {
+		t.Fatal("expected plain text to not auto trigger")
+	}
+
+	replyHook := NewReplyHook(pipeline)
+	if err := replyHook.OnMessage(context.Background(), &Message{ID: "msg-1"}); err != nil {
+		t.Fatalf("ReplyHook OnMessage: %v", err)
+	}
+	if err := replyHook.OnResponse(context.Background(), &Response{
+		Text: "/speak follow up",
+		Metadata: map[string]any{
+			"channel":   "telegram",
+			"recipient": "user-2",
+		},
+	}); err != nil {
+		t.Fatalf("ReplyHook OnResponse: %v", err)
+	}
+	if sender.sendCalls != 2 {
+		t.Fatalf("expected reply hook to send audio, got %d sends", sender.sendCalls)
+	}
+}
+
+func TestTTSPipelineFallbackAndConfigHelpers(t *testing.T) {
+	brokenProvider := &testSpeechProvider{name: "broken", synthErr: errors.New("boom")}
+	manager := NewManager(WithManagerProvider("broken", brokenProvider))
+
+	cfg := DefaultPipelineConfig()
+	cfg.DefaultProvider = "broken"
+	cfg.FallbackToText = true
+	cfg.Enabled = false
+
+	pipeline := NewTTSPipeline(manager, cfg)
+	if _, err := pipeline.Process(context.Background(), &TTSRequest{Text: "hello"}); err == nil {
+		t.Fatal("expected disabled pipeline to fail")
+	}
+
+	pipeline.SetEnabled(true)
+	if !pipeline.Enabled() {
+		t.Fatal("expected pipeline to be enabled")
+	}
+
+	pipeline.UpdateConfig(DefaultPipelineConfig())
+	updated := pipeline.Config()
+	updated.DefaultProvider = "broken"
+	updated.FallbackToText = true
+	pipeline.UpdateConfig(updated)
+
+	resp, err := pipeline.Process(context.Background(), &TTSRequest{Text: "hello"})
+	if err != nil {
+		t.Fatalf("expected fallback response, got error: %v", err)
+	}
+	if resp.Text != "hello" || resp.Audio != nil {
+		t.Fatalf("unexpected fallback response: %+v", resp)
+	}
+}
+
+func TestIntegrationFlows(t *testing.T) {
+	provider := &testSpeechProvider{name: "openai"}
+	manager := NewManager(WithManagerProvider("openai", provider))
+
+	pipelineCfg := DefaultPipelineConfig()
+	pipelineCfg.DefaultProvider = "openai"
+	pipeline := NewTTSPipeline(manager, pipelineCfg)
+	sender := &testAudioSenderImpl{id: "tts-id"}
+	pipeline.RegisterAudioSender("telegram", sender)
+
+	dispatcher := transportreply.NewDispatcher(tools.NewRegistry())
+	dispatcher.RegisterCommand(transportreply.CommandHandler{
+		Name: "echo",
+		Handler: func(ctx context.Context, args map[string]string) (string, error) {
+			_ = ctx
+			if _, ok := args["hello"]; ok {
+				return "echo:hello", nil
+			}
+			return "echo", nil
+		},
+	})
+
+	channelMgr := &testChannelManager{}
+	integration := NewIntegration(pipeline, dispatcher, channelMgr, DefaultIntegrationConfig())
+	hook := &testIntegrationHook{}
+	integration.RegisterHook(hook)
+
+	if err := integration.ProcessMessage(context.Background(), "telegram", "user-1", "/echo hello", map[string]any{"k": "v"}); err != nil {
+		t.Fatalf("ProcessMessage text-only: %v", err)
+	}
+	if len(channelMgr.messages) != 1 || channelMgr.messages[0].Content != "echo:hello" {
+		t.Fatalf("unexpected channel messages: %+v", channelMgr.messages)
+	}
+
+	integration.EnableAutoTTS()
+	if err := integration.ProcessMessage(context.Background(), "telegram", "user-2", "speak now", nil); err != nil {
+		t.Fatalf("ProcessMessage auto TTS: %v", err)
+	}
+	if sender.sendCalls == 0 {
+		t.Fatal("expected TTS sender to be used")
+	}
+	if hook.beforeCalls == 0 || hook.afterCalls == 0 {
+		t.Fatalf("expected integration hooks to run, got before=%d after=%d", hook.beforeCalls, hook.afterCalls)
+	}
+
+	integration.DisableAutoTTS()
+	integration.SetTriggerPrefix("/say")
+	integration.AllowChannel("telegram")
+	integration.ExcludeChannel("ignore-me")
+
+	cfg := integration.Config()
+	if cfg.TTSTriggerPrefix != "/say" || !cfg.Channels["telegram"] || !cfg.ExcludeChannels["ignore-me"] {
+		t.Fatalf("unexpected integration config: %+v", cfg)
+	}
+	cfg.Enabled = true
+	integration.UpdateConfig(cfg)
+
+	adapter := NewReplyDispatcherAdapter(integration)
+	if err := adapter.OnMessage(context.Background(), &transportreply.Message{ID: "msg-2"}); err != nil {
+		t.Fatalf("ReplyDispatcherAdapter OnMessage: %v", err)
+	}
+	integration.EnableAutoTTS()
+	if err := adapter.OnResponse(context.Background(), &transportreply.Response{
+		Text: "adapter text",
+		Metadata: map[string]any{
+			"channel":   "telegram",
+			"recipient": "user-3",
+		},
+	}); err != nil {
+		t.Fatalf("ReplyDispatcherAdapter OnResponse: %v", err)
+	}
+	if sender.sendCalls < 2 {
+		t.Fatalf("expected adapter to trigger TTS, got %d sends", sender.sendCalls)
+	}
+}
+
+func TestIntegrationFallbackAndWrapInboundHandler(t *testing.T) {
+	brokenProvider := &testSpeechProvider{name: "broken", synthErr: errors.New("boom")}
+	manager := NewManager(WithManagerProvider("broken", brokenProvider))
+
+	pipelineCfg := DefaultPipelineConfig()
+	pipelineCfg.DefaultProvider = "broken"
+	pipelineCfg.FallbackToText = false
+	pipeline := NewTTSPipeline(manager, pipelineCfg)
+
+	channelMgr := &testChannelManager{}
+	cfg := DefaultIntegrationConfig()
+	cfg.AutoTTS = true
+	cfg.FallbackToText = true
+	cfg.VoiceProvider = "broken"
+	integration := NewIntegration(pipeline, nil, channelMgr, cfg)
+
+	hook := &testIntegrationHook{beforeErr: errors.New("hook-failed")}
+	integration.RegisterHook(hook)
+
+	if err := integration.ProcessMessage(context.Background(), "telegram", "user-1", "hello", nil); err != nil {
+		t.Fatalf("expected fallback path to succeed, got %v", err)
+	}
+	if len(channelMgr.messages) != 1 || channelMgr.messages[0].Content != "hello" {
+		t.Fatalf("unexpected fallback messages: %+v", channelMgr.messages)
+	}
+	if hook.fallbackCalls != 1 {
+		t.Fatalf("expected fallback hook to run once, got %d", hook.fallbackCalls)
+	}
+
+	wrapped := integration.WrapInboundHandler(func(ctx context.Context, sessionID string, message string, meta map[string]string) (string, string, error) {
+		_, _, _ = ctx, message, meta
+		return sessionID + "-next", "ok", nil
+	})
+
+	nextSession, replyText, err := wrapped(context.Background(), "sess-1", "hi", map[string]string{
+		"channel":   "telegram",
+		"recipient": "user-2",
+	})
+	if err != nil {
+		t.Fatalf("WrapInboundHandler: %v", err)
+	}
+	if nextSession != "sess-1-next" || replyText != "ok" {
+		t.Fatalf("unexpected wrapped handler result: %q / %q", nextSession, replyText)
+	}
+}

--- a/pkg/speech/provider.go
+++ b/pkg/speech/provider.go
@@ -1,0 +1,204 @@
+package speech
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+)
+
+type ProviderType string
+
+const (
+	ProviderOpenAI     ProviderType = "openai"
+	ProviderElevenLabs ProviderType = "elevenlabs"
+	ProviderEdge       ProviderType = "edge"
+	ProviderAzure      ProviderType = "azure"
+	ProviderGoogle     ProviderType = "google"
+	ProviderAliyun     ProviderType = "aliyun"
+	ProviderPiper      ProviderType = "piper"
+	ProviderCoqui      ProviderType = "coqui"
+	ProviderCustom     ProviderType = "custom"
+)
+
+type AudioFormat string
+
+const (
+	FormatMP3  AudioFormat = "mp3"
+	FormatWAV  AudioFormat = "wav"
+	FormatOGG  AudioFormat = "ogg"
+	FormatFLAC AudioFormat = "flac"
+	FormatPCM  AudioFormat = "pcm"
+)
+
+type VoiceGender string
+
+const (
+	GenderMale    VoiceGender = "male"
+	GenderFemale  VoiceGender = "female"
+	GenderNeutral VoiceGender = "neutral"
+)
+
+type Provider interface {
+	Name() string
+	Type() ProviderType
+	Synthesize(ctx context.Context, text string, opts ...SynthesizeOption) (*AudioResult, error)
+	ListVoices(ctx context.Context) ([]Voice, error)
+}
+
+type Config struct {
+	Type        ProviderType
+	APIKey      string
+	BaseURL     string
+	Voice       string
+	Language    string
+	SampleRate  int
+	AudioFormat AudioFormat
+	Timeout     time.Duration
+}
+
+func NewProvider(cfg Config) (Provider, error) {
+	switch cfg.Type {
+	case ProviderOpenAI:
+		opts := []OpenAIOption{}
+		if cfg.BaseURL != "" {
+			opts = append(opts, WithOpenAIBaseURL(cfg.BaseURL))
+		}
+		if cfg.Voice != "" {
+			opts = append(opts, WithOpenAIVoice(cfg.Voice))
+		}
+		if cfg.Timeout > 0 {
+			opts = append(opts, WithOpenAITimeout(cfg.Timeout))
+		}
+		return NewOpenAIProvider(cfg.APIKey, opts...)
+	case ProviderElevenLabs:
+		opts := []ElevenLabsOption{}
+		if cfg.BaseURL != "" {
+			opts = append(opts, WithElevenLabsBaseURL(cfg.BaseURL))
+		}
+		if cfg.Voice != "" {
+			opts = append(opts, WithElevenLabsVoice(cfg.Voice))
+		}
+		if cfg.Timeout > 0 {
+			opts = append(opts, WithElevenLabsTimeout(cfg.Timeout))
+		}
+		return NewElevenLabsProvider(cfg.APIKey, opts...)
+	case ProviderEdge:
+		opts := []EdgeOption{}
+		if cfg.BaseURL != "" {
+			opts = append(opts, WithEdgeBaseURL(cfg.BaseURL))
+		}
+		if cfg.Voice != "" {
+			opts = append(opts, WithEdgeVoice(cfg.Voice))
+		}
+		if cfg.Language != "" {
+			opts = append(opts, WithEdgeLanguage(cfg.Language))
+		}
+		if cfg.Timeout > 0 {
+			opts = append(opts, WithEdgeTimeout(cfg.Timeout))
+		}
+		return NewEdgeProvider(opts...)
+	case ProviderPiper:
+		opts := []PiperOption{}
+		if cfg.Voice != "" {
+			opts = append(opts, WithPiperDefaultVoice(cfg.Voice))
+		}
+		if cfg.Language != "" {
+			opts = append(opts, WithPiperDefaultLanguage(cfg.Language))
+		}
+		return NewPiperProvider(opts...)
+	case ProviderCoqui:
+		opts := []CoquiOption{}
+		if cfg.Voice != "" {
+			opts = append(opts, WithCoquiSpeaker(cfg.Voice))
+		}
+		if cfg.Language != "" {
+			opts = append(opts, WithCoquiDefaultLanguage(cfg.Language))
+		}
+		return NewCoquiProvider(opts...)
+	default:
+		return nil, fmt.Errorf("unknown TTS provider: %s", cfg.Type)
+	}
+}
+
+type SynthesizeOptions struct {
+	Voice      string
+	Speed      float64
+	Pitch      float64
+	Volume     float64
+	Format     AudioFormat
+	Language   string
+	SampleRate int
+}
+
+type SynthesizeOption func(*SynthesizeOptions)
+
+func WithVoice(voice string) SynthesizeOption {
+	return func(o *SynthesizeOptions) {
+		o.Voice = voice
+	}
+}
+
+func WithSpeed(speed float64) SynthesizeOption {
+	return func(o *SynthesizeOptions) {
+		o.Speed = speed
+	}
+}
+
+func WithPitch(pitch float64) SynthesizeOption {
+	return func(o *SynthesizeOptions) {
+		o.Pitch = pitch
+	}
+}
+
+func WithVolume(volume float64) SynthesizeOption {
+	return func(o *SynthesizeOptions) {
+		o.Volume = volume
+	}
+}
+
+func WithFormat(format AudioFormat) SynthesizeOption {
+	return func(o *SynthesizeOptions) {
+		o.Format = format
+	}
+}
+
+func WithLanguage(lang string) SynthesizeOption {
+	return func(o *SynthesizeOptions) {
+		o.Language = lang
+	}
+}
+
+func WithSampleRate(rate int) SynthesizeOption {
+	return func(o *SynthesizeOptions) {
+		o.SampleRate = rate
+	}
+}
+
+type AudioResult struct {
+	Data        []byte
+	Format      AudioFormat
+	SampleRate  int
+	Channels    int
+	BitDepth    int
+	Duration    time.Duration
+	ContentType string
+}
+
+type Voice struct {
+	ID          string
+	Name        string
+	Language    string
+	LanguageTag string
+	Gender      VoiceGender
+	Provider    string
+	Description string
+}
+
+func AudioToBase64(data []byte) string {
+	return base64.StdEncoding.EncodeToString(data)
+}
+
+func Base64ToAudio(b64 string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(b64)
+}

--- a/pkg/speech/senders.go
+++ b/pkg/speech/senders.go
@@ -1,0 +1,449 @@
+package speech
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"time"
+)
+
+type TelegramAudioSender struct {
+	botToken string
+	baseURL  string
+	client   *http.Client
+}
+
+func NewTelegramAudioSender(botToken string) *TelegramAudioSender {
+	return &TelegramAudioSender{
+		botToken: botToken,
+		baseURL:  "https://api.telegram.org/bot" + botToken,
+		client:   &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (s *TelegramAudioSender) SendAudio(ctx context.Context, channel string, recipient string, audio *AudioResult, caption string) (string, error) {
+	if recipient == "" {
+		return "", fmt.Errorf("telegram: recipient chat ID is required")
+	}
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	audioPart, err := writer.CreateFormFile("audio", "tts.mp3")
+	if err != nil {
+		return "", fmt.Errorf("telegram: failed to create form file: %w", err)
+	}
+	audioPart.Write(audio.Data)
+
+	writer.WriteField("chat_id", recipient)
+	if caption != "" {
+		writer.WriteField("caption", caption)
+	}
+	writer.Close()
+
+	url := s.baseURL + "/sendAudio"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, &buf)
+	if err != nil {
+		return "", fmt.Errorf("telegram: failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("telegram: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("telegram: API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Ok     bool `json:"ok"`
+		Result struct {
+			MessageID int `json:"message_id"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("telegram: failed to decode response: %w", err)
+	}
+
+	if !result.Ok {
+		return "", fmt.Errorf("telegram: API returned ok=false: %s", string(respBody))
+	}
+
+	return fmt.Sprintf("%d", result.Result.MessageID), nil
+}
+
+func (s *TelegramAudioSender) CanSend(channel string) bool {
+	return channel == "telegram"
+}
+
+type DiscordAudioSender struct {
+	botToken string
+	apiBase  string
+	client   *http.Client
+}
+
+func NewDiscordAudioSender(botToken string) *DiscordAudioSender {
+	return &DiscordAudioSender{
+		botToken: botToken,
+		apiBase:  "https://discord.com/api/v10",
+		client:   &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (s *DiscordAudioSender) SendAudio(ctx context.Context, channel string, recipient string, audio *AudioResult, caption string) (string, error) {
+	if recipient == "" {
+		return "", fmt.Errorf("discord: channel ID is required")
+	}
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	filePart, err := writer.CreateFormFile("files[0]", "tts.mp3")
+	if err != nil {
+		return "", fmt.Errorf("discord: failed to create form file: %w", err)
+	}
+	filePart.Write(audio.Data)
+
+	payload := map[string]any{
+		"content": caption,
+	}
+	payloadJSON, _ := json.Marshal(payload)
+	writer.WriteField("payload_json", string(payloadJSON))
+	writer.Close()
+
+	url := s.apiBase + "/channels/" + recipient + "/messages"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, &buf)
+	if err != nil {
+		return "", fmt.Errorf("discord: failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bot "+s.botToken)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("discord: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("discord: API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("discord: failed to decode response: %w", err)
+	}
+
+	return result.ID, nil
+}
+
+func (s *DiscordAudioSender) CanSend(channel string) bool {
+	return channel == "discord"
+}
+
+type SlackAudioSender struct {
+	botToken string
+	baseURL  string
+	client   *http.Client
+}
+
+func NewSlackAudioSender(botToken string) *SlackAudioSender {
+	return &SlackAudioSender{
+		botToken: botToken,
+		baseURL:  "https://slack.com/api",
+		client:   &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (s *SlackAudioSender) SendAudio(ctx context.Context, channel string, recipient string, audio *AudioResult, caption string) (string, error) {
+	if recipient == "" {
+		return "", fmt.Errorf("slack: channel ID is required")
+	}
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	filePart, err := writer.CreateFormFile("file", "tts.mp3")
+	if err != nil {
+		return "", fmt.Errorf("slack: failed to create form file: %w", err)
+	}
+	filePart.Write(audio.Data)
+
+	writer.WriteField("channels", recipient)
+	writer.WriteField("filetype", "mp3")
+	writer.WriteField("initial_comment", caption)
+	writer.WriteField("filename", "tts.mp3")
+	writer.Close()
+
+	url := s.baseURL + "/files.upload"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, &buf)
+	if err != nil {
+		return "", fmt.Errorf("slack: failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.botToken)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("slack: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("slack: API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Ok   bool `json:"ok"`
+		File struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"file"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("slack: failed to decode response: %w", err)
+	}
+
+	if !result.Ok {
+		return "", fmt.Errorf("slack: API error: %s", result.Error)
+	}
+
+	return result.File.ID, nil
+}
+
+func (s *SlackAudioSender) CanSend(channel string) bool {
+	return channel == "slack"
+}
+
+type WhatsAppAudioSender struct {
+	phoneNumberID string
+	accessToken   string
+	baseURL       string
+	client        *http.Client
+}
+
+func NewWhatsAppAudioSender(phoneNumberID, accessToken string) *WhatsAppAudioSender {
+	return &WhatsAppAudioSender{
+		phoneNumberID: phoneNumberID,
+		accessToken:   accessToken,
+		baseURL:       "https://graph.facebook.com/v17.0",
+		client:        &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (s *WhatsAppAudioSender) SendAudio(ctx context.Context, channel string, recipient string, audio *AudioResult, caption string) (string, error) {
+	if recipient == "" {
+		return "", fmt.Errorf("whatsapp: recipient phone ID is required")
+	}
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	filePart, err := writer.CreateFormFile("file", "tts.mp3")
+	if err != nil {
+		return "", fmt.Errorf("whatsapp: failed to create form file: %w", err)
+	}
+	filePart.Write(audio.Data)
+
+	writer.WriteField("messaging_product", "whatsapp")
+	writer.WriteField("type", "audio")
+	writer.Close()
+
+	url := fmt.Sprintf("%s/%s/media", s.baseURL, s.phoneNumberID)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, &buf)
+	if err != nil {
+		return "", fmt.Errorf("whatsapp: failed to create upload request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.accessToken)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("whatsapp: upload request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("whatsapp: upload API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var uploadResult struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(respBody, &uploadResult); err != nil {
+		return "", fmt.Errorf("whatsapp: failed to decode upload response: %w", err)
+	}
+
+	payload := map[string]any{
+		"messaging_product": "whatsapp",
+		"to":                recipient,
+		"type":              "audio",
+		"audio": map[string]any{
+			"id": uploadResult.ID,
+		},
+	}
+	payloadBody, _ := json.Marshal(payload)
+
+	msgURL := fmt.Sprintf("%s/%s/messages", s.baseURL, s.phoneNumberID)
+	msgReq, err := http.NewRequestWithContext(ctx, "POST", msgURL, bytes.NewReader(payloadBody))
+	if err != nil {
+		return "", fmt.Errorf("whatsapp: failed to create send request: %w", err)
+	}
+	msgReq.Header.Set("Authorization", "Bearer "+s.accessToken)
+	msgReq.Header.Set("Content-Type", "application/json")
+
+	msgResp, err := s.client.Do(msgReq)
+	if err != nil {
+		return "", fmt.Errorf("whatsapp: send request failed: %w", err)
+	}
+	defer msgResp.Body.Close()
+
+	msgRespBody, _ := io.ReadAll(msgResp.Body)
+	if msgResp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("whatsapp: send API error (%d): %s", msgResp.StatusCode, string(msgRespBody))
+	}
+
+	var sendResult struct {
+		Messages []struct {
+			ID string `json:"id"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(msgRespBody, &sendResult); err != nil {
+		return "", fmt.Errorf("whatsapp: failed to decode send response: %w", err)
+	}
+
+	if len(sendResult.Messages) == 0 {
+		return "", fmt.Errorf("whatsapp: no message ID in response")
+	}
+
+	return sendResult.Messages[0].ID, nil
+}
+
+func (s *WhatsAppAudioSender) CanSend(channel string) bool {
+	return channel == "whatsapp"
+}
+
+type SignalAudioSender struct {
+	baseURL string
+	number  string
+	client  *http.Client
+}
+
+func NewSignalAudioSender(baseURL, number string) *SignalAudioSender {
+	return &SignalAudioSender{
+		baseURL: baseURL,
+		number:  number,
+		client:  &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (s *SignalAudioSender) SendAudio(ctx context.Context, channel string, recipient string, audio *AudioResult, caption string) (string, error) {
+	if recipient == "" {
+		return "", fmt.Errorf("signal: recipient is required")
+	}
+
+	payload := map[string]any{
+		"message":      caption,
+		"number":       s.number,
+		"recipients":   []string{recipient},
+		"base64_audio": fmt.Sprintf("data:audio/mpeg;base64,%s", AudioToBase64(audio.Data)),
+	}
+	body, _ := json.Marshal(payload)
+
+	url := s.baseURL + "/v2/send"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("signal: failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("signal: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("signal: API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Timestamp int64 `json:"timestamp"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("signal: failed to decode response: %w", err)
+	}
+
+	return fmt.Sprintf("%d", result.Timestamp), nil
+}
+
+func (s *SignalAudioSender) CanSend(channel string) bool {
+	return channel == "signal"
+}
+
+type GenericWebhookAudioSender struct {
+	webhookURL string
+	headers    map[string]string
+	client     *http.Client
+}
+
+func NewGenericWebhookAudioSender(webhookURL string, headers map[string]string) *GenericWebhookAudioSender {
+	return &GenericWebhookAudioSender{
+		webhookURL: webhookURL,
+		headers:    headers,
+		client:     &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (s *GenericWebhookAudioSender) SendAudio(ctx context.Context, channel string, recipient string, audio *AudioResult, caption string) (string, error) {
+	payload := map[string]any{
+		"channel":    channel,
+		"recipient":  recipient,
+		"caption":    caption,
+		"audio":      AudioToBase64(audio.Data),
+		"format":     string(audio.Format),
+		"sampleRate": audio.SampleRate,
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", s.webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("webhook: failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range s.headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("webhook: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("webhook: error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return string(respBody), nil
+}
+
+func (s *GenericWebhookAudioSender) CanSend(channel string) bool {
+	return true
+}

--- a/pkg/speech/senders_test.go
+++ b/pkg/speech/senders_test.go
@@ -1,0 +1,145 @@
+package speech
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAudioSenders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll(%s): %v", r.URL.Path, err)
+		}
+
+		switch r.URL.Path {
+		case "/botbot-token/sendAudio":
+			if !strings.Contains(string(body), "chat-1") {
+				t.Fatalf("telegram body missing recipient: %s", string(body))
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"result":{"message_id":42}}`))
+		case "/api/v10/channels/channel-1/messages":
+			if got := r.Header.Get("Authorization"); got != "Bot discord-token" {
+				t.Fatalf("unexpected discord auth header: %s", got)
+			}
+			_, _ = w.Write([]byte(`{"id":"discord-msg"}`))
+		case "/api/files.upload":
+			if got := r.Header.Get("Authorization"); got != "Bearer slack-token" {
+				t.Fatalf("unexpected slack auth header: %s", got)
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"file":{"id":"slack-file","name":"tts.mp3"}}`))
+		case "/wa-123/media":
+			if got := r.Header.Get("Authorization"); got != "Bearer wa-token" {
+				t.Fatalf("unexpected whatsapp auth header: %s", got)
+			}
+			_, _ = w.Write([]byte(`{"id":"media-1"}`))
+		case "/wa-123/messages":
+			if got := r.Header.Get("Authorization"); got != "Bearer wa-token" {
+				t.Fatalf("unexpected whatsapp send auth header: %s", got)
+			}
+			_, _ = w.Write([]byte(`{"messages":[{"id":"wa-message"}]}`))
+		case "/signal/v2/send":
+			if !strings.Contains(string(body), "base64_audio") {
+				t.Fatalf("signal body missing base64 audio: %s", string(body))
+			}
+			_, _ = w.Write([]byte(`{"timestamp":12345}`))
+		case "/hook":
+			if got := r.Header.Get("X-Test"); got != "ok" {
+				t.Fatalf("unexpected webhook header: %s", got)
+			}
+			_, _ = w.Write([]byte(`hook-id`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	audio := &AudioResult{
+		Data:       []byte("audio-bytes"),
+		Format:     FormatMP3,
+		SampleRate: 24000,
+	}
+
+	telegram := NewTelegramAudioSender("bot-token")
+	telegram.baseURL = server.URL + "/botbot-token"
+	telegram.client = server.Client()
+	if _, err := telegram.SendAudio(context.Background(), "telegram", "", audio, "hello"); err == nil {
+		t.Fatal("expected telegram sender to require recipient")
+	}
+	telegramID, err := telegram.SendAudio(context.Background(), "telegram", "chat-1", audio, "hello")
+	if err != nil {
+		t.Fatalf("Telegram SendAudio: %v", err)
+	}
+	if telegramID != "42" || !telegram.CanSend("telegram") {
+		t.Fatalf("unexpected telegram result: id=%s", telegramID)
+	}
+
+	discord := NewDiscordAudioSender("discord-token")
+	discord.apiBase = server.URL + "/api/v10"
+	discord.client = server.Client()
+	if _, err := discord.SendAudio(context.Background(), "discord", "", audio, "hello"); err == nil {
+		t.Fatal("expected discord sender to require recipient")
+	}
+	discordID, err := discord.SendAudio(context.Background(), "discord", "channel-1", audio, "hello")
+	if err != nil {
+		t.Fatalf("Discord SendAudio: %v", err)
+	}
+	if discordID != "discord-msg" || !discord.CanSend("discord") {
+		t.Fatalf("unexpected discord result: id=%s", discordID)
+	}
+
+	slack := NewSlackAudioSender("slack-token")
+	slack.baseURL = server.URL + "/api"
+	slack.client = server.Client()
+	if _, err := slack.SendAudio(context.Background(), "slack", "", audio, "hello"); err == nil {
+		t.Fatal("expected slack sender to require recipient")
+	}
+	slackID, err := slack.SendAudio(context.Background(), "slack", "channel-1", audio, "hello")
+	if err != nil {
+		t.Fatalf("Slack SendAudio: %v", err)
+	}
+	if slackID != "slack-file" || !slack.CanSend("slack") {
+		t.Fatalf("unexpected slack result: id=%s", slackID)
+	}
+
+	whatsApp := NewWhatsAppAudioSender("wa-123", "wa-token")
+	whatsApp.baseURL = server.URL
+	whatsApp.client = server.Client()
+	if _, err := whatsApp.SendAudio(context.Background(), "whatsapp", "", audio, "hello"); err == nil {
+		t.Fatal("expected whatsapp sender to require recipient")
+	}
+	waID, err := whatsApp.SendAudio(context.Background(), "whatsapp", "13800138000", audio, "hello")
+	if err != nil {
+		t.Fatalf("WhatsApp SendAudio: %v", err)
+	}
+	if waID != "wa-message" || !whatsApp.CanSend("whatsapp") {
+		t.Fatalf("unexpected whatsapp result: id=%s", waID)
+	}
+
+	signal := NewSignalAudioSender(server.URL+"/signal", "+10086")
+	signal.client = server.Client()
+	if _, err := signal.SendAudio(context.Background(), "signal", "", audio, "hello"); err == nil {
+		t.Fatal("expected signal sender to require recipient")
+	}
+	signalID, err := signal.SendAudio(context.Background(), "signal", "+10010", audio, "hello")
+	if err != nil {
+		t.Fatalf("Signal SendAudio: %v", err)
+	}
+	if signalID != "12345" || !signal.CanSend("signal") {
+		t.Fatalf("unexpected signal result: id=%s", signalID)
+	}
+
+	webhook := NewGenericWebhookAudioSender(server.URL+"/hook", map[string]string{"X-Test": "ok"})
+	webhook.client = server.Client()
+	webhookID, err := webhook.SendAudio(context.Background(), "custom", "recipient-1", audio, "hello")
+	if err != nil {
+		t.Fatalf("GenericWebhook SendAudio: %v", err)
+	}
+	if webhookID != "hook-id" || !webhook.CanSend("anything") {
+		t.Fatalf("unexpected webhook result: id=%s", webhookID)
+	}
+}

--- a/pkg/speech/voice_catalog.go
+++ b/pkg/speech/voice_catalog.go
@@ -1,0 +1,134 @@
+package speech
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type VoiceQuery struct {
+	Provider string
+	ID       string
+	Language string
+	Gender   VoiceGender
+}
+
+func (m *Manager) ListAllVoices(ctx context.Context) ([]Voice, error) {
+	providers := m.ListProviders()
+	sort.Strings(providers)
+
+	voices := make([]Voice, 0)
+	for _, name := range providers {
+		items, err := m.ListVoices(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		voices = append(voices, items...)
+	}
+
+	sort.Slice(voices, func(i, j int) bool {
+		if voices[i].Provider == voices[j].Provider {
+			if strings.EqualFold(voices[i].LanguageTag, voices[j].LanguageTag) {
+				return strings.ToLower(voices[i].Name) < strings.ToLower(voices[j].Name)
+			}
+			return strings.ToLower(voices[i].LanguageTag) < strings.ToLower(voices[j].LanguageTag)
+		}
+		return strings.ToLower(voices[i].Provider) < strings.ToLower(voices[j].Provider)
+	})
+	return voices, nil
+}
+
+func (m *Manager) RecommendVoice(ctx context.Context, query VoiceQuery) (*Voice, error) {
+	voices, err := m.ListAllVoices(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(voices) == 0 {
+		return nil, fmt.Errorf("tts: no voices available")
+	}
+
+	var best *Voice
+	bestScore := -1
+	for i := range voices {
+		score := scoreVoiceCandidate(voices[i], query)
+		if score > bestScore {
+			voice := voices[i]
+			best = &voice
+			bestScore = score
+		}
+	}
+	if best == nil || bestScore < 0 {
+		return nil, fmt.Errorf("tts: no voice matched query")
+	}
+	return best, nil
+}
+
+func scoreVoiceCandidate(voice Voice, query VoiceQuery) int {
+	score := 0
+
+	provider := strings.TrimSpace(strings.ToLower(query.Provider))
+	if provider != "" {
+		if strings.EqualFold(voice.Provider, provider) {
+			score += 40
+		} else {
+			return -1
+		}
+	}
+
+	voiceID := strings.TrimSpace(strings.ToLower(query.ID))
+	if voiceID != "" {
+		if strings.EqualFold(voice.ID, voiceID) || strings.EqualFold(voice.Name, voiceID) {
+			score += 80
+		} else {
+			return -1
+		}
+	}
+
+	queryLang := normalizeVoiceLocale(query.Language)
+	voiceLang := normalizeVoiceLocale(firstNonEmptyVoiceLocale(voice.LanguageTag, voice.Language))
+	if queryLang != "" {
+		switch {
+		case voiceLang == queryLang:
+			score += 50
+		case strings.HasPrefix(voiceLang, queryLang+"-"), strings.HasPrefix(queryLang, voiceLang+"-"):
+			score += 30
+		case strings.HasPrefix(voiceLang, queryLang), strings.HasPrefix(queryLang, voiceLang):
+			score += 20
+		default:
+			score -= 5
+		}
+	}
+
+	if query.Gender != "" {
+		if voice.Gender == query.Gender {
+			score += 10
+		} else if voice.Gender != "" {
+			score -= 3
+		}
+	}
+
+	if score == 0 {
+		score = 1
+	}
+	return score
+}
+
+func normalizeVoiceLocale(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" {
+		return ""
+	}
+	value = strings.ReplaceAll(value, "_", "-")
+	return value
+}
+
+func firstNonEmptyVoiceLocale(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/pkg/speech/voice_catalog_test.go
+++ b/pkg/speech/voice_catalog_test.go
@@ -1,0 +1,94 @@
+package speech
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type stubVoiceProvider struct {
+	name   string
+	voices []Voice
+}
+
+func (s *stubVoiceProvider) Name() string { return s.name }
+
+func (s *stubVoiceProvider) Type() ProviderType { return ProviderCustom }
+
+func (s *stubVoiceProvider) Synthesize(ctx context.Context, text string, opts ...SynthesizeOption) (*AudioResult, error) {
+	_, _ = ctx, text
+	payload, _ := json.Marshal(map[string]string{"ok": "true"})
+	return &AudioResult{Data: payload, Format: FormatMP3}, nil
+}
+
+func (s *stubVoiceProvider) ListVoices(ctx context.Context) ([]Voice, error) {
+	_ = ctx
+	return append([]Voice(nil), s.voices...), nil
+}
+
+func TestListAllVoicesAggregatesProviders(t *testing.T) {
+	manager := NewManager()
+	if err := manager.Register("openai", &stubVoiceProvider{name: "openai", voices: []Voice{
+		{ID: "alloy", Name: "Alloy", Provider: "openai", LanguageTag: "en-US"},
+	}}); err != nil {
+		t.Fatalf("Register openai: %v", err)
+	}
+	if err := manager.Register("piper", &stubVoiceProvider{name: "piper", voices: []Voice{
+		{ID: "huayan", Name: "Huayan", Provider: "piper", LanguageTag: "zh-CN"},
+		{ID: "tomoko", Name: "Tomoko", Provider: "piper", LanguageTag: "ja-JP"},
+	}}); err != nil {
+		t.Fatalf("Register piper: %v", err)
+	}
+
+	voices, err := manager.ListAllVoices(context.Background())
+	if err != nil {
+		t.Fatalf("ListAllVoices: %v", err)
+	}
+	if len(voices) != 3 {
+		t.Fatalf("expected 3 voices, got %d", len(voices))
+	}
+}
+
+func TestRecommendVoicePrefersLanguageAndProvider(t *testing.T) {
+	manager := NewManager()
+	if err := manager.Register("openai", &stubVoiceProvider{name: "openai", voices: []Voice{
+		{ID: "nova", Name: "Nova", Provider: "openai", LanguageTag: "en-US", Gender: GenderFemale},
+	}}); err != nil {
+		t.Fatalf("Register openai: %v", err)
+	}
+	if err := manager.Register("piper", &stubVoiceProvider{name: "piper", voices: []Voice{
+		{ID: "huayan", Name: "Huayan", Provider: "piper", LanguageTag: "zh-CN", Gender: GenderNeutral},
+		{ID: "lessac", Name: "Lessac", Provider: "piper", LanguageTag: "en-US", Gender: GenderFemale},
+	}}); err != nil {
+		t.Fatalf("Register piper: %v", err)
+	}
+
+	voice, err := manager.RecommendVoice(context.Background(), VoiceQuery{
+		Provider: "piper",
+		Language: "zh-CN",
+	})
+	if err != nil {
+		t.Fatalf("RecommendVoice: %v", err)
+	}
+	if voice.ID != "huayan" {
+		t.Fatalf("expected huayan, got %q", voice.ID)
+	}
+}
+
+func TestRecommendVoiceSupportsDirectIDLookup(t *testing.T) {
+	manager := NewManager(WithManagerProvider("edge", &stubVoiceProvider{name: "edge", voices: []Voice{
+		{ID: "aria", Name: "Aria", Provider: "edge", LanguageTag: "en-US", Gender: GenderFemale},
+		{ID: "guy", Name: "Guy", Provider: "edge", LanguageTag: "en-US", Gender: GenderMale},
+	}}))
+
+	voice, err := manager.RecommendVoice(context.Background(), VoiceQuery{
+		Provider: "edge",
+		ID:       "guy",
+	})
+	if err != nil {
+		t.Fatalf("RecommendVoice: %v", err)
+	}
+	if voice.Name != "Guy" {
+		t.Fatalf("expected Guy, got %q", voice.Name)
+	}
+}


### PR DESCRIPTION
## Summary
- split the speech synthesis core out of the old gateway and speech wiring branch
- add TTS providers, pipeline, integration, senders, and voice catalog helpers
- keep the diff focused so it can land cleanly on top of the merged runtime wiring work

## Testing
- go test ./pkg/speech/... ./pkg/gateway/transport/reply/...

## Notes
- this is part of the old 1024XEngineer/anyclaw#219 split
- follow-up slices still need to stay stacked to avoid cumulative diffs against main