### PR TITLE
feat(vec): chromem-go vec store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,15 @@ module github.com/1024XEngineer/anyclaw
 go 1.25.0
 
 require (
+	github.com/anyclaw/anyclaw v0.0.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/term v0.2.2
-	github.com/anyclaw/anyclaw v0.0.0
 	github.com/chromedp/cdproto v0.0.0-20240801214329-3f85d328b335
 	github.com/chromedp/chromedp v0.10.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/philippgille/chromem-go v0.7.0
 	github.com/wailsapp/wails/v2 v2.11.0
 	golang.org/x/sys v0.42.0
 	golang.org/x/text v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
+github.com/philippgille/chromem-go v0.7.0 h1:4jfvfyKymjKNfGxBUhHUcj1kp7B17NL/I1P+vGh1RvY=
+github.com/philippgille/chromem-go v0.7.0/go.mod h1:hTd+wGEm/fFPQl7ilfCwQXkgEUxceYh86iIdoKMolPo=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/capability/skills/skills.go
+++ b/pkg/capability/skills/skills.go
@@ -423,6 +423,9 @@ func resolveSkillLauncher(entrypoint string) (string, []string, error) {
 		if err != nil {
 			return "", nil, fmt.Errorf("powershell launcher not found for skill entrypoint %s", entrypoint)
 		}
+		if runtime.GOOS == "windows" {
+			return ps, []string{"-ExecutionPolicy", "Bypass", "-File", entrypoint}, nil
+		}
 		return ps, []string{"-File", entrypoint}, nil
 	default:
 		return entrypoint, nil, nil

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -292,18 +292,19 @@ func (im *IndexManager) Delete(ctx context.Context, name string) error {
 
 func (im *IndexManager) Get(name string) (*IndexInfo, error) {
 	im.mu.RLock()
-	defer im.mu.RUnlock()
-
 	info, exists := im.indexes[name]
 	if !exists {
+		im.mu.RUnlock()
 		return nil, fmt.Errorf("index %q not found", name)
 	}
+	cloned := cloneIndexInfo(info)
+	im.mu.RUnlock()
 
-	if count, err := im.countVectors(context.Background(), info); err == nil {
-		info.VectorCount = count
+	if count, err := im.countVectors(context.Background(), cloned); err == nil {
+		cloned.VectorCount = count
 	}
 
-	return info, nil
+	return cloned, nil
 }
 
 func (im *IndexManager) List() []*IndexInfo {
@@ -312,7 +313,7 @@ func (im *IndexManager) List() []*IndexInfo {
 
 	result := make([]*IndexInfo, 0, len(im.indexes))
 	for _, info := range im.indexes {
-		result = append(result, info)
+		result = append(result, cloneIndexInfo(info))
 	}
 	return result
 }
@@ -353,7 +354,10 @@ func (im *IndexManager) Index(ctx context.Context, indexName string, items []Ind
 		batch := items[i:end]
 
 		vecItems := make([]vec.VecItem, 0, len(batch))
-		for _, item := range batch {
+		pendingOffsets := make([]int, 0, len(batch))
+		pendingItems := make([]IndexItem, 0, len(batch))
+		pendingTexts := make([]string, 0, len(batch))
+		for offset, item := range batch {
 			if item.Vector != nil {
 				vecItems = append(vecItems, vec.VecItem{
 					ID:       item.ID,
@@ -368,27 +372,51 @@ func (im *IndexManager) Index(ctx context.Context, indexName string, items []Ind
 				continue
 			}
 
-			emb, err := im.embedder.Embed(ctx, item.Text)
+			pendingOffsets = append(pendingOffsets, offset)
+			pendingItems = append(pendingItems, item)
+			pendingTexts = append(pendingTexts, item.Text)
+		}
+
+		if len(pendingTexts) > 0 {
+			embeddings, err := im.embedder.EmbedBatch(ctx, pendingTexts)
 			if err != nil {
-				result.Failed++
-				if progress != nil {
-					progress(Progress{
-						Total:     len(items),
-						Processed: i + 1,
-						Failed:    result.Failed,
-						Elapsed:   time.Since(start),
-						CurrentID: item.ID,
-						Message:   fmt.Sprintf("embed failed: %v", err),
+				for idx, item := range pendingItems {
+					result.Failed++
+					if progress != nil {
+						progress(Progress{
+							Total:     len(items),
+							Processed: i + pendingOffsets[idx] + 1,
+							Failed:    result.Failed,
+							Elapsed:   time.Since(start),
+							CurrentID: item.ID,
+							Message:   fmt.Sprintf("embed failed: %v", err),
+						})
+					}
+				}
+			} else if len(embeddings) != len(pendingItems) {
+				err := fmt.Errorf("embed batch returned %d embeddings for %d texts", len(embeddings), len(pendingItems))
+				for idx, item := range pendingItems {
+					result.Failed++
+					if progress != nil {
+						progress(Progress{
+							Total:     len(items),
+							Processed: i + pendingOffsets[idx] + 1,
+							Failed:    result.Failed,
+							Elapsed:   time.Since(start),
+							CurrentID: item.ID,
+							Message:   fmt.Sprintf("embed failed: %v", err),
+						})
+					}
+				}
+			} else {
+				for idx, item := range pendingItems {
+					vecItems = append(vecItems, vec.VecItem{
+						ID:       item.ID,
+						Vector:   embeddings[idx],
+						Metadata: item.Metadata,
 					})
 				}
-				continue
 			}
-
-			vecItems = append(vecItems, vec.VecItem{
-				ID:       item.ID,
-				Vector:   emb,
-				Metadata: item.Metadata,
-			})
 		}
 
 		if len(vecItems) > 0 {
@@ -596,6 +624,17 @@ func (im *IndexManager) resolvedVectorDir() string {
 		return im.vecDir
 	}
 	return sqlite.SidecarDirForSQLDB(context.Background(), im.db, "vec")
+}
+
+func cloneIndexInfo(info *IndexInfo) *IndexInfo {
+	if info == nil {
+		return nil
+	}
+
+	cloned := *info
+	cloned.Metadata = append([]string(nil), info.Metadata...)
+	cloned.AuxColumns = append([]string(nil), info.AuxColumns...)
+	return &cloned
 }
 
 func (im *IndexManager) newVecStore(info *IndexInfo) *vec.VecStore {

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -393,9 +393,21 @@ func (im *IndexManager) Index(ctx context.Context, indexName string, items []Ind
 		if len(vecItems) > 0 {
 			if err := vs.InsertBatch(ctx, vecItems); err != nil {
 				result.Failed += len(vecItems)
-			} else {
-				result.Indexed += len(vecItems)
+				result.CompletedAt = time.Now()
+				result.Duration = result.CompletedAt.Sub(result.StartedAt)
+
+				im.mu.Lock()
+				info.Status = StatusError
+				info.Error = err.Error()
+				info.UpdatedAt = result.CompletedAt
+				count, _ := im.countVectors(ctx, info)
+				info.VectorCount = count
+				_ = im.saveIndexMeta(ctx, info)
+				im.mu.Unlock()
+
+				return result, fmt.Errorf("insert vectors: %w", err)
 			}
+			result.Indexed += len(vecItems)
 		}
 
 		processed := end

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -201,9 +201,9 @@ func (im *IndexManager) Create(ctx context.Context, cfg Config) (*IndexInfo, err
 
 	vs := im.newVecStore(info)
 	if err := vs.Init(ctx); err != nil {
-		info.Status = StatusError
-		info.Error = err.Error()
-		_ = im.saveIndexMeta(ctx, info)
+		if cleanupErr := im.deleteIndexMeta(ctx, info.Name); cleanupErr != nil {
+			return nil, fmt.Errorf("create vector collection: %w (cleanup index metadata: %v)", err, cleanupErr)
+		}
 		return nil, fmt.Errorf("create vector collection: %w", err)
 	}
 
@@ -282,7 +282,7 @@ func (im *IndexManager) Delete(ctx context.Context, name string) error {
 		return err
 	}
 
-	if _, err := im.db.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE name = ?", im.metaTable), name); err != nil {
+	if err := im.deleteIndexMeta(ctx, name); err != nil {
 		return fmt.Errorf("delete meta: %w", err)
 	}
 
@@ -501,7 +501,23 @@ func (im *IndexManager) RemoveVectors(ctx context.Context, indexName string, ids
 	vs := im.newVecStore(info)
 	removed := 0
 	for _, id := range ids {
-		if err := vs.Delete(ctx, id); err == nil {
+		before, err := vs.Count(ctx)
+		if err != nil {
+			return removed, fmt.Errorf("count vectors before delete: %w", err)
+		}
+		if before == 0 {
+			break
+		}
+
+		if err := vs.Delete(ctx, id); err != nil {
+			return removed, fmt.Errorf("delete vector %v: %w", id, err)
+		}
+
+		after, err := vs.Count(ctx)
+		if err != nil {
+			return removed, fmt.Errorf("count vectors after delete: %w", err)
+		}
+		if after < before {
 			removed++
 		}
 	}
@@ -617,6 +633,11 @@ func (im *IndexManager) saveIndexMeta(ctx context.Context, info *IndexInfo) erro
 
 func (im *IndexManager) countVectors(ctx context.Context, info *IndexInfo) (int64, error) {
 	return im.newVecStore(info).Count(ctx)
+}
+
+func (im *IndexManager) deleteIndexMeta(ctx context.Context, name string) error {
+	_, err := im.db.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE name = ?", im.metaTable), name)
+	return err
 }
 
 func (im *IndexManager) resolvedVectorDir() string {

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -1,0 +1,607 @@
+package index
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/embedding"
+	"github.com/1024XEngineer/anyclaw/pkg/vec"
+)
+
+type Status string
+
+const (
+	StatusPending    Status = "pending"
+	StatusCreating   Status = "creating"
+	StatusReady      Status = "ready"
+	StatusUpdating   Status = "updating"
+	StatusRebuilding Status = "rebuilding"
+	StatusError      Status = "error"
+	StatusDeleting   Status = "deleting"
+	StatusDeleted    Status = "deleted"
+)
+
+type Config struct {
+	Name       string
+	Dimensions int
+	Distance   vec.DistanceMetric
+	Metadata   []string
+	AuxColumns []string
+	TableName  string
+}
+
+func (c Config) TableNameOrDefault() string {
+	if c.TableName != "" {
+		return c.TableName
+	}
+	return "vec_" + c.Name
+}
+
+type IndexInfo struct {
+	Name        string    `json:"name"`
+	TableName   string    `json:"table_name"`
+	Dimensions  int       `json:"dimensions"`
+	Distance    string    `json:"distance"`
+	Metadata    []string  `json:"metadata"`
+	AuxColumns  []string  `json:"aux_columns"`
+	Status      Status    `json:"status"`
+	VectorCount int64     `json:"vector_count"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Error       string    `json:"error,omitempty"`
+}
+
+type Progress struct {
+	Total     int
+	Processed int
+	Failed    int
+	Elapsed   time.Duration
+	ETA       time.Duration
+	CurrentID any
+	Message   string
+	Done      bool
+}
+
+type ProgressFunc func(p Progress)
+
+type Option func(*IndexManager)
+
+func WithVectorDir(path string) Option {
+	return func(im *IndexManager) {
+		im.vecDir = path
+	}
+}
+
+type IndexManager struct {
+	db        *sql.DB
+	embedder  embedding.Provider
+	indexes   map[string]*IndexInfo
+	metaTable string
+	vecDir    string
+	mu        sync.RWMutex
+}
+
+func NewIndexManager(db *sql.DB, embedder embedding.Provider, opts ...Option) *IndexManager {
+	im := &IndexManager{
+		db:        db,
+		embedder:  embedder,
+		indexes:   make(map[string]*IndexInfo),
+		metaTable: "vector_index_meta",
+	}
+
+	for _, opt := range opts {
+		opt(im)
+	}
+
+	return im
+}
+
+func (im *IndexManager) Init(ctx context.Context) error {
+	if err := im.createMetaTable(ctx); err != nil {
+		return fmt.Errorf("create meta table: %w", err)
+	}
+	if err := im.loadIndexes(ctx); err != nil {
+		return fmt.Errorf("load indexes: %w", err)
+	}
+	return nil
+}
+
+func (im *IndexManager) createMetaTable(ctx context.Context) error {
+	query := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+		name TEXT PRIMARY KEY,
+		table_name TEXT NOT NULL,
+		dimensions INTEGER NOT NULL,
+		distance TEXT NOT NULL,
+		metadata TEXT,
+		aux_columns TEXT,
+		status TEXT NOT NULL,
+		vector_count INTEGER DEFAULT 0,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		error TEXT
+	)`, im.metaTable)
+
+	_, err := im.db.ExecContext(ctx, query)
+	return err
+}
+
+func (im *IndexManager) loadIndexes(ctx context.Context) error {
+	rows, err := im.db.QueryContext(ctx, fmt.Sprintf(
+		"SELECT name, table_name, dimensions, distance, metadata, aux_columns, status, vector_count, created_at, updated_at, error FROM %s",
+		im.metaTable,
+	))
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var info IndexInfo
+		var metaJSON, auxJSON, statusStr, createdAt, updatedAt string
+		var errStr sql.NullString
+
+		if err := rows.Scan(&info.Name, &info.TableName, &info.Dimensions, &info.Distance,
+			&metaJSON, &auxJSON, &statusStr, &info.VectorCount, &createdAt, &updatedAt, &errStr); err != nil {
+			continue
+		}
+
+		info.Status = Status(statusStr)
+		if metaJSON != "" {
+			_ = json.Unmarshal([]byte(metaJSON), &info.Metadata)
+		}
+		if auxJSON != "" {
+			_ = json.Unmarshal([]byte(auxJSON), &info.AuxColumns)
+		}
+		if errStr.Valid {
+			info.Error = errStr.String
+		}
+		info.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+		info.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
+
+		im.indexes[info.Name] = &info
+	}
+
+	return nil
+}
+
+func (im *IndexManager) Create(ctx context.Context, cfg Config) (*IndexInfo, error) {
+	im.mu.Lock()
+	defer im.mu.Unlock()
+
+	if _, exists := im.indexes[cfg.Name]; exists {
+		return nil, fmt.Errorf("index %q already exists", cfg.Name)
+	}
+
+	tableName := cfg.TableNameOrDefault()
+	distance := cfg.Distance
+	if distance == "" {
+		distance = vec.DistanceCosine
+	}
+
+	info := &IndexInfo{
+		Name:       cfg.Name,
+		TableName:  tableName,
+		Dimensions: cfg.Dimensions,
+		Distance:   string(distance),
+		Metadata:   append([]string(nil), cfg.Metadata...),
+		AuxColumns: append([]string(nil), cfg.AuxColumns...),
+		Status:     StatusCreating,
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+
+	if err := im.saveIndexMeta(ctx, info); err != nil {
+		return nil, err
+	}
+
+	vs := im.newVecStore(info)
+	if err := vs.Init(ctx); err != nil {
+		info.Status = StatusError
+		info.Error = err.Error()
+		_ = im.saveIndexMeta(ctx, info)
+		return nil, fmt.Errorf("create vector collection: %w", err)
+	}
+
+	info.Status = StatusReady
+	info.Error = ""
+	if err := im.saveIndexMeta(ctx, info); err != nil {
+		return nil, err
+	}
+	im.indexes[cfg.Name] = info
+
+	return info, nil
+}
+
+func (im *IndexManager) Update(ctx context.Context, name string, cfg Config) (*IndexInfo, error) {
+	im.mu.Lock()
+	defer im.mu.Unlock()
+
+	info, exists := im.indexes[name]
+	if !exists {
+		return nil, fmt.Errorf("index %q not found", name)
+	}
+
+	info.Status = StatusUpdating
+	info.UpdatedAt = time.Now()
+	_ = im.saveIndexMeta(ctx, info)
+
+	if cfg.Dimensions != 0 && cfg.Dimensions != info.Dimensions {
+		info.Status = StatusError
+		info.Error = "cannot change dimensions of existing index"
+		_ = im.saveIndexMeta(ctx, info)
+		return nil, fmt.Errorf("cannot change dimensions: existing=%d, requested=%d", info.Dimensions, cfg.Dimensions)
+	}
+
+	if cfg.Distance != "" && cfg.Distance != vec.DistanceMetric(info.Distance) {
+		info.Status = StatusError
+		info.Error = "cannot change distance metric of existing index"
+		_ = im.saveIndexMeta(ctx, info)
+		return nil, fmt.Errorf("cannot change distance metric")
+	}
+
+	if len(cfg.Metadata) > 0 {
+		info.Metadata = append([]string(nil), cfg.Metadata...)
+	}
+	if len(cfg.AuxColumns) > 0 {
+		info.AuxColumns = append([]string(nil), cfg.AuxColumns...)
+	}
+
+	info.Status = StatusReady
+	info.Error = ""
+	info.UpdatedAt = time.Now()
+	if err := im.saveIndexMeta(ctx, info); err != nil {
+		return nil, err
+	}
+	im.indexes[name] = info
+
+	return info, nil
+}
+
+func (im *IndexManager) Delete(ctx context.Context, name string) error {
+	im.mu.Lock()
+	defer im.mu.Unlock()
+
+	info, exists := im.indexes[name]
+	if !exists {
+		return fmt.Errorf("index %q not found", name)
+	}
+
+	info.Status = StatusDeleting
+	info.UpdatedAt = time.Now()
+	_ = im.saveIndexMeta(ctx, info)
+
+	if err := im.newVecStore(info).Drop(ctx); err != nil {
+		info.Status = StatusError
+		info.Error = err.Error()
+		_ = im.saveIndexMeta(ctx, info)
+		return err
+	}
+
+	if _, err := im.db.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE name = ?", im.metaTable), name); err != nil {
+		return fmt.Errorf("delete meta: %w", err)
+	}
+
+	delete(im.indexes, name)
+	return nil
+}
+
+func (im *IndexManager) Get(name string) (*IndexInfo, error) {
+	im.mu.RLock()
+	defer im.mu.RUnlock()
+
+	info, exists := im.indexes[name]
+	if !exists {
+		return nil, fmt.Errorf("index %q not found", name)
+	}
+
+	if count, err := im.countVectors(context.Background(), info); err == nil {
+		info.VectorCount = count
+	}
+
+	return info, nil
+}
+
+func (im *IndexManager) List() []*IndexInfo {
+	im.mu.RLock()
+	defer im.mu.RUnlock()
+
+	result := make([]*IndexInfo, 0, len(im.indexes))
+	for _, info := range im.indexes {
+		result = append(result, info)
+	}
+	return result
+}
+
+func (im *IndexManager) Index(ctx context.Context, indexName string, items []IndexItem, progress ProgressFunc) (*IndexResult, error) {
+	im.mu.RLock()
+	info, exists := im.indexes[indexName]
+	im.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("index %q not found", indexName)
+	}
+	if info.Status != StatusReady {
+		return nil, fmt.Errorf("index %q is not ready (status: %s)", indexName, info.Status)
+	}
+
+	im.mu.Lock()
+	info.Status = StatusUpdating
+	info.Error = ""
+	_ = im.saveIndexMeta(ctx, info)
+	im.mu.Unlock()
+
+	start := time.Now()
+	vs := im.newVecStore(info)
+
+	result := &IndexResult{
+		IndexName: indexName,
+		Total:     len(items),
+		StartedAt: start,
+	}
+
+	batchSize := 100
+	for i := 0; i < len(items); i += batchSize {
+		end := i + batchSize
+		if end > len(items) {
+			end = len(items)
+		}
+		batch := items[i:end]
+
+		vecItems := make([]vec.VecItem, 0, len(batch))
+		for _, item := range batch {
+			if item.Vector != nil {
+				vecItems = append(vecItems, vec.VecItem{
+					ID:       item.ID,
+					Vector:   item.Vector,
+					Metadata: item.Metadata,
+				})
+				continue
+			}
+
+			if im.embedder == nil || item.Text == "" {
+				result.Failed++
+				continue
+			}
+
+			emb, err := im.embedder.Embed(ctx, item.Text)
+			if err != nil {
+				result.Failed++
+				if progress != nil {
+					progress(Progress{
+						Total:     len(items),
+						Processed: i + 1,
+						Failed:    result.Failed,
+						Elapsed:   time.Since(start),
+						CurrentID: item.ID,
+						Message:   fmt.Sprintf("embed failed: %v", err),
+					})
+				}
+				continue
+			}
+
+			vecItems = append(vecItems, vec.VecItem{
+				ID:       item.ID,
+				Vector:   emb,
+				Metadata: item.Metadata,
+			})
+		}
+
+		if len(vecItems) > 0 {
+			if err := vs.InsertBatch(ctx, vecItems); err != nil {
+				result.Failed += len(vecItems)
+			} else {
+				result.Indexed += len(vecItems)
+			}
+		}
+
+		processed := end
+		elapsed := time.Since(start)
+		eta := time.Duration(0)
+		if processed > 0 && elapsed > 0 {
+			rate := float64(processed) / elapsed.Seconds()
+			if rate > 0 {
+				remaining := len(items) - processed
+				eta = time.Duration(float64(remaining)/rate) * time.Second
+			}
+		}
+
+		if progress != nil && len(batch) > 0 {
+			progress(Progress{
+				Total:     len(items),
+				Processed: processed,
+				Failed:    result.Failed,
+				Elapsed:   elapsed,
+				ETA:       eta,
+				CurrentID: batch[len(batch)-1].ID,
+				Message:   fmt.Sprintf("indexed %d/%d", processed, len(items)),
+			})
+		}
+	}
+
+	result.CompletedAt = time.Now()
+	result.Duration = result.CompletedAt.Sub(result.StartedAt)
+
+	im.mu.Lock()
+	info.Status = StatusReady
+	info.Error = ""
+	info.UpdatedAt = time.Now()
+	count, _ := im.countVectors(ctx, info)
+	info.VectorCount = count
+	_ = im.saveIndexMeta(ctx, info)
+	im.mu.Unlock()
+
+	if progress != nil {
+		progress(Progress{
+			Total:     len(items),
+			Processed: len(items),
+			Failed:    result.Failed,
+			Elapsed:   result.Duration,
+			Done:      true,
+			Message:   fmt.Sprintf("completed: %d indexed, %d failed", result.Indexed, result.Failed),
+		})
+	}
+
+	return result, nil
+}
+
+func (im *IndexManager) RemoveVectors(ctx context.Context, indexName string, ids []any) (int, error) {
+	im.mu.RLock()
+	info, exists := im.indexes[indexName]
+	im.mu.RUnlock()
+
+	if !exists {
+		return 0, fmt.Errorf("index %q not found", indexName)
+	}
+
+	vs := im.newVecStore(info)
+	removed := 0
+	for _, id := range ids {
+		if err := vs.Delete(ctx, id); err == nil {
+			removed++
+		}
+	}
+
+	im.mu.Lock()
+	info.UpdatedAt = time.Now()
+	count, _ := im.countVectors(ctx, info)
+	info.VectorCount = count
+	_ = im.saveIndexMeta(ctx, info)
+	im.mu.Unlock()
+
+	return removed, nil
+}
+
+func (im *IndexManager) Rebuild(ctx context.Context, indexName string, progress ProgressFunc) (*IndexResult, error) {
+	im.mu.RLock()
+	info, exists := im.indexes[indexName]
+	im.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("index %q not found", indexName)
+	}
+
+	im.mu.Lock()
+	info.Status = StatusRebuilding
+	info.Error = ""
+	info.UpdatedAt = time.Now()
+	_ = im.saveIndexMeta(ctx, info)
+	im.mu.Unlock()
+
+	vs := im.newVecStore(info)
+	if err := vs.Drop(ctx); err != nil {
+		im.mu.Lock()
+		info.Status = StatusError
+		info.Error = err.Error()
+		_ = im.saveIndexMeta(ctx, info)
+		im.mu.Unlock()
+		return nil, err
+	}
+	if err := vs.Init(ctx); err != nil {
+		im.mu.Lock()
+		info.Status = StatusError
+		info.Error = err.Error()
+		_ = im.saveIndexMeta(ctx, info)
+		im.mu.Unlock()
+		return nil, fmt.Errorf("recreate collection: %w", err)
+	}
+
+	completedAt := time.Now()
+
+	im.mu.Lock()
+	info.Status = StatusReady
+	info.Error = ""
+	info.UpdatedAt = completedAt
+	info.VectorCount = 0
+	_ = im.saveIndexMeta(ctx, info)
+	im.mu.Unlock()
+
+	if progress != nil {
+		progress(Progress{
+			Total:   0,
+			Done:    true,
+			Message: "index rebuilt (empty, re-index needed)",
+		})
+	}
+
+	return &IndexResult{
+		IndexName:   indexName,
+		CompletedAt: completedAt,
+		Duration:    0,
+	}, nil
+}
+
+func (im *IndexManager) Search(ctx context.Context, indexName string, queryVector []float32, limit int) ([]vec.VecSearchResult, error) {
+	im.mu.RLock()
+	info, exists := im.indexes[indexName]
+	im.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("index %q not found", indexName)
+	}
+
+	return im.newVecStore(info).Search(ctx, queryVector, limit)
+}
+
+func (im *IndexManager) SearchByText(ctx context.Context, indexName string, queryText string, limit int) ([]vec.VecSearchResult, error) {
+	if im.embedder == nil {
+		return nil, fmt.Errorf("no embedder configured")
+	}
+
+	queryVector, err := im.embedder.Embed(ctx, queryText)
+	if err != nil {
+		return nil, fmt.Errorf("embed query: %w", err)
+	}
+
+	return im.Search(ctx, indexName, queryVector, limit)
+}
+
+func (im *IndexManager) saveIndexMeta(ctx context.Context, info *IndexInfo) error {
+	metaJSON, _ := json.Marshal(info.Metadata)
+	auxJSON, _ := json.Marshal(info.AuxColumns)
+
+	_, err := im.db.ExecContext(ctx, fmt.Sprintf(
+		`INSERT OR REPLACE INTO %s (name, table_name, dimensions, distance, metadata, aux_columns, status, vector_count, created_at, updated_at, error)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		im.metaTable,
+	), info.Name, info.TableName, info.Dimensions, info.Distance,
+		string(metaJSON), string(auxJSON), string(info.Status), info.VectorCount,
+		info.CreatedAt.Format(time.RFC3339), info.UpdatedAt.Format(time.RFC3339), info.Error)
+
+	return err
+}
+
+func (im *IndexManager) countVectors(ctx context.Context, info *IndexInfo) (int64, error) {
+	return im.newVecStore(info).Count(ctx)
+}
+
+func (im *IndexManager) newVecStore(info *IndexInfo) *vec.VecStore {
+	return vec.NewVecStore(vec.VecStoreConfig{
+		TableName:   info.TableName,
+		Dimensions:  info.Dimensions,
+		Distance:    vec.DistanceMetric(info.Distance),
+		Metadata:    info.Metadata,
+		AuxColumns:  info.AuxColumns,
+		PersistPath: im.vecDir,
+	})
+}
+
+type IndexItem struct {
+	ID       any
+	Text     string
+	Vector   []float32
+	Metadata map[string]string
+}
+
+type IndexResult struct {
+	IndexName   string        `json:"index_name"`
+	Total       int           `json:"total"`
+	Indexed     int           `json:"indexed"`
+	Failed      int           `json:"failed"`
+	StartedAt   time.Time     `json:"started_at"`
+	CompletedAt time.Time     `json:"completed_at"`
+	Duration    time.Duration `json:"duration"`
+}

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/1024XEngineer/anyclaw/pkg/embedding"
+	"github.com/1024XEngineer/anyclaw/pkg/sqlite"
 	"github.com/1024XEngineer/anyclaw/pkg/vec"
 )
 
@@ -590,14 +591,22 @@ func (im *IndexManager) countVectors(ctx context.Context, info *IndexInfo) (int6
 	return im.newVecStore(info).Count(ctx)
 }
 
+func (im *IndexManager) resolvedVectorDir() string {
+	if im.vecDir != "" {
+		return im.vecDir
+	}
+	return sqlite.SidecarDirForSQLDB(context.Background(), im.db, "vec")
+}
+
 func (im *IndexManager) newVecStore(info *IndexInfo) *vec.VecStore {
 	return vec.NewVecStore(vec.VecStoreConfig{
+		DB:          im.db,
 		TableName:   info.TableName,
 		Dimensions:  info.Dimensions,
 		Distance:    vec.DistanceMetric(info.Distance),
 		Metadata:    info.Metadata,
 		AuxColumns:  info.AuxColumns,
-		PersistPath: im.vecDir,
+		PersistPath: im.resolvedVectorDir(),
 	})
 }
 

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -101,6 +101,51 @@ func TestGetIndex(t *testing.T) {
 	}
 }
 
+func TestGetAndListReturnClonedIndexInfo(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{
+		Name:       "clone_test",
+		Dimensions: 4,
+		Metadata:   []string{"tag"},
+		AuxColumns: []string{"aux"},
+	})
+
+	got, err := im.Get("clone_test")
+	if err != nil {
+		t.Fatalf("get clone_test: %v", err)
+	}
+	got.Status = StatusError
+	got.VectorCount = 99
+	got.Metadata[0] = "mutated"
+	got.AuxColumns[0] = "mutated"
+
+	listed := im.List()
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 listed index, got %d", len(listed))
+	}
+	listed[0].Metadata[0] = "listed"
+	listed[0].AuxColumns[0] = "listed"
+
+	refreshed, err := im.Get("clone_test")
+	if err != nil {
+		t.Fatalf("get refreshed clone_test: %v", err)
+	}
+	if refreshed.Status != StatusReady {
+		t.Fatalf("expected stored status ready, got %s", refreshed.Status)
+	}
+	if refreshed.VectorCount != 0 {
+		t.Fatalf("expected stored vector count 0, got %d", refreshed.VectorCount)
+	}
+	if len(refreshed.Metadata) != 1 || refreshed.Metadata[0] != "tag" {
+		t.Fatalf("expected stored metadata [tag], got %v", refreshed.Metadata)
+	}
+	if len(refreshed.AuxColumns) != 1 || refreshed.AuxColumns[0] != "aux" {
+		t.Fatalf("expected stored aux columns [aux], got %v", refreshed.AuxColumns)
+	}
+}
+
 func TestListIndexes(t *testing.T) {
 	im, _ := setupIndexManager(t)
 	ctx := context.Background()
@@ -241,8 +286,11 @@ func TestIndexWithEmbedding(t *testing.T) {
 	if result.Indexed != 2 {
 		t.Errorf("expected 2 indexed, got %d", result.Indexed)
 	}
-	if embedder.callCount.Load() != 2 {
-		t.Errorf("expected 2 embed calls, got %d", embedder.callCount.Load())
+	if embedder.batchCalls.Load() != 1 {
+		t.Errorf("expected 1 batch embed call, got %d", embedder.batchCalls.Load())
+	}
+	if embedder.embedCalls.Load() != 0 {
+		t.Errorf("expected 0 single embed calls during batch indexing, got %d", embedder.embedCalls.Load())
 	}
 }
 
@@ -269,8 +317,58 @@ func TestIndexMixedVectorsAndText(t *testing.T) {
 	if result.Indexed != 3 {
 		t.Errorf("expected 3 indexed, got %d", result.Indexed)
 	}
-	if embedder.callCount.Load() != 1 {
-		t.Errorf("expected 1 embed call, got %d", embedder.callCount.Load())
+	if embedder.batchCalls.Load() != 1 {
+		t.Errorf("expected 1 batch embed call, got %d", embedder.batchCalls.Load())
+	}
+	if embedder.embedCalls.Load() != 0 {
+		t.Errorf("expected 0 single embed calls during batch indexing, got %d", embedder.embedCalls.Load())
+	}
+}
+
+func TestIndexBatchEmbedFailureProgressUsesItemOffsets(t *testing.T) {
+	db, err := sqlite.Open(sqlite.InMemoryConfig())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	ctx := context.Background()
+	im := NewIndexManager(db.DB, &failingEmbedder{
+		dim: 4,
+		err: errors.New("embed failed"),
+	}, WithVectorDir(t.TempDir()))
+	if err := im.Init(ctx); err != nil {
+		t.Fatalf("init index manager: %v", err)
+	}
+	if _, err := im.Create(ctx, Config{Name: "batch_embed_fail", Dimensions: 4}); err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+
+	var processed []int
+	result, err := im.Index(ctx, "batch_embed_fail", []IndexItem{
+		{ID: 1, Text: "a"},
+		{ID: 2, Text: "b"},
+		{ID: 3, Text: "c"},
+	}, func(p Progress) {
+		if p.Message == "embed failed: embed failed" {
+			processed = append(processed, p.Processed)
+		}
+	})
+	if err != nil {
+		t.Fatalf("index with failed batch embed should not return error, got %v", err)
+	}
+	if result.Failed != 3 {
+		t.Fatalf("expected 3 failed items, got %+v", result)
+	}
+	if len(processed) != 3 {
+		t.Fatalf("expected 3 progress updates, got %v", processed)
+	}
+	for i, got := range processed {
+		if got != i+1 {
+			t.Fatalf("expected processed offsets [1 2 3], got %v", processed)
+		}
 	}
 }
 
@@ -725,27 +823,29 @@ func TestIndexUsesSQLiteSidecarWhenVectorDirUnset(t *testing.T) {
 }
 
 type mockEmbedder struct {
-	dim       int
-	callCount atomic.Int32
+	dim        int
+	embedCalls atomic.Int32
+	batchCalls atomic.Int32
 }
 
 func (m *mockEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
-	m.callCount.Add(1)
+	m.embedCalls.Add(1)
+	return m.embeddingForText(text), nil
+}
+
+func (m *mockEmbedder) embeddingForText(text string) []float32 {
 	result := make([]float32, m.dim)
 	for i := range result {
 		result[i] = float32(len(text)) / float32(m.dim)
 	}
-	return result, nil
+	return result
 }
 
 func (m *mockEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	m.batchCalls.Add(1)
 	var results [][]float32
 	for _, text := range texts {
-		emb, err := m.Embed(ctx, text)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, emb)
+		results = append(results, m.embeddingForText(text))
 	}
 	return results, nil
 }

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -1,0 +1,506 @@
+package index
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/sqlite"
+)
+
+func setupIndexManager(t *testing.T) (*IndexManager, *mockEmbedder) {
+	t.Helper()
+
+	db, err := sqlite.Open(sqlite.InMemoryConfig())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	embedder := &mockEmbedder{dim: 4}
+	im := NewIndexManager(db.DB, embedder, WithVectorDir(t.TempDir()))
+	if err := im.Init(context.Background()); err != nil {
+		t.Fatalf("init index manager: %v", err)
+	}
+
+	return im, embedder
+}
+
+func TestCreateIndex(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	info, err := im.Create(ctx, Config{
+		Name:       "test_index",
+		Dimensions: 4,
+		Distance:   "cosine",
+		Metadata:   []string{"category"},
+	})
+	if err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+
+	if info.Name != "test_index" {
+		t.Errorf("expected name test_index, got %s", info.Name)
+	}
+	if info.Status != StatusReady {
+		t.Errorf("expected status ready, got %s", info.Status)
+	}
+	if info.Dimensions != 4 {
+		t.Errorf("expected dimensions 4, got %d", info.Dimensions)
+	}
+}
+
+func TestCreateIndexRejectsL2(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	if _, err := im.Create(ctx, Config{
+		Name:       "l2_index",
+		Dimensions: 4,
+		Distance:   "l2",
+	}); err == nil {
+		t.Fatal("expected l2 unsupported error")
+	}
+}
+
+func TestCreateDuplicateIndex(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	if _, err := im.Create(ctx, Config{Name: "dup", Dimensions: 4}); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	if _, err := im.Create(ctx, Config{Name: "dup", Dimensions: 4}); err == nil {
+		t.Error("expected error for duplicate index")
+	}
+}
+
+func TestGetIndex(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{
+		Name:       "get_test",
+		Dimensions: 4,
+		Metadata:   []string{"tag"},
+	})
+
+	info, err := im.Get("get_test")
+	if err != nil {
+		t.Fatalf("get index: %v", err)
+	}
+
+	if len(info.Metadata) != 1 || info.Metadata[0] != "tag" {
+		t.Errorf("expected metadata [tag], got %v", info.Metadata)
+	}
+}
+
+func TestListIndexes(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{Name: "idx1", Dimensions: 4})
+	_, _ = im.Create(ctx, Config{Name: "idx2", Dimensions: 4})
+	_, _ = im.Create(ctx, Config{Name: "idx3", Dimensions: 8})
+
+	indexes := im.List()
+	if len(indexes) != 3 {
+		t.Errorf("expected 3 indexes, got %d", len(indexes))
+	}
+}
+
+func TestUpdateIndex(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{
+		Name:       "update_test",
+		Dimensions: 4,
+		Metadata:   []string{"old"},
+	})
+
+	info, err := im.Update(ctx, "update_test", Config{
+		Dimensions: 4,
+		Metadata:   []string{"new"},
+	})
+	if err != nil {
+		t.Fatalf("update index: %v", err)
+	}
+
+	if len(info.Metadata) != 1 || info.Metadata[0] != "new" {
+		t.Errorf("expected metadata [new], got %v", info.Metadata)
+	}
+}
+
+func TestUpdateIndexDimensionChange(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{Name: "dim_test", Dimensions: 4})
+
+	if _, err := im.Update(ctx, "dim_test", Config{Dimensions: 8}); err == nil {
+		t.Error("expected error when changing dimensions")
+	}
+}
+
+func TestDeleteIndex(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{Name: "del_test", Dimensions: 4})
+
+	indexes := im.List()
+	if len(indexes) != 1 {
+		t.Fatalf("expected 1 index before delete")
+	}
+
+	if err := im.Delete(ctx, "del_test"); err != nil {
+		t.Fatalf("delete index: %v", err)
+	}
+
+	indexes = im.List()
+	if len(indexes) != 0 {
+		t.Errorf("expected 0 indexes after delete, got %d", len(indexes))
+	}
+}
+
+func TestDeleteNonExistentIndex(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	if err := im.Delete(ctx, "nonexistent"); err == nil {
+		t.Error("expected error for non-existent index")
+	}
+}
+
+func TestIndexWithVectors(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{
+		Name:       "vec_index",
+		Dimensions: 4,
+		Distance:   "cosine",
+	})
+
+	items := []IndexItem{
+		{ID: 1, Vector: []float32{0.1, 0.2, 0.3, 0.4}},
+		{ID: 2, Vector: []float32{0.5, 0.6, 0.7, 0.8}},
+		{ID: 3, Vector: []float32{0.9, 1.0, 0.1, 0.2}},
+	}
+
+	var progressCount atomic.Int32
+	result, err := im.Index(ctx, "vec_index", items, func(p Progress) {
+		progressCount.Add(1)
+	})
+	if err != nil {
+		t.Fatalf("index: %v", err)
+	}
+
+	if result.Indexed != 3 {
+		t.Errorf("expected 3 indexed, got %d", result.Indexed)
+	}
+	if result.Failed != 0 {
+		t.Errorf("expected 0 failed, got %d", result.Failed)
+	}
+	if progressCount.Load() == 0 {
+		t.Error("expected progress callback to be called")
+	}
+
+	info, _ := im.Get("vec_index")
+	if info.VectorCount != 3 {
+		t.Errorf("expected vector count 3, got %d", info.VectorCount)
+	}
+}
+
+func TestIndexWithEmbedding(t *testing.T) {
+	im, embedder := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{
+		Name:       "embed_index",
+		Dimensions: 4,
+	})
+
+	items := []IndexItem{
+		{ID: 1, Text: "hello world"},
+		{ID: 2, Text: "foo bar"},
+	}
+
+	result, err := im.Index(ctx, "embed_index", items, nil)
+	if err != nil {
+		t.Fatalf("index: %v", err)
+	}
+
+	if result.Indexed != 2 {
+		t.Errorf("expected 2 indexed, got %d", result.Indexed)
+	}
+	if embedder.callCount.Load() != 2 {
+		t.Errorf("expected 2 embed calls, got %d", embedder.callCount.Load())
+	}
+}
+
+func TestIndexMixedVectorsAndText(t *testing.T) {
+	im, embedder := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{
+		Name:       "mixed_index",
+		Dimensions: 4,
+	})
+
+	items := []IndexItem{
+		{ID: 1, Vector: []float32{0.1, 0.2, 0.3, 0.4}},
+		{ID: 2, Text: "embed me"},
+		{ID: 3, Vector: []float32{0.5, 0.6, 0.7, 0.8}},
+	}
+
+	result, err := im.Index(ctx, "mixed_index", items, nil)
+	if err != nil {
+		t.Fatalf("index: %v", err)
+	}
+
+	if result.Indexed != 3 {
+		t.Errorf("expected 3 indexed, got %d", result.Indexed)
+	}
+	if embedder.callCount.Load() != 1 {
+		t.Errorf("expected 1 embed call, got %d", embedder.callCount.Load())
+	}
+}
+
+func TestSearch(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{
+		Name:       "search_index",
+		Dimensions: 4,
+		Distance:   "cosine",
+	})
+
+	items := []IndexItem{
+		{ID: 1, Vector: []float32{0.1, 0.2, 0.3, 0.4}},
+		{ID: 2, Vector: []float32{0.11, 0.21, 0.31, 0.41}},
+		{ID: 3, Vector: []float32{0.9, 0.8, 0.7, 0.6}},
+	}
+
+	_, _ = im.Index(ctx, "search_index", items, nil)
+
+	results, err := im.Search(ctx, "search_index", []float32{0.1, 0.2, 0.3, 0.4}, 10)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Errorf("expected 3 results, got %d", len(results))
+	}
+	if results[0].RowID != 1 {
+		t.Errorf("expected rowid 1 first, got %d", results[0].RowID)
+	}
+}
+
+func TestSearchByText(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{
+		Name:       "text_search_index",
+		Dimensions: 4,
+	})
+
+	items := []IndexItem{
+		{ID: 1, Vector: []float32{0.1, 0.2, 0.3, 0.4}},
+		{ID: 2, Vector: []float32{0.5, 0.6, 0.7, 0.8}},
+	}
+
+	_, _ = im.Index(ctx, "text_search_index", items, nil)
+
+	results, err := im.SearchByText(ctx, "text_search_index", "query", 10)
+	if err != nil {
+		t.Fatalf("search by text: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(results))
+	}
+}
+
+func TestSearchNonExistentIndex(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	if _, err := im.Search(ctx, "nonexistent", []float32{0.1, 0.2}, 10); err == nil {
+		t.Error("expected error for non-existent index")
+	}
+}
+
+func TestRemoveVectors(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{Name: "remove_index", Dimensions: 4})
+
+	items := []IndexItem{
+		{ID: 1, Vector: []float32{0.1, 0.2, 0.3, 0.4}},
+		{ID: 2, Vector: []float32{0.5, 0.6, 0.7, 0.8}},
+		{ID: 3, Vector: []float32{0.9, 1.0, 0.1, 0.2}},
+	}
+
+	_, _ = im.Index(ctx, "remove_index", items, nil)
+
+	removed, err := im.RemoveVectors(ctx, "remove_index", []any{1, 2})
+	if err != nil {
+		t.Fatalf("remove vectors: %v", err)
+	}
+
+	if removed != 2 {
+		t.Errorf("expected 2 removed, got %d", removed)
+	}
+
+	info, _ := im.Get("remove_index")
+	if info.VectorCount != 1 {
+		t.Errorf("expected vector count 1, got %d", info.VectorCount)
+	}
+}
+
+func TestRebuildIndex(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{Name: "rebuild_index", Dimensions: 4})
+
+	items := []IndexItem{
+		{ID: 1, Vector: []float32{0.1, 0.2, 0.3, 0.4}},
+		{ID: 2, Vector: []float32{0.5, 0.6, 0.7, 0.8}},
+	}
+
+	_, _ = im.Index(ctx, "rebuild_index", items, nil)
+
+	var progressCalled bool
+	result, err := im.Rebuild(ctx, "rebuild_index", func(p Progress) {
+		progressCalled = true
+	})
+	if err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+
+	if !progressCalled {
+		t.Error("expected progress callback")
+	}
+
+	info, _ := im.Get("rebuild_index")
+	if info.Status != StatusReady {
+		t.Errorf("expected status ready after rebuild, got %s", info.Status)
+	}
+	if info.VectorCount != 0 {
+		t.Errorf("expected vector count 0 after rebuild, got %d", info.VectorCount)
+	}
+	if result.IndexName != "rebuild_index" {
+		t.Errorf("expected rebuild result index name, got %s", result.IndexName)
+	}
+}
+
+func TestRebuildNonExistentIndex(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	if _, err := im.Rebuild(ctx, "nonexistent", nil); err == nil {
+		t.Error("expected error for non-existent index rebuild")
+	}
+}
+
+func TestIndexMetaPersistence(t *testing.T) {
+	db, err := sqlite.Open(sqlite.InMemoryConfig())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	vecDir := t.TempDir()
+	embedder := &mockEmbedder{dim: 4}
+	im := NewIndexManager(db.DB, embedder, WithVectorDir(vecDir))
+
+	ctx := context.Background()
+	if err := im.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if _, err := im.Create(ctx, Config{
+		Name:       "persist_test",
+		Dimensions: 4,
+		Distance:   "cosine",
+		Metadata:   []string{"tag1", "tag2"},
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	im2 := NewIndexManager(db.DB, embedder, WithVectorDir(vecDir))
+	if err := im2.Init(ctx); err != nil {
+		t.Fatalf("re-init: %v", err)
+	}
+
+	info, err := im2.Get("persist_test")
+	if err != nil {
+		t.Fatalf("get persisted index: %v", err)
+	}
+
+	if info.Dimensions != 4 {
+		t.Errorf("expected dimensions 4, got %d", info.Dimensions)
+	}
+	if info.Distance != "cosine" {
+		t.Errorf("expected distance cosine, got %s", info.Distance)
+	}
+	if len(info.Metadata) != 2 {
+		t.Errorf("expected 2 metadata fields, got %d", len(info.Metadata))
+	}
+}
+
+func TestIndexNotReady(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{Name: "not_ready", Dimensions: 4})
+
+	im.mu.Lock()
+	im.indexes["not_ready"].Status = StatusError
+	im.mu.Unlock()
+
+	if _, err := im.Index(ctx, "not_ready", []IndexItem{{ID: 1, Vector: []float32{0.1, 0.2, 0.3, 0.4}}}, nil); err == nil {
+		t.Error("expected error for non-ready index")
+	}
+}
+
+type mockEmbedder struct {
+	dim       int
+	callCount atomic.Int32
+}
+
+func (m *mockEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	m.callCount.Add(1)
+	result := make([]float32, m.dim)
+	for i := range result {
+		result[i] = float32(len(text)) / float32(m.dim)
+	}
+	return result, nil
+}
+
+func (m *mockEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	var results [][]float32
+	for _, text := range texts {
+		emb, err := m.Embed(ctx, text)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, emb)
+	}
+	return results, nil
+}
+
+func (m *mockEmbedder) Name() string   { return "mock" }
+func (m *mockEmbedder) Dimension() int { return m.dim }

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -68,6 +68,66 @@ func TestCreateIndexRejectsL2(t *testing.T) {
 	}
 }
 
+func TestCreateIndexRollsBackFailedMetadataAcrossRestart(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "index.db")
+
+	db, err := sqlite.Open(sqlite.DefaultConfig(dbPath))
+	if err != nil {
+		t.Fatalf("open file-backed db: %v", err)
+	}
+
+	ctx := context.Background()
+	im := NewIndexManager(db.DB, nil)
+	if err := im.Init(ctx); err != nil {
+		t.Fatalf("init index manager: %v", err)
+	}
+
+	if _, err := im.Create(ctx, Config{
+		Name:       "retryable_index",
+		Dimensions: 4,
+		Distance:   "l2",
+	}); err == nil {
+		t.Fatal("expected l2 create failure")
+	}
+
+	if len(im.List()) != 0 {
+		t.Fatalf("expected failed create metadata to be removed before restart, got %+v", im.List())
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close file-backed db: %v", err)
+	}
+
+	reopened, err := sqlite.Open(sqlite.DefaultConfig(dbPath))
+	if err != nil {
+		t.Fatalf("reopen file-backed db: %v", err)
+	}
+	defer func() {
+		_ = reopened.Close()
+	}()
+
+	im2 := NewIndexManager(reopened.DB, nil)
+	if err := im2.Init(ctx); err != nil {
+		t.Fatalf("re-init index manager: %v", err)
+	}
+
+	if len(im2.List()) != 0 {
+		t.Fatalf("expected no stale failed index after restart, got %+v", im2.List())
+	}
+
+	info, err := im2.Create(ctx, Config{
+		Name:       "retryable_index",
+		Dimensions: 4,
+		Distance:   "cosine",
+	})
+	if err != nil {
+		t.Fatalf("expected recreate after failed create rollback to succeed, got %v", err)
+	}
+	if info.Status != StatusReady {
+		t.Fatalf("expected recreated index to be ready, got %s", info.Status)
+	}
+}
+
 func TestCreateDuplicateIndex(t *testing.T) {
 	im, _ := setupIndexManager(t)
 	ctx := context.Background()
@@ -464,6 +524,33 @@ func TestRemoveVectors(t *testing.T) {
 	info, _ := im.Get("remove_index")
 	if info.VectorCount != 1 {
 		t.Errorf("expected vector count 1, got %d", info.VectorCount)
+	}
+}
+
+func TestRemoveVectorsCountsOnlyExistingIDs(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{Name: "remove_exact_count", Dimensions: 4})
+
+	_, _ = im.Index(ctx, "remove_exact_count", []IndexItem{
+		{ID: 1, Vector: []float32{0.1, 0.2, 0.3, 0.4}},
+	}, nil)
+
+	removed, err := im.RemoveVectors(ctx, "remove_exact_count", []any{1, 2, 3})
+	if err != nil {
+		t.Fatalf("remove vectors with missing ids: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("expected only 1 actual deletion, got %d", removed)
+	}
+
+	info, err := im.Get("remove_exact_count")
+	if err != nil {
+		t.Fatalf("get remove_exact_count: %v", err)
+	}
+	if info.VectorCount != 0 {
+		t.Fatalf("expected vector count 0 after removing existing id, got %d", info.VectorCount)
 	}
 }
 

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 
@@ -476,6 +477,183 @@ func TestIndexNotReady(t *testing.T) {
 	}
 }
 
+func TestConfigTableNameOrDefault(t *testing.T) {
+	if got := (Config{Name: "docs"}).TableNameOrDefault(); got != "vec_docs" {
+		t.Fatalf("expected default table name vec_docs, got %q", got)
+	}
+	if got := (Config{Name: "docs", TableName: "custom_docs"}).TableNameOrDefault(); got != "custom_docs" {
+		t.Fatalf("expected explicit table name custom_docs, got %q", got)
+	}
+}
+
+func TestCreateIndexUsesDefaultDistanceAndCustomTableName(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	info, err := im.Create(ctx, Config{
+		Name:       "custom_table",
+		Dimensions: 4,
+		TableName:  "custom_docs",
+	})
+	if err != nil {
+		t.Fatalf("create index with custom table: %v", err)
+	}
+
+	if info.TableName != "custom_docs" {
+		t.Fatalf("expected custom table name, got %q", info.TableName)
+	}
+	if info.Distance != "cosine" {
+		t.Fatalf("expected default cosine distance, got %q", info.Distance)
+	}
+}
+
+func TestInitFailsOnClosedDB(t *testing.T) {
+	db, err := sqlite.Open(sqlite.InMemoryConfig())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	_ = db.Close()
+
+	im := NewIndexManager(db.DB, nil, WithVectorDir(t.TempDir()))
+	if err := im.Init(context.Background()); err == nil {
+		t.Fatal("expected init on closed db to fail")
+	}
+}
+
+func TestUpdateIndexRejectsDistanceChangeAndMissingIndex(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	if _, err := im.Update(ctx, "missing", Config{}); err == nil {
+		t.Fatal("expected missing index update to fail")
+	}
+
+	_, _ = im.Create(ctx, Config{Name: "distance_change", Dimensions: 4})
+	if _, err := im.Update(ctx, "distance_change", Config{Distance: "l2"}); err == nil {
+		t.Fatal("expected distance change to fail")
+	}
+
+	info, err := im.Get("distance_change")
+	if err != nil {
+		t.Fatalf("get distance_change: %v", err)
+	}
+	if info.Status != StatusError {
+		t.Fatalf("expected status error after rejected distance change, got %s", info.Status)
+	}
+}
+
+func TestSearchByTextErrorPaths(t *testing.T) {
+	db, err := sqlite.Open(sqlite.InMemoryConfig())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	ctx := context.Background()
+
+	noEmbedder := NewIndexManager(db.DB, nil, WithVectorDir(t.TempDir()))
+	if err := noEmbedder.Init(ctx); err != nil {
+		t.Fatalf("init no-embedder manager: %v", err)
+	}
+	if _, err := noEmbedder.SearchByText(ctx, "any", "query", 5); err == nil {
+		t.Fatal("expected search by text without embedder to fail")
+	}
+
+	fail := &failingEmbedder{dim: 4, err: errors.New("embed failed")}
+	failingManager := NewIndexManager(db.DB, fail, WithVectorDir(t.TempDir()))
+	if err := failingManager.Init(ctx); err != nil {
+		t.Fatalf("init failing manager: %v", err)
+	}
+	if _, err := failingManager.SearchByText(ctx, "any", "query", 5); !errors.Is(err, fail.err) {
+		t.Fatalf("expected wrapped embed error %v, got %v", fail.err, err)
+	}
+}
+
+func TestDeleteMarksIndexErrorWhenDropFails(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{Name: "delete_fail", Dimensions: 4})
+
+	im.mu.Lock()
+	im.indexes["delete_fail"].TableName = " "
+	im.mu.Unlock()
+
+	if err := im.Delete(ctx, "delete_fail"); err == nil {
+		t.Fatal("expected delete to fail when drop fails")
+	}
+
+	info, err := im.Get("delete_fail")
+	if err != nil {
+		t.Fatalf("get delete_fail: %v", err)
+	}
+	if info.Status != StatusError {
+		t.Fatalf("expected status error after failed delete, got %s", info.Status)
+	}
+	if info.Error == "" {
+		t.Fatal("expected delete failure to be recorded")
+	}
+}
+
+func TestRebuildMarksIndexErrorWhenDropFails(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{Name: "rebuild_fail", Dimensions: 4})
+
+	im.mu.Lock()
+	im.indexes["rebuild_fail"].TableName = " "
+	im.mu.Unlock()
+
+	if _, err := im.Rebuild(ctx, "rebuild_fail", nil); err == nil {
+		t.Fatal("expected rebuild to fail when drop fails")
+	}
+
+	info, err := im.Get("rebuild_fail")
+	if err != nil {
+		t.Fatalf("get rebuild_fail: %v", err)
+	}
+	if info.Status != StatusError {
+		t.Fatalf("expected status error after failed rebuild, got %s", info.Status)
+	}
+	if info.Error == "" {
+		t.Fatal("expected rebuild failure to be recorded")
+	}
+}
+
+func TestIndexReturnsErrorOnInsertBatchFailure(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{Name: "broken_index", Dimensions: 4})
+
+	result, err := im.Index(ctx, "broken_index", []IndexItem{
+		{ID: 1, Vector: []float32{0.1, 0.2}},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected index batch insert failure to return error")
+	}
+	if result == nil {
+		t.Fatal("expected partial result on insert failure")
+	}
+	if result.Indexed != 0 || result.Failed != 1 {
+		t.Fatalf("expected 0 indexed and 1 failed, got %+v", result)
+	}
+
+	info, err := im.Get("broken_index")
+	if err != nil {
+		t.Fatalf("get broken_index: %v", err)
+	}
+	if info.Status != StatusError {
+		t.Fatalf("expected status error after insert failure, got %s", info.Status)
+	}
+	if info.VectorCount != 0 {
+		t.Fatalf("expected no vectors after failed batch insert, got %d", info.VectorCount)
+	}
+}
+
 type mockEmbedder struct {
 	dim       int
 	callCount atomic.Int32
@@ -504,3 +682,19 @@ func (m *mockEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]floa
 
 func (m *mockEmbedder) Name() string   { return "mock" }
 func (m *mockEmbedder) Dimension() int { return m.dim }
+
+type failingEmbedder struct {
+	dim int
+	err error
+}
+
+func (f *failingEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	return nil, f.err
+}
+
+func (f *failingEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	return nil, f.err
+}
+
+func (f *failingEmbedder) Name() string   { return "failing" }
+func (f *failingEmbedder) Dimension() int { return f.dim }

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -3,6 +3,7 @@ package index
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 
@@ -651,6 +652,75 @@ func TestIndexReturnsErrorOnInsertBatchFailure(t *testing.T) {
 	}
 	if info.VectorCount != 0 {
 		t.Fatalf("expected no vectors after failed batch insert, got %d", info.VectorCount)
+	}
+}
+
+func TestIndexUsesSQLiteSidecarWhenVectorDirUnset(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "index.db")
+	db, err := sqlite.Open(sqlite.DefaultConfig(dbPath))
+	if err != nil {
+		t.Fatalf("open file-backed db: %v", err)
+	}
+
+	ctx := context.Background()
+	im := NewIndexManager(db.DB, nil)
+	if err := im.Init(ctx); err != nil {
+		t.Fatalf("init index manager: %v", err)
+	}
+
+	if _, err := im.Create(ctx, Config{Name: "sidecar_index", Dimensions: 4}); err != nil {
+		t.Fatalf("create sidecar index: %v", err)
+	}
+
+	result, err := im.Index(ctx, "sidecar_index", []IndexItem{
+		{ID: 1, Vector: []float32{0.1, 0.2, 0.3, 0.4}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("index sidecar vectors: %v", err)
+	}
+	if result.Indexed != 1 {
+		t.Fatalf("expected 1 indexed vector, got %+v", result)
+	}
+
+	info, err := im.Get("sidecar_index")
+	if err != nil {
+		t.Fatalf("get sidecar index: %v", err)
+	}
+	if info.VectorCount != 1 {
+		t.Fatalf("expected vector count 1 with implicit sidecar dir, got %d", info.VectorCount)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close file-backed db: %v", err)
+	}
+
+	reopened, err := sqlite.Open(sqlite.DefaultConfig(dbPath))
+	if err != nil {
+		t.Fatalf("reopen file-backed db: %v", err)
+	}
+	defer func() {
+		_ = reopened.Close()
+	}()
+
+	im2 := NewIndexManager(reopened.DB, nil)
+	if err := im2.Init(ctx); err != nil {
+		t.Fatalf("re-init index manager: %v", err)
+	}
+
+	info, err = im2.Get("sidecar_index")
+	if err != nil {
+		t.Fatalf("get persisted sidecar index: %v", err)
+	}
+	if info.VectorCount != 1 {
+		t.Fatalf("expected persisted vector count 1, got %d", info.VectorCount)
+	}
+
+	results, err := im2.Search(ctx, "sidecar_index", []float32{0.1, 0.2, 0.3, 0.4}, 5)
+	if err != nil {
+		t.Fatalf("search persisted sidecar index: %v", err)
+	}
+	if len(results) != 1 || results[0].RowID != 1 {
+		t.Fatalf("expected persisted vector search result for rowid 1, got %+v", results)
 	}
 }
 

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -206,6 +206,12 @@ func TestGetAndListReturnClonedIndexInfo(t *testing.T) {
 	}
 }
 
+func TestCloneIndexInfoNil(t *testing.T) {
+	if got := cloneIndexInfo(nil); got != nil {
+		t.Fatalf("expected cloneIndexInfo(nil) to return nil, got %+v", got)
+	}
+}
+
 func TestListIndexes(t *testing.T) {
 	im, _ := setupIndexManager(t)
 	ctx := context.Background()
@@ -551,6 +557,21 @@ func TestRemoveVectorsCountsOnlyExistingIDs(t *testing.T) {
 	}
 	if info.VectorCount != 0 {
 		t.Fatalf("expected vector count 0 after removing existing id, got %d", info.VectorCount)
+	}
+}
+
+func TestRemoveVectorsEmptyIndexReturnsZero(t *testing.T) {
+	im, _ := setupIndexManager(t)
+	ctx := context.Background()
+
+	_, _ = im.Create(ctx, Config{Name: "remove_empty", Dimensions: 4})
+
+	removed, err := im.RemoveVectors(ctx, "remove_empty", []any{1, 2})
+	if err != nil {
+		t.Fatalf("remove vectors from empty index: %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("expected 0 removed from empty index, got %d", removed)
 	}
 }
 

--- a/pkg/sqlite/paths.go
+++ b/pkg/sqlite/paths.go
@@ -1,0 +1,42 @@
+package sqlite
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// SidecarDir returns a sibling directory next to the configured SQLite file.
+// For in-memory DSNs, it returns an empty string.
+func (db *DB) SidecarDir(name string) string {
+	if db == nil {
+		return ""
+	}
+
+	dsn := strings.TrimSpace(db.cfg.DSN)
+	if dsn == "" || dsn == ":memory:" || strings.Contains(dsn, "mode=memory") {
+		return ""
+	}
+
+	if strings.HasPrefix(dsn, "file:") {
+		dsn = strings.TrimPrefix(dsn, "file:")
+	}
+	if idx := strings.Index(dsn, "?"); idx >= 0 {
+		dsn = dsn[:idx]
+	}
+	if dsn == "" {
+		return ""
+	}
+
+	clean := filepath.Clean(dsn)
+	base := filepath.Base(clean)
+	ext := filepath.Ext(base)
+	stem := strings.TrimSuffix(base, ext)
+	if stem == "" {
+		stem = base
+	}
+	if name == "" {
+		return filepath.Join(filepath.Dir(clean), stem)
+	}
+
+	return filepath.Join(filepath.Dir(clean), stem+"."+name)
+}

--- a/pkg/sqlite/paths.go
+++ b/pkg/sqlite/paths.go
@@ -1,6 +1,8 @@
 package sqlite
 
 import (
+	"context"
+	"database/sql"
 	"path/filepath"
 	"strings"
 )
@@ -12,7 +14,43 @@ func (db *DB) SidecarDir(name string) string {
 		return ""
 	}
 
-	dsn := strings.TrimSpace(db.cfg.DSN)
+	return sidecarDirFromLocation(db.cfg.DSN, name)
+}
+
+// SidecarDirForSQLDB returns a sibling directory next to the main database file
+// for a generic *sql.DB handle. For in-memory databases or non-SQLite handles,
+// it returns an empty string.
+func SidecarDirForSQLDB(ctx context.Context, db *sql.DB, name string) string {
+	if db == nil {
+		return ""
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	rows, err := db.QueryContext(ctx, "PRAGMA database_list")
+	if err != nil {
+		return ""
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var seq int
+		var schema, file string
+		if err := rows.Scan(&seq, &schema, &file); err != nil {
+			continue
+		}
+		if schema != "main" {
+			continue
+		}
+		return sidecarDirFromLocation(file, name)
+	}
+
+	return ""
+}
+
+func sidecarDirFromLocation(dsn string, name string) string {
+	dsn = strings.TrimSpace(dsn)
 	if dsn == "" || dsn == ":memory:" || strings.Contains(dsn, "mode=memory") {
 		return ""
 	}

--- a/pkg/sqlite/paths_driver_test.go
+++ b/pkg/sqlite/paths_driver_test.go
@@ -125,16 +125,19 @@ func TestSidecarDirForSQLDBNilAndQueryError(t *testing.T) {
 }
 
 func TestSidecarDirForSQLDBSkipsInvalidAndNonMainRows(t *testing.T) {
+	mainDBPath := filepath.Join(t.TempDir(), "anyclaw.db")
+	ignoredPath := filepath.Join(t.TempDir(), "ignored.db")
+	auxPath := filepath.Join(t.TempDir(), "aux.db")
 	db := openFakeDatabaseListDB(t, fakeDatabaseListFixture{
 		rows: [][]driver.Value{
-			{"bad-seq", "main", `C:\ignored.db`},
-			{int64(1), "aux", `C:\aux.db`},
-			{int64(2), "main", `file:C:\work\anyclaw.db?cache=shared`},
+			{"bad-seq", "main", ignoredPath},
+			{int64(1), "aux", auxPath},
+			{int64(2), "main", fmt.Sprintf("file:%s?cache=shared", mainDBPath)},
 		},
 	})
 
 	got := SidecarDirForSQLDB(nil, db, "vec")
-	want := filepath.Join(`C:\work`, "anyclaw.vec")
+	want := filepath.Join(filepath.Dir(mainDBPath), "anyclaw.vec")
 	if got != want {
 		t.Fatalf("expected sidecar path %q, got %q", want, got)
 	}
@@ -143,8 +146,8 @@ func TestSidecarDirForSQLDBSkipsInvalidAndNonMainRows(t *testing.T) {
 func TestSidecarDirForSQLDBReturnsEmptyWithoutMainRow(t *testing.T) {
 	db := openFakeDatabaseListDB(t, fakeDatabaseListFixture{
 		rows: [][]driver.Value{
-			{int64(1), "temp", `C:\temp.db`},
-			{int64(2), "aux", `C:\aux.db`},
+			{int64(1), "temp", filepath.Join(t.TempDir(), "temp.db")},
+			{int64(2), "aux", filepath.Join(t.TempDir(), "aux.db")},
 		},
 	})
 

--- a/pkg/sqlite/paths_driver_test.go
+++ b/pkg/sqlite/paths_driver_test.go
@@ -1,0 +1,154 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+const fakeDatabaseListDriverName = "fake-database-list"
+
+var (
+	fakeDatabaseListRegisterOnce sync.Once
+	fakeDatabaseListFixturesMu   sync.Mutex
+	fakeDatabaseListFixtures     = make(map[string]fakeDatabaseListFixture)
+	fakeDatabaseListCounter      atomic.Uint64
+)
+
+type fakeDatabaseListFixture struct {
+	queryErr error
+	rows     [][]driver.Value
+}
+
+type fakeDatabaseListDriver struct{}
+
+type fakeDatabaseListConn struct {
+	fixture fakeDatabaseListFixture
+}
+
+type fakeDatabaseListRows struct {
+	rows [][]driver.Value
+	idx  int
+}
+
+func (d fakeDatabaseListDriver) Open(name string) (driver.Conn, error) {
+	fakeDatabaseListFixturesMu.Lock()
+	fixture := fakeDatabaseListFixtures[name]
+	fakeDatabaseListFixturesMu.Unlock()
+	return &fakeDatabaseListConn{fixture: fixture}, nil
+}
+
+func (c *fakeDatabaseListConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare not supported")
+}
+
+func (c *fakeDatabaseListConn) Close() error { return nil }
+
+func (c *fakeDatabaseListConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions not supported")
+}
+
+func (c *fakeDatabaseListConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	if c.fixture.queryErr != nil {
+		return nil, c.fixture.queryErr
+	}
+	return &fakeDatabaseListRows{rows: c.fixture.rows}, nil
+}
+
+func (r *fakeDatabaseListRows) Columns() []string {
+	return []string{"seq", "name", "file"}
+}
+
+func (r *fakeDatabaseListRows) Close() error { return nil }
+
+func (r *fakeDatabaseListRows) Next(dest []driver.Value) error {
+	if r.idx >= len(r.rows) {
+		return io.EOF
+	}
+
+	row := r.rows[r.idx]
+	r.idx++
+	for i := range dest {
+		if i < len(row) {
+			dest[i] = row[i]
+		}
+	}
+	return nil
+}
+
+func openFakeDatabaseListDB(t *testing.T, fixture fakeDatabaseListFixture) *sql.DB {
+	t.Helper()
+
+	fakeDatabaseListRegisterOnce.Do(func() {
+		sql.Register(fakeDatabaseListDriverName, fakeDatabaseListDriver{})
+	})
+
+	name := fmt.Sprintf("fixture-%d", fakeDatabaseListCounter.Add(1))
+	fakeDatabaseListFixturesMu.Lock()
+	fakeDatabaseListFixtures[name] = fixture
+	fakeDatabaseListFixturesMu.Unlock()
+
+	db, err := sql.Open(fakeDatabaseListDriverName, name)
+	if err != nil {
+		t.Fatalf("open fake database_list db: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Close()
+		fakeDatabaseListFixturesMu.Lock()
+		delete(fakeDatabaseListFixtures, name)
+		fakeDatabaseListFixturesMu.Unlock()
+	})
+
+	return db
+}
+
+func TestSidecarDirForSQLDBNilAndQueryError(t *testing.T) {
+	if got := SidecarDirForSQLDB(context.Background(), nil, "vec"); got != "" {
+		t.Fatalf("expected empty sidecar path for nil db, got %q", got)
+	}
+
+	db := openFakeDatabaseListDB(t, fakeDatabaseListFixture{
+		queryErr: errors.New("query failed"),
+	})
+
+	if got := SidecarDirForSQLDB(context.Background(), db, "vec"); got != "" {
+		t.Fatalf("expected empty sidecar path on query error, got %q", got)
+	}
+}
+
+func TestSidecarDirForSQLDBSkipsInvalidAndNonMainRows(t *testing.T) {
+	db := openFakeDatabaseListDB(t, fakeDatabaseListFixture{
+		rows: [][]driver.Value{
+			{"bad-seq", "main", `C:\ignored.db`},
+			{int64(1), "aux", `C:\aux.db`},
+			{int64(2), "main", `file:C:\work\anyclaw.db?cache=shared`},
+		},
+	})
+
+	got := SidecarDirForSQLDB(nil, db, "vec")
+	want := filepath.Join(`C:\work`, "anyclaw.vec")
+	if got != want {
+		t.Fatalf("expected sidecar path %q, got %q", want, got)
+	}
+}
+
+func TestSidecarDirForSQLDBReturnsEmptyWithoutMainRow(t *testing.T) {
+	db := openFakeDatabaseListDB(t, fakeDatabaseListFixture{
+		rows: [][]driver.Value{
+			{int64(1), "temp", `C:\temp.db`},
+			{int64(2), "aux", `C:\aux.db`},
+		},
+	})
+
+	if got := SidecarDirForSQLDB(context.Background(), db, "vec"); got != "" {
+		t.Fatalf("expected empty sidecar path without main row, got %q", got)
+	}
+}

--- a/pkg/sqlite/paths_test.go
+++ b/pkg/sqlite/paths_test.go
@@ -2,15 +2,17 @@ package sqlite
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 )
 
 func TestSidecarDirFileDB(t *testing.T) {
-	db := &DB{cfg: Config{DSN: `C:\tmp\anyclaw.db`}}
+	dbPath := filepath.Join("tmp", "anyclaw.db")
+	db := &DB{cfg: Config{DSN: dbPath}}
 
 	got := db.SidecarDir("vec")
-	want := `C:\tmp\anyclaw.vec`
+	want := filepath.Join("tmp", "anyclaw.vec")
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
 	}
@@ -42,13 +44,14 @@ func TestSidecarDirNilAndMemoryVariants(t *testing.T) {
 }
 
 func TestSidecarDirFileDSNVariants(t *testing.T) {
-	db := &DB{cfg: Config{DSN: `file:C:\tmp\anyclaw.db?cache=shared`}}
+	dbPath := filepath.Join("tmp", "anyclaw.db")
+	db := &DB{cfg: Config{DSN: fmt.Sprintf("file:%s?cache=shared", dbPath)}}
 
-	if got := db.SidecarDir(""); got != `C:\tmp\anyclaw` {
-		t.Fatalf("expected base sidecar path %q, got %q", `C:\tmp\anyclaw`, got)
+	if got := db.SidecarDir(""); got != filepath.Join("tmp", "anyclaw") {
+		t.Fatalf("expected base sidecar path %q, got %q", filepath.Join("tmp", "anyclaw"), got)
 	}
-	if got := db.SidecarDir("vec"); got != `C:\tmp\anyclaw.vec` {
-		t.Fatalf("expected vec sidecar path %q, got %q", `C:\tmp\anyclaw.vec`, got)
+	if got := db.SidecarDir("vec"); got != filepath.Join("tmp", "anyclaw.vec") {
+		t.Fatalf("expected vec sidecar path %q, got %q", filepath.Join("tmp", "anyclaw.vec"), got)
 	}
 }
 

--- a/pkg/sqlite/paths_test.go
+++ b/pkg/sqlite/paths_test.go
@@ -1,0 +1,21 @@
+package sqlite
+
+import "testing"
+
+func TestSidecarDirFileDB(t *testing.T) {
+	db := &DB{cfg: Config{DSN: `C:\tmp\anyclaw.db`}}
+
+	got := db.SidecarDir("vec")
+	want := `C:\tmp\anyclaw.vec`
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestSidecarDirInMemoryDB(t *testing.T) {
+	db := &DB{cfg: Config{DSN: ":memory:"}}
+
+	if got := db.SidecarDir("vec"); got != "" {
+		t.Fatalf("expected empty sidecar dir for in-memory db, got %q", got)
+	}
+}

--- a/pkg/sqlite/paths_test.go
+++ b/pkg/sqlite/paths_test.go
@@ -19,3 +19,31 @@ func TestSidecarDirInMemoryDB(t *testing.T) {
 		t.Fatalf("expected empty sidecar dir for in-memory db, got %q", got)
 	}
 }
+
+func TestSidecarDirNilAndMemoryVariants(t *testing.T) {
+	var nilDB *DB
+	if got := nilDB.SidecarDir("vec"); got != "" {
+		t.Fatalf("expected empty sidecar dir for nil db, got %q", got)
+	}
+
+	blank := &DB{cfg: Config{DSN: "   "}}
+	if got := blank.SidecarDir("vec"); got != "" {
+		t.Fatalf("expected empty sidecar dir for blank dsn, got %q", got)
+	}
+
+	mem := &DB{cfg: Config{DSN: "file:memdb1?mode=memory&cache=shared"}}
+	if got := mem.SidecarDir("vec"); got != "" {
+		t.Fatalf("expected empty sidecar dir for mode=memory dsn, got %q", got)
+	}
+}
+
+func TestSidecarDirFileDSNVariants(t *testing.T) {
+	db := &DB{cfg: Config{DSN: `file:C:\tmp\anyclaw.db?cache=shared`}}
+
+	if got := db.SidecarDir(""); got != `C:\tmp\anyclaw` {
+		t.Fatalf("expected base sidecar path %q, got %q", `C:\tmp\anyclaw`, got)
+	}
+	if got := db.SidecarDir("vec"); got != `C:\tmp\anyclaw.vec` {
+		t.Fatalf("expected vec sidecar path %q, got %q", `C:\tmp\anyclaw.vec`, got)
+	}
+}

--- a/pkg/sqlite/paths_test.go
+++ b/pkg/sqlite/paths_test.go
@@ -1,6 +1,10 @@
 package sqlite
 
-import "testing"
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
 
 func TestSidecarDirFileDB(t *testing.T) {
 	db := &DB{cfg: Config{DSN: `C:\tmp\anyclaw.db`}}
@@ -45,5 +49,36 @@ func TestSidecarDirFileDSNVariants(t *testing.T) {
 	}
 	if got := db.SidecarDir("vec"); got != `C:\tmp\anyclaw.vec` {
 		t.Fatalf("expected vec sidecar path %q, got %q", `C:\tmp\anyclaw.vec`, got)
+	}
+}
+
+func TestSidecarDirForSQLDBFileDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "anyclaw.db")
+	db, err := Open(DefaultConfig(dbPath))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	got := SidecarDirForSQLDB(context.Background(), db.DB, "vec")
+	want := filepath.Join(filepath.Dir(dbPath), "anyclaw.vec")
+	if got != want {
+		t.Fatalf("expected sidecar path %q, got %q", want, got)
+	}
+}
+
+func TestSidecarDirForSQLDBInMemoryDB(t *testing.T) {
+	db, err := Open(InMemoryConfig())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	if got := SidecarDirForSQLDB(context.Background(), db.DB, "vec"); got != "" {
+		t.Fatalf("expected empty sidecar path for in-memory sql db, got %q", got)
 	}
 }

--- a/pkg/sqlite/sqlite.go
+++ b/pkg/sqlite/sqlite.go
@@ -205,9 +205,12 @@ func (db *DB) checkpointWAL(ctx context.Context) {
 }
 
 func (db *DB) WALSize(ctx context.Context) (int64, error) {
-	var size int64
-	err := db.QueryRowContext(ctx, "PRAGMA wal_checkpoint").Scan(&size)
-	return size, err
+	var busy, log, checkpointed int64
+	err := db.QueryRowContext(ctx, "PRAGMA wal_checkpoint").Scan(&busy, &log, &checkpointed)
+	if err != nil {
+		return 0, err
+	}
+	return log, nil
 }
 
 func (db *DB) Stats() PoolStats {

--- a/pkg/sqlite/sqlite.go
+++ b/pkg/sqlite/sqlite.go
@@ -1,0 +1,283 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+type Config struct {
+	DSN               string
+	MaxOpenConns      int
+	MaxIdleConns      int
+	ConnMaxLifetime   time.Duration
+	ConnMaxIdleTime   time.Duration
+	BusyTimeout       time.Duration
+	JournalMode       string
+	Synchronous       string
+	CacheSize         int
+	ForeignKeyEnabled bool
+	WALEnabled        bool
+	WALAutoCheckpoint int
+	MmapSize          int64
+	TempStore         string
+}
+
+func DefaultConfig(dsn string) Config {
+	return Config{
+		DSN:               dsn,
+		MaxOpenConns:      5,
+		MaxIdleConns:      3,
+		ConnMaxLifetime:   30 * time.Minute,
+		ConnMaxIdleTime:   5 * time.Minute,
+		BusyTimeout:       30 * time.Second,
+		JournalMode:       "WAL",
+		Synchronous:       "NORMAL",
+		CacheSize:         -64000,
+		ForeignKeyEnabled: true,
+		WALEnabled:        true,
+		WALAutoCheckpoint: 1000,
+		MmapSize:          256 * 1024 * 1024,
+		TempStore:         "MEMORY",
+	}
+}
+
+func InMemoryConfig() Config {
+	cfg := DefaultConfig(":memory:")
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	cfg.WALEnabled = false
+	cfg.JournalMode = "MEMORY"
+	return cfg
+}
+
+type PoolStats struct {
+	OpenConnections   int
+	InUse             int64
+	Idle              int64
+	WaitCount         int64
+	WaitDuration      time.Duration
+	MaxIdleClosed     int64
+	MaxLifetimeClosed int64
+}
+
+type DB struct {
+	*sql.DB
+	mu         sync.RWMutex
+	closed     bool
+	cfg        Config
+	queryCount atomic.Int64
+	execCount  atomic.Int64
+}
+
+func (db *DB) DSN() string {
+	return db.cfg.DSN
+}
+
+func Open(cfg Config) (*DB, error) {
+	if cfg.DSN == "" {
+		cfg.DSN = ":memory:"
+	}
+	if cfg.MaxOpenConns <= 0 {
+		cfg.MaxOpenConns = 1
+	}
+	if cfg.MaxIdleConns <= 0 {
+		cfg.MaxIdleConns = 1
+	}
+	if cfg.MaxIdleConns > cfg.MaxOpenConns {
+		cfg.MaxIdleConns = cfg.MaxOpenConns
+	}
+
+	db, err := sql.Open("sqlite", cfg.DSN)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: open database: %w", err)
+	}
+
+	wrapper := &DB{DB: db, cfg: cfg}
+
+	if err := wrapper.configure(); err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	return wrapper, nil
+}
+
+func (db *DB) configure() error {
+	db.SetMaxOpenConns(db.cfg.MaxOpenConns)
+	db.SetMaxIdleConns(db.cfg.MaxIdleConns)
+	db.SetConnMaxLifetime(db.cfg.ConnMaxLifetime)
+	db.SetConnMaxIdleTime(db.cfg.ConnMaxIdleTime)
+
+	pragmas := db.buildPragmas()
+	for _, pragma := range pragmas {
+		if _, err := db.Exec(pragma); err != nil {
+			return fmt.Errorf("sqlite: exec pragma %q: %w", pragma, err)
+		}
+	}
+
+	return nil
+}
+
+func (db *DB) buildPragmas() []string {
+	var pragmas []string
+
+	pragmas = append(pragmas,
+		fmt.Sprintf("PRAGMA busy_timeout = %d", db.cfg.BusyTimeout.Milliseconds()),
+	)
+
+	if db.cfg.JournalMode != "" {
+		pragmas = append(pragmas, fmt.Sprintf("PRAGMA journal_mode = %s", db.cfg.JournalMode))
+	}
+
+	if db.cfg.Synchronous != "" {
+		pragmas = append(pragmas, fmt.Sprintf("PRAGMA synchronous = %s", db.cfg.Synchronous))
+	}
+
+	if db.cfg.CacheSize != 0 {
+		pragmas = append(pragmas, fmt.Sprintf("PRAGMA cache_size = %d", db.cfg.CacheSize))
+	}
+
+	if db.cfg.MmapSize > 0 {
+		pragmas = append(pragmas, fmt.Sprintf("PRAGMA mmap_size = %d", db.cfg.MmapSize))
+	}
+
+	if db.cfg.TempStore != "" {
+		pragmas = append(pragmas, fmt.Sprintf("PRAGMA temp_store = %s", db.cfg.TempStore))
+	}
+
+	if db.cfg.WALEnabled {
+		pragmas = append(pragmas, "PRAGMA journal_mode = WAL")
+		if db.cfg.WALAutoCheckpoint > 0 {
+			pragmas = append(pragmas, fmt.Sprintf("PRAGMA wal_autocheckpoint = %d", db.cfg.WALAutoCheckpoint))
+		}
+		pragmas = append(pragmas, "PRAGMA journal_size_limit = 67108864")
+	}
+
+	if db.cfg.ForeignKeyEnabled {
+		pragmas = append(pragmas, "PRAGMA foreign_keys = ON")
+	}
+
+	pragmas = append(pragmas,
+		"PRAGMA optimize",
+	)
+
+	return pragmas
+}
+
+func (db *DB) Close() error {
+	db.mu.Lock()
+	if db.closed {
+		db.mu.Unlock()
+		return nil
+	}
+	db.closed = true
+	db.mu.Unlock()
+
+	if db.cfg.WALEnabled && db.cfg.DSN != ":memory:" {
+		db.checkpointWAL(context.Background())
+	}
+
+	return db.DB.Close()
+}
+
+func (db *DB) Ping(ctx context.Context) error {
+	return db.DB.PingContext(ctx)
+}
+
+func (db *DB) Checkpoint(ctx context.Context, mode string) error {
+	if mode == "" {
+		mode = "PASSIVE"
+	}
+	_, err := db.ExecContext(ctx, fmt.Sprintf("PRAGMA wal_checkpoint(%s)", mode))
+	return err
+}
+
+func (db *DB) checkpointWAL(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)")
+}
+
+func (db *DB) WALSize(ctx context.Context) (int64, error) {
+	var size int64
+	err := db.QueryRowContext(ctx, "PRAGMA wal_checkpoint").Scan(&size)
+	return size, err
+}
+
+func (db *DB) Stats() PoolStats {
+	s := db.DB.Stats()
+	return PoolStats{
+		OpenConnections:   s.OpenConnections,
+		InUse:             int64(s.InUse),
+		Idle:              int64(s.Idle),
+		WaitCount:         s.WaitCount,
+		WaitDuration:      s.WaitDuration,
+		MaxIdleClosed:     s.MaxIdleClosed,
+		MaxLifetimeClosed: s.MaxLifetimeClosed,
+	}
+}
+
+func (db *DB) QueryCount() int64 {
+	return db.queryCount.Load()
+}
+
+func (db *DB) ExecCount() int64 {
+	return db.execCount.Load()
+}
+
+func (db *DB) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	db.execCount.Add(1)
+	return db.DB.ExecContext(ctx, query, args...)
+}
+
+func (db *DB) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	db.queryCount.Add(1)
+	return db.DB.QueryContext(ctx, query, args...)
+}
+
+func (db *DB) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	db.queryCount.Add(1)
+	return db.DB.QueryRowContext(ctx, query, args...)
+}
+
+func (db *DB) WithConn(ctx context.Context, fn func(conn *sql.Conn) error) error {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("sqlite: get connection: %w", err)
+	}
+	defer conn.Close()
+
+	if err := fn(conn); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (db *DB) IsWALMode(ctx context.Context) (bool, error) {
+	var mode string
+	err := db.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&mode)
+	if err != nil {
+		return false, err
+	}
+	return mode == "wal", nil
+}
+
+func (db *DB) Optimize(ctx context.Context) error {
+	_, err := db.ExecContext(ctx, "PRAGMA optimize")
+	return err
+}
+
+func (db *DB) IntegrityCheck(ctx context.Context) (bool, error) {
+	var result string
+	err := db.QueryRowContext(ctx, "PRAGMA integrity_check(1)").Scan(&result)
+	if err != nil {
+		return false, err
+	}
+	return result == "ok", nil
+}

--- a/pkg/sqlite/sqlite_test.go
+++ b/pkg/sqlite/sqlite_test.go
@@ -1,0 +1,433 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func setupTestDB(t *testing.T, cfg Config) *DB {
+	t.Helper()
+	if cfg.DSN == "" {
+		cfg.DSN = ":memory:"
+	}
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+
+	_, err = db.ExecContext(context.Background(), `CREATE TABLE test (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL,
+		value TEXT
+	)`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Close()
+		if cfg.DSN != ":memory:" {
+			_ = os.Remove(cfg.DSN)
+			_ = os.Remove(cfg.DSN + "-wal")
+			_ = os.Remove(cfg.DSN + "-shm")
+		}
+	})
+
+	return db
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig(":memory:")
+	if cfg.MaxOpenConns != 5 {
+		t.Errorf("expected MaxOpenConns 5, got %d", cfg.MaxOpenConns)
+	}
+	if cfg.MaxIdleConns != 3 {
+		t.Errorf("expected MaxIdleConns 3, got %d", cfg.MaxIdleConns)
+	}
+	if cfg.ConnMaxLifetime != 30*time.Minute {
+		t.Errorf("expected ConnMaxLifetime 30m, got %v", cfg.ConnMaxLifetime)
+	}
+	if !cfg.WALEnabled {
+		t.Error("expected WALEnabled true")
+	}
+}
+
+func TestInMemoryConfig(t *testing.T) {
+	cfg := InMemoryConfig()
+	if cfg.MaxOpenConns != 1 {
+		t.Errorf("expected MaxOpenConns 1, got %d", cfg.MaxOpenConns)
+	}
+	if cfg.WALEnabled {
+		t.Error("expected WALEnabled false for in-memory")
+	}
+}
+
+func TestOpenAndClose(t *testing.T) {
+	db, err := Open(DefaultConfig(":memory:"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("expected no error on close, got %v", err)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("expected no error on double close, got %v", err)
+	}
+}
+
+func TestConnectionPoolSettings(t *testing.T) {
+	cfg := DefaultConfig(":memory:")
+	cfg.MaxOpenConns = 10
+	cfg.MaxIdleConns = 5
+	cfg.ConnMaxLifetime = 10 * time.Minute
+	cfg.ConnMaxIdleTime = 2 * time.Minute
+
+	db := setupTestDB(t, cfg)
+
+	stats := db.Stats()
+	if stats.OpenConnections < 1 {
+		t.Errorf("expected at least 1 open connection after setup, got %d", stats.OpenConnections)
+	}
+}
+
+func TestConnectionPoolUnderLoad(t *testing.T) {
+	cfg := DefaultConfig(":memory:")
+	cfg.MaxOpenConns = 5
+	cfg.MaxIdleConns = 3
+	db := setupTestDB(t, cfg)
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	successCount := 0
+	failCount := 0
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			_, err := db.ExecContext(ctx, "INSERT INTO test (name, value) VALUES (?, ?)", "item", n)
+			mu.Lock()
+			if err != nil {
+				failCount++
+			} else {
+				successCount++
+			}
+			mu.Unlock()
+		}(i)
+	}
+
+	wg.Wait()
+
+	if successCount == 0 {
+		t.Error("expected at least some successful inserts")
+	}
+
+	stats := db.Stats()
+	if stats.OpenConnections > cfg.MaxOpenConns {
+		t.Errorf("open connections %d exceeds max %d", stats.OpenConnections, cfg.MaxOpenConns)
+	}
+}
+
+func TestWALModeDetection(t *testing.T) {
+	cfg := DefaultConfig(":memory:")
+	db := setupTestDB(t, cfg)
+
+	ctx := context.Background()
+	isWAL, err := db.IsWALMode(ctx)
+	if err != nil {
+		t.Fatalf("failed to check WAL mode: %v", err)
+	}
+
+	if !isWAL {
+		t.Log("WAL mode not active (expected for in-memory DB)")
+	}
+}
+
+func TestWALFileBased(t *testing.T) {
+	tmpFile := t.TempDir() + "/test_wal.db"
+
+	cfg := DefaultConfig(tmpFile)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db := setupTestDB(t, cfg)
+
+	ctx := context.Background()
+
+	isWAL, err := db.IsWALMode(ctx)
+	if err != nil {
+		t.Fatalf("failed to check WAL mode: %v", err)
+	}
+
+	if !isWAL {
+		t.Fatal("expected WAL mode for file-based DB")
+	}
+
+	_, err = db.ExecContext(ctx, "INSERT INTO test (name, value) VALUES (?, ?)", "wal_test", "value")
+	if err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	if err := db.Checkpoint(ctx, "PASSIVE"); err != nil {
+		t.Fatalf("checkpoint failed: %v", err)
+	}
+}
+
+func TestCheckpoint(t *testing.T) {
+	tmpFile := t.TempDir() + "/test_checkpoint.db"
+
+	cfg := DefaultConfig(tmpFile)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db := setupTestDB(t, cfg)
+
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		_, err := db.ExecContext(ctx, "INSERT INTO test (name, value) VALUES (?, ?)", "checkpoint", i)
+		if err != nil {
+			t.Fatalf("insert failed: %v", err)
+		}
+	}
+
+	if err := db.Checkpoint(ctx, "PASSIVE"); err != nil {
+		t.Fatalf("passive checkpoint failed: %v", err)
+	}
+	if err := db.Checkpoint(ctx, "FULL"); err != nil {
+		t.Fatalf("full checkpoint failed: %v", err)
+	}
+	if err := db.Checkpoint(ctx, "RESTART"); err != nil {
+		t.Fatalf("restart checkpoint failed: %v", err)
+	}
+	if err := db.Checkpoint(ctx, "TRUNCATE"); err != nil {
+		t.Fatalf("truncate checkpoint failed: %v", err)
+	}
+}
+
+func TestPoolStats(t *testing.T) {
+	cfg := DefaultConfig(":memory:")
+	cfg.MaxOpenConns = 5
+	cfg.MaxIdleConns = 3
+	db := setupTestDB(t, cfg)
+
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		_, _ = db.ExecContext(ctx, "INSERT INTO test (name, value) VALUES (?, ?)", "stats", i)
+	}
+
+	stats := db.Stats()
+
+	if stats.OpenConnections < 1 {
+		t.Errorf("expected at least 1 open connection, got %d", stats.OpenConnections)
+	}
+	if db.QueryCount() == 0 && db.ExecCount() == 0 {
+		t.Error("expected non-zero query or exec count")
+	}
+}
+
+func TestWithConn(t *testing.T) {
+	db := setupTestDB(t, DefaultConfig(":memory:"))
+	ctx := context.Background()
+
+	err := db.WithConn(ctx, func(conn *sql.Conn) error {
+		_, err := conn.ExecContext(ctx, "INSERT INTO test (name, value) VALUES (?, ?)", "conn_test", "value")
+		return err
+	})
+	if err != nil {
+		t.Fatalf("WithConn failed: %v", err)
+	}
+
+	var count int
+	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM test WHERE name = ?", "conn_test").Scan(&count)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 row, got %d", count)
+	}
+}
+
+func TestIntegrityCheck(t *testing.T) {
+	db := setupTestDB(t, DefaultConfig(":memory:"))
+	ctx := context.Background()
+
+	ok, err := db.IntegrityCheck(ctx)
+	if err != nil {
+		t.Fatalf("integrity check failed: %v", err)
+	}
+	if !ok {
+		t.Error("expected integrity check to pass")
+	}
+}
+
+func TestOptimize(t *testing.T) {
+	db := setupTestDB(t, DefaultConfig(":memory:"))
+	ctx := context.Background()
+
+	if err := db.Optimize(ctx); err != nil {
+		t.Fatalf("optimize failed: %v", err)
+	}
+}
+
+func TestQueryExecCounters(t *testing.T) {
+	db := setupTestDB(t, DefaultConfig(":memory:"))
+	ctx := context.Background()
+
+	initialExec := db.ExecCount()
+	initialQuery := db.QueryCount()
+
+	_, _ = db.ExecContext(ctx, "INSERT INTO test (name, value) VALUES (?, ?)", "counter", 1)
+	db.QueryRowContext(ctx, "SELECT COUNT(*) FROM test")
+
+	if db.ExecCount() != initialExec+1 {
+		t.Errorf("expected exec count %d, got %d", initialExec+1, db.ExecCount())
+	}
+	if db.QueryCount() != initialQuery+1 {
+		t.Errorf("expected query count %d, got %d", initialQuery+1, db.QueryCount())
+	}
+}
+
+func TestConnMaxIdleTime(t *testing.T) {
+	cfg := DefaultConfig(":memory:")
+	cfg.MaxIdleConns = 2
+	cfg.ConnMaxIdleTime = 100 * time.Millisecond
+	db := setupTestDB(t, cfg)
+
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		_, _ = db.ExecContext(ctx, "INSERT INTO test (name, value) VALUES (?, ?)", "idle", i)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	stats := db.Stats()
+	if stats.MaxIdleClosed == 0 {
+		t.Log("no idle connections closed yet (may be expected depending on timing)")
+	}
+}
+
+func TestWALAutoCheckpoint(t *testing.T) {
+	tmpFile := t.TempDir() + "/test_auto_checkpoint.db"
+
+	cfg := DefaultConfig(tmpFile)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	cfg.WALAutoCheckpoint = 100
+	db := setupTestDB(t, cfg)
+
+	ctx := context.Background()
+	for i := 0; i < 200; i++ {
+		_, err := db.ExecContext(ctx, "INSERT INTO test (name, value) VALUES (?, ?)", "auto_cp", i)
+		if err != nil {
+			t.Fatalf("insert failed: %v", err)
+		}
+	}
+
+	var count int
+	err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM test").Scan(&count)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if count != 200 {
+		t.Errorf("expected 200 rows, got %d", count)
+	}
+}
+
+func TestOpenAppliesDefaultsAndClamp(t *testing.T) {
+	db, err := Open(Config{})
+	if err != nil {
+		t.Fatalf("open with zero config: %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	if db.DSN() != ":memory:" {
+		t.Fatalf("expected default dsn :memory:, got %q", db.DSN())
+	}
+	if db.cfg.MaxOpenConns != 1 {
+		t.Fatalf("expected MaxOpenConns defaulted to 1, got %d", db.cfg.MaxOpenConns)
+	}
+	if db.cfg.MaxIdleConns != 1 {
+		t.Fatalf("expected MaxIdleConns defaulted to 1, got %d", db.cfg.MaxIdleConns)
+	}
+	if err := db.Ping(context.Background()); err != nil {
+		t.Fatalf("ping failed: %v", err)
+	}
+
+	clamped, err := Open(Config{
+		DSN:          ":memory:",
+		MaxOpenConns: 1,
+		MaxIdleConns: 3,
+	})
+	if err != nil {
+		t.Fatalf("open with clamped config: %v", err)
+	}
+	defer func() {
+		_ = clamped.Close()
+	}()
+
+	if clamped.cfg.MaxIdleConns != 1 {
+		t.Fatalf("expected MaxIdleConns to clamp to 1, got %d", clamped.cfg.MaxIdleConns)
+	}
+}
+
+func TestQueryContextWALSizeAndDefaultCheckpointMode(t *testing.T) {
+	tmpFile := t.TempDir() + "/test_wal_size.db"
+
+	cfg := DefaultConfig(tmpFile)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db := setupTestDB(t, cfg)
+
+	ctx := context.Background()
+	_, err := db.ExecContext(ctx, "INSERT INTO test (name, value) VALUES (?, ?)", "wal_size", "value")
+	if err != nil {
+		t.Fatalf("insert failed: %v", err)
+	}
+
+	rows, err := db.QueryContext(ctx, "SELECT name FROM test")
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+
+	if !rows.Next() {
+		t.Fatal("expected at least one row")
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatalf("close rows: %v", err)
+	}
+
+	walSize, err := db.WALSize(ctx)
+	if err != nil {
+		t.Fatalf("wal size failed: %v", err)
+	}
+	if walSize < 0 {
+		t.Fatalf("expected non-negative wal size, got %d", walSize)
+	}
+
+	if err := db.Checkpoint(ctx, ""); err != nil {
+		t.Fatalf("checkpoint with default mode failed: %v", err)
+	}
+}
+
+func TestWithConnReturnsCallbackError(t *testing.T) {
+	db := setupTestDB(t, DefaultConfig(":memory:"))
+
+	wantErr := errors.New("boom")
+	err := db.WithConn(context.Background(), func(conn *sql.Conn) error {
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected callback error %v, got %v", wantErr, err)
+	}
+}

--- a/pkg/state/memory/memory.go
+++ b/pkg/state/memory/memory.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	cryptorand "crypto/rand"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -36,6 +38,8 @@ const (
 	TypeReflection   = "reflection"
 	TypeFact         = "fact"
 )
+
+var randomIDFallbackCounter atomic.Uint64
 
 func NewFileMemory(workDir string) *FileMemory {
 	memoryDir := filepath.Join(workDir, "memory")
@@ -348,10 +352,23 @@ func (m *FileMemory) GetStats() (map[string]int, error) {
 }
 
 func randomID(length int) string {
+	if length <= 0 {
+		return ""
+	}
+
 	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
 	result := make([]byte, length)
+	randomBytes := make([]byte, length)
+	if _, err := cryptorand.Read(randomBytes); err == nil {
+		for i, b := range randomBytes {
+			result[i] = chars[int(b)%len(chars)]
+		}
+		return string(result)
+	}
+
+	seed := randomIDFallbackCounter.Add(1)
 	for i := range result {
-		result[i] = chars[time.Now().UnixNano()%int64(len(chars))]
+		result[i] = chars[int((seed+uint64(i))%uint64(len(chars)))]
 	}
 	return string(result)
 }

--- a/pkg/vec/registry.go
+++ b/pkg/vec/registry.go
@@ -1,0 +1,408 @@
+package vec
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/gob"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	pkgsqlite "github.com/1024XEngineer/anyclaw/pkg/sqlite"
+	chromem "github.com/philippgille/chromem-go"
+)
+
+const (
+	vecRegistryTable    = "vec_document_registry"
+	vecRegistryFilename = "vec-registry.sqlite"
+)
+
+func (vs *VecStore) ensureRegistryUpToDate(ctx context.Context, db *chromem.DB, count int) error {
+	registryCount, err := vs.registryCount(ctx)
+	if err != nil {
+		return err
+	}
+	if registryCount == count {
+		return nil
+	}
+
+	return vs.rebuildRegistry(ctx, db)
+}
+
+func (vs *VecStore) rebuildRegistry(ctx context.Context, db *chromem.DB) error {
+	ids, err := vs.exportedCollectionIDs(db)
+	if err != nil {
+		return err
+	}
+	return vs.replaceRegistryIDs(ctx, ids)
+}
+
+func (vs *VecStore) listItemsFromRegistry(ctx context.Context, col *chromem.Collection, limit int) ([]VecItem, bool, error) {
+	ids, err := vs.listRegistryIDs(ctx, limit)
+	if err != nil {
+		return nil, false, err
+	}
+
+	items := make([]VecItem, 0, len(ids))
+	stale := false
+	for _, id := range ids {
+		doc, err := col.GetByID(ctx, id)
+		if err != nil {
+			stale = true
+			continue
+		}
+		items = append(items, vecItemFromDocument(doc))
+	}
+
+	return items, stale, nil
+}
+
+func (vs *VecStore) exportedCollectionIDs(db *chromem.DB) ([]string, error) {
+	var buf bytes.Buffer
+	if err := db.ExportToWriter(&buf, false, "", vs.tableName); err != nil {
+		return nil, fmt.Errorf("export collection: %w", err)
+	}
+
+	type persistenceCollection struct {
+		Name      string
+		Metadata  map[string]string
+		Documents map[string]*chromem.Document
+	}
+	persistenceDB := struct {
+		Collections map[string]*persistenceCollection
+	}{}
+
+	if err := gob.NewDecoder(&buf).Decode(&persistenceDB); err != nil {
+		return nil, fmt.Errorf("decode collection export: %w", err)
+	}
+
+	pc, ok := persistenceDB.Collections[vs.tableName]
+	if !ok || len(pc.Documents) == 0 {
+		return nil, nil
+	}
+
+	ids := make([]string, 0, len(pc.Documents))
+	for id := range pc.Documents {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return lessDocumentID(ids[i], ids[j])
+	})
+
+	return ids, nil
+}
+
+func (vs *VecStore) openRegistry() (*sql.DB, func() error, error) {
+	if vs.legacyDB != nil {
+		return vs.legacyDB, func() error { return nil }, nil
+	}
+	if vs.persistPath == "" {
+		return nil, nil, nil
+	}
+
+	wrapper, err := pkgsqlite.Open(pkgsqlite.DefaultConfig(filepath.Join(filepath.Clean(vs.persistPath), vecRegistryFilename)))
+	if err != nil {
+		return nil, nil, fmt.Errorf("open vec registry: %w", err)
+	}
+
+	return wrapper.DB, wrapper.Close, nil
+}
+
+func (vs *VecStore) ensureRegistrySchema(ctx context.Context) (*sql.DB, func() error, error) {
+	db, closeFn, err := vs.openRegistry()
+	if err != nil || db == nil {
+		return db, closeFn, err
+	}
+
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+		collection_name TEXT NOT NULL,
+		doc_id TEXT NOT NULL,
+		is_numeric INTEGER NOT NULL DEFAULT 0,
+		numeric_id INTEGER,
+		PRIMARY KEY (collection_name, doc_id)
+	)`, vecRegistryTable)); err != nil {
+		_ = closeFn()
+		return nil, nil, fmt.Errorf("create vec registry table: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		"CREATE INDEX IF NOT EXISTS idx_%s_collection_order ON %s (collection_name, is_numeric DESC, numeric_id ASC, doc_id ASC)",
+		vecRegistryTable, vecRegistryTable,
+	)); err != nil {
+		_ = closeFn()
+		return nil, nil, fmt.Errorf("create vec registry index: %w", err)
+	}
+
+	return db, closeFn, nil
+}
+
+func (vs *VecStore) upsertRegistryIDs(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	db, closeFn, err := vs.ensureRegistrySchema(ctx)
+	if err != nil {
+		return err
+	}
+	if closeFn != nil {
+		defer closeFn()
+	}
+	if db == nil {
+		vs.mu.Lock()
+		if vs.ephemeralRegistry == nil {
+			vs.ephemeralRegistry = make(map[string]struct{}, len(ids))
+		}
+		for _, id := range ids {
+			vs.ephemeralRegistry[id] = struct{}{}
+		}
+		vs.mu.Unlock()
+		return nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin vec registry tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
+		"INSERT INTO %s (collection_name, doc_id, is_numeric, numeric_id) VALUES (?, ?, ?, ?) "+
+			"ON CONFLICT(collection_name, doc_id) DO UPDATE SET is_numeric = excluded.is_numeric, numeric_id = excluded.numeric_id",
+		vecRegistryTable,
+	))
+	if err != nil {
+		return fmt.Errorf("prepare vec registry upsert: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, id := range ids {
+		isNumeric, numericID := registryIDOrder(id)
+		if _, err := stmt.ExecContext(ctx, vs.tableName, id, isNumeric, numericID); err != nil {
+			return fmt.Errorf("upsert vec registry id %q: %w", id, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit vec registry tx: %w", err)
+	}
+	return nil
+}
+
+func (vs *VecStore) deleteRegistryIDs(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	db, closeFn, err := vs.ensureRegistrySchema(ctx)
+	if err != nil {
+		return err
+	}
+	if closeFn != nil {
+		defer closeFn()
+	}
+	if db == nil {
+		vs.mu.Lock()
+		for _, id := range ids {
+			delete(vs.ephemeralRegistry, id)
+		}
+		vs.mu.Unlock()
+		return nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin vec registry delete tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
+		"DELETE FROM %s WHERE collection_name = ? AND doc_id = ?",
+		vecRegistryTable,
+	))
+	if err != nil {
+		return fmt.Errorf("prepare vec registry delete: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, id := range ids {
+		if _, err := stmt.ExecContext(ctx, vs.tableName, id); err != nil {
+			return fmt.Errorf("delete vec registry id %q: %w", id, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit vec registry delete tx: %w", err)
+	}
+	return nil
+}
+
+func (vs *VecStore) clearRegistry(ctx context.Context) error {
+	db, closeFn, err := vs.ensureRegistrySchema(ctx)
+	if err != nil {
+		return err
+	}
+	if closeFn != nil {
+		defer closeFn()
+	}
+	if db == nil {
+		vs.mu.Lock()
+		vs.ephemeralRegistry = nil
+		vs.mu.Unlock()
+		return nil
+	}
+
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		"DELETE FROM %s WHERE collection_name = ?",
+		vecRegistryTable,
+	), vs.tableName); err != nil {
+		return fmt.Errorf("clear vec registry: %w", err)
+	}
+	return nil
+}
+
+func (vs *VecStore) replaceRegistryIDs(ctx context.Context, ids []string) error {
+	db, closeFn, err := vs.ensureRegistrySchema(ctx)
+	if err != nil {
+		return err
+	}
+	if closeFn != nil {
+		defer closeFn()
+	}
+	if db == nil {
+		vs.mu.Lock()
+		if len(ids) == 0 {
+			vs.ephemeralRegistry = nil
+		} else {
+			vs.ephemeralRegistry = make(map[string]struct{}, len(ids))
+			for _, id := range ids {
+				vs.ephemeralRegistry[id] = struct{}{}
+			}
+		}
+		vs.mu.Unlock()
+		return nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin vec registry rebuild tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+		"DELETE FROM %s WHERE collection_name = ?",
+		vecRegistryTable,
+	), vs.tableName); err != nil {
+		return fmt.Errorf("clear vec registry before rebuild: %w", err)
+	}
+
+	stmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
+		"INSERT INTO %s (collection_name, doc_id, is_numeric, numeric_id) VALUES (?, ?, ?, ?)",
+		vecRegistryTable,
+	))
+	if err != nil {
+		return fmt.Errorf("prepare vec registry rebuild: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, id := range ids {
+		isNumeric, numericID := registryIDOrder(id)
+		if _, err := stmt.ExecContext(ctx, vs.tableName, id, isNumeric, numericID); err != nil {
+			return fmt.Errorf("rebuild vec registry id %q: %w", id, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit vec registry rebuild tx: %w", err)
+	}
+	return nil
+}
+
+func (vs *VecStore) registryCount(ctx context.Context) (int, error) {
+	db, closeFn, err := vs.ensureRegistrySchema(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if closeFn != nil {
+		defer closeFn()
+	}
+	if db == nil {
+		vs.mu.Lock()
+		defer vs.mu.Unlock()
+		return len(vs.ephemeralRegistry), nil
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(
+		"SELECT COUNT(*) FROM %s WHERE collection_name = ?",
+		vecRegistryTable,
+	), vs.tableName).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count vec registry: %w", err)
+	}
+	return count, nil
+}
+
+func (vs *VecStore) listRegistryIDs(ctx context.Context, limit int) ([]string, error) {
+	db, closeFn, err := vs.ensureRegistrySchema(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if closeFn != nil {
+		defer closeFn()
+	}
+	if db == nil {
+		vs.mu.Lock()
+		ids := make([]string, 0, len(vs.ephemeralRegistry))
+		for id := range vs.ephemeralRegistry {
+			ids = append(ids, id)
+		}
+		vs.mu.Unlock()
+
+		sort.Slice(ids, func(i, j int) bool {
+			return lessDocumentID(ids[i], ids[j])
+		})
+		if limit > 0 && limit < len(ids) {
+			ids = ids[:limit]
+		}
+		return ids, nil
+	}
+
+	query := fmt.Sprintf(
+		"SELECT doc_id FROM %s WHERE collection_name = ? ORDER BY is_numeric DESC, numeric_id ASC, doc_id ASC",
+		vecRegistryTable,
+	)
+	args := []any{vs.tableName}
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list vec registry ids: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan vec registry id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate vec registry ids: %w", err)
+	}
+
+	return ids, nil
+}
+
+func registryIDOrder(docID string) (int, sql.NullInt64) {
+	numericID, ok := numericDocumentID(docID)
+	if !ok {
+		return 0, sql.NullInt64{}
+	}
+
+	return 1, sql.NullInt64{Int64: numericID, Valid: true}
+}

--- a/pkg/vec/registry_test.go
+++ b/pkg/vec/registry_test.go
@@ -1,0 +1,339 @@
+package vec
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	pkgsqlite "github.com/1024XEngineer/anyclaw/pkg/sqlite"
+	chromem "github.com/philippgille/chromem-go"
+)
+
+func TestRegistryEphemeralLifecycle(t *testing.T) {
+	ctx := context.Background()
+	vs := &VecStore{tableName: "ephemeral_registry"}
+
+	db, closeFn, err := vs.openRegistry()
+	if err != nil {
+		t.Fatalf("open ephemeral registry: %v", err)
+	}
+	if db != nil || closeFn != nil {
+		t.Fatalf("expected ephemeral registry to use in-memory map only, got db=%v closeFnNil=%t", db, closeFn == nil)
+	}
+
+	if err := vs.upsertRegistryIDs(ctx, nil); err != nil {
+		t.Fatalf("upsert empty registry ids: %v", err)
+	}
+	if err := vs.upsertRegistryIDs(ctx, []string{"10", "2", "doc"}); err != nil {
+		t.Fatalf("upsert registry ids: %v", err)
+	}
+
+	ids, err := vs.listRegistryIDs(ctx, 0)
+	if err != nil {
+		t.Fatalf("list registry ids: %v", err)
+	}
+	if want := []string{"2", "10", "doc"}; !reflect.DeepEqual(ids, want) {
+		t.Fatalf("expected registry ids %v, got %v", want, ids)
+	}
+
+	limited, err := vs.listRegistryIDs(ctx, 2)
+	if err != nil {
+		t.Fatalf("list limited registry ids: %v", err)
+	}
+	if want := []string{"2", "10"}; !reflect.DeepEqual(limited, want) {
+		t.Fatalf("expected limited registry ids %v, got %v", want, limited)
+	}
+
+	count, err := vs.registryCount(ctx)
+	if err != nil {
+		t.Fatalf("registry count: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("expected 3 registry ids, got %d", count)
+	}
+
+	if err := vs.deleteRegistryIDs(ctx, nil); err != nil {
+		t.Fatalf("delete empty registry ids: %v", err)
+	}
+	if err := vs.deleteRegistryIDs(ctx, []string{"10"}); err != nil {
+		t.Fatalf("delete registry id: %v", err)
+	}
+
+	ids, err = vs.listRegistryIDs(ctx, 0)
+	if err != nil {
+		t.Fatalf("list registry ids after delete: %v", err)
+	}
+	if want := []string{"2", "doc"}; !reflect.DeepEqual(ids, want) {
+		t.Fatalf("expected registry ids after delete %v, got %v", want, ids)
+	}
+
+	if err := vs.replaceRegistryIDs(ctx, []string{"z", "1"}); err != nil {
+		t.Fatalf("replace registry ids: %v", err)
+	}
+
+	ids, err = vs.listRegistryIDs(ctx, 0)
+	if err != nil {
+		t.Fatalf("list registry ids after replace: %v", err)
+	}
+	if want := []string{"1", "z"}; !reflect.DeepEqual(ids, want) {
+		t.Fatalf("expected registry ids after replace %v, got %v", want, ids)
+	}
+
+	if err := vs.clearRegistry(ctx); err != nil {
+		t.Fatalf("clear registry: %v", err)
+	}
+	if err := vs.replaceRegistryIDs(ctx, nil); err != nil {
+		t.Fatalf("replace empty registry ids: %v", err)
+	}
+
+	count, err = vs.registryCount(ctx)
+	if err != nil {
+		t.Fatalf("registry count after clear: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected empty registry after clear, got %d", count)
+	}
+}
+
+func TestRegistryLifecycleWithLegacyDB(t *testing.T) {
+	ctx := context.Background()
+	db, err := pkgsqlite.Open(pkgsqlite.InMemoryConfig())
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	vs := &VecStore{
+		tableName: "legacy_registry",
+		legacyDB:  db.DB,
+	}
+
+	registryDB, closeFn, err := vs.openRegistry()
+	if err != nil {
+		t.Fatalf("open legacy registry: %v", err)
+	}
+	if registryDB != db.DB {
+		t.Fatalf("expected legacy registry to reuse sqlite db")
+	}
+	if closeFn == nil {
+		t.Fatal("expected legacy registry closeFn")
+	}
+	if err := closeFn(); err != nil {
+		t.Fatalf("close legacy registry no-op: %v", err)
+	}
+
+	if err := vs.upsertRegistryIDs(ctx, []string{"20", "3", "doc"}); err != nil {
+		t.Fatalf("upsert legacy registry ids: %v", err)
+	}
+
+	ids, err := vs.listRegistryIDs(ctx, 0)
+	if err != nil {
+		t.Fatalf("list legacy registry ids: %v", err)
+	}
+	if want := []string{"3", "20", "doc"}; !reflect.DeepEqual(ids, want) {
+		t.Fatalf("expected legacy registry ids %v, got %v", want, ids)
+	}
+
+	if err := vs.clearRegistry(ctx); err != nil {
+		t.Fatalf("clear legacy registry: %v", err)
+	}
+	count, err := vs.registryCount(ctx)
+	if err != nil {
+		t.Fatalf("legacy registry count after clear: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected empty legacy registry after clear, got %d", count)
+	}
+}
+
+func TestOpenRegistryPersistentPathError(t *testing.T) {
+	ctx := context.Background()
+	blockedPath := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blockedPath, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("write blocking file: %v", err)
+	}
+
+	vs := &VecStore{
+		tableName:   "broken_registry",
+		persistPath: blockedPath,
+	}
+
+	db, closeFn, err := vs.openRegistry()
+	if err == nil {
+		t.Fatal("expected persistent registry open to fail for file path")
+	}
+	if db != nil || closeFn != nil {
+		t.Fatalf("expected failed registry open to return nil handles, got db=%v closeFnNil=%t", db, closeFn == nil)
+	}
+
+	db, closeFn, err = vs.ensureRegistrySchema(ctx)
+	if err == nil {
+		t.Fatal("expected ensureRegistrySchema to fail when registry open fails")
+	}
+	if db != nil || closeFn != nil {
+		t.Fatalf("expected failed schema setup to return nil handles, got db=%v closeFnNil=%t", db, closeFn == nil)
+	}
+}
+
+func TestRegistryEnsureUpToDateAndListItems(t *testing.T) {
+	ctx := context.Background()
+	path := t.TempDir()
+
+	db, err := chromem.NewPersistentDB(path, false)
+	if err != nil {
+		t.Fatalf("open persistent chromem db: %v", err)
+	}
+
+	col, err := db.CreateCollection("registry_docs", map[string]string{
+		"distance":   "cosine",
+		"dimensions": "2",
+		"backend":    "chromem-go",
+	}, nil)
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+
+	if err := col.AddDocuments(ctx, []chromem.Document{
+		{ID: "10", Embedding: normalized([]float32{1, 0})},
+		{ID: "2", Embedding: normalized([]float32{0, 1})},
+		{ID: "doc", Embedding: normalized([]float32{1, 1})},
+	}, 1); err != nil {
+		t.Fatalf("seed collection: %v", err)
+	}
+
+	vs := &VecStore{
+		tableName:   "registry_docs",
+		persistPath: path,
+	}
+
+	if err := vs.ensureRegistryUpToDate(ctx, db, col.Count()); err != nil {
+		t.Fatalf("ensure registry up to date: %v", err)
+	}
+	if err := vs.ensureRegistryUpToDate(ctx, db, col.Count()); err != nil {
+		t.Fatalf("ensure registry up to date no-op: %v", err)
+	}
+
+	exportedIDs, err := vs.exportedCollectionIDs(db)
+	if err != nil {
+		t.Fatalf("exported collection ids: %v", err)
+	}
+	if want := []string{"2", "10", "doc"}; !reflect.DeepEqual(exportedIDs, want) {
+		t.Fatalf("expected exported ids %v, got %v", want, exportedIDs)
+	}
+
+	items, stale, err := vs.listItemsFromRegistry(ctx, col, 2)
+	if err != nil {
+		t.Fatalf("list items from registry: %v", err)
+	}
+	if stale {
+		t.Fatal("expected fresh registry items, got stale")
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 listed items, got %d", len(items))
+	}
+	if items[0].RowID != 2 || items[1].RowID != 10 {
+		t.Fatalf("expected sorted registry items [2 10], got %+v", items)
+	}
+}
+
+func TestListItemsFromRegistryMarksStale(t *testing.T) {
+	ctx := context.Background()
+	db := chromem.NewDB()
+
+	col, err := db.CreateCollection("stale_registry_docs", nil, nil)
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if err := col.AddDocument(ctx, chromem.Document{
+		ID:        "1",
+		Embedding: normalized([]float32{1, 0}),
+	}); err != nil {
+		t.Fatalf("seed collection: %v", err)
+	}
+
+	vs := &VecStore{tableName: "stale_registry_docs"}
+	if err := vs.replaceRegistryIDs(ctx, []string{"1", "missing"}); err != nil {
+		t.Fatalf("replace registry ids: %v", err)
+	}
+
+	items, stale, err := vs.listItemsFromRegistry(ctx, col, 10)
+	if err != nil {
+		t.Fatalf("list items from stale registry: %v", err)
+	}
+	if !stale {
+		t.Fatal("expected stale registry to be detected")
+	}
+	if len(items) != 1 || items[0].RowID != 1 {
+		t.Fatalf("expected only existing registry item to be returned, got %+v", items)
+	}
+}
+
+func TestExportedCollectionIDsMissingCollection(t *testing.T) {
+	vs := &VecStore{tableName: "missing_registry_docs"}
+
+	ids, err := vs.exportedCollectionIDs(chromem.NewDB())
+	if err != nil {
+		t.Fatalf("export missing collection ids: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected no ids for missing collection, got %v", ids)
+	}
+}
+
+func TestRegistryMethodsPropagateSchemaErrors(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := pkgsqlite.Open(pkgsqlite.InMemoryConfig())
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	_ = sqliteDB.Close()
+
+	vs := &VecStore{
+		tableName: "broken_registry_methods",
+		legacyDB:  sqliteDB.DB,
+	}
+
+	if db, closeFn, err := vs.ensureRegistrySchema(ctx); err == nil {
+		t.Fatal("expected ensureRegistrySchema to fail on closed legacy db")
+	} else if db != nil || closeFn != nil {
+		t.Fatalf("expected failed schema setup to return nil handles, got db=%v closeFnNil=%t", db, closeFn == nil)
+	}
+
+	if err := vs.upsertRegistryIDs(ctx, []string{"1"}); err == nil {
+		t.Fatal("expected upsertRegistryIDs to fail on closed legacy db")
+	}
+	if err := vs.deleteRegistryIDs(ctx, []string{"1"}); err == nil {
+		t.Fatal("expected deleteRegistryIDs to fail on closed legacy db")
+	}
+	if err := vs.clearRegistry(ctx); err == nil {
+		t.Fatal("expected clearRegistry to fail on closed legacy db")
+	}
+	if _, err := vs.registryCount(ctx); err == nil {
+		t.Fatal("expected registryCount to fail on closed legacy db")
+	}
+	if _, err := vs.listRegistryIDs(ctx, 1); err == nil {
+		t.Fatal("expected listRegistryIDs to fail on closed legacy db")
+	}
+
+	chromemDB := chromem.NewDB()
+	col, err := chromemDB.CreateCollection("broken_registry_methods", nil, nil)
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+
+	if _, stale, err := vs.listItemsFromRegistry(ctx, col, 1); err == nil {
+		t.Fatal("expected listItemsFromRegistry to fail when registry lookup fails")
+	} else if stale {
+		t.Fatal("expected stale=false when listItemsFromRegistry fails before lookup")
+	}
+	if err := vs.ensureRegistryUpToDate(ctx, chromemDB, 1); err == nil {
+		t.Fatal("expected ensureRegistryUpToDate to fail when registry count fails")
+	}
+	if err := vs.rebuildRegistry(ctx, chromemDB); err == nil {
+		t.Fatal("expected rebuildRegistry to fail when registry replacement fails")
+	}
+}

--- a/pkg/vec/store.go
+++ b/pkg/vec/store.go
@@ -1,14 +1,11 @@
 package vec
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"encoding/binary"
-	"encoding/gob"
 	"fmt"
 	"math"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -43,6 +40,8 @@ type VecStore struct {
 	mu         sync.Mutex
 	chromemDB  *chromem.DB
 	collection *chromem.Collection
+
+	ephemeralRegistry map[string]struct{}
 }
 
 type VecStoreConfig struct {
@@ -100,6 +99,10 @@ func (vs *VecStore) Insert(ctx context.Context, id any, vector []float32, metada
 		return fmt.Errorf("insert vector: %w", err)
 	}
 
+	if err := vs.upsertRegistryIDs(ctx, []string{docID}); err != nil {
+		return fmt.Errorf("update vector registry: %w", err)
+	}
+
 	return nil
 }
 
@@ -133,6 +136,14 @@ func (vs *VecStore) InsertBatch(ctx context.Context, items []VecItem) error {
 
 	if err := col.AddDocuments(ctx, docs, 1); err != nil {
 		return fmt.Errorf("insert batch: %w", err)
+	}
+
+	docIDs := make([]string, 0, len(docs))
+	for _, doc := range docs {
+		docIDs = append(docIDs, doc.ID)
+	}
+	if err := vs.upsertRegistryIDs(ctx, docIDs); err != nil {
+		return fmt.Errorf("update vector registry: %w", err)
 	}
 
 	return nil
@@ -221,6 +232,10 @@ func (vs *VecStore) Delete(ctx context.Context, id any) error {
 		return fmt.Errorf("delete vector item: %w", err)
 	}
 
+	if err := vs.deleteRegistryIDs(ctx, []string{docID}); err != nil {
+		return fmt.Errorf("delete vector registry item: %w", err)
+	}
+
 	return nil
 }
 
@@ -268,86 +283,67 @@ func (vs *VecStore) Count(ctx context.Context) (int64, error) {
 }
 
 func (vs *VecStore) List(ctx context.Context, limit int) ([]VecItem, error) {
-	_ = ctx
-
 	db, err := vs.ensureDB()
 	if err != nil {
 		return nil, err
 	}
-	if _, err := vs.ensureCollection(context.Background(), false); err != nil {
+	col, err := vs.ensureCollection(ctx, false)
+	if err != nil {
 		return nil, err
 	}
 
-	var buf bytes.Buffer
-	if err := db.ExportToWriter(&buf, false, "", vs.tableName); err != nil {
-		return nil, fmt.Errorf("export collection: %w", err)
-	}
-
-	type persistenceCollection struct {
-		Name      string
-		Metadata  map[string]string
-		Documents map[string]*chromem.Document
-	}
-	persistenceDB := struct {
-		Collections map[string]*persistenceCollection
-	}{}
-
-	if err := gob.NewDecoder(&buf).Decode(&persistenceDB); err != nil {
-		return nil, fmt.Errorf("decode collection export: %w", err)
-	}
-
-	pc, ok := persistenceDB.Collections[vs.tableName]
-	if !ok || len(pc.Documents) == 0 {
+	count := col.Count()
+	if count == 0 {
 		return nil, nil
 	}
 
-	ids := make([]string, 0, len(pc.Documents))
-	for id := range pc.Documents {
-		ids = append(ids, id)
-	}
-	sort.Slice(ids, func(i, j int) bool {
-		return lessDocumentID(ids[i], ids[j])
-	})
-
-	if limit > 0 && limit < len(ids) {
-		ids = ids[:limit]
+	if err := vs.ensureRegistryUpToDate(ctx, db, count); err != nil {
+		return nil, err
 	}
 
-	items := make([]VecItem, 0, len(ids))
-	for _, id := range ids {
-		doc := pc.Documents[id]
-		if doc == nil {
-			continue
-		}
-		items = append(items, vecItemFromDocument(*doc))
+	items, stale, err := vs.listItemsFromRegistry(ctx, col, limit)
+	if err != nil {
+		return nil, err
+	}
+	if !stale {
+		return items, nil
 	}
 
-	return items, nil
+	if err := vs.rebuildRegistry(ctx, db); err != nil {
+		return nil, err
+	}
+	items, _, err = vs.listItemsFromRegistry(ctx, col, limit)
+	return items, err
 }
 
 func (vs *VecStore) Drop(ctx context.Context) error {
-	_ = ctx
-
 	vs.mu.Lock()
-	defer vs.mu.Unlock()
-
 	if err := vs.validateTableName(); err != nil {
+		vs.mu.Unlock()
 		return err
 	}
 
 	if vs.chromemDB == nil {
 		db, err := vs.openDB()
 		if err != nil {
+			vs.mu.Unlock()
 			return err
 		}
 		vs.chromemDB = db
 	}
 
 	if err := vs.chromemDB.DeleteCollection(vs.tableName); err != nil {
+		vs.mu.Unlock()
 		return fmt.Errorf("drop vector collection: %w", err)
 	}
 
 	vs.collection = nil
+	vs.ephemeralRegistry = nil
+	vs.mu.Unlock()
+
+	if err := vs.clearRegistry(ctx); err != nil {
+		return fmt.Errorf("drop vector registry: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/vec/store.go
+++ b/pkg/vec/store.go
@@ -1,0 +1,663 @@
+package vec
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"encoding/gob"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	chromem "github.com/philippgille/chromem-go"
+)
+
+type DistanceMetric string
+
+const (
+	DistanceCosine DistanceMetric = "cosine"
+	DistanceL2     DistanceMetric = "l2"
+)
+
+const vecBackendVersion = "chromem-go"
+
+var (
+	inMemoryDBsMu sync.Mutex
+	inMemoryDBs   = make(map[string]*chromem.DB)
+)
+
+type VecStore struct {
+	legacyDB    *sql.DB
+	tableName   string
+	dimensions  int
+	distance    DistanceMetric
+	metadata    []string
+	auxColumns  []string
+	persistPath string
+	compress    bool
+
+	mu         sync.Mutex
+	chromemDB  *chromem.DB
+	collection *chromem.Collection
+}
+
+type VecStoreConfig struct {
+	DB          *sql.DB
+	TableName   string
+	Dimensions  int
+	Distance    DistanceMetric
+	Metadata    []string
+	AuxColumns  []string
+	PersistPath string
+	Compress    bool
+}
+
+func NewVecStore(cfg VecStoreConfig) *VecStore {
+	if cfg.Distance == "" {
+		cfg.Distance = DistanceCosine
+	}
+	return &VecStore{
+		legacyDB:    cfg.DB,
+		tableName:   cfg.TableName,
+		dimensions:  cfg.Dimensions,
+		distance:    cfg.Distance,
+		metadata:    append([]string(nil), cfg.Metadata...),
+		auxColumns:  append([]string(nil), cfg.AuxColumns...),
+		persistPath: strings.TrimSpace(cfg.PersistPath),
+		compress:    cfg.Compress,
+	}
+}
+
+func (vs *VecStore) Init(ctx context.Context) error {
+	_, err := vs.ensureCollection(ctx, true)
+	return err
+}
+
+func (vs *VecStore) Insert(ctx context.Context, id any, vector []float32, metadata map[string]string) error {
+	col, err := vs.ensureCollection(ctx, true)
+	if err != nil {
+		return err
+	}
+	if err := vs.validateVector(vector); err != nil {
+		return err
+	}
+
+	docID, err := normalizeID(id)
+	if err != nil {
+		return err
+	}
+
+	err = col.AddDocument(ctx, chromem.Document{
+		ID:        docID,
+		Metadata:  sanitizeMetadata(vs.metadata, metadata),
+		Embedding: cloneVector(vector),
+	})
+	if err != nil {
+		return fmt.Errorf("insert vector: %w", err)
+	}
+
+	return nil
+}
+
+func (vs *VecStore) InsertBatch(ctx context.Context, items []VecItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	col, err := vs.ensureCollection(ctx, true)
+	if err != nil {
+		return err
+	}
+
+	docs := make([]chromem.Document, 0, len(items))
+	for _, item := range items {
+		if err := vs.validateVector(item.Vector); err != nil {
+			return fmt.Errorf("vector dimension mismatch for id %v: %w", item.ID, err)
+		}
+
+		docID, err := normalizeID(item.ID)
+		if err != nil {
+			return err
+		}
+
+		docs = append(docs, chromem.Document{
+			ID:        docID,
+			Metadata:  sanitizeMetadata(vs.metadata, item.Metadata),
+			Embedding: cloneVector(item.Vector),
+		})
+	}
+
+	if err := col.AddDocuments(ctx, docs, 1); err != nil {
+		return fmt.Errorf("insert batch: %w", err)
+	}
+
+	return nil
+}
+
+func (vs *VecStore) Search(ctx context.Context, queryVector []float32, limit int) ([]VecSearchResult, error) {
+	return vs.SearchWithFilter(ctx, queryVector, limit, 0, nil)
+}
+
+func (vs *VecStore) SearchWithFilter(ctx context.Context, queryVector []float32, limit int, threshold float64, metadataFilter map[string]string) ([]VecSearchResult, error) {
+	col, err := vs.ensureCollection(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	if err := vs.validateVector(queryVector); err != nil {
+		return nil, fmt.Errorf("query vector dimension mismatch: %w", err)
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+
+	count := col.Count()
+	if count == 0 {
+		return nil, nil
+	}
+	if limit > count {
+		limit = count
+	}
+
+	results, err := col.QueryEmbedding(ctx, cloneVector(queryVector), limit, metadataFilter, nil)
+	if err != nil {
+		return nil, fmt.Errorf("vector search: %w", err)
+	}
+
+	out := make([]VecSearchResult, 0, len(results))
+	for _, result := range results {
+		distance := 1.0 - float64(result.Similarity)
+		if threshold > 0 && distance > threshold {
+			continue
+		}
+
+		rowID, typedID := decodeID(result.ID)
+		out = append(out, VecSearchResult{
+			RowID:    rowID,
+			ID:       typedID,
+			Distance: distance,
+			Metadata: metadataToAny(result.Metadata),
+		})
+	}
+
+	return out, nil
+}
+
+func (vs *VecStore) Get(ctx context.Context, id any) (*VecItem, error) {
+	col, err := vs.ensureCollection(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+
+	docID, err := normalizeID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	doc, err := col.GetByID(ctx, docID)
+	if err != nil {
+		return nil, fmt.Errorf("get vector item: %w", err)
+	}
+
+	item := vecItemFromDocument(doc)
+	return &item, nil
+}
+
+func (vs *VecStore) Delete(ctx context.Context, id any) error {
+	col, err := vs.ensureCollection(ctx, false)
+	if err != nil {
+		return err
+	}
+
+	docID, err := normalizeID(id)
+	if err != nil {
+		return err
+	}
+
+	if err := col.Delete(ctx, nil, nil, docID); err != nil {
+		return fmt.Errorf("delete vector item: %w", err)
+	}
+
+	return nil
+}
+
+func (vs *VecStore) UpdateVector(ctx context.Context, id any, vector []float32) error {
+	if err := vs.validateVector(vector); err != nil {
+		return err
+	}
+
+	item, err := vs.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	return vs.Insert(ctx, item.ID, vector, item.Metadata)
+}
+
+func (vs *VecStore) UpdateMetadata(ctx context.Context, id any, metadata map[string]string) error {
+	if len(metadata) == 0 {
+		return nil
+	}
+
+	item, err := vs.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if item.Metadata == nil {
+		item.Metadata = make(map[string]string)
+	}
+	for _, key := range vs.metadata {
+		if value, ok := metadata[key]; ok {
+			item.Metadata[key] = value
+		}
+	}
+
+	return vs.Insert(ctx, item.ID, item.Vector, item.Metadata)
+}
+
+func (vs *VecStore) Count(ctx context.Context) (int64, error) {
+	col, err := vs.ensureCollection(ctx, false)
+	if err != nil {
+		return 0, err
+	}
+	return int64(col.Count()), nil
+}
+
+func (vs *VecStore) List(ctx context.Context, limit int) ([]VecItem, error) {
+	_ = ctx
+
+	db, err := vs.ensureDB()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := vs.ensureCollection(context.Background(), false); err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := db.ExportToWriter(&buf, false, "", vs.tableName); err != nil {
+		return nil, fmt.Errorf("export collection: %w", err)
+	}
+
+	type persistenceCollection struct {
+		Name      string
+		Metadata  map[string]string
+		Documents map[string]*chromem.Document
+	}
+	persistenceDB := struct {
+		Collections map[string]*persistenceCollection
+	}{}
+
+	if err := gob.NewDecoder(&buf).Decode(&persistenceDB); err != nil {
+		return nil, fmt.Errorf("decode collection export: %w", err)
+	}
+
+	pc, ok := persistenceDB.Collections[vs.tableName]
+	if !ok || len(pc.Documents) == 0 {
+		return nil, nil
+	}
+
+	ids := make([]string, 0, len(pc.Documents))
+	for id := range pc.Documents {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	if limit > 0 && limit < len(ids) {
+		ids = ids[:limit]
+	}
+
+	items := make([]VecItem, 0, len(ids))
+	for _, id := range ids {
+		doc := pc.Documents[id]
+		if doc == nil {
+			continue
+		}
+		items = append(items, vecItemFromDocument(*doc))
+	}
+
+	return items, nil
+}
+
+func (vs *VecStore) Drop(ctx context.Context) error {
+	_ = ctx
+
+	vs.mu.Lock()
+	defer vs.mu.Unlock()
+
+	if err := vs.validateTableName(); err != nil {
+		return err
+	}
+
+	if vs.chromemDB == nil {
+		db, err := vs.openDB()
+		if err != nil {
+			return err
+		}
+		vs.chromemDB = db
+	}
+
+	if err := vs.chromemDB.DeleteCollection(vs.tableName); err != nil {
+		return fmt.Errorf("drop vector collection: %w", err)
+	}
+
+	vs.collection = nil
+	return nil
+}
+
+func (vs *VecStore) VecVersion(ctx context.Context) (string, error) {
+	_, err := vs.ensureCollection(ctx, false)
+	if err != nil {
+		return "", err
+	}
+	return vecBackendVersion, nil
+}
+
+func (vs *VecStore) TableInfo(ctx context.Context) (*VecTableInfo, error) {
+	count, err := vs.Count(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VecTableInfo{
+		TableName:   vs.tableName,
+		Dimensions:  vs.dimensions,
+		Distance:    string(vs.distance),
+		VectorCount: count,
+		VecVersion:  vecBackendVersion,
+	}, nil
+}
+
+type VecItem struct {
+	RowID    int64
+	ID       any
+	Vector   []float32
+	Metadata map[string]string
+}
+
+type VecSearchResult struct {
+	RowID    int64
+	ID       any
+	Distance float64
+	Metadata map[string]any
+}
+
+type VecTableInfo struct {
+	TableName   string `json:"table_name"`
+	Dimensions  int    `json:"dimensions"`
+	Distance    string `json:"distance"`
+	VectorCount int64  `json:"vector_count"`
+	VecVersion  string `json:"vec_version"`
+}
+
+func (vs *VecStore) ensureDB() (*chromem.DB, error) {
+	vs.mu.Lock()
+	defer vs.mu.Unlock()
+	return vs.ensureDBLocked()
+}
+
+func (vs *VecStore) ensureDBLocked() (*chromem.DB, error) {
+	if vs.chromemDB != nil {
+		return vs.chromemDB, nil
+	}
+
+	db, err := vs.openDB()
+	if err != nil {
+		return nil, err
+	}
+
+	vs.chromemDB = db
+	return db, nil
+}
+
+func (vs *VecStore) openDB() (*chromem.DB, error) {
+	if key := vs.sharedDBKey(); key != "" {
+		inMemoryDBsMu.Lock()
+		defer inMemoryDBsMu.Unlock()
+
+		if db, ok := inMemoryDBs[key]; ok {
+			return db, nil
+		}
+
+		db := chromem.NewDB()
+		inMemoryDBs[key] = db
+		return db, nil
+	}
+
+	if vs.persistPath == "" {
+		return chromem.NewDB(), nil
+	}
+
+	db, err := chromem.NewPersistentDB(vs.persistPath, vs.compress)
+	if err != nil {
+		return nil, fmt.Errorf("open chromem db: %w", err)
+	}
+
+	return db, nil
+}
+
+func (vs *VecStore) sharedDBKey() string {
+	if vs.persistPath != "" || vs.legacyDB == nil {
+		return ""
+	}
+	return fmt.Sprintf("sql:%p", vs.legacyDB)
+}
+
+func (vs *VecStore) ensureCollection(ctx context.Context, create bool) (*chromem.Collection, error) {
+	vs.mu.Lock()
+	defer vs.mu.Unlock()
+
+	if err := vs.validateTableName(); err != nil {
+		return nil, err
+	}
+	if err := vs.validateDistance(); err != nil {
+		return nil, err
+	}
+	if create {
+		if err := vs.validateDimensions(); err != nil {
+			return nil, err
+		}
+	}
+
+	if vs.collection != nil {
+		return vs.collection, nil
+	}
+
+	db, err := vs.ensureDBLocked()
+	if err != nil {
+		return nil, err
+	}
+
+	collection := db.GetCollection(vs.tableName, nil)
+	if collection == nil {
+		if !create {
+			return nil, fmt.Errorf("vector collection %q not found", vs.tableName)
+		}
+
+		collection, err = db.CreateCollection(vs.tableName, vs.collectionMetadata(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("create vector collection: %w", err)
+		}
+	}
+
+	vs.collection = collection
+	return collection, nil
+}
+
+func (vs *VecStore) collectionMetadata() map[string]string {
+	return map[string]string{
+		"distance":   string(vs.distance),
+		"dimensions": strconv.Itoa(vs.dimensions),
+		"backend":    vecBackendVersion,
+	}
+}
+
+func (vs *VecStore) validateTableName() error {
+	if strings.TrimSpace(vs.tableName) == "" {
+		return fmt.Errorf("table name is required")
+	}
+	return nil
+}
+
+func (vs *VecStore) validateDimensions() error {
+	if vs.dimensions <= 0 {
+		return fmt.Errorf("dimensions must be positive")
+	}
+	return nil
+}
+
+func (vs *VecStore) validateDistance() error {
+	switch vs.distance {
+	case "", DistanceCosine:
+		return nil
+	case DistanceL2:
+		return fmt.Errorf("distance metric %q is unsupported by %s", vs.distance, vecBackendVersion)
+	default:
+		return fmt.Errorf("distance metric %q is unsupported", vs.distance)
+	}
+}
+
+func (vs *VecStore) validateVector(vector []float32) error {
+	if err := vs.validateDistance(); err != nil {
+		return err
+	}
+	if err := vs.validateDimensions(); err != nil {
+		return err
+	}
+	if len(vector) != vs.dimensions {
+		return fmt.Errorf("expected %d, got %d", vs.dimensions, len(vector))
+	}
+	return nil
+}
+
+func sanitizeMetadata(allowed []string, metadata map[string]string) map[string]string {
+	if len(allowed) == 0 {
+		if metadata == nil {
+			return nil
+		}
+		return cloneMetadata(metadata)
+	}
+
+	clean := make(map[string]string, len(allowed))
+	for _, key := range allowed {
+		clean[key] = metadata[key]
+	}
+	return clean
+}
+
+func cloneVector(v []float32) []float32 {
+	if v == nil {
+		return nil
+	}
+	out := make([]float32, len(v))
+	copy(out, v)
+	return out
+}
+
+func cloneMetadata(metadata map[string]string) map[string]string {
+	if metadata == nil {
+		return nil
+	}
+	out := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		out[key] = value
+	}
+	return out
+}
+
+func metadataToAny(metadata map[string]string) map[string]any {
+	if len(metadata) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(metadata))
+	for key, value := range metadata {
+		out[key] = value
+	}
+	return out
+}
+
+func normalizeID(id any) (string, error) {
+	if id == nil {
+		return "", fmt.Errorf("id is required")
+	}
+
+	switch value := id.(type) {
+	case string:
+		if strings.TrimSpace(value) == "" {
+			return "", fmt.Errorf("id is required")
+		}
+		return value, nil
+	default:
+		return fmt.Sprint(id), nil
+	}
+}
+
+func decodeID(id string) (int64, any) {
+	if rowID, err := strconv.ParseInt(id, 10, 64); err == nil {
+		return rowID, rowID
+	}
+	return 0, id
+}
+
+func vecItemFromDocument(doc chromem.Document) VecItem {
+	rowID, id := decodeID(doc.ID)
+	return VecItem{
+		RowID:    rowID,
+		ID:       id,
+		Vector:   cloneVector(doc.Embedding),
+		Metadata: cloneMetadata(doc.Metadata),
+	}
+}
+
+func vectorToBlob(v []float32) []byte {
+	blob := make([]byte, len(v)*4)
+	for i, f := range v {
+		binary.LittleEndian.PutUint32(blob[i*4:], math.Float32bits(f))
+	}
+	return blob
+}
+
+func blobToVector(blob []byte) []float32 {
+	n := len(blob) / 4
+	v := make([]float32, n)
+	for i := 0; i < n; i++ {
+		v[i] = math.Float32frombits(binary.LittleEndian.Uint32(blob[i*4:]))
+	}
+	return v
+}
+
+func CosineSimilarity(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, normA, normB float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		normA += float64(a[i]) * float64(a[i])
+		normB += float64(b[i]) * float64(b[i])
+	}
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
+}
+
+func CosineDistance(a, b []float32) float64 {
+	return 1.0 - CosineSimilarity(a, b)
+}
+
+func L2Distance(a, b []float32) float64 {
+	if len(a) != len(b) {
+		return math.MaxFloat64
+	}
+	var sum float64
+	for i := range a {
+		diff := float64(a[i]) - float64(b[i])
+		sum += diff * diff
+	}
+	return math.Sqrt(sum)
+}

--- a/pkg/vec/store.go
+++ b/pkg/vec/store.go
@@ -305,7 +305,9 @@ func (vs *VecStore) List(ctx context.Context, limit int) ([]VecItem, error) {
 	for id := range pc.Documents {
 		ids = append(ids, id)
 	}
-	sort.Strings(ids)
+	sort.Slice(ids, func(i, j int) bool {
+		return lessDocumentID(ids[i], ids[j])
+	})
 
 	if limit > 0 && limit < len(ids) {
 		ids = ids[:limit]
@@ -601,6 +603,28 @@ func decodeID(id string) (int64, any) {
 		return rowID, rowID
 	}
 	return 0, id
+}
+
+func lessDocumentID(left, right string) bool {
+	leftNum, leftIsNum := numericDocumentID(left)
+	rightNum, rightIsNum := numericDocumentID(right)
+
+	switch {
+	case leftIsNum && rightIsNum:
+		if leftNum != rightNum {
+			return leftNum < rightNum
+		}
+		return left < right
+	case leftIsNum != rightIsNum:
+		return leftIsNum
+	default:
+		return left < right
+	}
+}
+
+func numericDocumentID(id string) (int64, bool) {
+	rowID, err := strconv.ParseInt(id, 10, 64)
+	return rowID, err == nil
 }
 
 func vecItemFromDocument(doc chromem.Document) VecItem {

--- a/pkg/vec/store_test.go
+++ b/pkg/vec/store_test.go
@@ -311,6 +311,61 @@ func TestVecStoreListSortsNumericIDsNumerically(t *testing.T) {
 	}
 }
 
+func TestVecStoreListRebuildsRegistryForExistingCollection(t *testing.T) {
+	path := t.TempDir()
+	ctx := context.Background()
+
+	db, err := chromem.NewPersistentDB(path, false)
+	if err != nil {
+		t.Fatalf("open persistent chromem db: %v", err)
+	}
+
+	col, err := db.CreateCollection("legacy_vectors", map[string]string{
+		"distance":   "cosine",
+		"dimensions": "2",
+		"backend":    "chromem-go",
+	}, nil)
+	if err != nil {
+		t.Fatalf("create legacy collection: %v", err)
+	}
+
+	if err := col.AddDocuments(ctx, []chromem.Document{
+		{ID: "10", Embedding: normalized([]float32{1, 0})},
+		{ID: "2", Embedding: normalized([]float32{0, 1})},
+		{ID: "1", Embedding: normalized([]float32{1, 1})},
+	}, 1); err != nil {
+		t.Fatalf("seed legacy collection: %v", err)
+	}
+
+	vs := NewVecStore(VecStoreConfig{
+		TableName:   "legacy_vectors",
+		Dimensions:  2,
+		PersistPath: path,
+	})
+
+	limited, err := vs.List(ctx, 1)
+	if err != nil {
+		t.Fatalf("list legacy collection with rebuilt registry: %v", err)
+	}
+	if len(limited) != 1 {
+		t.Fatalf("expected 1 limited item, got %d", len(limited))
+	}
+	if limited[0].RowID != 1 {
+		t.Fatalf("expected numeric first rowid 1 after registry rebuild, got %+v", limited)
+	}
+
+	items, err := vs.List(ctx, 10)
+	if err != nil {
+		t.Fatalf("list legacy collection after rebuild: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items after registry rebuild, got %d", len(items))
+	}
+	if items[0].RowID != 1 || items[1].RowID != 2 || items[2].RowID != 10 {
+		t.Fatalf("expected rebuilt registry order [1 2 10], got %+v", items)
+	}
+}
+
 func TestVecStoreDimensionMismatch(t *testing.T) {
 	vs := setupVecStore(t)
 	ctx := context.Background()

--- a/pkg/vec/store_test.go
+++ b/pkg/vec/store_test.go
@@ -3,7 +3,11 @@ package vec
 import (
 	"context"
 	"math"
+	"strings"
 	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/sqlite"
+	chromem "github.com/philippgille/chromem-go"
 )
 
 func setupVecStore(t *testing.T) *VecStore {
@@ -377,6 +381,384 @@ func TestVecStoreUpsert(t *testing.T) {
 	}
 
 	assertVectorApproxEqual(t, item.Vector, normalized(updated))
+}
+
+func TestNewVecStoreDefaultsAndSharedInMemoryDB(t *testing.T) {
+	db, err := sqlite.Open(sqlite.InMemoryConfig())
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	cfg := VecStoreConfig{
+		DB:         db.DB,
+		TableName:  "shared_vectors",
+		Dimensions: 2,
+	}
+
+	vs1 := NewVecStore(cfg)
+	if vs1.distance != DistanceCosine {
+		t.Fatalf("expected default distance cosine, got %q", vs1.distance)
+	}
+	if got := vs1.sharedDBKey(); !strings.HasPrefix(got, "sql:") {
+		t.Fatalf("expected shared db key, got %q", got)
+	}
+
+	ctx := context.Background()
+	if err := vs1.Init(ctx); err != nil {
+		t.Fatalf("init shared store: %v", err)
+	}
+	if err := vs1.Insert(ctx, "doc-1", []float32{1, 0}, map[string]string{"category": "docs"}); err != nil {
+		t.Fatalf("insert shared doc: %v", err)
+	}
+
+	vs2 := NewVecStore(cfg)
+	if vs2.sharedDBKey() != vs1.sharedDBKey() {
+		t.Fatalf("expected shared db keys to match, got %q vs %q", vs2.sharedDBKey(), vs1.sharedDBKey())
+	}
+
+	item, err := vs2.Get(ctx, "doc-1")
+	if err != nil {
+		t.Fatalf("get from second shared store: %v", err)
+	}
+	if item.RowID != 0 {
+		t.Fatalf("expected string id rowid 0, got %d", item.RowID)
+	}
+	if item.ID != "doc-1" {
+		t.Fatalf("expected string id doc-1, got %#v", item.ID)
+	}
+	if item.Metadata["category"] != "docs" {
+		t.Fatalf("expected metadata to round-trip through shared db, got %+v", item.Metadata)
+	}
+}
+
+func TestVecStorePersistentReopenAndDrop(t *testing.T) {
+	path := t.TempDir()
+	cfg := VecStoreConfig{
+		TableName:   "persist_vectors",
+		Dimensions:  2,
+		PersistPath: path,
+	}
+
+	ctx := context.Background()
+	vs1 := NewVecStore(cfg)
+	if got := vs1.sharedDBKey(); got != "" {
+		t.Fatalf("expected no shared db key for persistent store, got %q", got)
+	}
+	if err := vs1.Init(ctx); err != nil {
+		t.Fatalf("init persistent store: %v", err)
+	}
+	if err := vs1.Insert(ctx, 1, []float32{1, 0}, nil); err != nil {
+		t.Fatalf("insert persistent doc: %v", err)
+	}
+
+	vs2 := NewVecStore(cfg)
+	count, err := vs2.Count(ctx)
+	if err != nil {
+		t.Fatalf("count after reopen: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 vector after reopen, got %d", count)
+	}
+
+	if err := vs2.Drop(ctx); err != nil {
+		t.Fatalf("drop persistent collection: %v", err)
+	}
+
+	vs3 := NewVecStore(cfg)
+	if _, err := vs3.Count(ctx); err == nil {
+		t.Fatal("expected missing collection error after drop")
+	}
+}
+
+func TestVecStoreValidationErrors(t *testing.T) {
+	ctx := context.Background()
+
+	if err := NewVecStore(VecStoreConfig{
+		TableName:   " ",
+		Dimensions:  2,
+		PersistPath: t.TempDir(),
+	}).Init(ctx); err == nil {
+		t.Fatal("expected blank table name to fail")
+	}
+
+	if err := NewVecStore(VecStoreConfig{
+		TableName:   "bad_dims",
+		Dimensions:  0,
+		PersistPath: t.TempDir(),
+	}).Init(ctx); err == nil {
+		t.Fatal("expected non-positive dimensions to fail")
+	}
+
+	if err := NewVecStore(VecStoreConfig{
+		TableName:   "bad_distance",
+		Dimensions:  2,
+		Distance:    DistanceMetric("dot"),
+		PersistPath: t.TempDir(),
+	}).Init(ctx); err == nil {
+		t.Fatal("expected unsupported custom distance to fail")
+	}
+
+	vs := NewVecStore(VecStoreConfig{
+		TableName:   "validation_vectors",
+		Dimensions:  2,
+		PersistPath: t.TempDir(),
+	})
+	if err := vs.Init(ctx); err != nil {
+		t.Fatalf("init validation store: %v", err)
+	}
+
+	if err := vs.Insert(ctx, nil, []float32{1, 0}, nil); err == nil {
+		t.Fatal("expected nil id to fail")
+	}
+	if err := vs.Insert(ctx, "   ", []float32{1, 0}, nil); err == nil {
+		t.Fatal("expected blank string id to fail")
+	}
+	if err := vs.InsertBatch(ctx, []VecItem{{ID: 1, Vector: []float32{1}}}); err == nil {
+		t.Fatal("expected insert batch dimension mismatch to fail")
+	}
+
+	if err := NewVecStore(VecStoreConfig{
+		TableName:   " ",
+		Dimensions:  2,
+		PersistPath: t.TempDir(),
+	}).Drop(ctx); err == nil {
+		t.Fatal("expected drop with blank table name to fail")
+	}
+
+	if _, err := NewVecStore(VecStoreConfig{
+		TableName:   "missing_vectors",
+		Dimensions:  2,
+		PersistPath: t.TempDir(),
+	}).Count(ctx); err == nil {
+		t.Fatal("expected missing collection count to fail")
+	}
+}
+
+func TestVecHelpers(t *testing.T) {
+	if got := sanitizeMetadata(nil, nil); got != nil {
+		t.Fatalf("expected nil metadata when nothing provided, got %+v", got)
+	}
+
+	meta := map[string]string{"keep": "yes", "drop": "no"}
+	cloned := sanitizeMetadata(nil, meta)
+	cloned["keep"] = "changed"
+	if meta["keep"] != "yes" {
+		t.Fatalf("expected sanitizeMetadata to clone unrestricted metadata, got %+v", meta)
+	}
+
+	filtered := sanitizeMetadata([]string{"keep", "missing"}, meta)
+	if filtered["keep"] != "yes" || filtered["missing"] != "" {
+		t.Fatalf("unexpected filtered metadata: %+v", filtered)
+	}
+
+	if cloneVector(nil) != nil {
+		t.Fatal("expected cloneVector(nil) to be nil")
+	}
+	vector := []float32{3, 4}
+	vectorClone := cloneVector(vector)
+	vectorClone[0] = 99
+	if vector[0] != 3 {
+		t.Fatalf("expected cloneVector to copy data, got %+v", vector)
+	}
+
+	if cloneMetadata(nil) != nil {
+		t.Fatal("expected cloneMetadata(nil) to be nil")
+	}
+	metadataClone := cloneMetadata(meta)
+	metadataClone["keep"] = "changed"
+	if meta["keep"] != "yes" {
+		t.Fatalf("expected cloneMetadata to copy data, got %+v", meta)
+	}
+
+	if metadataToAny(nil) != nil {
+		t.Fatal("expected metadataToAny(nil) to be nil")
+	}
+	if anyMeta := metadataToAny(map[string]string{"kind": "doc"}); anyMeta["kind"] != "doc" {
+		t.Fatalf("expected metadataToAny to preserve values, got %+v", anyMeta)
+	}
+
+	if _, err := normalizeID(nil); err == nil {
+		t.Fatal("expected nil id normalization to fail")
+	}
+	if _, err := normalizeID("   "); err == nil {
+		t.Fatal("expected blank string normalization to fail")
+	}
+	if got, err := normalizeID(7); err != nil || got != "7" {
+		t.Fatalf("expected numeric id to normalize to 7, got %q / %v", got, err)
+	}
+
+	rowID, id := decodeID("9")
+	if rowID != 9 || id != int64(9) {
+		t.Fatalf("expected numeric decode to return rowid 9/int64(9), got %d/%#v", rowID, id)
+	}
+	rowID, id = decodeID("doc-1")
+	if rowID != 0 || id != "doc-1" {
+		t.Fatalf("expected string decode to keep string id, got %d/%#v", rowID, id)
+	}
+
+	raw := []float32{3, 4}
+	doc := chromem.Document{
+		ID:        "doc-2",
+		Embedding: raw,
+		Metadata:  map[string]string{"kind": "doc"},
+	}
+	item := vecItemFromDocument(doc)
+	raw[0] = 99
+	if item.RowID != 0 || item.ID != "doc-2" {
+		t.Fatalf("unexpected vec item identity: %+v", item)
+	}
+	if item.Vector[0] == 99 {
+		t.Fatalf("expected vecItemFromDocument to clone embedding, got %+v", item.Vector)
+	}
+
+	if sim := CosineSimilarity([]float32{1}, []float32{1, 2}); sim != 0 {
+		t.Fatalf("expected cosine similarity 0 for mismatched vectors, got %f", sim)
+	}
+	if sim := CosineSimilarity([]float32{0, 0}, []float32{0, 0}); sim != 0 {
+		t.Fatalf("expected cosine similarity 0 for zero vectors, got %f", sim)
+	}
+	if dist := L2Distance([]float32{1}, []float32{1, 2}); dist != math.MaxFloat64 {
+		t.Fatalf("expected max float for mismatched L2 distance, got %f", dist)
+	}
+
+	if err := (&VecStore{dimensions: 0, distance: DistanceCosine}).validateVector([]float32{1}); err == nil {
+		t.Fatal("expected validateVector to fail when dimensions are non-positive")
+	}
+	if err := (&VecStore{dimensions: 2, distance: DistanceMetric("dot")}).validateVector([]float32{1, 0}); err == nil {
+		t.Fatal("expected validateVector to fail for unsupported distance")
+	}
+}
+
+func TestVecStoreOperationErrorPaths(t *testing.T) {
+	ctx := context.Background()
+	vs := NewVecStore(VecStoreConfig{
+		TableName:   "ops_vectors",
+		Dimensions:  2,
+		Metadata:    []string{"category"},
+		PersistPath: t.TempDir(),
+	})
+	if err := vs.Init(ctx); err != nil {
+		t.Fatalf("init ops store: %v", err)
+	}
+
+	if err := vs.InsertBatch(ctx, nil); err != nil {
+		t.Fatalf("expected empty batch insert to succeed, got %v", err)
+	}
+	if err := vs.InsertBatch(ctx, []VecItem{{ID: "   ", Vector: []float32{1, 0}}}); err == nil {
+		t.Fatal("expected blank batch id to fail")
+	}
+
+	results, err := vs.SearchWithFilter(ctx, []float32{1, 0}, 0, 0, nil)
+	if err != nil {
+		t.Fatalf("search empty store: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected no results from empty store, got %d", len(results))
+	}
+
+	if _, err := vs.Get(ctx, "   "); err == nil {
+		t.Fatal("expected blank get id to fail")
+	}
+	if _, err := vs.Get(ctx, "missing"); err == nil {
+		t.Fatal("expected missing document get to fail")
+	}
+
+	if err := vs.Delete(ctx, "   "); err == nil {
+		t.Fatal("expected blank delete id to fail")
+	}
+
+	if err := vs.UpdateVector(ctx, 1, []float32{1}); err == nil {
+		t.Fatal("expected update vector dimension mismatch to fail")
+	}
+	if err := vs.UpdateVector(ctx, "missing", []float32{1, 0}); err == nil {
+		t.Fatal("expected update vector for missing id to fail")
+	}
+
+	if err := vs.UpdateMetadata(ctx, 1, nil); err != nil {
+		t.Fatalf("expected empty metadata update to be a no-op, got %v", err)
+	}
+
+	if err := vs.Insert(ctx, 1, []float32{1, 0}, nil); err != nil {
+		t.Fatalf("insert metadata-less doc: %v", err)
+	}
+	if err := vs.UpdateMetadata(ctx, 1, map[string]string{"category": "docs"}); err != nil {
+		t.Fatalf("update metadata on nil metadata doc: %v", err)
+	}
+
+	item, err := vs.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("get metadata-updated doc: %v", err)
+	}
+	if item.Metadata["category"] != "docs" {
+		t.Fatalf("expected metadata update to populate nil map, got %+v", item.Metadata)
+	}
+}
+
+func TestVecStoreListDropAndVersionErrorPaths(t *testing.T) {
+	ctx := context.Background()
+
+	missing := NewVecStore(VecStoreConfig{
+		TableName:   "missing_info",
+		Dimensions:  2,
+		PersistPath: t.TempDir(),
+	})
+	if _, err := missing.VecVersion(ctx); err == nil {
+		t.Fatal("expected VecVersion on missing collection to fail")
+	}
+	if _, err := missing.TableInfo(ctx); err == nil {
+		t.Fatal("expected TableInfo on missing collection to fail")
+	}
+	if err := missing.Delete(ctx, 1); err == nil {
+		t.Fatal("expected Delete on missing collection to fail")
+	}
+
+	empty := NewVecStore(VecStoreConfig{
+		TableName:   "empty_list",
+		Dimensions:  2,
+		PersistPath: t.TempDir(),
+	})
+	if err := empty.Init(ctx); err != nil {
+		t.Fatalf("init empty list store: %v", err)
+	}
+	items, err := empty.List(ctx, 1)
+	if err != nil {
+		t.Fatalf("list empty store: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected empty list, got %+v", items)
+	}
+
+	cfg := VecStoreConfig{
+		TableName:   "drop_vectors",
+		Dimensions:  2,
+		PersistPath: t.TempDir(),
+	}
+	creator := NewVecStore(cfg)
+	if err := creator.Init(ctx); err != nil {
+		t.Fatalf("init drop store: %v", err)
+	}
+	if err := creator.Insert(ctx, 1, []float32{1, 0}, nil); err != nil {
+		t.Fatalf("insert drop store doc: %v", err)
+	}
+
+	limited, err := creator.List(ctx, 1)
+	if err != nil {
+		t.Fatalf("list with limit: %v", err)
+	}
+	if len(limited) != 1 {
+		t.Fatalf("expected limited list to return 1 item, got %d", len(limited))
+	}
+
+	dropper := NewVecStore(cfg)
+	if err := dropper.Drop(ctx); err != nil {
+		t.Fatalf("drop existing collection with fresh store: %v", err)
+	}
+	if err := dropper.Drop(ctx); err != nil {
+		t.Fatalf("expected repeat drop to remain safe, got %v", err)
+	}
 }
 
 func normalized(v []float32) []float32 {

--- a/pkg/vec/store_test.go
+++ b/pkg/vec/store_test.go
@@ -1,0 +1,414 @@
+package vec
+
+import (
+	"context"
+	"math"
+	"testing"
+)
+
+func setupVecStore(t *testing.T) *VecStore {
+	t.Helper()
+
+	vs := NewVecStore(VecStoreConfig{
+		TableName:   "test_vectors",
+		Dimensions:  4,
+		Distance:    DistanceCosine,
+		Metadata:    []string{"category", "source"},
+		PersistPath: t.TempDir(),
+	})
+
+	if err := vs.Init(context.Background()); err != nil {
+		t.Fatalf("failed to init vec store: %v", err)
+	}
+
+	return vs
+}
+
+func TestVecStoreInit(t *testing.T) {
+	vs := setupVecStore(t)
+
+	version, err := vs.VecVersion(context.Background())
+	if err != nil {
+		t.Fatalf("failed to get vec version: %v", err)
+	}
+	if version == "" {
+		t.Error("expected non-empty vec version")
+	}
+
+	info, err := vs.TableInfo(context.Background())
+	if err != nil {
+		t.Fatalf("failed to get table info: %v", err)
+	}
+
+	if info.TableName != "test_vectors" {
+		t.Errorf("expected table name test_vectors, got %s", info.TableName)
+	}
+	if info.Dimensions != 4 {
+		t.Errorf("expected dimensions 4, got %d", info.Dimensions)
+	}
+	if info.Distance != "cosine" {
+		t.Errorf("expected distance cosine, got %s", info.Distance)
+	}
+}
+
+func TestVecStoreInsert(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	err := vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{
+		"category": "test",
+		"source":   "unit",
+	})
+	if err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	count, err := vs.Count(ctx)
+	if err != nil {
+		t.Fatalf("failed to count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 vector, got %d", count)
+	}
+}
+
+func TestVecStoreInsertBatch(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	items := []VecItem{
+		{ID: int64(1), Vector: []float32{0.1, 0.2, 0.3, 0.4}, Metadata: map[string]string{"category": "a"}},
+		{ID: int64(2), Vector: []float32{0.5, 0.6, 0.7, 0.8}, Metadata: map[string]string{"category": "b"}},
+		{ID: int64(3), Vector: []float32{0.9, 1.0, 0.1, 0.2}, Metadata: map[string]string{"category": "a"}},
+	}
+
+	if err := vs.InsertBatch(ctx, items); err != nil {
+		t.Fatalf("failed to insert batch: %v", err)
+	}
+
+	count, err := vs.Count(ctx)
+	if err != nil {
+		t.Fatalf("failed to count: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 vectors, got %d", count)
+	}
+}
+
+func TestVecStoreSearch(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	_ = vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, nil)
+	_ = vs.Insert(ctx, 2, []float32{0.11, 0.21, 0.31, 0.41}, nil)
+	_ = vs.Insert(ctx, 3, []float32{0.9, 0.8, 0.7, 0.6}, nil)
+
+	results, err := vs.Search(ctx, []float32{0.1, 0.2, 0.3, 0.4}, 10)
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Errorf("expected 3 results, got %d", len(results))
+	}
+	if results[0].RowID != 1 {
+		t.Errorf("expected first result rowid 1, got %d", results[0].RowID)
+	}
+	if results[0].Distance > 0.001 {
+		t.Errorf("expected first result distance near 0, got %f", results[0].Distance)
+	}
+}
+
+func TestVecStoreSearchWithThreshold(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	_ = vs.Insert(ctx, 1, []float32{0.5, 0.5, 0.5, 0.5}, nil)
+	_ = vs.Insert(ctx, 2, []float32{0.51, 0.51, 0.51, 0.51}, nil)
+	_ = vs.Insert(ctx, 3, []float32{0.1, 0.2, 0.3, 0.4}, nil)
+
+	results, err := vs.SearchWithFilter(ctx, []float32{0.5, 0.5, 0.5, 0.5}, 10, 0.01, nil)
+	if err != nil {
+		t.Fatalf("search with threshold failed: %v", err)
+	}
+
+	if len(results) < 1 {
+		t.Errorf("expected at least 1 result, got %d", len(results))
+	}
+	if results[0].Distance > 0.01 {
+		t.Errorf("expected distance <= 0.01, got %f", results[0].Distance)
+	}
+}
+
+func TestVecStoreSearchWithMetadataFilter(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	_ = vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{"category": "a"})
+	_ = vs.Insert(ctx, 2, []float32{0.1, 0.2, 0.3, 0.41}, map[string]string{"category": "b"})
+
+	results, err := vs.SearchWithFilter(ctx, []float32{0.1, 0.2, 0.3, 0.4}, 10, 0, map[string]string{"category": "b"})
+	if err != nil {
+		t.Fatalf("search with metadata filter failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 filtered result, got %d", len(results))
+	}
+	if results[0].RowID != 2 {
+		t.Errorf("expected rowid 2, got %d", results[0].RowID)
+	}
+}
+
+func TestVecStoreGet(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	meta := map[string]string{"category": "test", "source": "unit"}
+	raw := []float32{0.1, 0.2, 0.3, 0.4}
+	_ = vs.Insert(ctx, 42, raw, meta)
+
+	item, err := vs.Get(ctx, 42)
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+
+	if item.RowID != 42 {
+		t.Errorf("expected rowid 42, got %d", item.RowID)
+	}
+	if len(item.Vector) != 4 {
+		t.Errorf("expected 4 dimensions, got %d", len(item.Vector))
+	}
+	assertVectorApproxEqual(t, item.Vector, normalized(raw))
+	if item.Metadata["category"] != "test" {
+		t.Errorf("expected category test, got %s", item.Metadata["category"])
+	}
+}
+
+func TestVecStoreDelete(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	_ = vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, nil)
+
+	count, _ := vs.Count(ctx)
+	if count != 1 {
+		t.Fatalf("expected 1 vector before delete")
+	}
+
+	if err := vs.Delete(ctx, 1); err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+
+	count, _ = vs.Count(ctx)
+	if count != 0 {
+		t.Errorf("expected 0 vectors after delete, got %d", count)
+	}
+}
+
+func TestVecStoreUpdateVector(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	_ = vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, nil)
+
+	newVec := []float32{0.9, 0.8, 0.7, 0.6}
+	if err := vs.UpdateVector(ctx, 1, newVec); err != nil {
+		t.Fatalf("update vector failed: %v", err)
+	}
+
+	item, err := vs.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("get after update failed: %v", err)
+	}
+
+	assertVectorApproxEqual(t, item.Vector, normalized(newVec))
+}
+
+func TestVecStoreUpdateMetadata(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	_ = vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, map[string]string{
+		"category": "old",
+		"source":   "old",
+	})
+
+	if err := vs.UpdateMetadata(ctx, 1, map[string]string{
+		"category": "new",
+	}); err != nil {
+		t.Fatalf("update metadata failed: %v", err)
+	}
+
+	item, err := vs.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("get after metadata update failed: %v", err)
+	}
+
+	if item.Metadata["category"] != "new" {
+		t.Errorf("expected category new, got %s", item.Metadata["category"])
+	}
+	if item.Metadata["source"] != "old" {
+		t.Errorf("expected source old, got %s", item.Metadata["source"])
+	}
+}
+
+func TestVecStoreList(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	_ = vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, nil)
+	_ = vs.Insert(ctx, 2, []float32{0.5, 0.6, 0.7, 0.8}, nil)
+
+	items, err := vs.List(ctx, 10)
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+
+	if len(items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(items))
+	}
+	if items[0].RowID != 1 || items[1].RowID != 2 {
+		t.Errorf("expected sorted items by id, got %+v", items)
+	}
+}
+
+func TestVecStoreDimensionMismatch(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	err := vs.Insert(ctx, 1, []float32{0.1, 0.2}, nil)
+	if err == nil {
+		t.Error("expected dimension mismatch error")
+	}
+
+	if _, err := vs.Search(ctx, []float32{0.1, 0.2}, 10); err == nil {
+		t.Error("expected dimension mismatch error on search")
+	}
+}
+
+func TestVecStoreUnsupportedL2(t *testing.T) {
+	vs := NewVecStore(VecStoreConfig{
+		TableName:   "l2_vectors",
+		Dimensions:  4,
+		Distance:    DistanceL2,
+		PersistPath: t.TempDir(),
+	})
+
+	if err := vs.Init(context.Background()); err == nil {
+		t.Fatal("expected unsupported l2 error")
+	}
+}
+
+func TestCosineSimilarity(t *testing.T) {
+	a := []float32{1.0, 0.0, 0.0}
+	b := []float32{1.0, 0.0, 0.0}
+
+	sim := CosineSimilarity(a, b)
+	if sim < 0.999 {
+		t.Errorf("expected similarity ~1.0, got %f", sim)
+	}
+
+	c := []float32{0.0, 1.0, 0.0}
+	sim = CosineSimilarity(a, c)
+	if sim > 0.001 {
+		t.Errorf("expected similarity ~0.0, got %f", sim)
+	}
+}
+
+func TestCosineDistance(t *testing.T) {
+	a := []float32{1.0, 0.0, 0.0}
+	b := []float32{1.0, 0.0, 0.0}
+
+	dist := CosineDistance(a, b)
+	if dist > 0.001 {
+		t.Errorf("expected distance ~0.0, got %f", dist)
+	}
+}
+
+func TestL2Distance(t *testing.T) {
+	a := []float32{0.0, 0.0}
+	b := []float32{3.0, 4.0}
+
+	dist := L2Distance(a, b)
+	if dist < 4.9 || dist > 5.1 {
+		t.Errorf("expected distance ~5.0, got %f", dist)
+	}
+}
+
+func TestVectorBlobRoundTrip(t *testing.T) {
+	original := []float32{0.1, 0.2, 0.3, 0.4, 0.5}
+	blob := vectorToBlob(original)
+	restored := blobToVector(blob)
+
+	if len(restored) != len(original) {
+		t.Fatalf("length mismatch: %d vs %d", len(restored), len(original))
+	}
+
+	for i := range original {
+		if restored[i] != original[i] {
+			t.Errorf("index %d: expected %f, got %f", i, original[i], restored[i])
+		}
+	}
+}
+
+func TestVecStoreUpsert(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	_ = vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, nil)
+
+	count, _ := vs.Count(ctx)
+	if count != 1 {
+		t.Fatalf("expected 1 vector after first insert")
+	}
+
+	updated := []float32{0.5, 0.6, 0.7, 0.8}
+	_ = vs.Insert(ctx, 1, updated, nil)
+
+	count, _ = vs.Count(ctx)
+	if count != 1 {
+		t.Errorf("expected 1 vector after upsert, got %d", count)
+	}
+
+	item, err := vs.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("get after upsert failed: %v", err)
+	}
+
+	assertVectorApproxEqual(t, item.Vector, normalized(updated))
+}
+
+func normalized(v []float32) []float32 {
+	out := make([]float32, len(v))
+	copy(out, v)
+
+	var sum float64
+	for _, value := range out {
+		sum += float64(value * value)
+	}
+	if sum == 0 {
+		return out
+	}
+
+	norm := float32(math.Sqrt(sum))
+	for i := range out {
+		out[i] /= norm
+	}
+	return out
+}
+
+func assertVectorApproxEqual(t *testing.T, got, want []float32) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("vector length mismatch: %d vs %d", len(got), len(want))
+	}
+
+	for i := range want {
+		diff := math.Abs(float64(got[i] - want[i]))
+		if diff > 1e-5 {
+			t.Fatalf("vector[%d] expected %f, got %f", i, want[i], got[i])
+		}
+	}
+}

--- a/pkg/vec/store_test.go
+++ b/pkg/vec/store_test.go
@@ -277,6 +277,40 @@ func TestVecStoreList(t *testing.T) {
 	}
 }
 
+func TestVecStoreListSortsNumericIDsNumerically(t *testing.T) {
+	vs := NewVecStore(VecStoreConfig{
+		TableName:   "numeric_sort_vectors",
+		Dimensions:  2,
+		PersistPath: t.TempDir(),
+	})
+	ctx := context.Background()
+	if err := vs.Init(ctx); err != nil {
+		t.Fatalf("init numeric sort store: %v", err)
+	}
+
+	for _, item := range []VecItem{
+		{ID: 10, Vector: []float32{1, 0}},
+		{ID: 2, Vector: []float32{0, 1}},
+		{ID: 1, Vector: []float32{1, 1}},
+	} {
+		if err := vs.Insert(ctx, item.ID, item.Vector, nil); err != nil {
+			t.Fatalf("insert item %v: %v", item.ID, err)
+		}
+	}
+
+	items, err := vs.List(ctx, 10)
+	if err != nil {
+		t.Fatalf("list numerically sorted items: %v", err)
+	}
+
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(items))
+	}
+	if items[0].RowID != 1 || items[1].RowID != 2 || items[2].RowID != 10 {
+		t.Fatalf("expected numeric ID order [1 2 10], got %+v", items)
+	}
+}
+
 func TestVecStoreDimensionMismatch(t *testing.T) {
 	vs := setupVecStore(t)
 	ctx := context.Background()

--- a/pkg/vec/store_test.go
+++ b/pkg/vec/store_test.go
@@ -3,6 +3,7 @@ package vec
 import (
 	"context"
 	"math"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -210,6 +211,27 @@ func TestVecStoreDelete(t *testing.T) {
 	}
 }
 
+func TestVecStoreDeleteMissingIDIsNoOp(t *testing.T) {
+	vs := setupVecStore(t)
+	ctx := context.Background()
+
+	if err := vs.Insert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}, nil); err != nil {
+		t.Fatalf("insert before missing delete: %v", err)
+	}
+
+	if err := vs.Delete(ctx, 999); err != nil {
+		t.Fatalf("delete missing id should be no-op, got %v", err)
+	}
+
+	count, err := vs.Count(ctx)
+	if err != nil {
+		t.Fatalf("count after missing delete: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected count to remain 1 after missing delete, got %d", count)
+	}
+}
+
 func TestVecStoreUpdateVector(t *testing.T) {
 	vs := setupVecStore(t)
 	ctx := context.Background()
@@ -274,6 +296,19 @@ func TestVecStoreList(t *testing.T) {
 	}
 	if items[0].RowID != 1 || items[1].RowID != 2 {
 		t.Errorf("expected sorted items by id, got %+v", items)
+	}
+}
+
+func TestVecStoreListMissingCollectionFails(t *testing.T) {
+	ctx := context.Background()
+	vs := NewVecStore(VecStoreConfig{
+		TableName:   "missing_list_vectors",
+		Dimensions:  2,
+		PersistPath: t.TempDir(),
+	})
+
+	if _, err := vs.List(ctx, 1); err == nil {
+		t.Fatal("expected list on missing collection to fail")
 	}
 }
 
@@ -366,6 +401,50 @@ func TestVecStoreListRebuildsRegistryForExistingCollection(t *testing.T) {
 	}
 }
 
+func TestVecStoreListRepairsStaleRegistryWithMatchingCount(t *testing.T) {
+	path := t.TempDir()
+	ctx := context.Background()
+
+	vs := NewVecStore(VecStoreConfig{
+		TableName:   "stale_registry_vectors",
+		Dimensions:  2,
+		PersistPath: path,
+	})
+	if err := vs.Init(ctx); err != nil {
+		t.Fatalf("init stale registry store: %v", err)
+	}
+
+	if err := vs.Insert(ctx, 1, []float32{1, 0}, nil); err != nil {
+		t.Fatalf("insert vector 1: %v", err)
+	}
+	if err := vs.Insert(ctx, 2, []float32{0, 1}, nil); err != nil {
+		t.Fatalf("insert vector 2: %v", err)
+	}
+
+	if err := vs.replaceRegistryIDs(ctx, []string{"1", "999"}); err != nil {
+		t.Fatalf("seed stale registry ids: %v", err)
+	}
+
+	items, err := vs.List(ctx, 10)
+	if err != nil {
+		t.Fatalf("list with stale registry: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected stale registry to rebuild 2 items, got %d", len(items))
+	}
+	if items[0].RowID != 1 || items[1].RowID != 2 {
+		t.Fatalf("expected rebuilt rowids [1 2], got %+v", items)
+	}
+
+	ids, err := vs.listRegistryIDs(ctx, 10)
+	if err != nil {
+		t.Fatalf("list registry ids after stale repair: %v", err)
+	}
+	if want := []string{"1", "2"}; !reflect.DeepEqual(ids, want) {
+		t.Fatalf("expected repaired registry ids %v, got %v", want, ids)
+	}
+}
+
 func TestVecStoreDimensionMismatch(t *testing.T) {
 	vs := setupVecStore(t)
 	ctx := context.Background()
@@ -390,6 +469,24 @@ func TestVecStoreUnsupportedL2(t *testing.T) {
 
 	if err := vs.Init(context.Background()); err == nil {
 		t.Fatal("expected unsupported l2 error")
+	}
+}
+
+func TestLessDocumentIDMixedOrdering(t *testing.T) {
+	if !lessDocumentID("2", "10") {
+		t.Fatal("expected numeric ids to compare numerically")
+	}
+	if !lessDocumentID("2", "doc") {
+		t.Fatal("expected numeric ids to sort before string ids")
+	}
+	if lessDocumentID("doc", "2") {
+		t.Fatal("expected string ids to sort after numeric ids")
+	}
+	if lessDocumentID("b", "a") {
+		t.Fatal("expected lexical string ordering to apply for non-numeric ids")
+	}
+	if lessDocumentID("10", "10") {
+		t.Fatal("expected equal ids to not compare as less")
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR updates the local vector storage implementation under `pkg/vec`, `pkg/index`, and `pkg/sqlite` to use `chromem-go` instead of the previous SQLite vec-table integration.


## What Changed

- use `chromem-go` as the local vector backend
- keep the public vec store behavior compatible where possible
- support cosine distance
- return unsupported for L2 for now
- add sidecar path support in `pkg/sqlite`
- register the SQLite driver inside `pkg/sqlite`
- update `pkg/index` to use the new vec backend while keeping metadata management logic
- keep `IndexManager` constructor compatible with the current `main` usage
- add/update tests inside the owned directories only

## Notes

- vector IDs are stored as string IDs internally by `chromem-go`
- `RowID` is kept as a compatibility field and is populated when the ID can be parsed as an integer
- embeddings may be normalized by the backend

## Test Plan

```bash
go test ./pkg/sqlite ./pkg/vec ./pkg/index
