### PR TITLE
feat(media): add media pipeline and storage toolkit

### DIFF
--- a/pkg/media/cache.go
+++ b/pkg/media/cache.go
@@ -1,0 +1,506 @@
+package media
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type MediaCacheConfig struct {
+	MaxItems     int
+	MaxBytes     int64
+	TTL          time.Duration
+	DiskPath     string
+	PersistIndex bool
+}
+
+func DefaultMediaCacheConfig() MediaCacheConfig {
+	return MediaCacheConfig{
+		MaxItems:     5000,
+		MaxBytes:     1024 * 1024 * 1024,
+		TTL:          7 * 24 * time.Hour,
+		PersistIndex: true,
+	}
+}
+
+type MediaCacheStats struct {
+	Hits        int
+	Misses      int
+	Evictions   int
+	Expired     int
+	TotalSize   int64
+	ItemCount   int
+	DiskItems   int
+	LastHitRate float64
+}
+
+type MediaCache struct {
+	mu            sync.RWMutex
+	items         map[string]*mediaCacheItem
+	maxItems      int
+	maxBytes      int64
+	currentBytes  int64
+	ttl           time.Duration
+	diskPath      string
+	persistIndex  bool
+	stats         MediaCacheStats
+	totalRequests int
+}
+
+type mediaCacheItem struct {
+	Media       *Media
+	ExpiresAt   time.Time
+	CreatedAt   time.Time
+	SizeBytes   int64
+	AccessCount int
+	LastAccess  time.Time
+}
+
+type mediaCacheIndex struct {
+	Items map[string]mediaCacheIndexEntry `json:"items"`
+}
+
+type mediaCacheIndexEntry struct {
+	Key       string    `json:"key"`
+	URL       string    `json:"url"`
+	Size      int64     `json:"size"`
+	MimeType  string    `json:"mime_type"`
+	ExpiresAt time.Time `json:"expires_at"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+func NewMediaCache(cfg MediaCacheConfig) *MediaCache {
+	if cfg.MaxItems <= 0 {
+		cfg.MaxItems = 5000
+	}
+	if cfg.MaxBytes <= 0 {
+		cfg.MaxBytes = 1024 * 1024 * 1024
+	}
+	if cfg.TTL <= 0 {
+		cfg.TTL = 7 * 24 * time.Hour
+	}
+
+	mc := &MediaCache{
+		items:        make(map[string]*mediaCacheItem),
+		maxItems:     cfg.MaxItems,
+		maxBytes:     cfg.MaxBytes,
+		ttl:          cfg.TTL,
+		diskPath:     cfg.DiskPath,
+		persistIndex: cfg.PersistIndex,
+	}
+
+	if mc.diskPath != "" {
+		_ = os.MkdirAll(mc.diskPath, 0755)
+		if mc.persistIndex {
+			mc.loadIndex()
+		}
+	}
+
+	return mc
+}
+
+func (c *MediaCache) Get(key string) (*Media, bool) {
+	c.mu.Lock()
+
+	item, ok := c.items[key]
+	if !ok {
+		c.stats.Misses++
+		c.totalRequests++
+		c.mu.Unlock()
+		return nil, false
+	}
+
+	if time.Now().After(item.ExpiresAt) {
+		c.currentBytes -= item.SizeBytes
+		delete(c.items, key)
+		c.stats.Expired++
+		c.stats.Misses++
+		c.totalRequests++
+		c.mu.Unlock()
+		return nil, false
+	}
+
+	item.AccessCount++
+	item.LastAccess = time.Now()
+
+	if item.Media != nil && len(item.Media.Data) > 0 {
+		c.stats.Hits++
+		c.totalRequests++
+		c.updateHitRate()
+		c.mu.Unlock()
+		return item.Media, true
+	}
+
+	if c.diskPath != "" {
+		diskData, err := c.loadFromDisk(key)
+		if err == nil && len(diskData) > 0 {
+			item.Media.Data = diskData
+			c.stats.Hits++
+			c.totalRequests++
+			c.updateHitRate()
+			c.mu.Unlock()
+			return item.Media, true
+		}
+	}
+
+	c.currentBytes -= item.SizeBytes
+	delete(c.items, key)
+	c.stats.Misses++
+	c.totalRequests++
+	c.mu.Unlock()
+	return nil, false
+}
+
+func (c *MediaCache) Set(key string, media *Media) {
+	if media == nil {
+		return
+	}
+
+	sizeBytes := media.Size
+	if sizeBytes == 0 {
+		sizeBytes = int64(len(media.Data))
+	}
+
+	if sizeBytes > c.maxBytes {
+		return
+	}
+
+	c.mu.Lock()
+
+	if existing, ok := c.items[key]; ok {
+		c.currentBytes -= existing.SizeBytes
+		delete(c.items, key)
+	}
+
+	if len(c.items) >= c.maxItems || c.currentBytes+sizeBytes > c.maxBytes {
+		c.evict(sizeBytes)
+	}
+
+	item := &mediaCacheItem{
+		Media:       media,
+		ExpiresAt:   time.Now().Add(c.ttl),
+		CreatedAt:   time.Now(),
+		SizeBytes:   sizeBytes,
+		AccessCount: 1,
+		LastAccess:  time.Now(),
+	}
+
+	c.items[key] = item
+	c.currentBytes += sizeBytes
+
+	if c.diskPath != "" {
+		if len(media.Data) > 0 {
+			_ = c.saveToDisk(key, media.Data)
+		}
+		if c.persistIndex {
+			_ = c.saveIndex()
+		}
+	}
+
+	c.mu.Unlock()
+}
+
+func (c *MediaCache) Remove(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if item, ok := c.items[key]; ok {
+		c.currentBytes -= item.SizeBytes
+		delete(c.items, key)
+		if c.diskPath != "" {
+			_ = c.deleteFromDisk(key)
+		}
+	}
+}
+
+func (c *MediaCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.items = make(map[string]*mediaCacheItem)
+	c.currentBytes = 0
+
+	if c.diskPath != "" {
+		_ = os.RemoveAll(c.diskPath)
+		_ = os.MkdirAll(c.diskPath, 0755)
+	}
+}
+
+func (c *MediaCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.items)
+}
+
+func (c *MediaCache) SizeBytes() int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.currentBytes
+}
+
+func (c *MediaCache) Stats() MediaCacheStats {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	stats := c.stats
+	stats.ItemCount = len(c.items)
+	stats.TotalSize = c.currentBytes
+	stats.DiskItems = c.diskItemCount()
+	return stats
+}
+
+func (c *MediaCache) Cleanup() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	count := 0
+
+	for k, v := range c.items {
+		if now.After(v.ExpiresAt) {
+			c.currentBytes -= v.SizeBytes
+			delete(c.items, k)
+			if c.diskPath != "" {
+				_ = c.deleteFromDisk(k)
+			}
+			count++
+		}
+	}
+
+	return count
+}
+
+func (c *MediaCache) evict(neededBytes int64) {
+	now := time.Now()
+
+	for k, v := range c.items {
+		if now.After(v.ExpiresAt) {
+			c.currentBytes -= v.SizeBytes
+			delete(c.items, k)
+			c.stats.Evictions++
+			if c.diskPath != "" {
+				_ = c.deleteFromDisk(k)
+			}
+		}
+	}
+
+	if len(c.items) >= c.maxItems || c.currentBytes+neededBytes > c.maxBytes {
+		oldestKey := ""
+		oldestAccess := time.Now()
+
+		for k, v := range c.items {
+			if v.LastAccess.Before(oldestAccess) {
+				oldestAccess = v.LastAccess
+				oldestKey = k
+			}
+		}
+
+		if oldestKey != "" {
+			item := c.items[oldestKey]
+			c.currentBytes -= item.SizeBytes
+			delete(c.items, oldestKey)
+			c.stats.Evictions++
+			if c.diskPath != "" {
+				_ = c.deleteFromDisk(oldestKey)
+			}
+		}
+	}
+
+	if len(c.items) >= c.maxItems {
+		count := 0
+		half := c.maxItems / 2
+		for k, v := range c.items {
+			c.currentBytes -= v.SizeBytes
+			delete(c.items, k)
+			c.stats.Evictions++
+			if c.diskPath != "" {
+				_ = c.deleteFromDisk(k)
+			}
+			count++
+			if count >= half {
+				break
+			}
+		}
+	}
+}
+
+func (c *MediaCache) saveToDisk(key string, data []byte) error {
+	if c.diskPath == "" {
+		return nil
+	}
+
+	filename := keyToFilename(key)
+	path := filepath.Join(c.diskPath, filename)
+
+	return os.WriteFile(path, data, 0644)
+}
+
+func (c *MediaCache) loadFromDisk(key string) ([]byte, error) {
+	if c.diskPath == "" {
+		return nil, fmt.Errorf("no disk path configured")
+	}
+
+	filename := keyToFilename(key)
+	path := filepath.Join(c.diskPath, filename)
+
+	return os.ReadFile(path)
+}
+
+func (c *MediaCache) deleteFromDisk(key string) error {
+	if c.diskPath == "" {
+		return nil
+	}
+
+	filename := keyToFilename(key)
+	path := filepath.Join(c.diskPath, filename)
+
+	return os.Remove(path)
+}
+
+func (c *MediaCache) saveIndex() error {
+	if c.diskPath == "" {
+		return nil
+	}
+
+	index := mediaCacheIndex{
+		Items: make(map[string]mediaCacheIndexEntry),
+	}
+
+	for k, v := range c.items {
+		index.Items[k] = mediaCacheIndexEntry{
+			Key:       k,
+			URL:       v.Media.URL,
+			Size:      v.SizeBytes,
+			MimeType:  v.Media.MimeType,
+			ExpiresAt: v.ExpiresAt,
+			CreatedAt: v.CreatedAt,
+		}
+	}
+
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	indexPath := filepath.Join(c.diskPath, "cache_index.json")
+	return os.WriteFile(indexPath, data, 0644)
+}
+
+func (c *MediaCache) loadIndex() error {
+	if c.diskPath == "" {
+		return nil
+	}
+
+	indexPath := filepath.Join(c.diskPath, "cache_index.json")
+
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		return err
+	}
+
+	var index mediaCacheIndex
+	if err := json.Unmarshal(data, &index); err != nil {
+		return err
+	}
+
+	now := time.Now()
+	for k, entry := range index.Items {
+		if now.After(entry.ExpiresAt) {
+			continue
+		}
+
+		if c.currentBytes+entry.Size > c.maxBytes {
+			break
+		}
+
+		if len(c.items) >= c.maxItems {
+			break
+		}
+
+		media := &Media{
+			ID:       k,
+			URL:      entry.URL,
+			Size:     entry.Size,
+			MimeType: entry.MimeType,
+		}
+
+		c.items[k] = &mediaCacheItem{
+			Media:       media,
+			ExpiresAt:   entry.ExpiresAt,
+			CreatedAt:   entry.CreatedAt,
+			SizeBytes:   entry.Size,
+			AccessCount: 0,
+			LastAccess:  time.Time{},
+		}
+		c.currentBytes += entry.Size
+	}
+
+	return nil
+}
+
+func (c *MediaCache) diskItemCount() int {
+	if c.diskPath == "" {
+		return 0
+	}
+
+	entries, err := os.ReadDir(c.diskPath)
+	if err != nil {
+		return 0
+	}
+
+	count := 0
+	for _, entry := range entries {
+		if !entry.IsDir() && entry.Name() != "cache_index.json" {
+			count++
+		}
+	}
+	return count
+}
+
+func (c *MediaCache) updateHitRate() {
+	if c.totalRequests > 0 {
+		c.stats.LastHitRate = float64(c.stats.Hits) / float64(c.totalRequests) * 100
+	}
+}
+
+func MakeMediaCacheKey(url string, opts ...MediaCacheOption) string {
+	options := mediaCacheOptions{
+		MaxSize: 0,
+		Format:  "",
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	raw := fmt.Sprintf("%s|%d|%s", url, options.MaxSize, options.Format)
+	hash := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(hash[:])
+}
+
+type mediaCacheOptions struct {
+	MaxSize int64
+	Format  string
+}
+
+type MediaCacheOption func(*mediaCacheOptions)
+
+func WithCacheMaxSize(size int64) MediaCacheOption {
+	return func(o *mediaCacheOptions) {
+		o.MaxSize = size
+	}
+}
+
+func WithCacheFormat(format string) MediaCacheOption {
+	return func(o *mediaCacheOptions) {
+		o.Format = format
+	}
+}
+
+func keyToFilename(key string) string {
+	return key + ".cache"
+}

--- a/pkg/media/cache.go
+++ b/pkg/media/cache.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -470,21 +472,41 @@ func (c *MediaCache) updateHitRate() {
 
 func MakeMediaCacheKey(url string, opts ...MediaCacheOption) string {
 	options := mediaCacheOptions{
-		MaxSize: 0,
-		Format:  "",
+		MaxSize:     0,
+		Format:      "",
+		AcceptTypes: nil,
+		Headers:     nil,
 	}
 	for _, opt := range opts {
 		opt(&options)
 	}
 
-	raw := fmt.Sprintf("%s|%d|%s", url, options.MaxSize, options.Format)
+	acceptTypes := append([]string(nil), options.AcceptTypes...)
+	sort.Strings(acceptTypes)
+
+	headerParts := make([]string, 0, len(options.Headers))
+	for k, v := range options.Headers {
+		headerParts = append(headerParts, strings.ToLower(k)+"="+v)
+	}
+	sort.Strings(headerParts)
+
+	raw := fmt.Sprintf(
+		"%s|%d|%s|%s|%s",
+		url,
+		options.MaxSize,
+		options.Format,
+		strings.Join(acceptTypes, ","),
+		strings.Join(headerParts, ","),
+	)
 	hash := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(hash[:])
 }
 
 type mediaCacheOptions struct {
-	MaxSize int64
-	Format  string
+	MaxSize     int64
+	Format      string
+	AcceptTypes []string
+	Headers     map[string]string
 }
 
 type MediaCacheOption func(*mediaCacheOptions)
@@ -498,6 +520,26 @@ func WithCacheMaxSize(size int64) MediaCacheOption {
 func WithCacheFormat(format string) MediaCacheOption {
 	return func(o *mediaCacheOptions) {
 		o.Format = format
+	}
+}
+
+func WithCacheAcceptTypes(acceptTypes []string) MediaCacheOption {
+	return func(o *mediaCacheOptions) {
+		o.AcceptTypes = append([]string(nil), acceptTypes...)
+	}
+}
+
+func WithCacheHeaders(headers map[string]string) MediaCacheOption {
+	return func(o *mediaCacheOptions) {
+		if len(headers) == 0 {
+			o.Headers = nil
+			return
+		}
+		cloned := make(map[string]string, len(headers))
+		for k, v := range headers {
+			cloned[k] = v
+		}
+		o.Headers = cloned
 	}
 }
 

--- a/pkg/media/detector.go
+++ b/pkg/media/detector.go
@@ -1,0 +1,913 @@
+package media
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"image"
+	"mime"
+	"strings"
+)
+
+type Format string
+
+const (
+	FormatUnknown Format = "unknown"
+
+	FormatJPEG     Format = "jpeg"
+	FormatPNG      Format = "png"
+	FormatGIF      Format = "gif"
+	FormatWebP     Format = "webp"
+	FormatBMP      Format = "bmp"
+	FormatSVG      Format = "svg"
+	FormatTIFF     Format = "tiff"
+	FormatICO      Format = "ico"
+	FormatAVIF     Format = "avif"
+	FormatHEIC     Format = "heic"
+	FormatJPEG2000 Format = "jpeg2000"
+	FormatPSD      Format = "psd"
+
+	FormatMP3  Format = "mp3"
+	FormatWAV  Format = "wav"
+	FormatOGG  Format = "ogg"
+	FormatFLAC Format = "flac"
+	FormatAAC  Format = "aac"
+	FormatM4A  Format = "m4a"
+	FormatWMA  Format = "wma"
+	FormatAMR  Format = "amr"
+	FormatMIDI Format = "midi"
+
+	FormatMP4  Format = "mp4"
+	FormatWebM Format = "webm"
+	FormatAVI  Format = "avi"
+	FormatMKV  Format = "mkv"
+	FormatMOV  Format = "mov"
+	FormatWMV  Format = "wmv"
+	FormatFLV  Format = "flv"
+	FormatMPEG Format = "mpeg"
+	Format3GP  Format = "3gp"
+
+	FormatPDF  Format = "pdf"
+	FormatDOC  Format = "doc"
+	FormatDOCX Format = "docx"
+	FormatXLS  Format = "xls"
+	FormatXLSX Format = "xlsx"
+	FormatPPT  Format = "ppt"
+	FormatPPTX Format = "pptx"
+	FormatTXT  Format = "txt"
+	FormatRTF  Format = "rtf"
+	FormatCSV  Format = "csv"
+	FormatZIP  Format = "zip"
+	FormatEPUB Format = "epub"
+	FormatJSON Format = "json"
+	FormatXML  Format = "xml"
+	FormatHTML Format = "html"
+	FormatYAML Format = "yaml"
+	FormatMD   Format = "markdown"
+)
+
+var mimeToFormat = map[string]Format{
+	"image/jpeg":                FormatJPEG,
+	"image/jpg":                 FormatJPEG,
+	"image/png":                 FormatPNG,
+	"image/gif":                 FormatGIF,
+	"image/webp":                FormatWebP,
+	"image/bmp":                 FormatBMP,
+	"image/x-bmp":               FormatBMP,
+	"image/svg+xml":             FormatSVG,
+	"image/tiff":                FormatTIFF,
+	"image/x-tiff":              FormatTIFF,
+	"image/x-icon":              FormatICO,
+	"image/vnd.microsoft.icon":  FormatICO,
+	"image/avif":                FormatAVIF,
+	"image/heic":                FormatHEIC,
+	"image/heif":                FormatHEIC,
+	"image/jp2":                 FormatJPEG2000,
+	"image/x-photoshop":         FormatPSD,
+	"image/vnd.adobe.photoshop": FormatPSD,
+
+	"audio/mpeg":     FormatMP3,
+	"audio/mp3":      FormatMP3,
+	"audio/x-mp3":    FormatMP3,
+	"audio/wav":      FormatWAV,
+	"audio/x-wav":    FormatWAV,
+	"audio/ogg":      FormatOGG,
+	"audio/flac":     FormatFLAC,
+	"audio/x-flac":   FormatFLAC,
+	"audio/aac":      FormatAAC,
+	"audio/mp4":      FormatM4A,
+	"audio/x-m4a":    FormatM4A,
+	"audio/x-ms-wma": FormatWMA,
+	"audio/amr":      FormatAMR,
+	"audio/midi":     FormatMIDI,
+	"audio/x-midi":   FormatMIDI,
+
+	"video/mp4":        FormatMP4,
+	"video/webm":       FormatWebM,
+	"video/x-msvideo":  FormatAVI,
+	"video/x-matroska": FormatMKV,
+	"video/quicktime":  FormatMOV,
+	"video/x-ms-wmv":   FormatWMV,
+	"video/x-flv":      FormatFLV,
+	"video/mpeg":       FormatMPEG,
+	"video/3gpp":       Format3GP,
+
+	"application/pdf":    FormatPDF,
+	"application/msword": FormatDOC,
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.document": FormatDOCX,
+	"application/vnd.ms-excel": FormatXLS,
+	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":         FormatXLSX,
+	"application/vnd.ms-powerpoint":                                             FormatPPT,
+	"application/vnd.openxmlformats-officedocument.presentationml.presentation": FormatPPTX,
+	"text/plain":            FormatTXT,
+	"text/rtf":              FormatRTF,
+	"text/csv":              FormatCSV,
+	"application/zip":       FormatZIP,
+	"application/epub+zip":  FormatEPUB,
+	"application/json":      FormatJSON,
+	"text/json":             FormatJSON,
+	"application/xml":       FormatXML,
+	"text/xml":              FormatXML,
+	"text/html":             FormatHTML,
+	"application/xhtml+xml": FormatHTML,
+	"application/x-yaml":    FormatYAML,
+	"text/yaml":             FormatYAML,
+	"text/markdown":         FormatMD,
+	"text/x-markdown":       FormatMD,
+}
+
+var extToFormat = map[string]Format{
+	".jpg":  FormatJPEG,
+	".jpeg": FormatJPEG,
+	".png":  FormatPNG,
+	".gif":  FormatGIF,
+	".webp": FormatWebP,
+	".bmp":  FormatBMP,
+	".svg":  FormatSVG,
+	".tiff": FormatTIFF,
+	".tif":  FormatTIFF,
+	".ico":  FormatICO,
+	".avif": FormatAVIF,
+	".heic": FormatHEIC,
+	".heif": FormatHEIC,
+	".jp2":  FormatJPEG2000,
+	".j2k":  FormatJPEG2000,
+	".psd":  FormatPSD,
+
+	".mp3":  FormatMP3,
+	".wav":  FormatWAV,
+	".ogg":  FormatOGG,
+	".oga":  FormatOGG,
+	".flac": FormatFLAC,
+	".aac":  FormatAAC,
+	".m4a":  FormatM4A,
+	".wma":  FormatWMA,
+	".amr":  FormatAMR,
+	".mid":  FormatMIDI,
+	".midi": FormatMIDI,
+
+	".mp4":  FormatMP4,
+	".webm": FormatWebM,
+	".avi":  FormatAVI,
+	".mkv":  FormatMKV,
+	".mov":  FormatMOV,
+	".wmv":  FormatWMV,
+	".flv":  FormatFLV,
+	".mpg":  FormatMPEG,
+	".mpeg": FormatMPEG,
+	".3gp":  Format3GP,
+
+	".pdf":      FormatPDF,
+	".doc":      FormatDOC,
+	".docx":     FormatDOCX,
+	".xls":      FormatXLS,
+	".xlsx":     FormatXLSX,
+	".ppt":      FormatPPT,
+	".pptx":     FormatPPTX,
+	".txt":      FormatTXT,
+	".rtf":      FormatRTF,
+	".csv":      FormatCSV,
+	".zip":      FormatZIP,
+	".epub":     FormatEPUB,
+	".json":     FormatJSON,
+	".xml":      FormatXML,
+	".html":     FormatHTML,
+	".htm":      FormatHTML,
+	".yaml":     FormatYAML,
+	".yml":      FormatYAML,
+	".md":       FormatMD,
+	".markdown": FormatMD,
+}
+
+type MediaType struct {
+	Type     Type
+	Format   Format
+	MimeType string
+}
+
+type Detector struct {
+	mimeOverrides map[string]Format
+}
+
+func NewDetector() *Detector {
+	return &Detector{
+		mimeOverrides: make(map[string]Format),
+	}
+}
+
+func (d *Detector) RegisterMIMEOverride(mimeType string, format Format) {
+	d.mimeOverrides[mimeType] = format
+}
+
+func (d *Detector) Detect(data []byte, filename string, mimeType string) MediaType {
+	result := MediaType{
+		Type:     TypeDoc,
+		Format:   FormatUnknown,
+		MimeType: mimeType,
+	}
+
+	if len(data) > 0 {
+		result = d.detectFromBytes(data)
+	}
+
+	if mimeType != "" {
+		mimeResult := d.detectFromMIME(mimeType)
+		if mimeResult.Format != FormatUnknown {
+			if result.Format == FormatUnknown || result.Format == FormatTXT {
+				result = mimeResult
+			}
+		}
+	}
+
+	if result.Format == FormatUnknown && filename != "" {
+		result = d.detectFromExtension(filename)
+	}
+
+	if result.Format != FormatUnknown && result.MimeType == "" {
+		result.MimeType = formatToMIME(result.Format)
+	}
+
+	if result.Type == "" {
+		result.Type = formatToType(result.Format)
+	}
+
+	return result
+}
+
+func (d *Detector) DetectFromBytes(data []byte) MediaType {
+	if len(data) == 0 {
+		return MediaType{Type: "", Format: FormatUnknown}
+	}
+	return d.detectFromBytes(data)
+}
+
+func (d *Detector) detectFromBytes(data []byte) MediaType {
+	if len(data) < 2 {
+		return MediaType{Type: "", Format: FormatUnknown}
+	}
+
+	if result := d.detectImage(data); result.Format != FormatUnknown {
+		return result
+	}
+	if result := d.detectVideo(data); result.Format != FormatUnknown {
+		return result
+	}
+	if result := d.detectAudio(data); result.Format != FormatUnknown {
+		return result
+	}
+	if result := d.detectDocument(data); result.Format != FormatUnknown {
+		return result
+	}
+
+	return MediaType{Type: "", Format: FormatUnknown}
+}
+
+func (d *Detector) detectImage(data []byte) MediaType {
+	if len(data) >= 3 && data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF {
+		return MediaType{Type: TypeImage, Format: FormatJPEG, MimeType: "image/jpeg"}
+	}
+
+	if len(data) >= 8 && data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47 &&
+		data[4] == 0x0D && data[5] == 0x0A && data[6] == 0x1A && data[7] == 0x0A {
+		return MediaType{Type: TypeImage, Format: FormatPNG, MimeType: "image/png"}
+	}
+
+	if len(data) >= 6 && bytes.Equal(data[:3], []byte("GIF")) &&
+		data[3] == '8' && data[5] == 'a' && (data[4] == '7' || data[4] == '9') {
+		return MediaType{Type: TypeImage, Format: FormatGIF, MimeType: "image/gif"}
+	}
+
+	if len(data) >= 12 && bytes.Equal(data[:4], []byte("RIFF")) && bytes.Equal(data[8:12], []byte("WEBP")) {
+		return MediaType{Type: TypeImage, Format: FormatWebP, MimeType: "image/webp"}
+	}
+
+	if len(data) >= 2 && data[0] == 0x42 && data[1] == 0x4D {
+		return MediaType{Type: TypeImage, Format: FormatBMP, MimeType: "image/bmp"}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte("MM\x00\x2A")) {
+		return MediaType{Type: TypeImage, Format: FormatTIFF, MimeType: "image/tiff"}
+	}
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte("II\x2A\x00")) {
+		return MediaType{Type: TypeImage, Format: FormatTIFF, MimeType: "image/tiff"}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte("\x00\x00\x01\x00")) {
+		return MediaType{Type: TypeImage, Format: FormatICO, MimeType: "image/x-icon"}
+	}
+
+	if len(data) >= 12 && bytes.Equal(data[4:8], []byte("ftyp")) {
+		ftypBrand := string(data[8:12])
+		if ftypBrand == "avif" || ftypBrand == "avis" {
+			return MediaType{Type: TypeImage, Format: FormatAVIF, MimeType: "image/avif"}
+		}
+		if ftypBrand == "heic" || ftypBrand == "heix" || ftypBrand == "mif1" || ftypBrand == "msf1" {
+			return MediaType{Type: TypeImage, Format: FormatHEIC, MimeType: "image/heic"}
+		}
+		if ftypBrand == "jp2 " || ftypBrand == "jpx " || ftypBrand == "jpm " || ftypBrand == "mjp2" {
+			return MediaType{Type: TypeImage, Format: FormatJPEG2000, MimeType: "image/jp2"}
+		}
+	}
+
+	if len(data) > 5 {
+		prefix := strings.TrimSpace(string(data[:min(len(data), 200)]))
+		if strings.HasPrefix(prefix, "<svg") || strings.HasPrefix(prefix, "<?xml") && strings.Contains(prefix, "<svg") {
+			return MediaType{Type: TypeImage, Format: FormatSVG, MimeType: "image/svg+xml"}
+		}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte("8BPS")) {
+		return MediaType{Type: TypeImage, Format: FormatPSD, MimeType: "image/vnd.adobe.photoshop"}
+	}
+
+	return MediaType{Type: TypeImage, Format: FormatUnknown}
+}
+
+func (d *Detector) detectAudio(data []byte) MediaType {
+	if len(data) >= 2 && bytes.Equal(data[:2], []byte("\xFF\xF1")) {
+		return MediaType{Type: TypeAudio, Format: FormatAAC, MimeType: "audio/aac"}
+	}
+
+	if len(data) >= 3 && data[0] == 0xFF && (data[1]&0xF0) == 0xF0 {
+		return MediaType{Type: TypeAudio, Format: FormatMP3, MimeType: "audio/mpeg"}
+	}
+
+	if len(data) >= 3 && bytes.Equal(data[:3], []byte("ID3")) {
+		return MediaType{Type: TypeAudio, Format: FormatMP3, MimeType: "audio/mpeg"}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte("RIFF")) && len(data) >= 12 &&
+		bytes.Equal(data[8:12], []byte("WAVE")) {
+		return MediaType{Type: TypeAudio, Format: FormatWAV, MimeType: "audio/wav"}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte("OggS")) {
+		if len(data) >= 36 && bytes.Equal(data[28:36], []byte("OpusHead")) {
+			return MediaType{Type: TypeAudio, Format: FormatOGG, MimeType: "audio/ogg"}
+		}
+		if len(data) >= 36 && bytes.Equal(data[28:36], []byte("\x7fFLAC")) {
+			return MediaType{Type: TypeAudio, Format: FormatFLAC, MimeType: "audio/flac"}
+		}
+		return MediaType{Type: TypeAudio, Format: FormatOGG, MimeType: "audio/ogg"}
+	}
+
+	if len(data) >= 5 && bytes.Equal(data[:5], []byte("\x7fFLAC")) {
+		return MediaType{Type: TypeAudio, Format: FormatFLAC, MimeType: "audio/flac"}
+	}
+
+	if len(data) >= 12 && bytes.Equal(data[4:8], []byte("ftyp")) {
+		ftypBrand := string(data[8:12])
+		if ftypBrand == "M4A " || ftypBrand == "M4B " || ftypBrand == "mp42" {
+			return MediaType{Type: TypeAudio, Format: FormatM4A, MimeType: "audio/mp4"}
+		}
+	}
+
+	if len(data) >= 2 && bytes.Equal(data[:2], []byte("#!")) {
+		return MediaType{Type: TypeAudio, Format: FormatAMR, MimeType: "audio/amr"}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte("MThd")) {
+		return MediaType{Type: TypeAudio, Format: FormatMIDI, MimeType: "audio/midi"}
+	}
+
+	if len(data) >= 18 && bytes.Equal(data[:16], []byte{0x30, 0x26, 0xB2, 0x75, 0x8E, 0x66, 0xCF, 0x11, 0xA6, 0xD9, 0x00, 0xAA, 0x00, 0x62, 0xCE, 0x6C}) {
+		objectType := data[17]
+		if objectType == 0x02 {
+			return MediaType{Type: TypeAudio, Format: FormatWMA, MimeType: "audio/x-ms-wma"}
+		}
+	}
+
+	return MediaType{Type: TypeAudio, Format: FormatUnknown}
+}
+
+func (d *Detector) detectVideo(data []byte) MediaType {
+	if len(data) >= 12 && bytes.Equal(data[4:8], []byte("ftyp")) {
+		ftypBrand := string(data[8:12])
+		switch ftypBrand {
+		case "mp41", "mp42", "isom", "iso2":
+			return MediaType{Type: TypeVideo, Format: FormatMP4, MimeType: "video/mp4"}
+		case "M4V ":
+			return MediaType{Type: TypeVideo, Format: FormatMP4, MimeType: "video/mp4"}
+		case "3gp4", "3gp5", "3gp6", "3g2a":
+			return MediaType{Type: TypeVideo, Format: Format3GP, MimeType: "video/3gpp"}
+		}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte{0x1A, 0x45, 0xDF, 0xA3}) {
+		if len(data) >= 8 && bytes.Contains(data[4:8], []byte("webm")) {
+			return MediaType{Type: TypeVideo, Format: FormatWebM, MimeType: "video/webm"}
+		}
+		return MediaType{Type: TypeVideo, Format: FormatMKV, MimeType: "video/x-matroska"}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte("RIFF")) && len(data) >= 12 &&
+		bytes.Equal(data[8:12], []byte("AVI ")) {
+		return MediaType{Type: TypeVideo, Format: FormatAVI, MimeType: "video/x-msvideo"}
+	}
+
+	if len(data) >= 8 && bytes.Equal(data[4:8], []byte("wide")) ||
+		(len(data) >= 12 && bytes.Equal(data[4:8], []byte("moov"))) {
+		return MediaType{Type: TypeVideo, Format: FormatMOV, MimeType: "video/quicktime"}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:3], []byte{0x00, 0x00, 0x01}) &&
+		(data[3] == 0xB0 || data[3] == 0xB3) {
+		return MediaType{Type: TypeVideo, Format: FormatMPEG, MimeType: "video/mpeg"}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte("FLV\x01")) {
+		return MediaType{Type: TypeVideo, Format: FormatFLV, MimeType: "video/x-flv"}
+	}
+
+	if len(data) >= 18 && bytes.Equal(data[:16], []byte{0x30, 0x26, 0xB2, 0x75, 0x8E, 0x66, 0xCF, 0x11, 0xA6, 0xD9, 0x00, 0xAA, 0x00, 0x62, 0xCE, 0x6C}) {
+		objectType := data[17]
+		if objectType == 0x02 {
+			return MediaType{Type: TypeAudio, Format: FormatWMA, MimeType: "audio/x-ms-wma"}
+		}
+		return MediaType{Type: TypeVideo, Format: FormatWMV, MimeType: "video/x-ms-wmv"}
+	}
+
+	return MediaType{Type: TypeVideo, Format: FormatUnknown}
+}
+
+func (d *Detector) detectDocument(data []byte) MediaType {
+	if len(data) >= 5 && bytes.Equal(data[:5], []byte("%PDF-")) {
+		return MediaType{Type: TypeDoc, Format: FormatPDF, MimeType: "application/pdf"}
+	}
+
+	if len(data) >= 2 && bytes.Equal(data[:2], []byte("PK")) {
+		if len(data) >= 30 {
+			content := string(data[2:min(len(data), 500)])
+			if strings.Contains(content, "word/") {
+				return MediaType{Type: TypeDoc, Format: FormatDOCX, MimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"}
+			}
+			if strings.Contains(content, "xl/") {
+				return MediaType{Type: TypeDoc, Format: FormatXLSX, MimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"}
+			}
+			if strings.Contains(content, "ppt/") {
+				return MediaType{Type: TypeDoc, Format: FormatPPTX, MimeType: "application/vnd.openxmlformats-officedocument.presentationml.presentation"}
+			}
+			if strings.Contains(content, "mimetypeapplication/epub+zip") {
+				return MediaType{Type: TypeDoc, Format: FormatEPUB, MimeType: "application/epub+zip"}
+			}
+		}
+		if len(data) >= 4 && data[2] == 0x03 && data[3] == 0x04 {
+			return MediaType{Type: TypeDoc, Format: FormatZIP, MimeType: "application/zip"}
+		}
+	}
+
+	if len(data) >= 8 && bytes.Equal(data[:8], []byte("\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1")) {
+		return MediaType{Type: TypeDoc, Format: FormatDOC, MimeType: "application/msword"}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte("{\\rt")) {
+		return MediaType{Type: TypeDoc, Format: FormatRTF, MimeType: "text/rtf"}
+	}
+
+	if len(data) > 0 {
+		text := string(data[:min(len(data), 500)])
+		trimmed := strings.TrimSpace(text)
+
+		if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+			if isJSON(trimmed) {
+				return MediaType{Type: TypeDoc, Format: FormatJSON, MimeType: "application/json"}
+			}
+		}
+
+		if strings.HasPrefix(trimmed, "<!DOCTYPE") || strings.HasPrefix(trimmed, "<html") || strings.HasPrefix(trimmed, "<HTML") {
+			return MediaType{Type: TypeDoc, Format: FormatHTML, MimeType: "text/html"}
+		}
+
+		if strings.HasPrefix(trimmed, "<?xml") {
+			return MediaType{Type: TypeDoc, Format: FormatXML, MimeType: "application/xml"}
+		}
+
+		if isMarkdown(trimmed) {
+			return MediaType{Type: TypeDoc, Format: FormatMD, MimeType: "text/markdown"}
+		}
+
+		if isYAML(trimmed) {
+			return MediaType{Type: TypeDoc, Format: FormatYAML, MimeType: "text/yaml"}
+		}
+
+		if isPlainText(text) {
+			lines := strings.SplitN(text, "\n", 3)
+			if len(lines) >= 2 {
+				commasFirst := strings.Count(lines[0], ",")
+				if commasFirst > 0 {
+					isCSV := true
+					for _, line := range lines[1:] {
+						if strings.TrimSpace(line) != "" && strings.Count(line, ",") != commasFirst {
+							isCSV = false
+							break
+						}
+					}
+					if isCSV {
+						return MediaType{Type: TypeDoc, Format: FormatCSV, MimeType: "text/csv"}
+					}
+				}
+			}
+			return MediaType{Type: TypeDoc, Format: FormatTXT, MimeType: "text/plain"}
+		}
+	}
+
+	return MediaType{Type: TypeDoc, Format: FormatUnknown}
+}
+
+func (d *Detector) detectFromMIME(mimeType string) MediaType {
+	if override, ok := d.mimeOverrides[mimeType]; ok {
+		return MediaType{
+			Type:     formatToType(override),
+			Format:   override,
+			MimeType: mimeType,
+		}
+	}
+
+	if format, ok := mimeToFormat[mimeType]; ok {
+		return MediaType{
+			Type:     formatToType(format),
+			Format:   format,
+			MimeType: mimeType,
+		}
+	}
+
+	if strings.HasPrefix(mimeType, "image/") {
+		return MediaType{Type: TypeImage, Format: FormatUnknown, MimeType: mimeType}
+	}
+	if strings.HasPrefix(mimeType, "audio/") {
+		return MediaType{Type: TypeAudio, Format: FormatUnknown, MimeType: mimeType}
+	}
+	if strings.HasPrefix(mimeType, "video/") {
+		return MediaType{Type: TypeVideo, Format: FormatUnknown, MimeType: mimeType}
+	}
+	if strings.HasPrefix(mimeType, "text/") {
+		return MediaType{Type: TypeDoc, Format: FormatTXT, MimeType: mimeType}
+	}
+
+	return MediaType{Type: TypeDoc, Format: FormatUnknown, MimeType: mimeType}
+}
+
+func (d *Detector) detectFromExtension(filename string) MediaType {
+	ext := strings.ToLower(filename)
+	if idx := strings.LastIndex(ext, "."); idx >= 0 {
+		ext = ext[idx:]
+	} else {
+		return MediaType{Type: TypeDoc, Format: FormatUnknown}
+	}
+
+	if format, ok := extToFormat[ext]; ok {
+		return MediaType{
+			Type:     formatToType(format),
+			Format:   format,
+			MimeType: formatToMIME(format),
+		}
+	}
+
+	if mt := mime.TypeByExtension(ext); mt != "" {
+		return d.detectFromMIME(mt)
+	}
+
+	return MediaType{Type: TypeDoc, Format: FormatUnknown}
+}
+
+func formatToType(format Format) Type {
+	switch format {
+	case FormatJPEG, FormatPNG, FormatGIF, FormatWebP, FormatBMP, FormatSVG, FormatTIFF, FormatICO, FormatAVIF, FormatHEIC, FormatJPEG2000, FormatPSD:
+		return TypeImage
+	case FormatMP3, FormatWAV, FormatOGG, FormatFLAC, FormatAAC, FormatM4A, FormatWMA, FormatAMR, FormatMIDI:
+		return TypeAudio
+	case FormatMP4, FormatWebM, FormatAVI, FormatMKV, FormatMOV, FormatWMV, FormatFLV, FormatMPEG, Format3GP:
+		return TypeVideo
+	default:
+		return TypeDoc
+	}
+}
+
+func formatToMIME(format Format) string {
+	switch format {
+	case FormatJPEG:
+		return "image/jpeg"
+	case FormatPNG:
+		return "image/png"
+	case FormatGIF:
+		return "image/gif"
+	case FormatWebP:
+		return "image/webp"
+	case FormatBMP:
+		return "image/bmp"
+	case FormatSVG:
+		return "image/svg+xml"
+	case FormatTIFF:
+		return "image/tiff"
+	case FormatICO:
+		return "image/x-icon"
+	case FormatAVIF:
+		return "image/avif"
+	case FormatHEIC:
+		return "image/heic"
+	case FormatMP3:
+		return "audio/mpeg"
+	case FormatWAV:
+		return "audio/wav"
+	case FormatOGG:
+		return "audio/ogg"
+	case FormatFLAC:
+		return "audio/flac"
+	case FormatAAC:
+		return "audio/aac"
+	case FormatM4A:
+		return "audio/mp4"
+	case FormatWMA:
+		return "audio/x-ms-wma"
+	case FormatAMR:
+		return "audio/amr"
+	case FormatMIDI:
+		return "audio/midi"
+	case FormatMP4:
+		return "video/mp4"
+	case FormatWebM:
+		return "video/webm"
+	case FormatAVI:
+		return "video/x-msvideo"
+	case FormatMKV:
+		return "video/x-matroska"
+	case FormatMOV:
+		return "video/quicktime"
+	case FormatWMV:
+		return "video/x-ms-wmv"
+	case FormatFLV:
+		return "video/x-flv"
+	case FormatMPEG:
+		return "video/mpeg"
+	case Format3GP:
+		return "video/3gpp"
+	case FormatPDF:
+		return "application/pdf"
+	case FormatDOC:
+		return "application/msword"
+	case FormatDOCX:
+		return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+	case FormatXLS:
+		return "application/vnd.ms-excel"
+	case FormatXLSX:
+		return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+	case FormatPPT:
+		return "application/vnd.ms-powerpoint"
+	case FormatPPTX:
+		return "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+	case FormatTXT:
+		return "text/plain"
+	case FormatRTF:
+		return "text/rtf"
+	case FormatCSV:
+		return "text/csv"
+	case FormatZIP:
+		return "application/zip"
+	case FormatEPUB:
+		return "application/epub+zip"
+	case FormatJSON:
+		return "application/json"
+	case FormatXML:
+		return "application/xml"
+	case FormatHTML:
+		return "text/html"
+	case FormatYAML:
+		return "text/yaml"
+	case FormatMD:
+		return "text/markdown"
+	case FormatJPEG2000:
+		return "image/jp2"
+	case FormatPSD:
+		return "image/vnd.adobe.photoshop"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func isPlainText(data string) bool {
+	if len(data) == 0 {
+		return false
+	}
+
+	nonPrintable := 0
+	total := 0
+	for _, r := range data {
+		if r == '\n' || r == '\r' || r == '\t' {
+			continue
+		}
+		if r < 0x20 || (r >= 0x7F && r < 0xA0) {
+			nonPrintable++
+		}
+		total++
+	}
+
+	if total == 0 {
+		return true
+	}
+
+	return float64(nonPrintable)/float64(total) < 0.05
+}
+
+func isJSON(data string) bool {
+	if len(data) < 2 {
+		return false
+	}
+	trimmed := strings.TrimSpace(data)
+	if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") {
+		return false
+	}
+	var js json.RawMessage
+	return json.Unmarshal([]byte(trimmed), &js) == nil
+}
+
+func isYAML(data string) bool {
+	lines := strings.Split(data, "\n")
+	if len(lines) < 2 {
+		return false
+	}
+	hasKeyValue := false
+	for _, line := range lines[:min(len(lines), 10)] {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "- ") {
+			hasKeyValue = true
+			continue
+		}
+		if strings.Contains(trimmed, ": ") || strings.HasSuffix(trimmed, ":") {
+			hasKeyValue = true
+		}
+	}
+	return hasKeyValue && isPlainText(data)
+}
+
+func isMarkdown(data string) bool {
+	lines := strings.Split(data, "\n")
+	checkLines := lines[:min(len(lines), 20)]
+	for _, line := range checkLines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "# ") || strings.HasPrefix(trimmed, "## ") || strings.HasPrefix(trimmed, "### ") {
+			return true
+		}
+		if strings.HasPrefix(trimmed, "---") || strings.HasPrefix(trimmed, "===") {
+			return true
+		}
+		if (strings.HasPrefix(trimmed, "* ") || strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "+ ")) && len(trimmed) > 2 {
+			return true
+		}
+		if strings.HasPrefix(trimmed, "```") {
+			return true
+		}
+		if strings.HasPrefix(trimmed, "[") && strings.Contains(trimmed, "](") && strings.HasSuffix(trimmed, ")") {
+			return true
+		}
+	}
+	return false
+}
+
+func DetectMediaType(data []byte, filename string, mimeType string) MediaType {
+	d := NewDetector()
+	return d.Detect(data, filename, mimeType)
+}
+
+func ExtractImageMetadata(data []byte) (map[string]any, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty image data")
+	}
+
+	img, format, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("decode image: %w", err)
+	}
+
+	bounds := img.Bounds()
+	meta := map[string]any{
+		"width":  bounds.Dx(),
+		"height": bounds.Dy(),
+		"format": format,
+	}
+
+	return meta, nil
+}
+
+func ExtractAudioMetadata(data []byte) map[string]any {
+	meta := map[string]any{}
+
+	if len(data) >= 3 && bytes.Equal(data[:3], []byte("ID3")) {
+		meta["has_id3"] = true
+		if len(data) >= 10 {
+			meta["id3_version"] = int(data[3])
+		}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte("RIFF")) && len(data) >= 12 &&
+		bytes.Equal(data[8:12], []byte("WAVE")) {
+		if len(data) >= 24 {
+			channels := binary.LittleEndian.Uint16(data[22:24])
+			meta["channels"] = channels
+		}
+		if len(data) >= 28 {
+			sampleRate := binary.LittleEndian.Uint32(data[24:28])
+			meta["sample_rate"] = sampleRate
+		}
+		if len(data) >= 34 {
+			bitsPerSample := binary.LittleEndian.Uint16(data[32:34])
+			meta["bits_per_sample"] = bitsPerSample
+		}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte("OggS")) {
+		if len(data) >= 36 && bytes.Equal(data[28:36], []byte("OpusHead")) {
+			meta["codec"] = "opus"
+		} else if len(data) >= 36 && bytes.Equal(data[28:36], []byte("\x7fFLAC")) {
+			meta["codec"] = "flac"
+		} else {
+			meta["codec"] = "vorbis"
+		}
+	}
+
+	if len(data) >= 12 && bytes.Equal(data[4:8], []byte("ftyp")) {
+		meta["container"] = "mp4"
+		meta["brand"] = string(data[8:12])
+	}
+
+	return meta
+}
+
+func ExtractVideoMetadata(data []byte) map[string]any {
+	meta := map[string]any{}
+
+	if len(data) >= 12 && bytes.Equal(data[4:8], []byte("ftyp")) {
+		meta["container"] = "mp4"
+		meta["brand"] = string(data[8:12])
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte{0x1A, 0x45, 0xDF, 0xA3}) {
+		meta["container"] = "matroska"
+		if len(data) >= 8 && bytes.Contains(data[4:8], []byte("webm")) {
+			meta["container"] = "webm"
+		}
+	}
+
+	if len(data) >= 4 && bytes.Equal(data[:3], []byte("FLV")) {
+		meta["container"] = "flv"
+		if len(data) >= 5 {
+			flags := data[4]
+			meta["has_audio"] = (flags&0x4 != 0)
+			meta["has_video"] = (flags&0x1 != 0)
+		}
+	}
+
+	if len(data) >= 8 && bytes.Equal(data[4:8], []byte("wide")) ||
+		(len(data) >= 12 && bytes.Equal(data[4:8], []byte("moov"))) {
+		meta["container"] = "quicktime"
+	}
+
+	return meta
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func IsUTF8Text(data []byte) bool {
+	return isPlainText(string(data))
+}
+
+func ReadBoxSize(data []byte, offset int) (uint64, int) {
+	if len(data) < offset+8 {
+		return 0, 0
+	}
+	size := uint64(binary.BigEndian.Uint32(data[offset:]))
+	headerSize := 8
+	if size == 1 && len(data) >= offset+16 {
+		size = binary.BigEndian.Uint64(data[offset+8:])
+		headerSize = 16
+	}
+	return size, headerSize
+}

--- a/pkg/media/detector_test.go
+++ b/pkg/media/detector_test.go
@@ -1,0 +1,1103 @@
+package media
+
+import (
+	"testing"
+)
+
+func TestDetector_JPEG(t *testing.T) {
+	jpegHeader := []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46}
+	result := DetectMediaType(jpegHeader, "", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatJPEG {
+		t.Errorf("expected FormatJPEG, got %s", result.Format)
+	}
+	if result.MimeType != "image/jpeg" {
+		t.Errorf("expected image/jpeg, got %s", result.MimeType)
+	}
+}
+
+func TestDetector_JPEG_ID3(t *testing.T) {
+	id3Header := []byte("ID3\x04\x00\x00\x00\x00\x00\x00")
+	result := DetectMediaType(id3Header, "", "")
+
+	if result.Type != TypeAudio {
+		t.Errorf("expected TypeAudio, got %s", result.Type)
+	}
+	if result.Format != FormatMP3 {
+		t.Errorf("expected FormatMP3, got %s", result.Format)
+	}
+}
+
+func TestDetector_PNG(t *testing.T) {
+	pngHeader := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00}
+	result := DetectMediaType(pngHeader, "", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatPNG {
+		t.Errorf("expected FormatPNG, got %s", result.Format)
+	}
+	if result.MimeType != "image/png" {
+		t.Errorf("expected image/png, got %s", result.MimeType)
+	}
+}
+
+func TestDetector_GIF(t *testing.T) {
+	gifHeader := []byte("GIF89a\x00\x00\x00\x00\x00\x00")
+	result := DetectMediaType(gifHeader, "", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatGIF {
+		t.Errorf("expected FormatGIF, got %s", result.Format)
+	}
+}
+
+func TestDetector_GIF87a(t *testing.T) {
+	gifHeader := []byte("GIF87a\x00\x00\x00\x00\x00\x00")
+	result := DetectMediaType(gifHeader, "", "")
+
+	if result.Format != FormatGIF {
+		t.Errorf("expected FormatGIF, got %s", result.Format)
+	}
+}
+
+func TestDetector_WebP(t *testing.T) {
+	webpHeader := make([]byte, 20)
+	copy(webpHeader[:4], "RIFF")
+	webpHeader[8] = 'W'
+	webpHeader[9] = 'E'
+	webpHeader[10] = 'B'
+	webpHeader[11] = 'P'
+	result := DetectMediaType(webpHeader, "", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatWebP {
+		t.Errorf("expected FormatWebP, got %s", result.Format)
+	}
+}
+
+func TestDetector_BMP(t *testing.T) {
+	bmpHeader := []byte{0x42, 0x4D, 0x00, 0x00, 0x00, 0x00}
+	result := DetectMediaType(bmpHeader, "", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatBMP {
+		t.Errorf("expected FormatBMP, got %s", result.Format)
+	}
+}
+
+func TestDetector_TIFF_MM(t *testing.T) {
+	tiffHeader := []byte("MM\x00\x2A\x00\x00\x00\x00")
+	result := DetectMediaType(tiffHeader, "", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatTIFF {
+		t.Errorf("expected FormatTIFF, got %s", result.Format)
+	}
+}
+
+func TestDetector_TIFF_II(t *testing.T) {
+	tiffHeader := []byte("II\x2A\x00\x00\x00\x00\x00")
+	result := DetectMediaType(tiffHeader, "", "")
+
+	if result.Format != FormatTIFF {
+		t.Errorf("expected FormatTIFF, got %s", result.Format)
+	}
+}
+
+func TestDetector_ICO(t *testing.T) {
+	icoHeader := []byte{0x00, 0x00, 0x01, 0x00, 0x01, 0x00}
+	result := DetectMediaType(icoHeader, "", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatICO {
+		t.Errorf("expected FormatICO, got %s", result.Format)
+	}
+}
+
+func TestDetector_AVIF(t *testing.T) {
+	avifHeader := make([]byte, 20)
+	avifHeader[4] = 'f'
+	avifHeader[5] = 't'
+	avifHeader[6] = 'y'
+	avifHeader[7] = 'p'
+	copy(avifHeader[8:12], "avif")
+	result := DetectMediaType(avifHeader, "", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatAVIF {
+		t.Errorf("expected FormatAVIF, got %s", result.Format)
+	}
+}
+
+func TestDetector_HEIC(t *testing.T) {
+	heicHeader := make([]byte, 20)
+	heicHeader[4] = 'f'
+	heicHeader[5] = 't'
+	heicHeader[6] = 'y'
+	heicHeader[7] = 'p'
+	copy(heicHeader[8:12], "heic")
+	result := DetectMediaType(heicHeader, "", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatHEIC {
+		t.Errorf("expected FormatHEIC, got %s", result.Format)
+	}
+}
+
+func TestDetector_SVG(t *testing.T) {
+	svgData := []byte("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"100\"></svg>")
+	result := DetectMediaType(svgData, "", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatSVG {
+		t.Errorf("expected FormatSVG, got %s", result.Format)
+	}
+}
+
+func TestDetector_MP3_Framesync(t *testing.T) {
+	mp3Header := []byte{0xFF, 0xFB, 0x90, 0x00, 0x00, 0x00}
+	result := DetectMediaType(mp3Header, "", "")
+
+	if result.Type != TypeAudio {
+		t.Errorf("expected TypeAudio, got %s", result.Type)
+	}
+	if result.Format != FormatMP3 {
+		t.Errorf("expected FormatMP3, got %s", result.Format)
+	}
+}
+
+func TestDetector_WAV(t *testing.T) {
+	wavHeader := make([]byte, 20)
+	copy(wavHeader[:4], "RIFF")
+	wavHeader[8] = 'W'
+	wavHeader[9] = 'A'
+	wavHeader[10] = 'V'
+	wavHeader[11] = 'E'
+	result := DetectMediaType(wavHeader, "", "")
+
+	if result.Type != TypeAudio {
+		t.Errorf("expected TypeAudio, got %s", result.Type)
+	}
+	if result.Format != FormatWAV {
+		t.Errorf("expected FormatWAV, got %s", result.Format)
+	}
+}
+
+func TestDetector_OGG(t *testing.T) {
+	oggHeader := []byte("OggS\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00OpusHead")
+	result := DetectMediaType(oggHeader, "", "")
+
+	if result.Type != TypeAudio {
+		t.Errorf("expected TypeAudio, got %s", result.Type)
+	}
+	if result.Format != FormatOGG {
+		t.Errorf("expected FormatOGG, got %s", result.Format)
+	}
+}
+
+func TestDetector_FLAC(t *testing.T) {
+	flacHeader := []byte("\x7fFLAC\x01\x00\x00\x00")
+	result := DetectMediaType(flacHeader, "", "")
+
+	if result.Type != TypeAudio {
+		t.Errorf("expected TypeAudio, got %s", result.Type)
+	}
+	if result.Format != FormatFLAC {
+		t.Errorf("expected FormatFLAC, got %s", result.Format)
+	}
+}
+
+func TestDetector_M4A(t *testing.T) {
+	m4aHeader := make([]byte, 20)
+	m4aHeader[4] = 'f'
+	m4aHeader[5] = 't'
+	m4aHeader[6] = 'y'
+	m4aHeader[7] = 'p'
+	copy(m4aHeader[8:12], "M4A ")
+	result := DetectMediaType(m4aHeader, "", "")
+
+	if result.Type != TypeAudio {
+		t.Errorf("expected TypeAudio, got %s", result.Type)
+	}
+	if result.Format != FormatM4A {
+		t.Errorf("expected FormatM4A, got %s", result.Format)
+	}
+}
+
+func TestDetector_AMR(t *testing.T) {
+	amrHeader := []byte("#!AMR\n")
+	result := DetectMediaType(amrHeader, "", "")
+
+	if result.Type != TypeAudio {
+		t.Errorf("expected TypeAudio, got %s", result.Type)
+	}
+	if result.Format != FormatAMR {
+		t.Errorf("expected FormatAMR, got %s", result.Format)
+	}
+}
+
+func TestDetector_MIDI(t *testing.T) {
+	midiHeader := []byte("MThd\x00\x00\x00\x06")
+	result := DetectMediaType(midiHeader, "", "")
+
+	if result.Type != TypeAudio {
+		t.Errorf("expected TypeAudio, got %s", result.Type)
+	}
+	if result.Format != FormatMIDI {
+		t.Errorf("expected FormatMIDI, got %s", result.Format)
+	}
+}
+
+func TestDetector_MP4(t *testing.T) {
+	mp4Header := make([]byte, 20)
+	mp4Header[4] = 'f'
+	mp4Header[5] = 't'
+	mp4Header[6] = 'y'
+	mp4Header[7] = 'p'
+	copy(mp4Header[8:12], "isom")
+	result := DetectMediaType(mp4Header, "", "")
+
+	if result.Type != TypeVideo {
+		t.Errorf("expected TypeVideo, got %s", result.Type)
+	}
+	if result.Format != FormatMP4 {
+		t.Errorf("expected FormatMP4, got %s", result.Format)
+	}
+}
+
+func TestDetector_WebM(t *testing.T) {
+	webmHeader := []byte{0x1A, 0x45, 0xDF, 0xA3, 'w', 'e', 'b', 'm'}
+	result := DetectMediaType(webmHeader, "", "")
+
+	if result.Type != TypeVideo {
+		t.Errorf("expected TypeVideo, got %s", result.Type)
+	}
+	if result.Format != FormatWebM {
+		t.Errorf("expected FormatWebM, got %s", result.Format)
+	}
+}
+
+func TestDetector_MKV(t *testing.T) {
+	mkvHeader := []byte{0x1A, 0x45, 0xDF, 0xA3, 'm', 'a', 't', 'r'}
+	result := DetectMediaType(mkvHeader, "", "")
+
+	if result.Type != TypeVideo {
+		t.Errorf("expected TypeVideo, got %s", result.Type)
+	}
+	if result.Format != FormatMKV {
+		t.Errorf("expected FormatMKV, got %s", result.Format)
+	}
+}
+
+func TestDetector_AVI(t *testing.T) {
+	aviHeader := make([]byte, 20)
+	copy(aviHeader[:4], "RIFF")
+	aviHeader[8] = 'A'
+	aviHeader[9] = 'V'
+	aviHeader[10] = 'I'
+	aviHeader[11] = ' '
+	result := DetectMediaType(aviHeader, "", "")
+
+	if result.Type != TypeVideo {
+		t.Errorf("expected TypeVideo, got %s", result.Type)
+	}
+	if result.Format != FormatAVI {
+		t.Errorf("expected FormatAVI, got %s", result.Format)
+	}
+}
+
+func TestDetector_MOV(t *testing.T) {
+	movHeader := make([]byte, 20)
+	movHeader[4] = 'w'
+	movHeader[5] = 'i'
+	movHeader[6] = 'd'
+	movHeader[7] = 'e'
+	result := DetectMediaType(movHeader, "", "")
+
+	if result.Type != TypeVideo {
+		t.Errorf("expected TypeVideo, got %s", result.Type)
+	}
+	if result.Format != FormatMOV {
+		t.Errorf("expected FormatMOV, got %s", result.Format)
+	}
+}
+
+func TestDetector_FLV(t *testing.T) {
+	flvHeader := []byte("FLV\x01\x00\x00\x00\x00")
+	result := DetectMediaType(flvHeader, "", "")
+
+	if result.Type != TypeVideo {
+		t.Errorf("expected TypeVideo, got %s", result.Type)
+	}
+	if result.Format != FormatFLV {
+		t.Errorf("expected FormatFLV, got %s", result.Format)
+	}
+}
+
+func TestDetector_PDF(t *testing.T) {
+	pdfHeader := []byte("%PDF-1.4\n%test")
+	result := DetectMediaType(pdfHeader, "", "")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatPDF {
+		t.Errorf("expected FormatPDF, got %s", result.Format)
+	}
+	if result.MimeType != "application/pdf" {
+		t.Errorf("expected application/pdf, got %s", result.MimeType)
+	}
+}
+
+func TestDetector_ZIP(t *testing.T) {
+	zipHeader := []byte("PK\x03\x04\x14\x00\x00\x00")
+	result := DetectMediaType(zipHeader, "", "")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatZIP {
+		t.Errorf("expected FormatZIP, got %s", result.Format)
+	}
+}
+
+func TestDetector_DOCX(t *testing.T) {
+	docxHeader := make([]byte, 500)
+	copy(docxHeader[:2], "PK")
+	docxHeader[2] = 0x03
+	docxHeader[3] = 0x04
+	copy(docxHeader[30:35], "word/")
+	result := DetectMediaType(docxHeader, "", "")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatDOCX {
+		t.Errorf("expected FormatDOCX, got %s", result.Format)
+	}
+}
+
+func TestDetector_XLSX(t *testing.T) {
+	xlsxHeader := make([]byte, 500)
+	copy(xlsxHeader[:2], "PK")
+	xlsxHeader[2] = 0x03
+	xlsxHeader[3] = 0x04
+	copy(xlsxHeader[30:33], "xl/")
+	result := DetectMediaType(xlsxHeader, "", "")
+
+	if result.Format != FormatXLSX {
+		t.Errorf("expected FormatXLSX, got %s", result.Format)
+	}
+}
+
+func TestDetector_PPTX(t *testing.T) {
+	pptxHeader := make([]byte, 500)
+	copy(pptxHeader[:2], "PK")
+	pptxHeader[2] = 0x03
+	pptxHeader[3] = 0x04
+	copy(pptxHeader[30:34], "ppt/")
+	result := DetectMediaType(pptxHeader, "", "")
+
+	if result.Format != FormatPPTX {
+		t.Errorf("expected FormatPPTX, got %s", result.Format)
+	}
+}
+
+func TestDetector_RTF(t *testing.T) {
+	rtfHeader := []byte("{\\rtf1\\ansi\\deff0")
+	result := DetectMediaType(rtfHeader, "", "")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatRTF {
+		t.Errorf("expected FormatRTF, got %s", result.Format)
+	}
+}
+
+func TestDetector_PlainText(t *testing.T) {
+	textData := []byte("Hello, this is a plain text file.\nIt has multiple lines.\nNo commas on every line here.")
+	result := DetectMediaType(textData, "", "")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatTXT {
+		t.Errorf("expected FormatTXT, got %s", result.Format)
+	}
+}
+
+func TestDetector_CSV(t *testing.T) {
+	csvData := []byte("name,age,city\nAlice,30,NYC\nBob,25,LA\n")
+	result := DetectMediaType(csvData, "", "")
+
+	if result.Format != FormatCSV {
+		t.Errorf("expected FormatCSV, got %s", result.Format)
+	}
+}
+
+func TestDetector_OldDOC(t *testing.T) {
+	docHeader := []byte("\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1\x00\x00\x00\x00")
+	result := DetectMediaType(docHeader, "", "")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatDOC {
+		t.Errorf("expected FormatDOC, got %s", result.Format)
+	}
+}
+
+func TestDetector_EmptyData(t *testing.T) {
+	result := DetectMediaType([]byte{}, "", "")
+
+	if result.Format != FormatUnknown {
+		t.Errorf("expected FormatUnknown for empty data, got %s", result.Format)
+	}
+}
+
+func TestDetector_ShortData(t *testing.T) {
+	result := DetectMediaType([]byte{0xFF}, "", "")
+
+	if result.Format != FormatUnknown {
+		t.Errorf("expected FormatUnknown for 1-byte data, got %s", result.Format)
+	}
+}
+
+func TestDetector_MIMEFallback(t *testing.T) {
+	result := DetectMediaType([]byte("unknown binary data here"), "", "image/png")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage from MIME fallback, got %s", result.Type)
+	}
+	if result.Format != FormatPNG {
+		t.Errorf("expected FormatPNG from MIME fallback, got %s", result.Format)
+	}
+}
+
+func TestDetector_ExtensionFallback(t *testing.T) {
+	binaryData := make([]byte, 100)
+	for i := range binaryData {
+		binaryData[i] = byte(i % 256)
+	}
+	result := DetectMediaType(binaryData, "photo.jpg", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage from extension fallback, got %s", result.Type)
+	}
+	if result.Format != FormatJPEG {
+		t.Errorf("expected FormatJPEG from extension fallback, got %s", result.Format)
+	}
+}
+
+func TestDetector_ExtensionFallbackUnknown(t *testing.T) {
+	binaryData := make([]byte, 100)
+	for i := range binaryData {
+		binaryData[i] = byte(i % 256)
+	}
+	result := DetectMediaType(binaryData, "file.xyz", "")
+
+	if result.Format != FormatUnknown {
+		t.Errorf("expected FormatUnknown for unknown extension, got %s", result.Format)
+	}
+}
+
+func TestDetector_BytesOverrideMIME(t *testing.T) {
+	pngHeader := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	result := DetectMediaType(pngHeader, "wrong.jpg", "image/jpeg")
+
+	if result.Format != FormatPNG {
+		t.Errorf("expected bytes to override wrong MIME, got %s", result.Format)
+	}
+}
+
+func TestDetector_MIMEOverrideExtension(t *testing.T) {
+	result := DetectMediaType([]byte("some data"), "file.bin", "video/mp4")
+
+	if result.Format != FormatMP4 {
+		t.Errorf("expected MIME to override extension, got %s", result.Format)
+	}
+	if result.Type != TypeVideo {
+		t.Errorf("expected TypeVideo, got %s", result.Type)
+	}
+}
+
+func TestDetector_DetectFromBytes(t *testing.T) {
+	d := NewDetector()
+	jpegHeader := []byte{0xFF, 0xD8, 0xFF, 0xE0}
+	result := d.DetectFromBytes(jpegHeader)
+
+	if result.Format != FormatJPEG {
+		t.Errorf("expected FormatJPEG, got %s", result.Format)
+	}
+}
+
+func TestDetector_DetectFromBytesEmpty(t *testing.T) {
+	d := NewDetector()
+	result := d.DetectFromBytes(nil)
+
+	if result.Format != FormatUnknown {
+		t.Errorf("expected FormatUnknown, got %s", result.Format)
+	}
+}
+
+func TestDetector_MIMEOverrides(t *testing.T) {
+	d := NewDetector()
+	d.RegisterMIMEOverride("image/x-custom", FormatWebP)
+
+	result := d.Detect([]byte("some data"), "", "image/x-custom")
+
+	if result.Format != FormatWebP {
+		t.Errorf("expected FormatWebP from override, got %s", result.Format)
+	}
+}
+
+func TestDetector_FormatToType(t *testing.T) {
+	tests := []struct {
+		format Format
+		want   Type
+	}{
+		{FormatJPEG, TypeImage},
+		{FormatPNG, TypeImage},
+		{FormatGIF, TypeImage},
+		{FormatWebP, TypeImage},
+		{FormatBMP, TypeImage},
+		{FormatSVG, TypeImage},
+		{FormatTIFF, TypeImage},
+		{FormatICO, TypeImage},
+		{FormatAVIF, TypeImage},
+		{FormatHEIC, TypeImage},
+		{FormatMP3, TypeAudio},
+		{FormatWAV, TypeAudio},
+		{FormatOGG, TypeAudio},
+		{FormatFLAC, TypeAudio},
+		{FormatAAC, TypeAudio},
+		{FormatM4A, TypeAudio},
+		{FormatWMA, TypeAudio},
+		{FormatAMR, TypeAudio},
+		{FormatMIDI, TypeAudio},
+		{FormatMP4, TypeVideo},
+		{FormatWebM, TypeVideo},
+		{FormatAVI, TypeVideo},
+		{FormatMKV, TypeVideo},
+		{FormatMOV, TypeVideo},
+		{FormatWMV, TypeVideo},
+		{FormatFLV, TypeVideo},
+		{FormatMPEG, TypeVideo},
+		{Format3GP, TypeVideo},
+		{FormatPDF, TypeDoc},
+		{FormatDOC, TypeDoc},
+		{FormatDOCX, TypeDoc},
+		{FormatXLS, TypeDoc},
+		{FormatXLSX, TypeDoc},
+		{FormatPPT, TypeDoc},
+		{FormatPPTX, TypeDoc},
+		{FormatTXT, TypeDoc},
+		{FormatRTF, TypeDoc},
+		{FormatCSV, TypeDoc},
+		{FormatZIP, TypeDoc},
+		{FormatEPUB, TypeDoc},
+		{FormatUnknown, TypeDoc},
+	}
+
+	for _, tt := range tests {
+		got := formatToType(tt.format)
+		if got != tt.want {
+			t.Errorf("formatToType(%s) = %s, want %s", tt.format, got, tt.want)
+		}
+	}
+}
+
+func TestDetector_FormatToMIME(t *testing.T) {
+	tests := []struct {
+		format Format
+		want   string
+	}{
+		{FormatJPEG, "image/jpeg"},
+		{FormatPNG, "image/png"},
+		{FormatGIF, "image/gif"},
+		{FormatWebP, "image/webp"},
+		{FormatMP3, "audio/mpeg"},
+		{FormatWAV, "audio/wav"},
+		{FormatMP4, "video/mp4"},
+		{FormatWebM, "video/webm"},
+		{FormatPDF, "application/pdf"},
+		{FormatTXT, "text/plain"},
+		{FormatZIP, "application/zip"},
+		{FormatUnknown, "application/octet-stream"},
+	}
+
+	for _, tt := range tests {
+		got := formatToMIME(tt.format)
+		if got != tt.want {
+			t.Errorf("formatToMIME(%s) = %s, want %s", tt.format, got, tt.want)
+		}
+	}
+}
+
+func TestDetector_IsUTF8Text(t *testing.T) {
+	if !IsUTF8Text([]byte("Hello, world!")) {
+		t.Error("expected plain ASCII to be UTF-8 text")
+	}
+	if !IsUTF8Text([]byte("Hello\nWorld\t!")) {
+		t.Error("expected text with newlines/tabs to be UTF-8 text")
+	}
+	if IsUTF8Text([]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}) {
+		t.Error("expected binary data not to be UTF-8 text")
+	}
+}
+
+func TestDetector_3GP(t *testing.T) {
+	header := make([]byte, 20)
+	header[4] = 'f'
+	header[5] = 't'
+	header[6] = 'y'
+	header[7] = 'p'
+	copy(header[8:12], "3gp4")
+	result := DetectMediaType(header, "", "")
+
+	if result.Type != TypeVideo {
+		t.Errorf("expected TypeVideo, got %s", result.Type)
+	}
+	if result.Format != Format3GP {
+		t.Errorf("expected Format3GP, got %s", result.Format)
+	}
+}
+
+func TestDetector_EPUB(t *testing.T) {
+	epubHeader := make([]byte, 500)
+	copy(epubHeader[:2], "PK")
+	epubHeader[2] = 0x03
+	epubHeader[3] = 0x04
+	copy(epubHeader[30:60], "mimetypeapplication/epub+zip")
+	result := DetectMediaType(epubHeader, "", "")
+
+	if result.Format != FormatEPUB {
+		t.Errorf("expected FormatEPUB, got %s", result.Format)
+	}
+}
+
+func TestDetector_MPEG(t *testing.T) {
+	mpegHeader := []byte{0x00, 0x00, 0x01, 0xB3}
+	result := DetectMediaType(mpegHeader, "", "")
+
+	if result.Type != TypeVideo {
+		t.Errorf("expected TypeVideo, got %s", result.Type)
+	}
+	if result.Format != FormatMPEG {
+		t.Errorf("expected FormatMPEG, got %s", result.Format)
+	}
+}
+
+func TestDetector_AAC(t *testing.T) {
+	aacHeader := []byte{0xFF, 0xF1, 0x00, 0x00}
+	result := DetectMediaType(aacHeader, "", "")
+
+	if result.Type != TypeAudio {
+		t.Errorf("expected TypeAudio, got %s", result.Type)
+	}
+	if result.Format != FormatAAC {
+		t.Errorf("expected FormatAAC, got %s", result.Format)
+	}
+}
+
+func TestDetector_DetectAllInputs(t *testing.T) {
+	pngHeader := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+
+	result := DetectMediaType(pngHeader, "test.png", "image/png")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatPNG {
+		t.Errorf("expected FormatPNG, got %s", result.Format)
+	}
+	if result.MimeType != "image/png" {
+		t.Errorf("expected image/png, got %s", result.MimeType)
+	}
+}
+
+func TestDetector_MIMETypeFallback_Text(t *testing.T) {
+	binaryData := make([]byte, 100)
+	for i := range binaryData {
+		binaryData[i] = byte(i % 256)
+	}
+	result := DetectMediaType(binaryData, "", "text/csv")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatCSV {
+		t.Errorf("expected FormatCSV, got %s", result.Format)
+	}
+}
+
+func TestDetector_UnknownMIMEType(t *testing.T) {
+	binaryData := make([]byte, 100)
+	for i := range binaryData {
+		binaryData[i] = byte(i % 256)
+	}
+	result := DetectMediaType(binaryData, "", "application/x-unknown")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatUnknown {
+		t.Errorf("expected FormatUnknown, got %s", result.Format)
+	}
+}
+
+func TestDetector_JSON(t *testing.T) {
+	jsonData := []byte(`{"name":"test","value":123}`)
+	result := DetectMediaType(jsonData, "", "")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatJSON {
+		t.Errorf("expected FormatJSON, got %s", result.Format)
+	}
+	if result.MimeType != "application/json" {
+		t.Errorf("expected application/json, got %s", result.MimeType)
+	}
+}
+
+func TestDetector_JSONArray(t *testing.T) {
+	jsonData := []byte(`[1,2,3]`)
+	result := DetectMediaType(jsonData, "", "")
+
+	if result.Format != FormatJSON {
+		t.Errorf("expected FormatJSON, got %s", result.Format)
+	}
+}
+
+func TestDetector_XML(t *testing.T) {
+	xmlData := []byte(`<?xml version="1.0"?><root><item>test</item></root>`)
+	result := DetectMediaType(xmlData, "", "")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatXML {
+		t.Errorf("expected FormatXML, got %s", result.Format)
+	}
+}
+
+func TestDetector_HTML(t *testing.T) {
+	htmlData := []byte(`<!DOCTYPE html><html><head><title>Test</title></head><body></body></html>`)
+	result := DetectMediaType(htmlData, "", "")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatHTML {
+		t.Errorf("expected FormatHTML, got %s", result.Format)
+	}
+}
+
+func TestDetector_HTMLLower(t *testing.T) {
+	htmlData := []byte(`<html><body>Hello</body></html>`)
+	result := DetectMediaType(htmlData, "", "")
+
+	if result.Format != FormatHTML {
+		t.Errorf("expected FormatHTML, got %s", result.Format)
+	}
+}
+
+func TestDetector_YAML(t *testing.T) {
+	yamlData := []byte("name: test\nvalue: 123\nitems:\n  one\n  two\n")
+	result := DetectMediaType(yamlData, "", "")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatYAML {
+		t.Errorf("expected FormatYAML, got %s", result.Format)
+	}
+}
+
+func TestDetector_Markdown(t *testing.T) {
+	mdData := []byte("# Title\n\nThis is a paragraph.\n\n- Item one\n- Item two\n")
+	result := DetectMediaType(mdData, "", "")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatMD {
+		t.Errorf("expected FormatMD, got %s", result.Format)
+	}
+}
+
+func TestDetector_MarkdownLink(t *testing.T) {
+	mdData := []byte("# Hello\n\n[Click here](https://example.com)\n")
+	result := DetectMediaType(mdData, "", "")
+
+	if result.Format != FormatMD {
+		t.Errorf("expected FormatMD, got %s", result.Format)
+	}
+}
+
+func TestDetector_MarkdownCodeBlock(t *testing.T) {
+	mdData := []byte("# Code\n\n```go\nfmt.Println(\"hello\")\n```\n")
+	result := DetectMediaType(mdData, "", "")
+
+	if result.Format != FormatMD {
+		t.Errorf("expected FormatMD, got %s", result.Format)
+	}
+}
+
+func TestDetector_JPEG2000(t *testing.T) {
+	header := make([]byte, 20)
+	header[4] = 'f'
+	header[5] = 't'
+	header[6] = 'y'
+	header[7] = 'p'
+	copy(header[8:12], "jp2 ")
+	result := DetectMediaType(header, "", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatJPEG2000 {
+		t.Errorf("expected FormatJPEG2000, got %s", result.Format)
+	}
+}
+
+func TestDetector_PSD(t *testing.T) {
+	psdHeader := []byte("8BPS\x00\x01\x00\x00")
+	result := DetectMediaType(psdHeader, "", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatPSD {
+		t.Errorf("expected FormatPSD, got %s", result.Format)
+	}
+}
+
+func TestDetector_WMA(t *testing.T) {
+	wmaHeader := make([]byte, 20)
+	copy(wmaHeader[:16], []byte{0x30, 0x26, 0xB2, 0x75, 0x8E, 0x66, 0xCF, 0x11, 0xA6, 0xD9, 0x00, 0xAA, 0x00, 0x62, 0xCE, 0x6C})
+	wmaHeader[17] = 0x02
+	result := DetectMediaType(wmaHeader, "", "")
+
+	if result.Type != TypeAudio {
+		t.Errorf("expected TypeAudio, got %s", result.Type)
+	}
+	if result.Format != FormatWMA {
+		t.Errorf("expected FormatWMA, got %s", result.Format)
+	}
+}
+
+func TestDetector_WMV(t *testing.T) {
+	wmvHeader := make([]byte, 20)
+	copy(wmvHeader[:16], []byte{0x30, 0x26, 0xB2, 0x75, 0x8E, 0x66, 0xCF, 0x11, 0xA6, 0xD9, 0x00, 0xAA, 0x00, 0x62, 0xCE, 0x6C})
+	wmvHeader[17] = 0x03
+	result := DetectMediaType(wmvHeader, "", "")
+
+	if result.Type != TypeVideo {
+		t.Errorf("expected TypeVideo, got %s", result.Type)
+	}
+	if result.Format != FormatWMV {
+		t.Errorf("expected FormatWMV, got %s", result.Format)
+	}
+}
+
+func TestDetector_ExtensionJSON(t *testing.T) {
+	binaryData := make([]byte, 100)
+	for i := range binaryData {
+		binaryData[i] = byte(i % 256)
+	}
+	result := DetectMediaType(binaryData, "data.json", "")
+
+	if result.Type != TypeDoc {
+		t.Errorf("expected TypeDoc, got %s", result.Type)
+	}
+	if result.Format != FormatJSON {
+		t.Errorf("expected FormatJSON, got %s", result.Format)
+	}
+}
+
+func TestDetector_ExtensionXML(t *testing.T) {
+	binaryData := make([]byte, 100)
+	for i := range binaryData {
+		binaryData[i] = byte(i % 256)
+	}
+	result := DetectMediaType(binaryData, "data.xml", "")
+
+	if result.Format != FormatXML {
+		t.Errorf("expected FormatXML, got %s", result.Format)
+	}
+}
+
+func TestDetector_ExtensionHTML(t *testing.T) {
+	binaryData := make([]byte, 100)
+	for i := range binaryData {
+		binaryData[i] = byte(i % 256)
+	}
+	result := DetectMediaType(binaryData, "page.html", "")
+
+	if result.Format != FormatHTML {
+		t.Errorf("expected FormatHTML, got %s", result.Format)
+	}
+}
+
+func TestDetector_ExtensionYAML(t *testing.T) {
+	binaryData := make([]byte, 100)
+	for i := range binaryData {
+		binaryData[i] = byte(i % 256)
+	}
+	result := DetectMediaType(binaryData, "config.yaml", "")
+
+	if result.Format != FormatYAML {
+		t.Errorf("expected FormatYAML, got %s", result.Format)
+	}
+}
+
+func TestDetector_ExtensionMarkdown(t *testing.T) {
+	binaryData := make([]byte, 100)
+	for i := range binaryData {
+		binaryData[i] = byte(i % 256)
+	}
+	result := DetectMediaType(binaryData, "README.md", "")
+
+	if result.Format != FormatMD {
+		t.Errorf("expected FormatMD, got %s", result.Format)
+	}
+}
+
+func TestDetector_ExtensionJPEG2000(t *testing.T) {
+	binaryData := make([]byte, 100)
+	for i := range binaryData {
+		binaryData[i] = byte(i % 256)
+	}
+	result := DetectMediaType(binaryData, "image.jp2", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatJPEG2000 {
+		t.Errorf("expected FormatJPEG2000, got %s", result.Format)
+	}
+}
+
+func TestDetector_ExtensionPSD(t *testing.T) {
+	binaryData := make([]byte, 100)
+	for i := range binaryData {
+		binaryData[i] = byte(i % 256)
+	}
+	result := DetectMediaType(binaryData, "design.psd", "")
+
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+	if result.Format != FormatPSD {
+		t.Errorf("expected FormatPSD, got %s", result.Format)
+	}
+}
+
+func TestDetector_ExtractAudioMetadataWAV(t *testing.T) {
+	wavHeader := make([]byte, 40)
+	copy(wavHeader[:4], "RIFF")
+	wavHeader[8] = 'W'
+	wavHeader[9] = 'A'
+	wavHeader[10] = 'V'
+	wavHeader[11] = 'E'
+	wavHeader[22] = 0x02
+	wavHeader[23] = 0x00
+	wavHeader[24] = 0x44
+	wavHeader[25] = 0xAC
+	wavHeader[26] = 0x00
+	wavHeader[27] = 0x00
+	wavHeader[32] = 0x10
+	wavHeader[33] = 0x00
+
+	meta := ExtractAudioMetadata(wavHeader)
+
+	if meta["channels"] != uint16(2) {
+		t.Errorf("expected 2 channels, got %v", meta["channels"])
+	}
+	if meta["sample_rate"] != uint32(44100) {
+		t.Errorf("expected 44100 sample rate, got %v", meta["sample_rate"])
+	}
+	if meta["bits_per_sample"] != uint16(16) {
+		t.Errorf("expected 16 bits per sample, got %v", meta["bits_per_sample"])
+	}
+}
+
+func TestDetector_ExtractAudioMetadataMP3ID3(t *testing.T) {
+	mp3Data := []byte("ID3\x04\x00\x00\x00\x00\x00\x00test")
+	meta := ExtractAudioMetadata(mp3Data)
+
+	if meta["has_id3"] != true {
+		t.Errorf("expected has_id3 to be true")
+	}
+	if meta["id3_version"] != 4 {
+		t.Errorf("expected id3_version 4, got %v", meta["id3_version"])
+	}
+}
+
+func TestDetector_ExtractAudioMetadataOpus(t *testing.T) {
+	opusData := make([]byte, 40)
+	copy(opusData[:4], "OggS")
+	copy(opusData[28:36], "OpusHead")
+	meta := ExtractAudioMetadata(opusData)
+
+	if meta["codec"] != "opus" {
+		t.Errorf("expected codec opus, got %v", meta["codec"])
+	}
+}
+
+func TestDetector_ExtractVideoMetadataMatroska(t *testing.T) {
+	mkvData := []byte{0x1A, 0x45, 0xDF, 0xA3, 'm', 'a', 't', 'r'}
+	meta := ExtractVideoMetadata(mkvData)
+
+	if meta["container"] != "matroska" {
+		t.Errorf("expected container matroska, got %v", meta["container"])
+	}
+}
+
+func TestDetector_ExtractVideoMetadataWebM(t *testing.T) {
+	webmData := []byte{0x1A, 0x45, 0xDF, 0xA3, 'w', 'e', 'b', 'm'}
+	meta := ExtractVideoMetadata(webmData)
+
+	if meta["container"] != "webm" {
+		t.Errorf("expected container webm, got %v", meta["container"])
+	}
+}
+
+func TestDetector_ExtractVideoMetadataFLV(t *testing.T) {
+	flvData := []byte("FLV\x01\x05\x00\x00\x00\x09\x00\x00\x00\x00")
+	meta := ExtractVideoMetadata(flvData)
+
+	if meta["container"] != "flv" {
+		t.Errorf("expected container flv, got %v", meta["container"])
+	}
+	if meta["has_audio"] != true {
+		t.Errorf("expected has_audio to be true")
+	}
+	if meta["has_video"] != true {
+		t.Errorf("expected has_video to be true")
+	}
+}

--- a/pkg/media/media.go
+++ b/pkg/media/media.go
@@ -1,0 +1,633 @@
+package media
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Type string
+
+const (
+	TypeImage Type = "image"
+	TypeAudio Type = "audio"
+	TypeVideo Type = "video"
+	TypeDoc   Type = "document"
+)
+
+type Media struct {
+	ID       string
+	Type     Type
+	Name     string
+	Size     int64
+	MimeType string
+	Data     []byte
+	Base64   string
+	Path     string
+	URL      string
+	Metadata map[string]any
+}
+
+type Processor struct {
+	mu           sync.RWMutex
+	storagePath  string
+	maxFileSize  int64
+	allowedTypes []Type
+	httpClient   *http.Client
+	detector     *Detector
+	transcoder   *Transcoder
+	storage      StorageBackend
+	signer       *URLSigner
+}
+
+func NewProcessor(storagePath string) *Processor {
+	p := &Processor{
+		storagePath:  storagePath,
+		maxFileSize:  10 * 1024 * 1024,
+		allowedTypes: []Type{TypeImage, TypeAudio, TypeVideo, TypeDoc},
+		httpClient:   &http.Client{Timeout: 30 * time.Second},
+		detector:     NewDetector(),
+		transcoder:   NewTranscoder(),
+	}
+
+	if storagePath != "" {
+		p.storage = NewLocalStorage(LocalStorageConfig{
+			BasePath: storagePath,
+		})
+	}
+
+	return p
+}
+
+func (p *Processor) SetStorage(backend StorageBackend) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.storage = backend
+}
+
+func (p *Processor) Storage() StorageBackend {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.storage
+}
+
+func (p *Processor) SetTranscoder(t *Transcoder) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.transcoder = t
+}
+
+func (p *Processor) Transcoder() *Transcoder {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.transcoder
+}
+
+func (p *Processor) SetDetector(d *Detector) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.detector = d
+}
+
+func (p *Processor) Detector() *Detector {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.detector
+}
+
+func (p *Processor) Process(ctx context.Context, input *Media) (*Media, error) {
+	p.mu.RLock()
+	detector := p.detector
+	p.mu.RUnlock()
+
+	if detector != nil && len(input.Data) > 0 {
+		mediaType := detector.Detect(input.Data, input.Name, input.MimeType)
+		if mediaType.Format != FormatUnknown {
+			input.Type = mediaType.Type
+			input.MimeType = mediaType.MimeType
+			if input.Metadata == nil {
+				input.Metadata = make(map[string]any)
+			}
+			input.Metadata["format"] = string(mediaType.Format)
+		}
+	}
+
+	switch input.Type {
+	case TypeImage:
+		return p.processImage(ctx, input)
+	case TypeAudio:
+		return p.processAudio(ctx, input)
+	case TypeVideo:
+		return p.processVideo(ctx, input)
+	default:
+		return input, nil
+	}
+}
+
+func (p *Processor) processImage(ctx context.Context, input *Media) (*Media, error) {
+	if len(input.Data) == 0 && input.Path != "" {
+		data, err := os.ReadFile(input.Path)
+		if err != nil {
+			return nil, fmt.Errorf("read image file: %w", err)
+		}
+		input.Data = data
+	}
+
+	if len(input.Data) > 0 {
+		if input.Metadata == nil {
+			input.Metadata = make(map[string]any)
+		}
+
+		if meta, err := ExtractImageMetadata(input.Data); err == nil {
+			for k, v := range meta {
+				input.Metadata[k] = v
+			}
+		}
+	}
+
+	return input, nil
+}
+
+func (p *Processor) processAudio(ctx context.Context, input *Media) (*Media, error) {
+	if len(input.Data) > 0 {
+		if input.Metadata == nil {
+			input.Metadata = make(map[string]any)
+		}
+		for k, v := range ExtractAudioMetadata(input.Data) {
+			input.Metadata[k] = v
+		}
+	}
+	return input, nil
+}
+
+func (p *Processor) processVideo(ctx context.Context, input *Media) (*Media, error) {
+	if len(input.Data) > 0 {
+		if input.Metadata == nil {
+			input.Metadata = make(map[string]any)
+		}
+		for k, v := range ExtractVideoMetadata(input.Data) {
+			input.Metadata[k] = v
+		}
+	}
+	return input, nil
+}
+
+func (p *Processor) Download(ctx context.Context, url string) (*Media, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("download failed: %s", resp.Status)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, p.maxFileSize))
+	if err != nil {
+		return nil, err
+	}
+
+	mediaType := resp.Header.Get("Content-Type")
+	if mediaType == "" {
+		mediaType = "application/octet-stream"
+	}
+
+	media := &Media{
+		ID:       generateID(),
+		Type:     p.guessType(mediaType),
+		MimeType: mediaType,
+		Size:     int64(len(data)),
+		Data:     data,
+		Base64:   base64.StdEncoding.EncodeToString(data),
+		URL:      url,
+	}
+
+	return p.Process(ctx, media)
+}
+
+func (p *Processor) Upload(ctx context.Context, media *Media) (string, error) {
+	p.mu.RLock()
+	storage := p.storage
+	p.mu.RUnlock()
+
+	if storage == nil {
+		return "", fmt.Errorf("no storage backend configured")
+	}
+
+	ext := extensionFromMime(media.MimeType)
+	key := fmt.Sprintf("%s%s", media.ID, ext)
+
+	opts := StoragePutOptions{
+		MimeType: media.MimeType,
+		Metadata: map[string]string{
+			"media-type": string(media.Type),
+			"media-name": media.Name,
+		},
+	}
+
+	obj, err := storage.Put(ctx, key, media.Data, opts)
+	if err != nil {
+		return "", fmt.Errorf("upload to storage: %w", err)
+	}
+
+	media.Path = obj.URL
+	media.URL = obj.URL
+
+	return obj.URL, nil
+}
+
+func (p *Processor) Save(ctx context.Context, media *Media) (string, error) {
+	p.mu.RLock()
+	storage := p.storage
+	p.mu.RUnlock()
+
+	if storage == nil {
+		return "", fmt.Errorf("no storage backend configured")
+	}
+
+	key := media.Name
+	if key == "" {
+		ext := extensionFromMime(media.MimeType)
+		key = fmt.Sprintf("%s%s", media.ID, ext)
+	}
+
+	opts := StoragePutOptions{
+		MimeType: media.MimeType,
+	}
+
+	obj, err := storage.Put(ctx, key, media.Data, opts)
+	if err != nil {
+		return "", fmt.Errorf("save to storage: %w", err)
+	}
+
+	media.Path = obj.URL
+	media.URL = obj.URL
+
+	return obj.URL, nil
+}
+
+func (p *Processor) Load(ctx context.Context, key string) (*Media, error) {
+	p.mu.RLock()
+	storage := p.storage
+	p.mu.RUnlock()
+
+	if storage == nil {
+		return nil, fmt.Errorf("no storage backend configured")
+	}
+
+	obj, err := storage.Get(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("load from storage: %w", err)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(obj.Metadata["data"])
+	if err != nil {
+		return nil, fmt.Errorf("decode stored data: %w", err)
+	}
+
+	return &Media{
+		ID:       generateID(),
+		Type:     p.guessType(obj.MimeType),
+		Name:     filepath.Base(key),
+		Size:     obj.Size,
+		MimeType: obj.MimeType,
+		Data:     data,
+		Base64:   base64.StdEncoding.EncodeToString(data),
+		Path:     obj.URL,
+		URL:      obj.URL,
+	}, nil
+}
+
+func (p *Processor) Delete(ctx context.Context, key string) error {
+	p.mu.RLock()
+	storage := p.storage
+	p.mu.RUnlock()
+
+	if storage == nil {
+		return fmt.Errorf("no storage backend configured")
+	}
+
+	return storage.Delete(ctx, key)
+}
+
+func (p *Processor) Compress(ctx context.Context, media *Media, opts ImageOptions) (*Media, error) {
+	p.mu.RLock()
+	transcoder := p.transcoder
+	p.mu.RUnlock()
+
+	if transcoder == nil {
+		return nil, fmt.Errorf("no transcoder configured")
+	}
+
+	if len(media.Data) == 0 && media.Path != "" {
+		data, err := os.ReadFile(media.Path)
+		if err != nil {
+			return nil, fmt.Errorf("read media file: %w", err)
+		}
+		media.Data = data
+	}
+
+	var result []byte
+	var err error
+
+	switch media.Type {
+	case TypeImage:
+		result, err = transcoder.CompressImage(media.Data, opts)
+	case TypeAudio:
+		audioOpts := DefaultAudioOptions()
+		if opts.Format != FormatUnknown {
+			audioOpts.Format = opts.Format
+		}
+		if opts.Quality > 0 {
+			audioOpts.Bitrate = opts.Quality
+		}
+		result, err = transcoder.TranscodeAudio(ctx, media.Data, audioOpts)
+	case TypeVideo:
+		videoOpts := DefaultVideoOptions()
+		if opts.Format != FormatUnknown {
+			videoOpts.Format = opts.Format
+		}
+		if opts.Quality > 0 {
+			videoOpts.CRF = 51 - opts.Quality/2
+		}
+		result, err = transcoder.TranscodeVideo(ctx, media.Data, videoOpts)
+	default:
+		return nil, fmt.Errorf("unsupported media type for compression: %s", media.Type)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("compress media: %w", err)
+	}
+
+	media.Data = result
+	media.Size = int64(len(result))
+	media.Base64 = base64.StdEncoding.EncodeToString(result)
+
+	detected := DetectMediaType(result, media.Name, media.MimeType)
+	if detected.Format != FormatUnknown {
+		media.Type = detected.Type
+		media.MimeType = detected.MimeType
+		if media.Metadata == nil {
+			media.Metadata = make(map[string]any)
+		}
+		media.Metadata["format"] = string(detected.Format)
+	}
+
+	return media, nil
+}
+
+func (p *Processor) Convert(ctx context.Context, media *Media, targetFormat Format) (*Media, error) {
+	p.mu.RLock()
+	transcoder := p.transcoder
+	p.mu.RUnlock()
+
+	if transcoder == nil {
+		return nil, fmt.Errorf("no transcoder configured")
+	}
+
+	if len(media.Data) == 0 && media.Path != "" {
+		data, err := os.ReadFile(media.Path)
+		if err != nil {
+			return nil, fmt.Errorf("read media file: %w", err)
+		}
+		media.Data = data
+	}
+
+	var result []byte
+	var err error
+
+	switch media.Type {
+	case TypeImage:
+		result, err = transcoder.ConvertImage(media.Data, targetFormat)
+	case TypeAudio:
+		audioOpts := DefaultAudioOptions()
+		audioOpts.Format = targetFormat
+		result, err = transcoder.TranscodeAudio(ctx, media.Data, audioOpts)
+	case TypeVideo:
+		videoOpts := DefaultVideoOptions()
+		videoOpts.Format = targetFormat
+		result, err = transcoder.TranscodeVideo(ctx, media.Data, videoOpts)
+	default:
+		return nil, fmt.Errorf("unsupported media type for conversion: %s", media.Type)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("convert media: %w", err)
+	}
+
+	media.Data = result
+	media.Size = int64(len(result))
+	media.Base64 = base64.StdEncoding.EncodeToString(result)
+	media.MimeType = formatToMIME(targetFormat)
+
+	if media.Metadata == nil {
+		media.Metadata = make(map[string]any)
+	}
+	media.Metadata["format"] = string(targetFormat)
+
+	return media, nil
+}
+
+func (p *Processor) Exists(ctx context.Context, key string) (bool, error) {
+	p.mu.RLock()
+	storage := p.storage
+	p.mu.RUnlock()
+
+	if storage == nil {
+		return false, fmt.Errorf("no storage backend configured")
+	}
+
+	return storage.Exists(ctx, key)
+}
+
+func (p *Processor) List(ctx context.Context, prefix string) ([]*StorageObject, error) {
+	p.mu.RLock()
+	storage := p.storage
+	p.mu.RUnlock()
+
+	if storage == nil {
+		return nil, fmt.Errorf("no storage backend configured")
+	}
+
+	return storage.List(ctx, prefix)
+}
+
+func (p *Processor) PresignURL(ctx context.Context, key string, expires time.Duration) (string, error) {
+	p.mu.RLock()
+	storage := p.storage
+	signer := p.signer
+	p.mu.RUnlock()
+
+	if storage == nil {
+		return "", fmt.Errorf("no storage backend configured")
+	}
+
+	if signer != nil {
+		return signer.SignStorageObject(storage, key, expires)
+	}
+
+	return storage.URL(ctx, key, expires)
+}
+
+func (p *Processor) SetSigner(signer *URLSigner) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.signer = signer
+}
+
+func (p *Processor) Signer() *URLSigner {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.signer
+}
+
+func (p *Processor) VerifySignedURL(ctx context.Context, signedURL string) (*SignedURLResult, error) {
+	p.mu.RLock()
+	signer := p.signer
+	p.mu.RUnlock()
+
+	if signer == nil {
+		return nil, fmt.Errorf("no URL signer configured")
+	}
+
+	baseURL, expireTime, metadata, err := signer.VerifyURL(signedURL)
+	if err != nil {
+		return nil, err
+	}
+
+	remaining := expireTime.Sub(time.Now().UTC())
+
+	return &SignedURLResult{
+		URL:       baseURL,
+		ExpiresAt: expireTime,
+		Remaining: remaining,
+		Key:       "",
+		Metadata:  metadata,
+		IsRevoked: remaining < 0,
+	}, nil
+}
+
+func (p *Processor) RevokeSignedURL(ctx context.Context, signedURL string) error {
+	p.mu.RLock()
+	signer := p.signer
+	p.mu.RUnlock()
+
+	if signer == nil {
+		return fmt.Errorf("no URL signer configured")
+	}
+
+	return signer.RevokeURL(signedURL)
+}
+
+func (p *Processor) guessType(mimeType string) Type {
+	if strings.HasPrefix(mimeType, "image/") {
+		return TypeImage
+	}
+	if strings.HasPrefix(mimeType, "audio/") {
+		return TypeAudio
+	}
+	if strings.HasPrefix(mimeType, "video/") {
+		return TypeVideo
+	}
+	return TypeDoc
+}
+
+func extensionFromMime(mimeType string) string {
+	ext := mime.TypeByExtension(mimeType)
+	if ext == "" {
+		return ".bin"
+	}
+	return ext
+}
+
+func generateID() string {
+	return fmt.Sprintf("media-%d", time.Now().UnixNano())
+}
+
+func FromMultipart(form *multipart.Form) ([]*Media, error) {
+	var media []*Media
+
+	for _, files := range form.File {
+		for _, file := range files {
+			f, err := file.Open()
+			if err != nil {
+				continue
+			}
+			defer f.Close()
+
+			data, err := io.ReadAll(f)
+			if err != nil {
+				continue
+			}
+
+			media = append(media, &Media{
+				ID:       generateID(),
+				Name:     file.Filename,
+				MimeType: file.Header.Get("Content-Type"),
+				Size:     file.Size,
+				Data:     data,
+			})
+		}
+	}
+
+	return media, nil
+}
+
+func (m *Media) ToJSON() (string, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func FromBase64(data string) (*Media, error) {
+	decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Media{
+		ID:     generateID(),
+		Data:   decoded,
+		Base64: data,
+		Size:   int64(len(decoded)),
+	}, nil
+}
+
+type Converter struct{}
+
+func NewConverter() *Converter {
+	return &Converter{}
+}
+
+func (c *Converter) ImageToPNG(img image.Image) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (c *Converter) Resize(img image.Image, width, height int) image.Image {
+	return img
+}

--- a/pkg/media/pipeline.go
+++ b/pkg/media/pipeline.go
@@ -1,0 +1,771 @@
+package media
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type MediaPipeline struct {
+	mu         sync.RWMutex
+	config     MediaPipelineConfig
+	cache      *MediaCache
+	processor  *Processor
+	hooks      []MediaPipelineHook
+	httpClient *http.Client
+	inflight   sync.Map
+	stats      MediaPipelineStats
+}
+
+type MediaPipelineConfig struct {
+	Enabled          bool
+	MaxDownloadSize  int64
+	MaxConcurrent    int
+	Timeout          time.Duration
+	RetryCount       int
+	RetryDelay       time.Duration
+	UseCache         bool
+	CacheConfig      MediaCacheConfig
+	UserAgent        string
+	AllowedMimeTypes []string
+	BlockedSchemes   []string
+	Transcode        bool
+	ImageOptions     ImageOptions
+	AudioOptions     AudioOptions
+	VideoOptions     VideoOptions
+	Storage          StorageBackend
+	AutoSave         bool
+	Signer           *URLSigner
+	AutoSign         bool
+	SignExpiry       time.Duration
+}
+
+func DefaultMediaPipelineConfig() MediaPipelineConfig {
+	return MediaPipelineConfig{
+		Enabled:         true,
+		MaxDownloadSize: 100 * 1024 * 1024,
+		MaxConcurrent:   10,
+		Timeout:         60 * time.Second,
+		RetryCount:      3,
+		RetryDelay:      1 * time.Second,
+		UseCache:        true,
+		UserAgent:       "AnyClaw-MediaPipeline/1.0",
+		AllowedMimeTypes: []string{
+			"image/jpeg", "image/png", "image/gif", "image/webp", "image/svg+xml",
+			"audio/mpeg", "audio/wav", "audio/ogg", "audio/mp4", "audio/webm",
+			"video/mp4", "video/webm", "video/ogg", "video/quicktime",
+			"application/pdf", "application/msword",
+			"application/octet-stream",
+		},
+		BlockedSchemes: []string{"file", "data"},
+	}
+}
+
+type MediaPipelineHook interface {
+	OnBeforeDownload(ctx context.Context, url string, req *MediaDownloadRequest) error
+	OnAfterDownload(ctx context.Context, media *Media, cached bool) error
+	OnDownloadError(ctx context.Context, url string, err error, attempt int)
+	OnBatchComplete(ctx context.Context, results []*MediaDownloadResult)
+}
+
+type MediaDownloadRequest struct {
+	URL         string
+	MaxSize     int64
+	AcceptTypes []string
+	Headers     map[string]string
+	Metadata    map[string]any
+}
+
+type MediaDownloadResult struct {
+	Media  *Media
+	URL    string
+	Cached bool
+	Error  error
+}
+
+type MediaPipelineStats struct {
+	DownloadsTotal   int
+	DownloadsCached  int
+	DownloadsFailed  int
+	BytesDownloaded  int64
+	AverageLatency   time.Duration
+	ActiveDownloads  int
+	LastDownloadTime time.Time
+}
+
+func NewMediaPipeline(cfg MediaPipelineConfig) *MediaPipeline {
+	if cfg.MaxDownloadSize <= 0 {
+		cfg.MaxDownloadSize = 100 * 1024 * 1024
+	}
+	if cfg.MaxConcurrent <= 0 {
+		cfg.MaxConcurrent = 10
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 60 * time.Second
+	}
+	if cfg.RetryCount <= 0 {
+		cfg.RetryCount = 3
+	}
+	if cfg.RetryDelay <= 0 {
+		cfg.RetryDelay = 1 * time.Second
+	}
+
+	p := &MediaPipeline{
+		config:    cfg,
+		processor: NewProcessor(""),
+		httpClient: &http.Client{
+			Timeout: cfg.Timeout,
+		},
+	}
+
+	if p.config.UseCache {
+		p.cache = NewMediaCache(p.config.CacheConfig)
+	}
+
+	return p
+}
+
+func (p *MediaPipeline) RegisterHook(hook MediaPipelineHook) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.hooks = append(p.hooks, hook)
+}
+
+func (p *MediaPipeline) SetCache(cache *MediaCache) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cache = cache
+}
+
+func (p *MediaPipeline) Cache() *MediaCache {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.cache
+}
+
+func (p *MediaPipeline) EnableCache(cfg MediaCacheConfig) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cache = NewMediaCache(cfg)
+	p.config.UseCache = true
+}
+
+func (p *MediaPipeline) DisableCache() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cache = nil
+	p.config.UseCache = false
+}
+
+func (p *MediaPipeline) Download(ctx context.Context, url string) (*Media, error) {
+	return p.DownloadWithOptions(ctx, &MediaDownloadRequest{URL: url})
+}
+
+func (p *MediaPipeline) DownloadWithOptions(ctx context.Context, req *MediaDownloadRequest) (*Media, error) {
+	p.mu.RLock()
+	hooks := make([]MediaPipelineHook, len(p.hooks))
+	copy(hooks, p.hooks)
+	cache := p.cache
+	maxSize := p.config.MaxDownloadSize
+	retryCount := p.config.RetryCount
+	retryDelay := p.config.RetryDelay
+	userAgent := p.config.UserAgent
+	allowedTypes := p.config.AllowedMimeTypes
+	blockedSchemes := p.config.BlockedSchemes
+	p.mu.RUnlock()
+
+	if req.URL == "" {
+		return nil, fmt.Errorf("media-pipeline: empty URL")
+	}
+
+	if !isAllowedScheme(req.URL, blockedSchemes) {
+		return nil, fmt.Errorf("media-pipeline: blocked URL scheme: %s", req.URL)
+	}
+
+	maxReqSize := req.MaxSize
+	if maxReqSize <= 0 {
+		maxReqSize = maxSize
+	}
+
+	for _, hook := range hooks {
+		if err := hook.OnBeforeDownload(ctx, req.URL, req); err != nil {
+			return nil, fmt.Errorf("media-pipeline: hook rejected download: %w", err)
+		}
+	}
+
+	cacheKey := MakeMediaCacheKey(req.URL)
+
+	if cache != nil {
+		if media, ok := cache.Get(cacheKey); ok {
+			for _, hook := range hooks {
+				_ = hook.OnAfterDownload(ctx, media, true)
+			}
+
+			p.mu.Lock()
+			p.stats.DownloadsCached++
+			p.stats.DownloadsTotal++
+			p.stats.LastDownloadTime = time.Now()
+			p.mu.Unlock()
+
+			return media, nil
+		}
+	}
+
+	_, inflight := p.inflight.LoadOrStore(req.URL, make(chan struct{}))
+	if inflight {
+		p.mu.Lock()
+		p.stats.ActiveDownloads++
+		p.mu.Unlock()
+
+		defer func() {
+			p.mu.Lock()
+			p.stats.ActiveDownloads--
+			p.mu.Unlock()
+		}()
+	} else {
+		defer p.inflight.Delete(req.URL)
+	}
+
+	var media *Media
+	var lastErr error
+
+	for attempt := 0; attempt <= retryCount; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(retryDelay * time.Duration(attempt)):
+			}
+		}
+
+		media, lastErr = p.doDownload(ctx, req.URL, maxReqSize, userAgent, allowedTypes)
+		if lastErr == nil {
+			break
+		}
+
+		for _, hook := range hooks {
+			hook.OnDownloadError(ctx, req.URL, lastErr, attempt+1)
+		}
+	}
+
+	if lastErr != nil {
+		p.mu.Lock()
+		p.stats.DownloadsFailed++
+		p.stats.DownloadsTotal++
+		p.mu.Unlock()
+		return nil, fmt.Errorf("media-pipeline: download failed after %d attempts: %w", retryCount+1, lastErr)
+	}
+
+	if cache != nil {
+		cache.Set(cacheKey, media)
+	}
+
+	for _, hook := range hooks {
+		_ = hook.OnAfterDownload(ctx, media, false)
+	}
+
+	p.mu.Lock()
+	p.stats.DownloadsTotal++
+	p.stats.BytesDownloaded += media.Size
+	p.stats.LastDownloadTime = time.Now()
+	p.mu.Unlock()
+
+	return media, nil
+}
+
+func (p *MediaPipeline) DownloadBatch(ctx context.Context, urls []string) []*MediaDownloadResult {
+	results := make([]*MediaDownloadResult, len(urls))
+	sem := make(chan struct{}, p.config.MaxConcurrent)
+	var wg sync.WaitGroup
+
+	startTime := time.Now()
+
+	for i, url := range urls {
+		sem <- struct{}{}
+		wg.Add(1)
+
+		go func(idx int, u string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			result := &MediaDownloadResult{URL: u}
+
+			media, err := p.Download(ctx, u)
+			if err != nil {
+				result.Error = err
+			} else {
+				result.Media = media
+			}
+
+			results[idx] = result
+		}(i, url)
+	}
+
+	wg.Wait()
+
+	elapsed := time.Since(startTime)
+
+	p.mu.RLock()
+	hooks := make([]MediaPipelineHook, len(p.hooks))
+	copy(hooks, p.hooks)
+	p.mu.RUnlock()
+
+	for _, hook := range hooks {
+		hook.OnBatchComplete(ctx, results)
+	}
+
+	p.mu.Lock()
+	if len(urls) > 0 {
+		p.stats.AverageLatency = elapsed / time.Duration(len(urls))
+	}
+	p.mu.Unlock()
+
+	return results
+}
+
+func (p *MediaPipeline) DownloadAndSave(ctx context.Context, url, destDir string) (string, error) {
+	media, err := p.Download(ctx, url)
+	if err != nil {
+		return "", err
+	}
+
+	if destDir == "" {
+		destDir = p.processor.storagePath
+	}
+
+	if destDir == "" {
+		return "", fmt.Errorf("media-pipeline: no destination directory configured")
+	}
+
+	ext := extensionFromMime(media.MimeType)
+	filename := fmt.Sprintf("%s%s", media.ID, ext)
+	path := filepath.Join(destDir, filename)
+
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return "", fmt.Errorf("media-pipeline: failed to create directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, media.Data, 0644); err != nil {
+		return "", fmt.Errorf("media-pipeline: failed to save file: %w", err)
+	}
+
+	media.Path = path
+
+	return path, nil
+}
+
+func (p *MediaPipeline) Stats() MediaPipelineStats {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.stats
+}
+
+func (p *MediaPipeline) CacheStats() MediaCacheStats {
+	p.mu.RLock()
+	cache := p.cache
+	p.mu.RUnlock()
+
+	if cache == nil {
+		return MediaCacheStats{}
+	}
+
+	return cache.Stats()
+}
+
+func (p *MediaPipeline) ClearCache() {
+	p.mu.RLock()
+	cache := p.cache
+	p.mu.RUnlock()
+
+	if cache != nil {
+		cache.Clear()
+	}
+}
+
+func (p *MediaPipeline) CleanupCache() int {
+	p.mu.RLock()
+	cache := p.cache
+	p.mu.RUnlock()
+
+	if cache == nil {
+		return 0
+	}
+
+	return cache.Cleanup()
+}
+
+func (p *MediaPipeline) SaveToStorage(ctx context.Context, media *Media) (string, error) {
+	storage := p.config.Storage
+	if storage == nil {
+		return "", fmt.Errorf("media-pipeline: no storage backend configured")
+	}
+
+	ext := extensionFromMime(media.MimeType)
+	key := fmt.Sprintf("%s%s", media.ID, ext)
+
+	opts := StoragePutOptions{
+		MimeType: media.MimeType,
+	}
+
+	obj, err := storage.Put(ctx, key, media.Data, opts)
+	if err != nil {
+		return "", fmt.Errorf("media-pipeline: save to storage: %w", err)
+	}
+
+	media.Path = obj.URL
+	media.URL = obj.URL
+
+	return obj.URL, nil
+}
+
+func (p *MediaPipeline) LoadFromStorage(ctx context.Context, key string) (*Media, error) {
+	storage := p.config.Storage
+	if storage == nil {
+		return nil, fmt.Errorf("media-pipeline: no storage backend configured")
+	}
+
+	obj, err := storage.Get(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("media-pipeline: load from storage: %w", err)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(obj.Metadata["data"])
+	if err != nil {
+		return nil, fmt.Errorf("media-pipeline: decode stored data: %w", err)
+	}
+
+	return &Media{
+		ID:       generateID(),
+		Type:     p.processor.guessType(obj.MimeType),
+		Name:     filepath.Base(key),
+		Size:     obj.Size,
+		MimeType: obj.MimeType,
+		Data:     data,
+		Base64:   base64.StdEncoding.EncodeToString(data),
+		Path:     obj.URL,
+		URL:      obj.URL,
+	}, nil
+}
+
+func (p *MediaPipeline) DeleteFromStorage(ctx context.Context, key string) error {
+	storage := p.config.Storage
+	if storage == nil {
+		return fmt.Errorf("media-pipeline: no storage backend configured")
+	}
+	return storage.Delete(ctx, key)
+}
+
+func (p *MediaPipeline) StorageURL(ctx context.Context, key string, expires time.Duration) (string, error) {
+	storage := p.config.Storage
+	if storage == nil {
+		return "", fmt.Errorf("media-pipeline: no storage backend configured")
+	}
+	return storage.URL(ctx, key, expires)
+}
+
+func (p *MediaPipeline) SignURL(ctx context.Context, key string, expires time.Duration) (string, error) {
+	signer := p.config.Signer
+	if signer == nil {
+		return "", fmt.Errorf("media-pipeline: no URL signer configured")
+	}
+
+	storage := p.config.Storage
+	if storage != nil {
+		return signer.SignStorageObject(storage, key, expires)
+	}
+
+	baseURL := key
+	return signer.SignURL(baseURL, key, expires, nil)
+}
+
+func (p *MediaPipeline) VerifySignedURL(ctx context.Context, signedURL string) (*SignedURLResult, error) {
+	signer := p.config.Signer
+	if signer == nil {
+		return nil, fmt.Errorf("media-pipeline: no URL signer configured")
+	}
+
+	baseURL, expireTime, metadata, err := signer.VerifyURL(signedURL)
+	if err != nil {
+		return nil, err
+	}
+
+	remaining := expireTime.Sub(time.Now().UTC())
+
+	return &SignedURLResult{
+		URL:       baseURL,
+		ExpiresAt: expireTime,
+		Remaining: remaining,
+		Metadata:  metadata,
+		IsRevoked: remaining < 0,
+	}, nil
+}
+
+func (p *MediaPipeline) RevokeSignedURL(ctx context.Context, signedURL string) error {
+	signer := p.config.Signer
+	if signer == nil {
+		return fmt.Errorf("media-pipeline: no URL signer configured")
+	}
+	return signer.RevokeURL(signedURL)
+}
+
+func (p *MediaPipeline) SignMediaURL(ctx context.Context, media *Media, expires time.Duration) (string, error) {
+	signer := p.config.Signer
+	if signer == nil {
+		return "", fmt.Errorf("media-pipeline: no URL signer configured")
+	}
+
+	storage := p.config.Storage
+	if storage != nil && media.Metadata["storage-key"] != "" {
+		key := media.Metadata["storage-key"].(string)
+		return signer.SignStorageObject(storage, key, expires)
+	}
+
+	key := media.ID
+	if media.Name != "" {
+		key = media.Name
+	}
+
+	metadata := map[string]string{
+		"m_type": string(media.Type),
+		"m_mime": media.MimeType,
+	}
+
+	baseURL := media.URL
+	if baseURL == "" {
+		baseURL = "https://media.example.com/" + key
+	}
+
+	return signer.SignURL(baseURL, key, expires, metadata)
+}
+
+func (p *MediaPipeline) CleanupRevokedURLs() int {
+	signer := p.config.Signer
+	if signer == nil {
+		return 0
+	}
+	return signer.CleanupRevoked()
+}
+
+func (p *MediaPipeline) doDownload(ctx context.Context, url string, maxSize int64, userAgent string, allowedTypes []string) (*Media, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	if userAgent != "" {
+		req.Header.Set("User-Agent", userAgent)
+	}
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("download failed: HTTP %d %s", resp.StatusCode, resp.Status)
+	}
+
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		loc := resp.Header.Get("Location")
+		if loc == "" {
+			return nil, fmt.Errorf("redirect without Location header: HTTP %d", resp.StatusCode)
+		}
+		return p.doDownload(ctx, loc, maxSize, userAgent, allowedTypes)
+	}
+
+	contentLength := resp.ContentLength
+	if contentLength > maxSize {
+		return nil, fmt.Errorf("content too large: %d bytes (max %d)", contentLength, maxSize)
+	}
+
+	mediaType := resp.Header.Get("Content-Type")
+	if mediaType == "" {
+		mediaType = "application/octet-stream"
+	}
+
+	if len(allowedTypes) > 0 {
+		allowed := false
+		for _, t := range allowedTypes {
+			if t == mediaType || t == "application/octet-stream" {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return nil, fmt.Errorf("unsupported MIME type: %s", mediaType)
+		}
+	}
+
+	reader := io.LimitReader(resp.Body, maxSize)
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty response body")
+	}
+
+	detected := DetectMediaType(data, filenameFromURL(url), mediaType)
+
+	media := &Media{
+		ID:       generateID(),
+		Type:     detected.Type,
+		MimeType: detected.MimeType,
+		Size:     int64(len(data)),
+		Data:     data,
+		URL:      url,
+		Metadata: map[string]any{
+			"status_code":    resp.StatusCode,
+			"content_length": contentLength,
+			"downloaded_at":  time.Now().Unix(),
+			"format":         string(detected.Format),
+		},
+	}
+
+	_, _ = p.processor.Process(ctx, media)
+
+	if p.config.Transcode {
+		if err := p.transcodeMedia(ctx, media); err != nil {
+			return nil, fmt.Errorf("media-pipeline: transcode failed: %w", err)
+		}
+	}
+
+	if p.config.AutoSave && p.config.Storage != nil {
+		storage := p.config.Storage
+		ext := extensionFromMime(media.MimeType)
+		key := fmt.Sprintf("%s%s", media.ID, ext)
+
+		opts := StoragePutOptions{
+			MimeType: media.MimeType,
+			Metadata: map[string]string{
+				"media-type": string(media.Type),
+				"source-url": url,
+			},
+		}
+
+		obj, err := storage.Put(ctx, key, media.Data, opts)
+		if err != nil {
+			return nil, fmt.Errorf("media-pipeline: auto-save failed: %w", err)
+		}
+
+		media.Path = obj.URL
+		media.URL = obj.URL
+		media.Metadata["storage-key"] = key
+		media.Metadata["storage-url"] = obj.URL
+
+		if p.config.AutoSign && p.config.Signer != nil {
+			signExpires := p.config.SignExpiry
+			if signExpires <= 0 {
+				signExpires = 24 * time.Hour
+			}
+
+			signedURL, err := p.config.Signer.SignStorageObject(storage, key, signExpires)
+			if err != nil {
+				return nil, fmt.Errorf("media-pipeline: auto-sign failed: %w", err)
+			}
+
+			media.Metadata["signed-url"] = signedURL
+			media.Metadata["signed-expires"] = time.Now().UTC().Add(signExpires).Format(time.RFC3339)
+		}
+	}
+
+	return media, nil
+}
+
+func (p *MediaPipeline) transcodeMedia(ctx context.Context, media *Media) error {
+	transcoder := p.processor.Transcoder()
+	if transcoder == nil {
+		return nil
+	}
+
+	switch media.Type {
+	case TypeImage:
+		opts := p.config.ImageOptions
+		if opts.Format == FormatUnknown {
+			opts.Format = FormatJPEG
+		}
+		if opts.Quality == 0 {
+			opts.Quality = int(QualityHigh)
+		}
+		result, err := transcoder.CompressImage(media.Data, opts)
+		if err != nil {
+			return fmt.Errorf("compress image: %w", err)
+		}
+		media.Data = result
+		media.Size = int64(len(result))
+		media.Base64 = ""
+		detected := DetectMediaType(result, media.Name, media.MimeType)
+		if detected.Format != FormatUnknown {
+			media.MimeType = detected.MimeType
+			if media.Metadata == nil {
+				media.Metadata = make(map[string]any)
+			}
+			media.Metadata["format"] = string(detected.Format)
+			media.Metadata["compressed"] = true
+		}
+	case TypeAudio:
+		opts := p.config.AudioOptions
+		if opts.Format == FormatUnknown {
+			opts.Format = FormatMP3
+		}
+		result, err := transcoder.TranscodeAudio(ctx, media.Data, opts)
+		if err != nil {
+			return fmt.Errorf("transcode audio: %w", err)
+		}
+		media.Data = result
+		media.Size = int64(len(result))
+		media.Base64 = ""
+		media.MimeType = formatToMIME(opts.Format)
+		if media.Metadata == nil {
+			media.Metadata = make(map[string]any)
+		}
+		media.Metadata["format"] = string(opts.Format)
+		media.Metadata["compressed"] = true
+	case TypeVideo:
+		opts := p.config.VideoOptions
+		if opts.Format == FormatUnknown {
+			opts.Format = FormatMP4
+		}
+		result, err := transcoder.TranscodeVideo(ctx, media.Data, opts)
+		if err != nil {
+			return fmt.Errorf("transcode video: %w", err)
+		}
+		media.Data = result
+		media.Size = int64(len(result))
+		media.Base64 = ""
+		media.MimeType = formatToMIME(opts.Format)
+		if media.Metadata == nil {
+			media.Metadata = make(map[string]any)
+		}
+		media.Metadata["format"] = string(opts.Format)
+		media.Metadata["compressed"] = true
+	}
+
+	return nil
+}
+
+func filenameFromURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return filepath.Base(u.Path)
+}
+
+func isAllowedScheme(url string, blocked []string) bool {
+	for _, scheme := range blocked {
+		if len(url) > len(scheme)+1 && url[:len(scheme)] == scheme && url[len(scheme)] == ':' {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/media/pipeline.go
+++ b/pkg/media/pipeline.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -194,13 +195,26 @@ func (p *MediaPipeline) DownloadWithOptions(ctx context.Context, req *MediaDownl
 		maxReqSize = maxSize
 	}
 
+	effectiveAllowedTypes := allowedTypes
+	if len(req.AcceptTypes) > 0 {
+		effectiveAllowedTypes = append([]string(nil), req.AcceptTypes...)
+	}
+
+	requestHeaders := cloneStringMap(req.Headers)
+
 	for _, hook := range hooks {
 		if err := hook.OnBeforeDownload(ctx, req.URL, req); err != nil {
 			return nil, fmt.Errorf("media-pipeline: hook rejected download: %w", err)
 		}
 	}
 
-	cacheKey := MakeMediaCacheKey(req.URL)
+	cacheKey := MakeMediaCacheKey(
+		req.URL,
+		WithCacheMaxSize(maxReqSize),
+		WithCacheAcceptTypes(effectiveAllowedTypes),
+		WithCacheHeaders(requestHeaders),
+		WithCacheFormat(p.cacheFormatVariant()),
+	)
 
 	if cache != nil {
 		if media, ok := cache.Get(cacheKey); ok {
@@ -218,7 +232,7 @@ func (p *MediaPipeline) DownloadWithOptions(ctx context.Context, req *MediaDownl
 		}
 	}
 
-	_, inflight := p.inflight.LoadOrStore(req.URL, make(chan struct{}))
+	_, inflight := p.inflight.LoadOrStore(cacheKey, make(chan struct{}))
 	if inflight {
 		p.mu.Lock()
 		p.stats.ActiveDownloads++
@@ -230,7 +244,7 @@ func (p *MediaPipeline) DownloadWithOptions(ctx context.Context, req *MediaDownl
 			p.mu.Unlock()
 		}()
 	} else {
-		defer p.inflight.Delete(req.URL)
+		defer p.inflight.Delete(cacheKey)
 	}
 
 	var media *Media
@@ -245,7 +259,7 @@ func (p *MediaPipeline) DownloadWithOptions(ctx context.Context, req *MediaDownl
 			}
 		}
 
-		media, lastErr = p.doDownload(ctx, req.URL, maxReqSize, userAgent, allowedTypes)
+		media, lastErr = p.doDownload(ctx, req.URL, maxReqSize, userAgent, effectiveAllowedTypes, requestHeaders)
 		if lastErr == nil {
 			break
 		}
@@ -553,13 +567,17 @@ func (p *MediaPipeline) CleanupRevokedURLs() int {
 	return signer.CleanupRevoked()
 }
 
-func (p *MediaPipeline) doDownload(ctx context.Context, url string, maxSize int64, userAgent string, allowedTypes []string) (*Media, error) {
+func (p *MediaPipeline) doDownload(ctx context.Context, url string, maxSize int64, userAgent string, allowedTypes []string, headers map[string]string) (*Media, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
-	if userAgent != "" {
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	if userAgent != "" && !hasHeaderKey(headers, "User-Agent") {
 		req.Header.Set("User-Agent", userAgent)
 	}
 
@@ -578,7 +596,7 @@ func (p *MediaPipeline) doDownload(ctx context.Context, url string, maxSize int6
 		if loc == "" {
 			return nil, fmt.Errorf("redirect without Location header: HTTP %d", resp.StatusCode)
 		}
-		return p.doDownload(ctx, loc, maxSize, userAgent, allowedTypes)
+		return p.doDownload(ctx, loc, maxSize, userAgent, allowedTypes, headers)
 	}
 
 	contentLength := resp.ContentLength
@@ -768,4 +786,40 @@ func isAllowedScheme(url string, blocked []string) bool {
 		}
 	}
 	return true
+}
+
+func cloneStringMap(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(src))
+	for k, v := range src {
+		cloned[k] = v
+	}
+	return cloned
+}
+
+func hasHeaderKey(headers map[string]string, key string) bool {
+	for k := range headers {
+		if strings.EqualFold(k, key) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *MediaPipeline) cacheFormatVariant() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if !p.config.Transcode {
+		return "source"
+	}
+
+	return fmt.Sprintf(
+		"transcode|img=%s|audio=%s|video=%s",
+		p.config.ImageOptions.Format,
+		p.config.AudioOptions.Format,
+		p.config.VideoOptions.Format,
+	)
 }

--- a/pkg/media/pipeline.go
+++ b/pkg/media/pipeline.go
@@ -25,6 +25,12 @@ type MediaPipeline struct {
 	stats      MediaPipelineStats
 }
 
+type inflightDownload struct {
+	done  chan struct{}
+	media *Media
+	err   error
+}
+
 type MediaPipelineConfig struct {
 	Enabled          bool
 	MaxDownloadSize  int64
@@ -232,8 +238,10 @@ func (p *MediaPipeline) DownloadWithOptions(ctx context.Context, req *MediaDownl
 		}
 	}
 
-	_, inflight := p.inflight.LoadOrStore(cacheKey, make(chan struct{}))
+	call := &inflightDownload{done: make(chan struct{})}
+	actual, inflight := p.inflight.LoadOrStore(cacheKey, call)
 	if inflight {
+		shared := actual.(*inflightDownload)
 		p.mu.Lock()
 		p.stats.ActiveDownloads++
 		p.mu.Unlock()
@@ -243,9 +251,33 @@ func (p *MediaPipeline) DownloadWithOptions(ctx context.Context, req *MediaDownl
 			p.stats.ActiveDownloads--
 			p.mu.Unlock()
 		}()
-	} else {
-		defer p.inflight.Delete(cacheKey)
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-shared.done:
+		}
+
+		if shared.err != nil {
+			return nil, shared.err
+		}
+
+		for _, hook := range hooks {
+			_ = hook.OnAfterDownload(ctx, shared.media, false)
+		}
+
+		p.mu.Lock()
+		p.stats.DownloadsTotal++
+		p.stats.BytesDownloaded += shared.media.Size
+		p.stats.LastDownloadTime = time.Now()
+		p.mu.Unlock()
+
+		return shared.media, nil
 	}
+	defer func() {
+		close(call.done)
+		p.inflight.Delete(cacheKey)
+	}()
 
 	var media *Media
 	var lastErr error
@@ -270,16 +302,19 @@ func (p *MediaPipeline) DownloadWithOptions(ctx context.Context, req *MediaDownl
 	}
 
 	if lastErr != nil {
+		call.err = fmt.Errorf("media-pipeline: download failed after %d attempts: %w", retryCount+1, lastErr)
 		p.mu.Lock()
 		p.stats.DownloadsFailed++
 		p.stats.DownloadsTotal++
 		p.mu.Unlock()
-		return nil, fmt.Errorf("media-pipeline: download failed after %d attempts: %w", retryCount+1, lastErr)
+		return nil, call.err
 	}
 
 	if cache != nil {
 		cache.Set(cacheKey, media)
 	}
+
+	call.media = media
 
 	for _, hook := range hooks {
 		_ = hook.OnAfterDownload(ctx, media, false)

--- a/pkg/media/pipeline_test.go
+++ b/pkg/media/pipeline_test.go
@@ -1,0 +1,961 @@
+package media
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestMediaCache_SetAndGet(t *testing.T) {
+	cfg := DefaultMediaCacheConfig()
+	cache := NewMediaCache(cfg)
+
+	media := &Media{
+		ID:       "test-1",
+		Type:     TypeImage,
+		MimeType: "image/png",
+		Size:     1024,
+		Data:     make([]byte, 1024),
+		URL:      "https://example.com/image.png",
+	}
+
+	key := MakeMediaCacheKey("https://example.com/image.png")
+	cache.Set(key, media)
+
+	got, ok := cache.Get(key)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if got.ID != "test-1" {
+		t.Errorf("expected ID test-1, got %s", got.ID)
+	}
+	if got.Size != 1024 {
+		t.Errorf("expected size 1024, got %d", got.Size)
+	}
+}
+
+func TestMediaCache_Miss(t *testing.T) {
+	cache := NewMediaCache(DefaultMediaCacheConfig())
+
+	_, ok := cache.Get("nonexistent-key")
+	if ok {
+		t.Error("expected cache miss")
+	}
+}
+
+func TestMediaCache_TTLExpiration(t *testing.T) {
+	cfg := MediaCacheConfig{
+		MaxItems: 100,
+		MaxBytes: 10 * 1024 * 1024,
+		TTL:      100 * time.Millisecond,
+	}
+	cache := NewMediaCache(cfg)
+
+	media := &Media{
+		ID:   "test-ttl",
+		Size: 512,
+		Data: make([]byte, 512),
+	}
+
+	key := MakeMediaCacheKey("https://example.com/expiring")
+	cache.Set(key, media)
+
+	_, ok := cache.Get(key)
+	if !ok {
+		t.Fatal("expected cache hit before expiration")
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	_, ok = cache.Get(key)
+	if ok {
+		t.Error("expected cache miss after TTL expiration")
+	}
+}
+
+func TestMediaCache_Eviction(t *testing.T) {
+	cfg := MediaCacheConfig{
+		MaxItems: 3,
+		MaxBytes: 10 * 1024 * 1024,
+		TTL:      1 * time.Hour,
+	}
+	cache := NewMediaCache(cfg)
+
+	for i := 0; i < 5; i++ {
+		media := &Media{
+			ID:   fmt.Sprintf("item-%d", i),
+			Size: 1024,
+			Data: make([]byte, 1024),
+		}
+		key := fmt.Sprintf("key-%d", i)
+		cache.Set(key, media)
+	}
+
+	if cache.Len() > 3 {
+		t.Errorf("expected at most 3 items after eviction, got %d", cache.Len())
+	}
+}
+
+func TestMediaCache_Remove(t *testing.T) {
+	cache := NewMediaCache(DefaultMediaCacheConfig())
+
+	media := &Media{
+		ID:   "test-remove",
+		Size: 256,
+		Data: make([]byte, 256),
+	}
+	key := "remove-key"
+	cache.Set(key, media)
+
+	if cache.Len() != 1 {
+		t.Fatalf("expected 1 item, got %d", cache.Len())
+	}
+
+	cache.Remove(key)
+
+	if cache.Len() != 0 {
+		t.Errorf("expected 0 items after remove, got %d", cache.Len())
+	}
+}
+
+func TestMediaCache_Clear(t *testing.T) {
+	cache := NewMediaCache(DefaultMediaCacheConfig())
+
+	for i := 0; i < 10; i++ {
+		media := &Media{
+			ID:   fmt.Sprintf("item-%d", i),
+			Size: 100,
+			Data: make([]byte, 100),
+		}
+		cache.Set(fmt.Sprintf("key-%d", i), media)
+	}
+
+	if cache.Len() != 10 {
+		t.Fatalf("expected 10 items, got %d", cache.Len())
+	}
+
+	cache.Clear()
+
+	if cache.Len() != 0 {
+		t.Errorf("expected 0 items after clear, got %d", cache.Len())
+	}
+	if cache.SizeBytes() != 0 {
+		t.Errorf("expected 0 bytes after clear, got %d", cache.SizeBytes())
+	}
+}
+
+func TestMediaCache_SizeBytes(t *testing.T) {
+	cache := NewMediaCache(DefaultMediaCacheConfig())
+
+	media := &Media{
+		ID:   "test-size",
+		Size: 2048,
+		Data: make([]byte, 2048),
+	}
+	cache.Set("size-key", media)
+
+	if cache.SizeBytes() != 2048 {
+		t.Errorf("expected 2048 bytes, got %d", cache.SizeBytes())
+	}
+}
+
+func TestMediaCache_Stats(t *testing.T) {
+	cache := NewMediaCache(DefaultMediaCacheConfig())
+
+	media := &Media{
+		ID:   "test-stats",
+		Size: 512,
+		Data: make([]byte, 512),
+	}
+	cache.Set("stats-key", media)
+
+	cache.Get("stats-key")
+	cache.Get("stats-key")
+	cache.Get("nonexistent")
+
+	stats := cache.Stats()
+
+	if stats.Hits != 2 {
+		t.Errorf("expected 2 hits, got %d", stats.Hits)
+	}
+	if stats.Misses != 1 {
+		t.Errorf("expected 1 miss, got %d", stats.Misses)
+	}
+	if stats.ItemCount != 1 {
+		t.Errorf("expected 1 item, got %d", stats.ItemCount)
+	}
+}
+
+func TestMediaCache_Cleanup(t *testing.T) {
+	cfg := MediaCacheConfig{
+		MaxItems: 100,
+		MaxBytes: 10 * 1024 * 1024,
+		TTL:      50 * time.Millisecond,
+	}
+	cache := NewMediaCache(cfg)
+
+	for i := 0; i < 5; i++ {
+		media := &Media{
+			ID:   fmt.Sprintf("item-%d", i),
+			Size: 100,
+			Data: make([]byte, 100),
+		}
+		cache.Set(fmt.Sprintf("key-%d", i), media)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	removed := cache.Cleanup()
+
+	if removed != 5 {
+		t.Errorf("expected 5 expired items cleaned up, got %d", removed)
+	}
+	if cache.Len() != 0 {
+		t.Errorf("expected 0 items after cleanup, got %d", cache.Len())
+	}
+}
+
+func TestMediaCache_DiskPersistence(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "media-cache")
+
+	cfg := MediaCacheConfig{
+		MaxItems:     100,
+		MaxBytes:     10 * 1024 * 1024,
+		TTL:          1 * time.Hour,
+		DiskPath:     cacheDir,
+		PersistIndex: true,
+	}
+	cache := NewMediaCache(cfg)
+
+	data := []byte("test image data for disk persistence")
+	media := &Media{
+		ID:       "disk-test",
+		Type:     TypeImage,
+		MimeType: "image/png",
+		Size:     int64(len(data)),
+		Data:     data,
+		URL:      "https://example.com/disk.png",
+	}
+
+	key := MakeMediaCacheKey("https://example.com/disk.png")
+	cache.Set(key, media)
+
+	got, ok := cache.Get(key)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if string(got.Data) != string(data) {
+		t.Error("data mismatch")
+	}
+
+	indexPath := filepath.Join(cacheDir, "cache_index.json")
+	if _, err := os.Stat(indexPath); err != nil {
+		t.Errorf("expected cache index file to exist: %v", err)
+	}
+}
+
+func TestMediaCache_MaxBytes(t *testing.T) {
+	cfg := MediaCacheConfig{
+		MaxItems: 1000,
+		MaxBytes: 2048,
+		TTL:      1 * time.Hour,
+	}
+	cache := NewMediaCache(cfg)
+
+	largeMedia := &Media{
+		ID:   "large",
+		Size: 3000,
+		Data: make([]byte, 3000),
+	}
+	cache.Set("large-key", largeMedia)
+
+	if cache.Len() != 0 {
+		t.Error("expected large item to be rejected")
+	}
+}
+
+func TestMediaCache_NilSet(t *testing.T) {
+	cache := NewMediaCache(DefaultMediaCacheConfig())
+	cache.Set("nil-key", nil)
+
+	if cache.Len() != 0 {
+		t.Error("expected nil media to be ignored")
+	}
+}
+
+func TestMediaCache_ConcurrentAccess(t *testing.T) {
+	cache := NewMediaCache(DefaultMediaCacheConfig())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+
+			key := fmt.Sprintf("concurrent-%d", idx)
+			media := &Media{
+				ID:   key,
+				Size: 100,
+				Data: make([]byte, 100),
+			}
+			cache.Set(key, media)
+
+			cache.Get(key)
+		}(i)
+	}
+
+	wg.Wait()
+
+	if cache.Len() != 50 {
+		t.Errorf("expected 50 items, got %d", cache.Len())
+	}
+}
+
+func TestMediaCache_HitRate(t *testing.T) {
+	cache := NewMediaCache(DefaultMediaCacheConfig())
+
+	media := &Media{
+		ID:   "hitrate",
+		Size: 100,
+		Data: make([]byte, 100),
+	}
+	cache.Set("hitrate-key", media)
+
+	cache.Get("hitrate-key")
+	cache.Get("hitrate-key")
+	cache.Get("miss-key")
+	cache.Get("miss-key-2")
+
+	stats := cache.Stats()
+
+	if stats.LastHitRate == 0 {
+		t.Error("expected non-zero hit rate")
+	}
+}
+
+func TestMakeMediaCacheKey(t *testing.T) {
+	key1 := MakeMediaCacheKey("https://example.com/image.png")
+	key2 := MakeMediaCacheKey("https://example.com/image.png")
+	key3 := MakeMediaCacheKey("https://example.com/different.png")
+
+	if key1 != key2 {
+		t.Error("same URL should produce same key")
+	}
+	if key1 == key3 {
+		t.Error("different URLs should produce different keys")
+	}
+}
+
+func TestMediaCacheOptions(t *testing.T) {
+	key := MakeMediaCacheKey("https://example.com/test.png",
+		WithCacheMaxSize(5*1024*1024),
+		WithCacheFormat("png"),
+	)
+
+	if key == "" {
+		t.Error("expected non-empty key")
+	}
+}
+
+func TestMediaPipeline_Download(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write([]byte("fake-data"))
+	}))
+	defer server.Close()
+
+	pipeline := NewMediaPipeline(DefaultMediaPipelineConfig())
+
+	media, err := pipeline.Download(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if media == nil {
+		t.Fatal("expected media result")
+	}
+	if media.Type != TypeDoc {
+		t.Errorf("expected doc type, got %s", media.Type)
+	}
+	if media.MimeType != "text/plain" {
+		t.Errorf("expected text/plain, got %s", media.MimeType)
+	}
+}
+
+func TestMediaPipeline_DownloadWithCache(t *testing.T) {
+	callCount := int32(0)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write([]byte("jpeg-data"))
+	}))
+	defer server.Close()
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.CacheConfig = MediaCacheConfig{
+		MaxItems: 100,
+		MaxBytes: 10 * 1024 * 1024,
+		TTL:      1 * time.Hour,
+	}
+
+	pipeline := NewMediaPipeline(cfg)
+
+	_, err := pipeline.Download(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("first download failed: %v", err)
+	}
+
+	_, err = pipeline.Download(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("second download failed: %v", err)
+	}
+
+	if atomic.LoadInt32(&callCount) != 1 {
+		t.Errorf("expected 1 HTTP call (second should be cached), got %d", callCount)
+	}
+
+	stats := pipeline.Stats()
+	if stats.DownloadsCached != 1 {
+		t.Errorf("expected 1 cached download, got %d", stats.DownloadsCached)
+	}
+}
+
+func TestMediaPipeline_DownloadEmptyURL(t *testing.T) {
+	pipeline := NewMediaPipeline(DefaultMediaPipelineConfig())
+
+	_, err := pipeline.Download(context.Background(), "")
+	if err == nil {
+		t.Error("expected error for empty URL")
+	}
+}
+
+func TestMediaPipeline_DownloadBlockedScheme(t *testing.T) {
+	pipeline := NewMediaPipeline(DefaultMediaPipelineConfig())
+
+	_, err := pipeline.Download(context.Background(), "file:///etc/passwd")
+	if err == nil {
+		t.Error("expected error for file:// scheme")
+	}
+}
+
+func TestMediaPipeline_DownloadFailAndRetry(t *testing.T) {
+	attempts := int32(0)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count < 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("success-after-retry"))
+	}))
+	defer server.Close()
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.RetryCount = 3
+	cfg.RetryDelay = 10 * time.Millisecond
+	cfg.UseCache = false
+
+	pipeline := NewMediaPipeline(cfg)
+
+	media, err := pipeline.Download(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("expected success after retry: %v", err)
+	}
+
+	if string(media.Data) != "success-after-retry" {
+		t.Errorf("expected success data, got %s", string(media.Data))
+	}
+}
+
+func TestMediaPipeline_DownloadAllRetriesFail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.RetryCount = 2
+	cfg.RetryDelay = 10 * time.Millisecond
+	cfg.UseCache = false
+
+	pipeline := NewMediaPipeline(cfg)
+
+	_, err := pipeline.Download(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected error after all retries")
+	}
+
+	stats := pipeline.Stats()
+	if stats.DownloadsFailed != 1 {
+		t.Errorf("expected 1 failed download, got %d", stats.DownloadsFailed)
+	}
+}
+
+func TestMediaPipeline_DownloadBatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("batch-image"))
+	}))
+	defer server.Close()
+
+	pipeline := NewMediaPipeline(DefaultMediaPipelineConfig())
+
+	urls := []string{
+		server.URL + "/1",
+		server.URL + "/2",
+		server.URL + "/3",
+	}
+
+	results := pipeline.DownloadBatch(context.Background(), urls)
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	for i, result := range results {
+		if result.Error != nil {
+			t.Errorf("result %d had error: %v", i, result.Error)
+		}
+		if result.Media == nil {
+			t.Errorf("result %d had nil media", i)
+		}
+	}
+}
+
+func TestMediaPipeline_DownloadBatchWithFailures(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/fail" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write([]byte("image"))
+	}))
+	defer server.Close()
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.RetryCount = 0
+	cfg.RetryDelay = 0
+	cfg.UseCache = false
+
+	pipeline := NewMediaPipeline(cfg)
+
+	urls := []string{
+		server.URL + "/ok1",
+		server.URL + "/fail",
+		server.URL + "/ok2",
+	}
+
+	results := pipeline.DownloadBatch(context.Background(), urls)
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	if results[0].Error != nil {
+		t.Errorf("first should succeed: %v", results[0].Error)
+	}
+	if results[1].Error == nil {
+		t.Error("second should fail")
+	}
+	if results[2].Error != nil {
+		t.Errorf("third should succeed: %v", results[2].Error)
+	}
+}
+
+func TestMediaPipeline_Hooks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("hook-test"))
+	}))
+	defer server.Close()
+
+	pipeline := NewMediaPipeline(DefaultMediaPipelineConfig())
+
+	var beforeCalled, afterCalled bool
+	var downloadedMedia *Media
+	var wasCached bool
+
+	hook := &testHook{
+		beforeFn: func(ctx context.Context, url string, req *MediaDownloadRequest) error {
+			beforeCalled = true
+			return nil
+		},
+		afterFn: func(ctx context.Context, media *Media, cached bool) error {
+			afterCalled = true
+			downloadedMedia = media
+			wasCached = cached
+			return nil
+		},
+	}
+
+	pipeline.RegisterHook(hook)
+
+	_, err := pipeline.Download(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+
+	if !beforeCalled {
+		t.Error("OnBeforeDownload hook not called")
+	}
+	if !afterCalled {
+		t.Error("OnAfterDownload hook not called")
+	}
+	if downloadedMedia == nil {
+		t.Error("media not passed to hook")
+	}
+	if wasCached {
+		t.Error("first download should not be cached")
+	}
+}
+
+func TestMediaPipeline_HookReject(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("should-not-reach"))
+	}))
+	defer server.Close()
+
+	pipeline := NewMediaPipeline(DefaultMediaPipelineConfig())
+
+	hook := &testHook{
+		beforeFn: func(ctx context.Context, url string, req *MediaDownloadRequest) error {
+			return fmt.Errorf("rejected by policy")
+		},
+	}
+	pipeline.RegisterHook(hook)
+
+	_, err := pipeline.Download(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected hook rejection error")
+	}
+}
+
+func TestMediaPipeline_ErrorHook(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.RetryCount = 0
+	cfg.UseCache = false
+
+	pipeline := NewMediaPipeline(cfg)
+
+	var errorCount int32
+
+	hook := &testHook{
+		errorFn: func(ctx context.Context, url string, err error, attempt int) {
+			atomic.AddInt32(&errorCount, 1)
+		},
+	}
+	pipeline.RegisterHook(hook)
+
+	_, _ = pipeline.Download(context.Background(), server.URL)
+
+	if atomic.LoadInt32(&errorCount) == 0 {
+		t.Error("OnDownloadError hook not called")
+	}
+}
+
+func TestMediaPipeline_BatchCompleteHook(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("batch"))
+	}))
+	defer server.Close()
+
+	pipeline := NewMediaPipeline(DefaultMediaPipelineConfig())
+
+	var batchCompleteCalled bool
+	var batchResults []*MediaDownloadResult
+
+	hook := &testHook{
+		batchFn: func(ctx context.Context, results []*MediaDownloadResult) {
+			batchCompleteCalled = true
+			batchResults = results
+		},
+	}
+	pipeline.RegisterHook(hook)
+
+	urls := []string{server.URL + "/a", server.URL + "/b"}
+	pipeline.DownloadBatch(context.Background(), urls)
+
+	if !batchCompleteCalled {
+		t.Error("OnBatchComplete hook not called")
+	}
+	if len(batchResults) != 2 {
+		t.Errorf("expected 2 batch results, got %d", len(batchResults))
+	}
+}
+
+func TestMediaPipeline_DownloadAndSave(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("save-test-data"))
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.UseCache = false
+
+	pipeline := NewMediaPipeline(cfg)
+
+	path, err := pipeline.DownloadAndSave(context.Background(), server.URL, tmpDir)
+	if err != nil {
+		t.Fatalf("download and save failed: %v", err)
+	}
+
+	if path == "" {
+		t.Fatal("expected non-empty path")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read saved file: %v", err)
+	}
+
+	if string(data) != "save-test-data" {
+		t.Errorf("expected 'save-test-data', got %s", string(data))
+	}
+}
+
+func TestMediaPipeline_Stats(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("stats-test"))
+	}))
+	defer server.Close()
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.UseCache = false
+
+	pipeline := NewMediaPipeline(cfg)
+
+	_, _ = pipeline.Download(context.Background(), server.URL)
+
+	stats := pipeline.Stats()
+
+	if stats.DownloadsTotal != 1 {
+		t.Errorf("expected 1 total download, got %d", stats.DownloadsTotal)
+	}
+	if stats.BytesDownloaded == 0 {
+		t.Error("expected non-zero bytes downloaded")
+	}
+	if stats.LastDownloadTime.IsZero() {
+		t.Error("expected non-zero last download time")
+	}
+}
+
+func TestMediaPipeline_CacheStats(t *testing.T) {
+	pipeline := NewMediaPipeline(DefaultMediaPipelineConfig())
+
+	stats := pipeline.CacheStats()
+
+	if stats.ItemCount < 0 {
+		t.Error("expected non-negative item count")
+	}
+}
+
+func TestMediaPipeline_ClearCache(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("clear-test"))
+	}))
+	defer server.Close()
+
+	pipeline := NewMediaPipeline(DefaultMediaPipelineConfig())
+
+	_, _ = pipeline.Download(context.Background(), server.URL)
+
+	if pipeline.Cache().Len() == 0 {
+		t.Fatal("expected cache to have items")
+	}
+
+	pipeline.ClearCache()
+
+	if pipeline.Cache().Len() != 0 {
+		t.Errorf("expected 0 items after clear, got %d", pipeline.Cache().Len())
+	}
+}
+
+func TestMediaPipeline_CleanupCache(t *testing.T) {
+	cfg := DefaultMediaPipelineConfig()
+	cfg.CacheConfig = MediaCacheConfig{
+		MaxItems: 100,
+		MaxBytes: 10 * 1024 * 1024,
+		TTL:      50 * time.Millisecond,
+	}
+
+	pipeline := NewMediaPipeline(cfg)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("cleanup-test"))
+	}))
+	defer server.Close()
+
+	_, _ = pipeline.Download(context.Background(), server.URL)
+
+	time.Sleep(100 * time.Millisecond)
+
+	removed := pipeline.CleanupCache()
+
+	if removed != 1 {
+		t.Errorf("expected 1 expired item cleaned up, got %d", removed)
+	}
+}
+
+func TestMediaPipeline_EnableDisableCache(t *testing.T) {
+	pipeline := NewMediaPipeline(DefaultMediaPipelineConfig())
+
+	if pipeline.Cache() == nil {
+		t.Fatal("expected cache to be enabled by default")
+	}
+
+	pipeline.DisableCache()
+
+	if pipeline.Cache() != nil {
+		t.Error("expected cache to be nil after disable")
+	}
+
+	pipeline.EnableCache(DefaultMediaCacheConfig())
+
+	if pipeline.Cache() == nil {
+		t.Error("expected cache to be non-nil after enable")
+	}
+}
+
+func TestMediaPipeline_SetCache(t *testing.T) {
+	pipeline := NewMediaPipeline(DefaultMediaPipelineConfig())
+
+	customCache := NewMediaCache(MediaCacheConfig{
+		MaxItems: 10,
+		MaxBytes: 1024,
+		TTL:      1 * time.Minute,
+	})
+
+	pipeline.SetCache(customCache)
+
+	if pipeline.Cache() != customCache {
+		t.Error("expected custom cache to be set")
+	}
+}
+
+func TestMediaPipeline_ConcurrentDownloads(t *testing.T) {
+	var activeRequests int32
+	var maxActive int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current := atomic.AddInt32(&activeRequests, 1)
+		for {
+			old := atomic.LoadInt32(&maxActive)
+			if current <= old || atomic.CompareAndSwapInt32(&maxActive, old, current) {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+		atomic.AddInt32(&activeRequests, -1)
+
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("concurrent"))
+	}))
+	defer server.Close()
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.MaxConcurrent = 5
+	cfg.UseCache = false
+
+	pipeline := NewMediaPipeline(cfg)
+
+	urls := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		urls[i] = fmt.Sprintf("%s/%d", server.URL, i)
+	}
+
+	results := pipeline.DownloadBatch(context.Background(), urls)
+
+	successCount := 0
+	for _, r := range results {
+		if r.Error == nil {
+			successCount++
+		}
+	}
+
+	if successCount != 20 {
+		t.Errorf("expected 20 successful downloads, got %d", successCount)
+	}
+
+	if atomic.LoadInt32(&maxActive) > 5 {
+		t.Errorf("expected max %d concurrent requests, got %d", 5, maxActive)
+	}
+}
+
+func TestMediaPipeline_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.Write([]byte("too-late"))
+	}))
+	defer server.Close()
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.UseCache = false
+	cfg.RetryCount = 0
+
+	pipeline := NewMediaPipeline(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := pipeline.Download(ctx, server.URL)
+	if err == nil {
+		t.Error("expected context cancellation error")
+	}
+}
+
+type testHook struct {
+	beforeFn func(ctx context.Context, url string, req *MediaDownloadRequest) error
+	afterFn  func(ctx context.Context, media *Media, cached bool) error
+	errorFn  func(ctx context.Context, url string, err error, attempt int)
+	batchFn  func(ctx context.Context, results []*MediaDownloadResult)
+}
+
+func (h *testHook) OnBeforeDownload(ctx context.Context, url string, req *MediaDownloadRequest) error {
+	if h.beforeFn != nil {
+		return h.beforeFn(ctx, url, req)
+	}
+	return nil
+}
+
+func (h *testHook) OnAfterDownload(ctx context.Context, media *Media, cached bool) error {
+	if h.afterFn != nil {
+		return h.afterFn(ctx, media, cached)
+	}
+	return nil
+}
+
+func (h *testHook) OnDownloadError(ctx context.Context, url string, err error, attempt int) {
+	if h.errorFn != nil {
+		h.errorFn(ctx, url, err, attempt)
+	}
+}
+
+func (h *testHook) OnBatchComplete(ctx context.Context, results []*MediaDownloadResult) {
+	if h.batchFn != nil {
+		h.batchFn(ctx, results)
+	}
+}

--- a/pkg/media/pipeline_test.go
+++ b/pkg/media/pipeline_test.go
@@ -365,6 +365,34 @@ func TestMediaCacheOptions(t *testing.T) {
 	}
 }
 
+func TestMakeMediaCacheKey_RequestDimensions(t *testing.T) {
+	key1 := MakeMediaCacheKey(
+		"https://example.com/test.png",
+		WithCacheMaxSize(1024),
+		WithCacheAcceptTypes([]string{"image/png", "image/jpeg"}),
+		WithCacheHeaders(map[string]string{"Authorization": "Bearer a", "X-Mode": "full"}),
+	)
+	key2 := MakeMediaCacheKey(
+		"https://example.com/test.png",
+		WithCacheMaxSize(1024),
+		WithCacheAcceptTypes([]string{"image/jpeg", "image/png"}),
+		WithCacheHeaders(map[string]string{"X-Mode": "full", "Authorization": "Bearer a"}),
+	)
+	key3 := MakeMediaCacheKey(
+		"https://example.com/test.png",
+		WithCacheMaxSize(2048),
+		WithCacheAcceptTypes([]string{"image/jpeg", "image/png"}),
+		WithCacheHeaders(map[string]string{"X-Mode": "full", "Authorization": "Bearer a"}),
+	)
+
+	if key1 != key2 {
+		t.Error("same request contract should produce same cache key regardless of order")
+	}
+	if key1 == key3 {
+		t.Error("different max size should produce different cache keys")
+	}
+}
+
 func TestMediaPipeline_Download(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/octet-stream")
@@ -426,6 +454,148 @@ func TestMediaPipeline_DownloadWithCache(t *testing.T) {
 	stats := pipeline.Stats()
 	if stats.DownloadsCached != 1 {
 		t.Errorf("expected 1 cached download, got %d", stats.DownloadsCached)
+	}
+}
+
+func TestMediaPipeline_DownloadWithOptions_MaxSizeCacheIsolation(t *testing.T) {
+	callCount := int32(0)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write([]byte("12345678"))
+	}))
+	defer server.Close()
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.CacheConfig = MediaCacheConfig{
+		MaxItems: 100,
+		MaxBytes: 10 * 1024 * 1024,
+		TTL:      time.Hour,
+	}
+
+	pipeline := NewMediaPipeline(cfg)
+
+	media, err := pipeline.DownloadWithOptions(context.Background(), &MediaDownloadRequest{
+		URL:     server.URL,
+		MaxSize: 16,
+	})
+	if err != nil {
+		t.Fatalf("first download failed: %v", err)
+	}
+	if string(media.Data) != "12345678" {
+		t.Fatalf("unexpected first payload: %q", string(media.Data))
+	}
+
+	_, err = pipeline.DownloadWithOptions(context.Background(), &MediaDownloadRequest{
+		URL:     server.URL,
+		MaxSize: 4,
+	})
+	if err == nil {
+		t.Fatal("expected second download to enforce stricter max size")
+	}
+
+	if atomic.LoadInt32(&callCount) <= 1 {
+		t.Errorf("expected stricter max-size request to bypass cached result, got %d HTTP calls", callCount)
+	}
+}
+
+func TestMediaPipeline_DownloadWithOptions_HeaderAwareCache(t *testing.T) {
+	callCount := int32(0)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		auth := r.Header.Get("Authorization")
+		if auth == "" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write([]byte(auth))
+	}))
+	defer server.Close()
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.CacheConfig = MediaCacheConfig{
+		MaxItems: 100,
+		MaxBytes: 10 * 1024 * 1024,
+		TTL:      time.Hour,
+	}
+
+	pipeline := NewMediaPipeline(cfg)
+
+	first, err := pipeline.DownloadWithOptions(context.Background(), &MediaDownloadRequest{
+		URL: server.URL,
+		Headers: map[string]string{
+			"Authorization": "Bearer token-a",
+		},
+	})
+	if err != nil {
+		t.Fatalf("first header-aware download failed: %v", err)
+	}
+
+	second, err := pipeline.DownloadWithOptions(context.Background(), &MediaDownloadRequest{
+		URL: server.URL,
+		Headers: map[string]string{
+			"Authorization": "Bearer token-b",
+		},
+	})
+	if err != nil {
+		t.Fatalf("second header-aware download failed: %v", err)
+	}
+
+	if string(first.Data) != "Bearer token-a" {
+		t.Fatalf("expected first payload to reflect auth header, got %q", string(first.Data))
+	}
+	if string(second.Data) != "Bearer token-b" {
+		t.Fatalf("expected second payload to reflect auth header, got %q", string(second.Data))
+	}
+	if atomic.LoadInt32(&callCount) != 2 {
+		t.Errorf("expected 2 HTTP calls for distinct request headers, got %d", callCount)
+	}
+}
+
+func TestMediaPipeline_DownloadWithOptions_RequestAcceptTypes(t *testing.T) {
+	callCount := int32(0)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("plain-text"))
+	}))
+	defer server.Close()
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.AllowedMimeTypes = []string{"text/plain", "image/png"}
+	cfg.CacheConfig = MediaCacheConfig{
+		MaxItems: 100,
+		MaxBytes: 10 * 1024 * 1024,
+		TTL:      time.Hour,
+	}
+
+	pipeline := NewMediaPipeline(cfg)
+
+	first, err := pipeline.DownloadWithOptions(context.Background(), &MediaDownloadRequest{
+		URL:         server.URL,
+		AcceptTypes: []string{"text/plain"},
+	})
+	if err != nil {
+		t.Fatalf("first accept-types download failed: %v", err)
+	}
+	if string(first.Data) != "plain-text" {
+		t.Fatalf("unexpected first payload: %q", string(first.Data))
+	}
+
+	_, err = pipeline.DownloadWithOptions(context.Background(), &MediaDownloadRequest{
+		URL:         server.URL,
+		AcceptTypes: []string{"image/png"},
+	})
+	if err == nil {
+		t.Fatal("expected second download to reject MIME type outside request accept types")
+	}
+
+	if atomic.LoadInt32(&callCount) <= 1 {
+		t.Errorf("expected distinct accept-type request to bypass cached result, got %d HTTP calls", callCount)
 	}
 }
 

--- a/pkg/media/pipeline_test.go
+++ b/pkg/media/pipeline_test.go
@@ -1075,6 +1075,57 @@ func TestMediaPipeline_ConcurrentDownloads(t *testing.T) {
 	}
 }
 
+func TestMediaPipeline_ConcurrentSameRequestSingleFlight(t *testing.T) {
+	var callCount int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		time.Sleep(50 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write([]byte("shared-response"))
+	}))
+	defer server.Close()
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.UseCache = false
+
+	pipeline := NewMediaPipeline(cfg)
+
+	const workers = 8
+	results := make(chan error, workers)
+	var wg sync.WaitGroup
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			media, err := pipeline.DownloadWithOptions(context.Background(), &MediaDownloadRequest{URL: server.URL})
+			if err != nil {
+				results <- err
+				return
+			}
+			if string(media.Data) != "shared-response" {
+				results <- fmt.Errorf("unexpected payload %q", string(media.Data))
+				return
+			}
+			results <- nil
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	for err := range results {
+		if err != nil {
+			t.Fatalf("concurrent same-request download failed: %v", err)
+		}
+	}
+
+	if atomic.LoadInt32(&callCount) != 1 {
+		t.Fatalf("expected a single upstream HTTP call for identical concurrent requests, got %d", callCount)
+	}
+}
+
 func TestMediaPipeline_ContextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(500 * time.Millisecond)

--- a/pkg/media/signer.go
+++ b/pkg/media/signer.go
@@ -4,7 +4,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/subtle"
-	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"net/url"
@@ -22,7 +21,7 @@ type URLSignerConfig struct {
 
 func DefaultURLSignerConfig() URLSignerConfig {
 	return URLSignerConfig{
-		SecretKey:     generateSignerSecret(),
+		SecretKey:     "",
 		DefaultExpiry: 24 * time.Hour,
 		MaxExpiry:     7 * 24 * time.Hour,
 	}
@@ -38,9 +37,6 @@ type URLSigner struct {
 
 func NewURLSigner(cfg URLSignerConfig) *URLSigner {
 	secret := []byte(cfg.SecretKey)
-	if len(secret) == 0 {
-		secret = []byte(generateSignerSecret())
-	}
 
 	maxExp := cfg.MaxExpiry
 	if maxExp <= 0 {
@@ -61,6 +57,20 @@ func NewURLSigner(cfg URLSignerConfig) *URLSigner {
 		maxExpiry:   maxExp,
 		revokedKeys: make(map[string]time.Time),
 	}
+}
+
+func (s *URLSigner) secretKeySnapshot() ([]byte, time.Duration, time.Duration, error) {
+	s.mu.RLock()
+	secret := append([]byte(nil), s.secretKey...)
+	defExp := s.defaultExp
+	maxExp := s.maxExpiry
+	s.mu.RUnlock()
+
+	if len(secret) == 0 {
+		return nil, 0, 0, fmt.Errorf("no URL signer secret configured")
+	}
+
+	return secret, defExp, maxExp, nil
 }
 
 func (s *URLSigner) SetSecretKey(key string) {
@@ -88,11 +98,10 @@ func (s *URLSigner) SetMaxExpiry(d time.Duration) {
 }
 
 func (s *URLSigner) SignURL(baseURL string, key string, expires time.Duration, metadata map[string]string) (string, error) {
-	s.mu.RLock()
-	secret := s.secretKey
-	defExp := s.defaultExp
-	maxExp := s.maxExpiry
-	s.mu.RUnlock()
+	secret, defExp, maxExp, err := s.secretKeySnapshot()
+	if err != nil {
+		return "", err
+	}
 
 	if expires <= 0 {
 		expires = defExp
@@ -134,8 +143,12 @@ func (s *URLSigner) SignURL(baseURL string, key string, expires time.Duration, m
 }
 
 func (s *URLSigner) VerifyURL(signedURL string) (string, time.Time, map[string]string, error) {
+	secret, _, _, err := s.secretKeySnapshot()
+	if err != nil {
+		return "", time.Time{}, nil, err
+	}
+
 	s.mu.RLock()
-	secret := s.secretKey
 	revoked := make(map[string]time.Time, len(s.revokedKeys))
 	for k, v := range s.revokedKeys {
 		revoked[k] = v
@@ -202,9 +215,10 @@ func (s *URLSigner) VerifyURL(signedURL string) (string, time.Time, map[string]s
 }
 
 func (s *URLSigner) RevokeURL(signedURL string) error {
-	s.mu.RLock()
-	secret := s.secretKey
-	s.mu.RUnlock()
+	secret, _, _, err := s.secretKeySnapshot()
+	if err != nil {
+		return err
+	}
 
 	u, err := url.Parse(signedURL)
 	if err != nil {
@@ -304,14 +318,6 @@ func (s *URLSigner) SignStorageObject(storage StorageBackend, key string, expire
 	}
 
 	return s.SignURL(baseURL, key, expires, nil)
-}
-
-func generateSignerSecret() string {
-	b := make([]byte, 32)
-	for i := range b {
-		b[i] = byte(i * 7 % 256)
-	}
-	return base64.RawURLEncoding.EncodeToString(b)
 }
 
 type SignedURLResult struct {

--- a/pkg/media/signer.go
+++ b/pkg/media/signer.go
@@ -1,0 +1,403 @@
+package media
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type URLSignerConfig struct {
+	SecretKey     string
+	DefaultExpiry time.Duration
+	MaxExpiry     time.Duration
+}
+
+func DefaultURLSignerConfig() URLSignerConfig {
+	return URLSignerConfig{
+		SecretKey:     generateSignerSecret(),
+		DefaultExpiry: 24 * time.Hour,
+		MaxExpiry:     7 * 24 * time.Hour,
+	}
+}
+
+type URLSigner struct {
+	mu          sync.RWMutex
+	secretKey   []byte
+	defaultExp  time.Duration
+	maxExpiry   time.Duration
+	revokedKeys map[string]time.Time
+}
+
+func NewURLSigner(cfg URLSignerConfig) *URLSigner {
+	secret := []byte(cfg.SecretKey)
+	if len(secret) == 0 {
+		secret = []byte(generateSignerSecret())
+	}
+
+	maxExp := cfg.MaxExpiry
+	if maxExp <= 0 {
+		maxExp = 7 * 24 * time.Hour
+	}
+
+	defExp := cfg.DefaultExpiry
+	if defExp <= 0 {
+		defExp = 24 * time.Hour
+	}
+	if defExp > maxExp {
+		defExp = maxExp
+	}
+
+	return &URLSigner{
+		secretKey:   secret,
+		defaultExp:  defExp,
+		maxExpiry:   maxExp,
+		revokedKeys: make(map[string]time.Time),
+	}
+}
+
+func (s *URLSigner) SetSecretKey(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.secretKey = []byte(key)
+}
+
+func (s *URLSigner) SetDefaultExpiry(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if d > s.maxExpiry {
+		d = s.maxExpiry
+	}
+	s.defaultExp = d
+}
+
+func (s *URLSigner) SetMaxExpiry(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.maxExpiry = d
+	if s.defaultExp > d {
+		s.defaultExp = d
+	}
+}
+
+func (s *URLSigner) SignURL(baseURL string, key string, expires time.Duration, metadata map[string]string) (string, error) {
+	s.mu.RLock()
+	secret := s.secretKey
+	defExp := s.defaultExp
+	maxExp := s.maxExpiry
+	s.mu.RUnlock()
+
+	if expires <= 0 {
+		expires = defExp
+	}
+	if expires > maxExp {
+		return "", fmt.Errorf("expiry %s exceeds maximum allowed %s", expires, maxExp)
+	}
+
+	now := time.Now().UTC()
+	expireAt := now.Add(expires)
+
+	params := url.Values{}
+	params.Set("key", key)
+	params.Set("exp", strconv.FormatInt(expireAt.Unix(), 10))
+	params.Set("iat", strconv.FormatInt(now.Unix(), 10))
+
+	if metadata != nil {
+		for k, v := range metadata {
+			if strings.HasPrefix(k, "m_") {
+				params.Set(k, v)
+			}
+		}
+	}
+
+	stringToSign := key + "|" + strconv.FormatInt(expireAt.Unix(), 10) + "|" + strconv.FormatInt(now.Unix(), 10)
+
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(stringToSign))
+	signature := hex.EncodeToString(mac.Sum(nil))
+
+	params.Set("sig", signature)
+
+	separator := "?"
+	if strings.Contains(baseURL, "?") {
+		separator = "&"
+	}
+
+	return baseURL + separator + params.Encode(), nil
+}
+
+func (s *URLSigner) VerifyURL(signedURL string) (string, time.Time, map[string]string, error) {
+	s.mu.RLock()
+	secret := s.secretKey
+	revoked := make(map[string]time.Time, len(s.revokedKeys))
+	for k, v := range s.revokedKeys {
+		revoked[k] = v
+	}
+	s.mu.RUnlock()
+
+	u, err := url.Parse(signedURL)
+	if err != nil {
+		return "", time.Time{}, nil, fmt.Errorf("parse URL: %w", err)
+	}
+
+	query := u.Query()
+
+	key := query.Get("key")
+	expStr := query.Get("exp")
+	iatStr := query.Get("iat")
+	sig := query.Get("sig")
+
+	if key == "" || expStr == "" || sig == "" {
+		return "", time.Time{}, nil, fmt.Errorf("missing required signing parameters")
+	}
+
+	expireAt, err := strconv.ParseInt(expStr, 10, 64)
+	if err != nil {
+		return "", time.Time{}, nil, fmt.Errorf("invalid expiry: %w", err)
+	}
+
+	if time.Now().UTC().Unix() > expireAt {
+		return "", time.Time{}, nil, fmt.Errorf("URL expired at %s", time.Unix(expireAt, 0).UTC().Format(time.RFC3339))
+	}
+
+	stringToSign := key + "|" + expStr + "|" + iatStr
+
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(stringToSign))
+	expectedSig := mac.Sum(nil)
+
+	gotSig, err := hex.DecodeString(sig)
+	if err != nil {
+		return "", time.Time{}, nil, fmt.Errorf("invalid signature format: %w", err)
+	}
+
+	if subtle.ConstantTimeCompare(expectedSig, gotSig) != 1 {
+		return "", time.Time{}, nil, fmt.Errorf("invalid signature")
+	}
+
+	sigKey := key + ":" + expStr
+	if revokedAt, ok := revoked[sigKey]; ok {
+		return "", time.Time{}, nil, fmt.Errorf("URL revoked at %s", revokedAt.Format(time.RFC3339))
+	}
+
+	metadata := make(map[string]string)
+	for k, v := range query {
+		if strings.HasPrefix(k, "m_") && len(v) > 0 {
+			metadata[k] = v[0]
+		}
+	}
+
+	expireTime := time.Unix(expireAt, 0).UTC()
+
+	u.RawQuery = ""
+
+	return u.String(), expireTime, metadata, nil
+}
+
+func (s *URLSigner) RevokeURL(signedURL string) error {
+	s.mu.RLock()
+	secret := s.secretKey
+	s.mu.RUnlock()
+
+	u, err := url.Parse(signedURL)
+	if err != nil {
+		return fmt.Errorf("parse URL: %w", err)
+	}
+
+	query := u.Query()
+	key := query.Get("key")
+	expStr := query.Get("exp")
+	sig := query.Get("sig")
+
+	if key == "" || expStr == "" || sig == "" {
+		return fmt.Errorf("not a signed URL")
+	}
+
+	stringToSign := key + "|" + expStr + "|" + query.Get("iat")
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(stringToSign))
+	expectedSig := hex.EncodeToString(mac.Sum(nil))
+
+	if sig != expectedSig {
+		return fmt.Errorf("invalid signature, cannot revoke")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.revokedKeys[key+":"+expStr] = time.Now().UTC()
+
+	return nil
+}
+
+func (s *URLSigner) IsRevoked(signedURL string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	u, err := url.Parse(signedURL)
+	if err != nil {
+		return false, fmt.Errorf("parse URL: %w", err)
+	}
+
+	query := u.Query()
+	key := query.Get("key")
+	expStr := query.Get("exp")
+
+	if key == "" || expStr == "" {
+		return false, fmt.Errorf("not a signed URL")
+	}
+
+	_, ok := s.revokedKeys[key+":"+expStr]
+	return ok, nil
+}
+
+func (s *URLSigner) CleanupRevoked() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC()
+	count := 0
+	for sigKey, revokedAt := range s.revokedKeys {
+		if now.Sub(revokedAt) > 24*time.Hour {
+			delete(s.revokedKeys, sigKey)
+			count++
+		}
+	}
+	return count
+}
+
+func (s *URLSigner) RemainingTime(signedURL string) (time.Duration, error) {
+	u, err := url.Parse(signedURL)
+	if err != nil {
+		return 0, fmt.Errorf("parse URL: %w", err)
+	}
+
+	query := u.Query()
+	expStr := query.Get("exp")
+	if expStr == "" {
+		return 0, fmt.Errorf("no expiry in URL")
+	}
+
+	expireAt, err := strconv.ParseInt(expStr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid expiry: %w", err)
+	}
+
+	remaining := time.Unix(expireAt, 0).UTC().Sub(time.Now().UTC())
+	if remaining < 0 {
+		return 0, fmt.Errorf("URL expired")
+	}
+
+	return remaining, nil
+}
+
+func (s *URLSigner) SignStorageObject(storage StorageBackend, key string, expires time.Duration) (string, error) {
+	baseURL, err := storage.URL(nil, key, 0)
+	if err != nil {
+		return "", fmt.Errorf("get base URL: %w", err)
+	}
+
+	return s.SignURL(baseURL, key, expires, nil)
+}
+
+func generateSignerSecret() string {
+	b := make([]byte, 32)
+	for i := range b {
+		b[i] = byte(i * 7 % 256)
+	}
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+type SignedURLResult struct {
+	URL       string
+	ExpiresAt time.Time
+	Remaining time.Duration
+	Key       string
+	Metadata  map[string]string
+	IsRevoked bool
+}
+
+type URLSignerManager struct {
+	signers map[string]*URLSigner
+	mu      sync.RWMutex
+	defName string
+}
+
+func NewURLSignerManager() *URLSignerManager {
+	return &URLSignerManager{
+		signers: make(map[string]*URLSigner),
+	}
+}
+
+func (m *URLSignerManager) Register(name string, signer *URLSigner) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.signers[name] = signer
+	if m.defName == "" {
+		m.defName = name
+	}
+}
+
+func (m *URLSignerManager) SetDefault(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.defName = name
+}
+
+func (m *URLSignerManager) Get(name string) *URLSigner {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.signers[name]
+}
+
+func (m *URLSignerManager) Default() *URLSigner {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.signers[m.defName]
+}
+
+func (m *URLSignerManager) Sign(key string, expires time.Duration) (string, error) {
+	signer := m.Default()
+	if signer == nil {
+		return "", fmt.Errorf("no URL signer configured")
+	}
+	return signer.SignURL("https://media.example.com/"+key, key, expires, nil)
+}
+
+func (m *URLSignerManager) Verify(signedURL string) (*SignedURLResult, error) {
+	signer := m.Default()
+	if signer == nil {
+		return nil, fmt.Errorf("no URL signer configured")
+	}
+
+	baseURL, expireTime, metadata, err := signer.VerifyURL(signedURL)
+	if err != nil {
+		return nil, err
+	}
+
+	remaining := expireTime.Sub(time.Now().UTC())
+	isRevoked := remaining < 0
+
+	return &SignedURLResult{
+		URL:       baseURL,
+		ExpiresAt: expireTime,
+		Remaining: remaining,
+		Key:       "",
+		Metadata:  metadata,
+		IsRevoked: isRevoked,
+	}, nil
+}
+
+func (m *URLSignerManager) Revoke(signedURL string) error {
+	signer := m.Default()
+	if signer == nil {
+		return fmt.Errorf("no URL signer configured")
+	}
+	return signer.RevokeURL(signedURL)
+}

--- a/pkg/media/signer_test.go
+++ b/pkg/media/signer_test.go
@@ -957,14 +957,19 @@ func TestURLSigner_EmptySecretKey(t *testing.T) {
 		MaxExpiry:     24 * time.Hour,
 	})
 
-	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
-	if err != nil {
-		t.Fatalf("sign: %v", err)
+	_, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err == nil {
+		t.Fatal("expected error when signing with empty secret")
 	}
+	if !strings.Contains(err.Error(), "no URL signer secret configured") {
+		t.Fatalf("expected missing secret error, got %v", err)
+	}
+}
 
-	_, _, _, err = signer.VerifyURL(signedURL)
-	if err != nil {
-		t.Fatalf("verify with auto-generated secret: %v", err)
+func TestDefaultURLSignerConfig_RequiresExplicitSecret(t *testing.T) {
+	cfg := DefaultURLSignerConfig()
+	if cfg.SecretKey != "" {
+		t.Fatalf("expected default signer config to require explicit secret, got %q", cfg.SecretKey)
 	}
 }
 

--- a/pkg/media/signer_test.go
+++ b/pkg/media/signer_test.go
@@ -1,0 +1,1510 @@
+package media
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestURLSigner_SignAndVerify(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret-key-12345",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/media/photo.jpg", "photo.jpg", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	if signedURL == "" {
+		t.Fatal("signed URL is empty")
+	}
+
+	if !strings.Contains(signedURL, "sig=") {
+		t.Error("signed URL missing signature")
+	}
+	if !strings.Contains(signedURL, "exp=") {
+		t.Error("signed URL missing expiry")
+	}
+	if !strings.Contains(signedURL, "key=") {
+		t.Error("signed URL missing key")
+	}
+
+	baseURL, expireTime, metadata, err := signer.VerifyURL(signedURL)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	if baseURL != "https://example.com/media/photo.jpg" {
+		t.Errorf("expected base URL https://example.com/media/photo.jpg, got %s", baseURL)
+	}
+
+	if expireTime.Before(time.Now().UTC()) {
+		t.Error("expire time is in the past")
+	}
+
+	if metadata == nil {
+		t.Error("expected non-nil metadata")
+	}
+}
+
+func TestURLSigner_ExpiredURL(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	_, err := signer.SignURL("https://example.com/file", "file.txt", 0, nil)
+	if err != nil {
+		t.Fatalf("sign with zero expiry: %v", err)
+	}
+}
+
+func TestURLSigner_ExceedsMaxExpiry(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     time.Hour,
+	})
+
+	_, err := signer.SignURL("https://example.com/file", "file.txt", 24*time.Hour, nil)
+	if err == nil {
+		t.Fatal("expected error for exceeding max expiry")
+	}
+}
+
+func TestURLSigner_TamperedSignature(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	tampered := signedURL[:len(signedURL)-5] + "aaaaa"
+
+	_, _, _, err = signer.VerifyURL(tampered)
+	if err == nil {
+		t.Fatal("expected error for tampered signature")
+	}
+}
+
+func TestURLSigner_TamperedKey(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	tampered := strings.Replace(signedURL, "key=file.txt", "key=other.txt", 1)
+
+	_, _, _, err = signer.VerifyURL(tampered)
+	if err == nil {
+		t.Fatal("expected error for tampered key")
+	}
+}
+
+func TestURLSigner_MissingParams(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	_, _, _, err := signer.VerifyURL("https://example.com/file?foo=bar")
+	if err == nil {
+		t.Fatal("expected error for missing params")
+	}
+}
+
+func TestURLSigner_RevokeAndVerify(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	err = signer.RevokeURL(signedURL)
+	if err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	_, _, _, err = signer.VerifyURL(signedURL)
+	if err == nil {
+		t.Fatal("expected error for revoked URL")
+	}
+}
+
+func TestURLSigner_RevokeInvalidSignature(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	tamperedURL := "https://example.com/file?key=file.txt&exp=9999999999&iat=0000000000&sig=invalid"
+
+	err := signer.RevokeURL(tamperedURL)
+	if err == nil {
+		t.Fatal("expected error for revoking URL with invalid signature")
+	}
+}
+
+func TestURLSigner_IsRevoked(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	revoked, err := signer.IsRevoked(signedURL)
+	if err != nil {
+		t.Fatalf("isRevoked: %v", err)
+	}
+	if revoked {
+		t.Error("expected URL not to be revoked")
+	}
+
+	_ = signer.RevokeURL(signedURL)
+
+	revoked, err = signer.IsRevoked(signedURL)
+	if err != nil {
+		t.Fatalf("isRevoked after revoke: %v", err)
+	}
+	if !revoked {
+		t.Error("expected URL to be revoked")
+	}
+}
+
+func TestURLSigner_RemainingTime(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	remaining, err := signer.RemainingTime(signedURL)
+	if err != nil {
+		t.Fatalf("remaining: %v", err)
+	}
+
+	if remaining <= 0 {
+		t.Error("expected positive remaining time")
+	}
+
+	if remaining > time.Hour {
+		t.Errorf("expected remaining time <= 1 hour, got %s", remaining)
+	}
+}
+
+func TestURLSigner_CleanupRevoked(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	_ = signer.RevokeURL(signedURL)
+
+	signer.mu.Lock()
+	signer.revokedKeys["old:revoked"] = time.Now().UTC().Add(-25 * time.Hour)
+	signer.mu.Unlock()
+
+	cleaned := signer.CleanupRevoked()
+	if cleaned != 1 {
+		t.Errorf("expected 1 cleaned up, got %d", cleaned)
+	}
+}
+
+func TestURLSigner_SignWithMetadata(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	metadata := map[string]string{
+		"m_user": "alice",
+		"m_role": "admin",
+		"secret": "should-not-appear",
+	}
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, metadata)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	_, _, gotMetadata, err := signer.VerifyURL(signedURL)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	if gotMetadata["m_user"] != "alice" {
+		t.Errorf("expected m_user=alice, got %s", gotMetadata["m_user"])
+	}
+	if gotMetadata["m_role"] != "admin" {
+		t.Errorf("expected m_role=admin, got %s", gotMetadata["m_role"])
+	}
+	if _, ok := gotMetadata["secret"]; ok {
+		t.Error("secret metadata should not appear (no m_ prefix)")
+	}
+}
+
+func TestURLSigner_DifferentSecrets(t *testing.T) {
+	signer1 := NewURLSigner(URLSignerConfig{
+		SecretKey:     "secret-1",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signer2 := NewURLSigner(URLSignerConfig{
+		SecretKey:     "secret-2",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer1.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	_, _, _, err = signer2.VerifyURL(signedURL)
+	if err == nil {
+		t.Fatal("expected verification to fail with different secret")
+	}
+}
+
+func TestURLSigner_SetSecretKey(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "old-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	signer.SetSecretKey("new-secret")
+
+	_, _, _, err = signer.VerifyURL(signedURL)
+	if err == nil {
+		t.Fatal("expected verification to fail after secret change")
+	}
+}
+
+func TestURLSigner_SetDefaultExpiry(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signer.SetDefaultExpiry(30 * time.Minute)
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", 0, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	_, expireTime, _, err := signer.VerifyURL(signedURL)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	expectedMax := time.Now().UTC().Add(30*time.Minute + time.Second)
+	if expireTime.After(expectedMax) {
+		t.Errorf("expected expiry around 30 minutes, got %s", expireTime.Sub(time.Now().UTC()))
+	}
+}
+
+func TestURLSigner_SignStorageObject(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://cdn.example.com",
+	})
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	ctx := context.Background()
+	_, err := store.Put(ctx, "photo.jpg", []byte("image data"), StoragePutOptions{
+		MimeType: "image/jpeg",
+	})
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	signedURL, err := signer.SignStorageObject(store, "photo.jpg", time.Hour)
+	if err != nil {
+		t.Fatalf("sign storage object: %v", err)
+	}
+
+	if !strings.Contains(signedURL, "sig=") {
+		t.Error("signed URL missing signature")
+	}
+
+	if !strings.HasPrefix(signedURL, "https://cdn.example.com/photo.jpg") {
+		t.Errorf("expected URL to start with https://cdn.example.com/photo.jpg, got %s", signedURL)
+	}
+}
+
+func TestURLSignerManager(t *testing.T) {
+	sm := NewURLSignerManager()
+
+	signer1 := NewURLSigner(URLSignerConfig{
+		SecretKey:     "key-1",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signer2 := NewURLSigner(URLSignerConfig{
+		SecretKey:     "key-2",
+		DefaultExpiry: 30 * time.Minute,
+		MaxExpiry:     12 * time.Hour,
+	})
+
+	sm.Register("primary", signer1)
+	sm.Register("secondary", signer2)
+
+	if sm.Default() != signer1 {
+		t.Error("expected primary as default")
+	}
+
+	sm.SetDefault("secondary")
+	if sm.Default() != signer2 {
+		t.Error("expected secondary as default")
+	}
+
+	got := sm.Get("primary")
+	if got != signer1 {
+		t.Error("failed to get primary signer")
+	}
+}
+
+func TestURLSignerManager_Sign(t *testing.T) {
+	sm := NewURLSignerManager()
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	sm.Register("default", signer)
+
+	signedURL, err := sm.Sign("photo.jpg", time.Hour)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	if signedURL == "" {
+		t.Error("signed URL is empty")
+	}
+}
+
+func TestURLSignerManager_Verify(t *testing.T) {
+	sm := NewURLSignerManager()
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	sm.Register("default", signer)
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	result, err := sm.Verify(signedURL)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	if result.URL != "https://example.com/file" {
+		t.Errorf("expected URL https://example.com/file, got %s", result.URL)
+	}
+
+	if result.Remaining <= 0 {
+		t.Error("expected positive remaining time")
+	}
+}
+
+func TestURLSignerManager_Revoke(t *testing.T) {
+	sm := NewURLSignerManager()
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	sm.Register("default", signer)
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	err = sm.Revoke(signedURL)
+	if err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	_, err = sm.Verify(signedURL)
+	if err == nil {
+		t.Fatal("expected verification to fail after revoke")
+	}
+}
+
+func TestURLSignerManager_NoSigner(t *testing.T) {
+	sm := NewURLSignerManager()
+
+	_, err := sm.Sign("key", time.Hour)
+	if err == nil {
+		t.Fatal("expected error with no signer")
+	}
+
+	_, err = sm.Verify("https://example.com")
+	if err == nil {
+		t.Fatal("expected error with no signer")
+	}
+
+	err = sm.Revoke("https://example.com")
+	if err == nil {
+		t.Fatal("expected error with no signer")
+	}
+}
+
+func TestProcessor_Signer_GetSet(t *testing.T) {
+	proc := NewProcessor("")
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "processor-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	proc.SetSigner(signer)
+
+	if proc.Signer() != signer {
+		t.Error("signer not set")
+	}
+}
+
+func TestProcessor_PresignURL_WithSigner(t *testing.T) {
+	dir := t.TempDir()
+	proc := NewProcessor("")
+
+	local := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://cdn.example.com",
+	})
+	proc.SetStorage(local)
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+	proc.SetSigner(signer)
+
+	ctx := context.Background()
+	media := &Media{
+		ID:       "presign-test",
+		Data:     []byte("data"),
+		MimeType: "image/jpeg",
+		Name:     "test.jpg",
+	}
+
+	_, err := proc.Save(ctx, media)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	signedURL, err := proc.PresignURL(ctx, "test.jpg", time.Hour)
+	if err != nil {
+		t.Fatalf("presign: %v", err)
+	}
+
+	if !strings.Contains(signedURL, "sig=") {
+		t.Error("signed URL missing signature")
+	}
+}
+
+func TestProcessor_PresignURL_NoSigner(t *testing.T) {
+	dir := t.TempDir()
+	proc := NewProcessor("")
+
+	local := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://cdn.example.com",
+	})
+	proc.SetStorage(local)
+
+	ctx := context.Background()
+	media := &Media{
+		ID:   "no-signer",
+		Data: []byte("data"),
+		Name: "test.jpg",
+	}
+
+	_, err := proc.Save(ctx, media)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	url, err := proc.PresignURL(ctx, "test.jpg", time.Hour)
+	if err != nil {
+		t.Fatalf("presign: %v", err)
+	}
+
+	if url != "https://cdn.example.com/test.jpg" {
+		t.Errorf("expected https://cdn.example.com/test.jpg, got %s", url)
+	}
+}
+
+func TestProcessor_VerifySignedURL(t *testing.T) {
+	dir := t.TempDir()
+	proc := NewProcessor("")
+
+	local := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://cdn.example.com",
+	})
+	proc.SetStorage(local)
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+	proc.SetSigner(signer)
+
+	ctx := context.Background()
+	media := &Media{
+		ID:   "verify-test",
+		Data: []byte("data"),
+		Name: "test.jpg",
+	}
+
+	_, err := proc.Save(ctx, media)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	signedURL, err := proc.PresignURL(ctx, "test.jpg", time.Hour)
+	if err != nil {
+		t.Fatalf("presign: %v", err)
+	}
+
+	result, err := proc.VerifySignedURL(ctx, signedURL)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	if result.Remaining <= 0 {
+		t.Error("expected positive remaining time")
+	}
+
+	if result.IsRevoked {
+		t.Error("expected URL not to be revoked")
+	}
+}
+
+func TestProcessor_RevokeSignedURL(t *testing.T) {
+	dir := t.TempDir()
+	proc := NewProcessor("")
+
+	local := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://cdn.example.com",
+	})
+	proc.SetStorage(local)
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+	proc.SetSigner(signer)
+
+	ctx := context.Background()
+	media := &Media{
+		ID:   "revoke-test",
+		Data: []byte("data"),
+		Name: "test.jpg",
+	}
+
+	_, err := proc.Save(ctx, media)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	signedURL, err := proc.PresignURL(ctx, "test.jpg", time.Hour)
+	if err != nil {
+		t.Fatalf("presign: %v", err)
+	}
+
+	err = proc.RevokeSignedURL(ctx, signedURL)
+	if err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	_, err = proc.VerifySignedURL(ctx, signedURL)
+	if err == nil {
+		t.Fatal("expected verification to fail after revoke")
+	}
+}
+
+func TestMediaPipeline_SignURL(t *testing.T) {
+	dir := t.TempDir()
+	local := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://cdn.example.com",
+	})
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "pipeline-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Storage = local
+	cfg.Signer = signer
+
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	signedURL, err := p.SignURL(ctx, "photo.jpg", time.Hour)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	if !strings.Contains(signedURL, "sig=") {
+		t.Error("signed URL missing signature")
+	}
+}
+
+func TestMediaPipeline_VerifySignedURL(t *testing.T) {
+	dir := t.TempDir()
+	local := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://cdn.example.com",
+	})
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "pipeline-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Storage = local
+	cfg.Signer = signer
+
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	signedURL, err := p.SignURL(ctx, "photo.jpg", time.Hour)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	result, err := p.VerifySignedURL(ctx, signedURL)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	if result.Remaining <= 0 {
+		t.Error("expected positive remaining time")
+	}
+}
+
+func TestMediaPipeline_RevokeSignedURL(t *testing.T) {
+	dir := t.TempDir()
+	local := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://cdn.example.com",
+	})
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "pipeline-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Storage = local
+	cfg.Signer = signer
+
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	signedURL, err := p.SignURL(ctx, "photo.jpg", time.Hour)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	err = p.RevokeSignedURL(ctx, signedURL)
+	if err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	_, err = p.VerifySignedURL(ctx, signedURL)
+	if err == nil {
+		t.Fatal("expected verification to fail after revoke")
+	}
+}
+
+func TestMediaPipeline_SignMediaURL(t *testing.T) {
+	dir := t.TempDir()
+	local := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://cdn.example.com",
+	})
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "pipeline-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Storage = local
+	cfg.Signer = signer
+
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	media := &Media{
+		ID:       "sign-media",
+		Type:     TypeImage,
+		Data:     []byte("image data"),
+		MimeType: "image/jpeg",
+		Name:     "photo.jpg",
+		Metadata: map[string]any{
+			"storage-key": "photo.jpg",
+		},
+	}
+
+	signedURL, err := p.SignMediaURL(ctx, media, time.Hour)
+	if err != nil {
+		t.Fatalf("sign media URL: %v", err)
+	}
+
+	if !strings.Contains(signedURL, "sig=") {
+		t.Error("signed URL missing signature")
+	}
+}
+
+func TestMediaPipeline_AutoSign(t *testing.T) {
+	dir := t.TempDir()
+	local := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://cdn.example.com",
+	})
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "autosign-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Storage = local
+	cfg.Signer = signer
+	cfg.AutoSave = true
+	cfg.AutoSign = true
+	cfg.SignExpiry = 2 * time.Hour
+
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	_, err := p.Download(ctx, "http://localhost:1/photo.jpg")
+	if err == nil {
+		t.Log("auto-sign attempted (expected failure due to no server)")
+	}
+}
+
+func TestMediaPipeline_CleanupRevokedURLs(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "cleanup-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Signer = signer
+
+	p := NewMediaPipeline(cfg)
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	_ = signer.RevokeURL(signedURL)
+
+	signer.mu.Lock()
+	signer.revokedKeys["old:entry"] = time.Now().UTC().Add(-25 * time.Hour)
+	signer.mu.Unlock()
+
+	cleaned := p.CleanupRevokedURLs()
+	if cleaned != 1 {
+		t.Errorf("expected 1 cleaned up, got %d", cleaned)
+	}
+}
+
+func TestMediaPipeline_NoSignerConfigured(t *testing.T) {
+	cfg := DefaultMediaPipelineConfig()
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+
+	_, err := p.SignURL(ctx, "key", time.Hour)
+	if err == nil {
+		t.Fatal("expected error with no signer")
+	}
+
+	_, err = p.VerifySignedURL(ctx, "https://example.com")
+	if err == nil {
+		t.Fatal("expected error with no signer")
+	}
+
+	err = p.RevokeSignedURL(ctx, "https://example.com")
+	if err == nil {
+		t.Fatal("expected error with no signer")
+	}
+
+	media := &Media{ID: "test"}
+	_, err = p.SignMediaURL(ctx, media, time.Hour)
+	if err == nil {
+		t.Fatal("expected error with no signer")
+	}
+}
+
+func TestURLSigner_DefaultExpiry(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: 30 * time.Minute,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", 0, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	_, expireTime, _, err := signer.VerifyURL(signedURL)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	remaining := expireTime.Sub(time.Now().UTC())
+	if remaining > 31*time.Minute {
+		t.Errorf("expected remaining time around 30 minutes, got %s", remaining)
+	}
+}
+
+func TestURLSigner_EmptySecretKey(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	_, _, _, err = signer.VerifyURL(signedURL)
+	if err != nil {
+		t.Fatalf("verify with auto-generated secret: %v", err)
+	}
+}
+
+func TestURLSigner_URLWithExistingQuery(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file?version=1", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	if !strings.Contains(signedURL, "&sig=") {
+		t.Error("expected & separator for existing query params")
+	}
+}
+
+func TestURLSigner_RemainingTimeExpired(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	u := "https://example.com/file?key=file.txt&exp=0&iat=0&sig=invalid"
+
+	_, err := signer.RemainingTime(u)
+	if err == nil {
+		t.Log("remaining time check passed (may vary by implementation)")
+	}
+}
+
+func TestLocalStorage_SignAndAccess(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://cdn.example.com",
+	})
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "storage-sign-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	ctx := context.Background()
+	_, err := store.Put(ctx, "docs/report.pdf", []byte("report content"), StoragePutOptions{
+		MimeType: "application/pdf",
+	})
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	signedURL, err := signer.SignStorageObject(store, "docs/report.pdf", time.Hour)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	baseURL, expireTime, _, err := signer.VerifyURL(signedURL)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	if !strings.HasPrefix(baseURL, "https://cdn.example.com/docs/report.pdf") {
+		t.Errorf("expected base URL to start with https://cdn.example.com/docs/report.pdf, got %s", baseURL)
+	}
+
+	if expireTime.Before(time.Now().UTC()) {
+		t.Error("expire time is in the past")
+	}
+}
+
+func TestURLSigner_ConcurrentAccess(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "concurrent-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	done := make(chan bool, 10)
+
+	for i := 0; i < 10; i++ {
+		go func(idx int) {
+			key := "file" + string(rune('0'+idx)) + ".txt"
+			signedURL, err := signer.SignURL("https://example.com/"+key, key, time.Hour, nil)
+			if err != nil {
+				t.Errorf("sign %d: %v", idx, err)
+				done <- false
+				return
+			}
+
+			_, _, _, err = signer.VerifyURL(signedURL)
+			if err != nil {
+				t.Errorf("verify %d: %v", idx, err)
+				done <- false
+				return
+			}
+
+			done <- true
+		}(i)
+	}
+
+	for i := 0; i < 10; i++ {
+		if !<-done {
+			t.Fatal("concurrent test failed")
+		}
+	}
+}
+
+func TestURLSigner_RevokeAndIsRevoked(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "revoke-test",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	revoked, err := signer.IsRevoked(signedURL)
+	if err != nil {
+		t.Fatalf("isRevoked before: %v", err)
+	}
+	if revoked {
+		t.Error("should not be revoked yet")
+	}
+
+	err = signer.RevokeURL(signedURL)
+	if err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	revoked, err = signer.IsRevoked(signedURL)
+	if err != nil {
+		t.Fatalf("isRevoked after: %v", err)
+	}
+	if !revoked {
+		t.Error("should be revoked now")
+	}
+}
+
+func TestURLSignerManager_MultipleSigners(t *testing.T) {
+	sm := NewURLSignerManager()
+
+	signer1 := NewURLSigner(URLSignerConfig{
+		SecretKey:     "key-1",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signer2 := NewURLSigner(URLSignerConfig{
+		SecretKey:     "key-2",
+		DefaultExpiry: 2 * time.Hour,
+		MaxExpiry:     48 * time.Hour,
+	})
+
+	sm.Register("short", signer1)
+	sm.Register("long", signer2)
+
+	signedURL1, err := signer1.SignURL("https://example.com/f1", "f1", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign1: %v", err)
+	}
+
+	signedURL2, err := signer2.SignURL("https://example.com/f2", "f2", 2*time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign2: %v", err)
+	}
+
+	sm.SetDefault("short")
+	result1, err := sm.Verify(signedURL1)
+	if err != nil {
+		t.Fatalf("verify1 via manager: %v", err)
+	}
+	if result1.URL != "https://example.com/f1" {
+		t.Errorf("expected https://example.com/f1, got %s", result1.URL)
+	}
+
+	sm.SetDefault("long")
+	result2, err := sm.Verify(signedURL2)
+	if err != nil {
+		t.Fatalf("verify2 via manager: %v", err)
+	}
+	if result2.URL != "https://example.com/f2" {
+		t.Errorf("expected https://example.com/f2, got %s", result2.URL)
+	}
+}
+
+func TestMediaPipeline_DownloadWithAutoSign(t *testing.T) {
+	dir := t.TempDir()
+	local := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://cdn.example.com",
+	})
+
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "autosign-pipeline",
+		DefaultExpiry: 2 * time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Storage = local
+	cfg.Signer = signer
+	cfg.AutoSave = true
+	cfg.AutoSign = true
+	cfg.SignExpiry = 2 * time.Hour
+
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	_, err := p.Download(ctx, "http://localhost:1/test.jpg")
+	if err == nil {
+		t.Log("download with auto-sign attempted (expected failure due to no server)")
+	}
+}
+
+func TestURLSigner_VerifyInvalidURL(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	_, _, _, err := signer.VerifyURL("://invalid-url")
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestURLSigner_VerifyInvalidExpiry(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	_, _, _, err := signer.VerifyURL("https://example.com?key=test&exp=not-a-number&iat=0&sig=abc")
+	if err == nil {
+		t.Fatal("expected error for invalid expiry")
+	}
+}
+
+func TestURLSigner_VerifyInvalidSignature(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	_, _, _, err := signer.VerifyURL("https://example.com?key=test&exp=9999999999&iat=0&sig=not-hex!!")
+	if err == nil {
+		t.Fatal("expected error for invalid hex signature")
+	}
+}
+
+func TestURLSigner_RemainingTimeNoExpiry(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	_, err := signer.RemainingTime("https://example.com/file")
+	if err == nil {
+		t.Fatal("expected error for URL without expiry")
+	}
+}
+
+func TestURLSigner_RemainingTimeInvalidExpiry(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	_, err := signer.RemainingTime("https://example.com/file?exp=not-a-number")
+	if err == nil {
+		t.Fatal("expected error for invalid expiry")
+	}
+}
+
+func TestURLSigner_IsRevokedNotSignedURL(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	_, err := signer.IsRevoked("https://example.com/file")
+	if err == nil {
+		t.Fatal("expected error for non-signed URL")
+	}
+}
+
+func TestURLSigner_RevokeNotSignedURL(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	err := signer.RevokeURL("https://example.com/file")
+	if err == nil {
+		t.Fatal("expected error for non-signed URL")
+	}
+}
+
+func TestURLSigner_CleanupRevokedEmpty(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	cleaned := signer.CleanupRevoked()
+	if cleaned != 0 {
+		t.Errorf("expected 0 cleaned up, got %d", cleaned)
+	}
+}
+
+func TestURLSignerManager_NoSignerErrors(t *testing.T) {
+	sm := NewURLSignerManager()
+
+	_, err := sm.Sign("key", time.Hour)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	_, err = sm.Verify("https://example.com")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	err = sm.Revoke("https://example.com")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestProcessor_VerifySignedURL_NoSigner(t *testing.T) {
+	proc := NewProcessor("")
+
+	ctx := context.Background()
+	_, err := proc.VerifySignedURL(ctx, "https://example.com/file?sig=abc")
+	if err == nil {
+		t.Fatal("expected error with no signer")
+	}
+}
+
+func TestProcessor_RevokeSignedURL_NoSigner(t *testing.T) {
+	proc := NewProcessor("")
+
+	ctx := context.Background()
+	err := proc.RevokeSignedURL(ctx, "https://example.com/file?sig=abc")
+	if err == nil {
+		t.Fatal("expected error with no signer")
+	}
+}
+
+func TestMediaPipeline_SignURL_NoSigner(t *testing.T) {
+	cfg := DefaultMediaPipelineConfig()
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	_, err := p.SignURL(ctx, "key", time.Hour)
+	if err == nil {
+		t.Fatal("expected error with no signer")
+	}
+}
+
+func TestMediaPipeline_VerifySignedURL_NoSigner(t *testing.T) {
+	cfg := DefaultMediaPipelineConfig()
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	_, err := p.VerifySignedURL(ctx, "https://example.com")
+	if err == nil {
+		t.Fatal("expected error with no signer")
+	}
+}
+
+func TestMediaPipeline_RevokeSignedURL_NoSigner(t *testing.T) {
+	cfg := DefaultMediaPipelineConfig()
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	err := p.RevokeSignedURL(ctx, "https://example.com")
+	if err == nil {
+		t.Fatal("expected error with no signer")
+	}
+}
+
+func TestMediaPipeline_SignMediaURL_NoSigner(t *testing.T) {
+	cfg := DefaultMediaPipelineConfig()
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	media := &Media{ID: "test"}
+	_, err := p.SignMediaURL(ctx, media, time.Hour)
+	if err == nil {
+		t.Fatal("expected error with no signer")
+	}
+}
+
+func TestMediaPipeline_CleanupRevokedURLs_NoSigner(t *testing.T) {
+	cfg := DefaultMediaPipelineConfig()
+	p := NewMediaPipeline(cfg)
+
+	cleaned := p.CleanupRevokedURLs()
+	if cleaned != 0 {
+		t.Errorf("expected 0, got %d", cleaned)
+	}
+}
+
+func TestURLSigner_VerifyExpiredURL(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	signer.mu.Lock()
+	u, _ := parseURLForTest(signedURL)
+	q := u.Query()
+	q.Set("exp", "0")
+	u.RawQuery = q.Encode()
+	signedURL = u.String()
+	signer.mu.Unlock()
+
+	_, _, _, err = signer.VerifyURL(signedURL)
+	if err == nil {
+		t.Fatal("expected error for expired URL")
+	}
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("expected expired error, got: %v", err)
+	}
+}
+
+func parseURLForTest(rawURL string) (*url.URL, error) {
+	return url.Parse(rawURL)
+}
+
+func TestURLSigner_RevokedURLErrorMessage(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	_ = signer.RevokeURL(signedURL)
+
+	_, _, _, err = signer.VerifyURL(signedURL)
+	if err == nil {
+		t.Fatal("expected error for revoked URL")
+	}
+	if !strings.Contains(err.Error(), "revoked") {
+		t.Errorf("expected revoked error, got: %v", err)
+	}
+}
+
+func TestURLSigner_SignURLWithSpecialCharacters(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	key := "files/my photo (1).jpg"
+	signedURL, err := signer.SignURL("https://example.com/"+key, key, time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	baseURL, _, _, err := signer.VerifyURL(signedURL)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	decoded, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("parse base URL: %v", err)
+	}
+
+	if !strings.Contains(decoded.Path, "my photo") {
+		t.Errorf("expected URL path to contain 'my photo', got %s", decoded.Path)
+	}
+}
+
+func TestSignedURLResult_Fields(t *testing.T) {
+	signer := NewURLSigner(URLSignerConfig{
+		SecretKey:     "test-secret",
+		DefaultExpiry: time.Hour,
+		MaxExpiry:     24 * time.Hour,
+	})
+
+	signedURL, err := signer.SignURL("https://example.com/file", "file.txt", time.Hour, map[string]string{
+		"m_user": "test",
+	})
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	baseURL, expireTime, metadata, err := signer.VerifyURL(signedURL)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	result := &SignedURLResult{
+		URL:       baseURL,
+		ExpiresAt: expireTime,
+		Remaining: expireTime.Sub(time.Now().UTC()),
+		Metadata:  metadata,
+		IsRevoked: false,
+	}
+
+	if result.URL != "https://example.com/file" {
+		t.Errorf("expected URL https://example.com/file, got %s", result.URL)
+	}
+
+	if result.Metadata["m_user"] != "test" {
+		t.Errorf("expected m_user=test, got %s", result.Metadata["m_user"])
+	}
+
+	if result.IsRevoked {
+		t.Error("expected not revoked")
+	}
+}

--- a/pkg/media/storage.go
+++ b/pkg/media/storage.go
@@ -1,0 +1,935 @@
+package media
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type StorageBackendType string
+
+const (
+	StorageLocal StorageBackendType = "local"
+	StorageS3    StorageBackendType = "s3"
+)
+
+type StorageObject struct {
+	Key          string
+	Size         int64
+	MimeType     string
+	LastModified time.Time
+	URL          string
+	Metadata     map[string]string
+}
+
+type StorageBackend interface {
+	Type() StorageBackendType
+	Put(ctx context.Context, key string, data []byte, opts StoragePutOptions) (*StorageObject, error)
+	Get(ctx context.Context, key string) (*StorageObject, error)
+	Delete(ctx context.Context, key string) error
+	Exists(ctx context.Context, key string) (bool, error)
+	List(ctx context.Context, prefix string) ([]*StorageObject, error)
+	URL(ctx context.Context, key string, expires time.Duration) (string, error)
+}
+
+type StoragePutOptions struct {
+	MimeType     string
+	Metadata     map[string]string
+	ACL          string
+	CacheControl string
+}
+
+type LocalStorageConfig struct {
+	BasePath string
+	BaseURL  string
+}
+
+type LocalStorage struct {
+	mu       sync.RWMutex
+	basePath string
+	baseURL  string
+}
+
+func NewLocalStorage(cfg LocalStorageConfig) *LocalStorage {
+	return &LocalStorage{
+		basePath: cfg.BasePath,
+		baseURL:  cfg.BaseURL,
+	}
+}
+
+func (s *LocalStorage) Type() StorageBackendType {
+	return StorageLocal
+}
+
+func (s *LocalStorage) Put(ctx context.Context, key string, data []byte, opts StoragePutOptions) (*StorageObject, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path := filepath.Join(s.basePath, key)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, fmt.Errorf("create directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return nil, fmt.Errorf("write file: %w", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat file: %w", err)
+	}
+
+	obj := &StorageObject{
+		Key:          key,
+		Size:         info.Size(),
+		MimeType:     opts.MimeType,
+		LastModified: info.ModTime(),
+		Metadata:     opts.Metadata,
+	}
+
+	if s.baseURL != "" {
+		obj.URL = strings.TrimRight(s.baseURL, "/") + "/" + key
+	} else {
+		obj.URL = "file://" + path
+	}
+
+	return obj, nil
+}
+
+func (s *LocalStorage) Get(ctx context.Context, key string) (*StorageObject, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	path := filepath.Join(s.basePath, key)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("object not found: %s", key)
+		}
+		return nil, fmt.Errorf("stat file: %w", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+
+	mimeType := mime.TypeByExtension(filepath.Ext(key))
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+
+	obj := &StorageObject{
+		Key:          key,
+		Size:         info.Size(),
+		MimeType:     mimeType,
+		LastModified: info.ModTime(),
+		Metadata:     map[string]string{"data": base64.StdEncoding.EncodeToString(data)},
+	}
+
+	if s.baseURL != "" {
+		obj.URL = strings.TrimRight(s.baseURL, "/") + "/" + key
+	} else {
+		obj.URL = "file://" + path
+	}
+
+	return obj, nil
+}
+
+func (s *LocalStorage) Delete(ctx context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path := filepath.Join(s.basePath, key)
+
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("object not found: %s", key)
+		}
+		return fmt.Errorf("delete file: %w", err)
+	}
+
+	return nil
+}
+
+func (s *LocalStorage) Exists(ctx context.Context, key string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	path := filepath.Join(s.basePath, key)
+
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat file: %w", err)
+	}
+
+	return true, nil
+}
+
+func (s *LocalStorage) List(ctx context.Context, prefix string) ([]*StorageObject, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	searchDir := s.basePath
+	if prefix != "" {
+		searchDir = filepath.Join(s.basePath, filepath.Dir(prefix))
+	}
+
+	entries, err := os.ReadDir(searchDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read directory: %w", err)
+	}
+
+	var objects []*StorageObject
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if prefix != "" {
+			basePrefix := filepath.Base(prefix)
+			if basePrefix != "." && !strings.HasPrefix(name, basePrefix) {
+				continue
+			}
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
+		key := name
+		if prefix != "" {
+			key = filepath.Join(filepath.Dir(prefix), name)
+		}
+		objURL := ""
+		if s.baseURL != "" {
+			objURL = strings.TrimRight(s.baseURL, "/") + "/" + key
+		}
+
+		objects = append(objects, &StorageObject{
+			Key:          key,
+			Size:         info.Size(),
+			LastModified: info.ModTime(),
+			URL:          objURL,
+		})
+	}
+
+	return objects, nil
+}
+
+func (s *LocalStorage) URL(ctx context.Context, key string, expires time.Duration) (string, error) {
+	if s.baseURL != "" {
+		return strings.TrimRight(s.baseURL, "/") + "/" + key, nil
+	}
+	return "file://" + filepath.Join(s.basePath, key), nil
+}
+
+type S3Config struct {
+	Endpoint        string
+	Region          string
+	Bucket          string
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+	UsePathStyle    bool
+	ForcePathStyle  bool
+	PublicRead      bool
+}
+
+type S3Storage struct {
+	mu     sync.RWMutex
+	cfg    S3Config
+	client *http.Client
+}
+
+func NewS3Storage(cfg S3Config) *S3Storage {
+	endpoint := cfg.Endpoint
+	if endpoint == "" {
+		endpoint = fmt.Sprintf("s3.%s.amazonaws.com", cfg.Region)
+	}
+
+	return &S3Storage{
+		cfg: cfg,
+		client: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+func (s *S3Storage) Type() StorageBackendType {
+	return StorageS3
+}
+
+func (s *S3Storage) host() string {
+	if s.cfg.ForcePathStyle || s.cfg.UsePathStyle {
+		endpoint := s.cfg.Endpoint
+		if !strings.HasPrefix(endpoint, "http") {
+			endpoint = "https://" + endpoint
+		}
+		return endpoint
+	}
+	return fmt.Sprintf("https://%s.%s", s.cfg.Bucket, s.cfg.Endpoint)
+}
+
+func (s *S3Storage) objectURL(key string) string {
+	if s.cfg.ForcePathStyle || s.cfg.UsePathStyle {
+		endpoint := strings.TrimRight(s.cfg.Endpoint, "/")
+		if !strings.HasPrefix(endpoint, "http") {
+			endpoint = "https://" + endpoint
+		}
+		return fmt.Sprintf("%s/%s/%s", endpoint, s.cfg.Bucket, key)
+	}
+	return fmt.Sprintf("https://%s.%s/%s", s.cfg.Bucket, s.cfg.Endpoint, key)
+}
+
+func (s *S3Storage) Put(ctx context.Context, key string, data []byte, opts StoragePutOptions) (*StorageObject, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	method := "PUT"
+	contentType := opts.MimeType
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	bodyHash := sha256Hex(data)
+
+	headers := map[string]string{
+		"Host":                 s.hostURL().Host,
+		"Content-Type":         contentType,
+		"Content-Length":       fmt.Sprintf("%d", len(data)),
+		"X-Amz-Content-Sha256": bodyHash,
+		"X-Amz-Date":           time.Now().UTC().Format("20060102T150405Z"),
+	}
+
+	if opts.CacheControl != "" {
+		headers["Cache-Control"] = opts.CacheControl
+	}
+
+	if s.cfg.PublicRead {
+		headers["X-Amz-Acl"] = "public-read"
+	} else if opts.ACL != "" {
+		headers["X-Amz-Acl"] = opts.ACL
+	}
+
+	for k, v := range opts.Metadata {
+		headers["X-Amz-Meta-"+k] = v
+	}
+
+	if s.cfg.SessionToken != "" {
+		headers["X-Amz-Security-Token"] = s.cfg.SessionToken
+	}
+
+	path := "/" + s.cfg.Bucket + "/" + key
+	authHeader := s.signV4(method, path, "", headers, bodyHash)
+
+	reqURL := s.objectURL(key)
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Authorization", authHeader)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("put request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("s3 put failed: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	obj := &StorageObject{
+		Key:          key,
+		Size:         int64(len(data)),
+		MimeType:     contentType,
+		LastModified: time.Now(),
+		URL:          s.objectURL(key),
+		Metadata:     opts.Metadata,
+	}
+
+	return obj, nil
+}
+
+func (s *S3Storage) Get(ctx context.Context, key string) (*StorageObject, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	method := "GET"
+	bodyHash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	headers := map[string]string{
+		"Host":                 s.hostURL().Host,
+		"X-Amz-Content-Sha256": bodyHash,
+		"X-Amz-Date":           time.Now().UTC().Format("20060102T150405Z"),
+	}
+
+	if s.cfg.SessionToken != "" {
+		headers["X-Amz-Security-Token"] = s.cfg.SessionToken
+	}
+
+	path := "/" + s.cfg.Bucket + "/" + key
+	authHeader := s.signV4(method, path, "", headers, bodyHash)
+
+	reqURL := s.objectURL(key)
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Authorization", authHeader)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("s3 get failed: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	metadata := make(map[string]string)
+	for k, v := range resp.Header {
+		if strings.HasPrefix(k, "X-Amz-Meta-") {
+			metadata[strings.TrimPrefix(k, "X-Amz-Meta-")] = v[0]
+		}
+	}
+
+	obj := &StorageObject{
+		Key:      key,
+		Size:     resp.ContentLength,
+		MimeType: resp.Header.Get("Content-Type"),
+		URL:      s.objectURL(key),
+		Metadata: metadata,
+	}
+
+	if resp.Header.Get("Last-Modified") != "" {
+		if t, err := time.Parse(time.RFC1123, resp.Header.Get("Last-Modified")); err == nil {
+			obj.LastModified = t
+		}
+	}
+
+	obj.Metadata["data"] = base64.StdEncoding.EncodeToString(data)
+
+	return obj, nil
+}
+
+func (s *S3Storage) Delete(ctx context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	method := "DELETE"
+	bodyHash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	headers := map[string]string{
+		"Host":                 s.hostURL().Host,
+		"X-Amz-Content-Sha256": bodyHash,
+		"X-Amz-Date":           time.Now().UTC().Format("20060102T150405Z"),
+	}
+
+	if s.cfg.SessionToken != "" {
+		headers["X-Amz-Security-Token"] = s.cfg.SessionToken
+	}
+
+	path := "/" + s.cfg.Bucket + "/" + key
+	authHeader := s.signV4(method, path, "", headers, bodyHash)
+
+	reqURL := s.objectURL(key)
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Authorization", authHeader)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("delete request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode >= 300 && resp.StatusCode != 404 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("s3 delete failed: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func (s *S3Storage) Exists(ctx context.Context, key string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	method := "HEAD"
+	bodyHash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	headers := map[string]string{
+		"Host":                 s.hostURL().Host,
+		"X-Amz-Content-Sha256": bodyHash,
+		"X-Amz-Date":           time.Now().UTC().Format("20060102T150405Z"),
+	}
+
+	if s.cfg.SessionToken != "" {
+		headers["X-Amz-Security-Token"] = s.cfg.SessionToken
+	}
+
+	path := "/" + s.cfg.Bucket + "/" + key
+	authHeader := s.signV4(method, path, "", headers, bodyHash)
+
+	reqURL := s.objectURL(key)
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("create request: %w", err)
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Authorization", authHeader)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("head request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode == 404 {
+		return false, nil
+	}
+	if resp.StatusCode >= 300 {
+		return false, fmt.Errorf("s3 head failed: HTTP %d", resp.StatusCode)
+	}
+
+	return true, nil
+}
+
+func (s *S3Storage) List(ctx context.Context, prefix string) ([]*StorageObject, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	method := "GET"
+	bodyHash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	query := url.Values{}
+	if prefix != "" {
+		query.Set("prefix", prefix)
+	}
+	query.Set("max-keys", "1000")
+	queryStr := query.Encode()
+
+	headers := map[string]string{
+		"Host":                 s.hostURL().Host,
+		"X-Amz-Content-Sha256": bodyHash,
+		"X-Amz-Date":           time.Now().UTC().Format("20060102T150405Z"),
+	}
+
+	if s.cfg.SessionToken != "" {
+		headers["X-Amz-Security-Token"] = s.cfg.SessionToken
+	}
+
+	path := "/" + s.cfg.Bucket + "/"
+	authHeader := s.signV4(method, path, queryStr, headers, bodyHash)
+
+	var reqURL string
+	if s.cfg.ForcePathStyle || s.cfg.UsePathStyle {
+		endpoint := strings.TrimRight(s.cfg.Endpoint, "/")
+		if !strings.HasPrefix(endpoint, "http") {
+			endpoint = "https://" + endpoint
+		}
+		reqURL = fmt.Sprintf("%s/%s?%s", endpoint, s.cfg.Bucket, queryStr)
+	} else {
+		reqURL = fmt.Sprintf("https://%s.%s/?%s", s.cfg.Bucket, s.cfg.Endpoint, queryStr)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Authorization", authHeader)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("s3 list failed: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	return parseS3ListResponse(body, s.objectURL(""))
+}
+
+func (s *S3Storage) URL(ctx context.Context, key string, expires time.Duration) (string, error) {
+	if expires <= 0 {
+		return s.objectURL(key), nil
+	}
+
+	now := time.Now().UTC()
+
+	query := url.Values{}
+	query.Set("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
+	query.Set("X-Amz-Credential", fmt.Sprintf("%s/%s/%s/s3/aws4_request", s.cfg.AccessKeyID, now.Format("20060102"), s.cfg.Region))
+	query.Set("X-Amz-Date", now.Format("20060102T150405Z"))
+	query.Set("X-Amz-Expires", fmt.Sprintf("%d", int(expires.Seconds())))
+	query.Set("X-Amz-SignedHeaders", "host")
+
+	if s.cfg.SessionToken != "" {
+		query.Set("X-Amz-Security-Token", s.cfg.SessionToken)
+	}
+
+	stringToSign := s.presignStringToSign(methodGET, "/"+s.cfg.Bucket+"/"+key, query.Encode(), now.Format("20060102"))
+	signingKey := s.deriveSigningKey(now.Format("20060102"))
+	signature := hmacSHA256(signingKey, stringToSign)
+
+	query.Set("X-Amz-Signature", hex.EncodeToString(signature))
+
+	var reqURL string
+	if s.cfg.ForcePathStyle || s.cfg.UsePathStyle {
+		endpoint := strings.TrimRight(s.cfg.Endpoint, "/")
+		if !strings.HasPrefix(endpoint, "http") {
+			endpoint = "https://" + endpoint
+		}
+		reqURL = fmt.Sprintf("%s/%s/%s?%s", endpoint, s.cfg.Bucket, url.PathEscape(key), query.Encode())
+	} else {
+		reqURL = fmt.Sprintf("https://%s.%s/%s?%s", s.cfg.Bucket, s.cfg.Endpoint, url.PathEscape(key), query.Encode())
+	}
+
+	return reqURL, nil
+}
+
+const methodGET = "GET"
+
+func (s *S3Storage) hostURL() *url.URL {
+	h := s.host()
+	if !strings.HasPrefix(h, "http") {
+		h = "https://" + h
+	}
+	u, _ := url.Parse(h)
+	return u
+}
+
+func (s *S3Storage) signV4(method, path, query string, headers map[string]string, bodyHash string) string {
+	now := time.Now().UTC()
+	dateStamp := now.Format("20060102")
+
+	signedHeaders := make([]string, 0, len(headers))
+	for k := range headers {
+		lower := strings.ToLower(k)
+		if lower == "authorization" {
+			continue
+		}
+		signedHeaders = append(signedHeaders, lower)
+	}
+	sort.Strings(signedHeaders)
+
+	canonicalHeaders := ""
+	for _, h := range signedHeaders {
+		canonicalHeaders += h + ":" + strings.TrimSpace(headers[headerKey(h)]) + "\n"
+	}
+
+	canonicalRequest := method + "\n" + path + "\n" + query + "\n" + canonicalHeaders + "\n" + strings.Join(signedHeaders, ";") + "\n" + bodyHash
+
+	stringToSign := "AWS4-HMAC-SHA256\n" + now.Format("20060102T150405Z") + "\n" + dateStamp + "/" + s.cfg.Region + "/s3/aws4_request\n" + sha256HexString(canonicalRequest)
+
+	signingKey := s.deriveSigningKey(dateStamp)
+	signature := hmacSHA256(signingKey, stringToSign)
+
+	return "AWS4-HMAC-SHA256 Credential=" + s.cfg.AccessKeyID + "/" + dateStamp + "/" + s.cfg.Region + "/s3/aws4_request, SignedHeaders=" + strings.Join(signedHeaders, ";") + ", Signature=" + hex.EncodeToString(signature)
+}
+
+func (s *S3Storage) presignStringToSign(method, path, query, dateStamp string) string {
+	return "AWS4-HMAC-SHA256\n" + dateStamp + "T000000Z\n" + dateStamp + "/" + s.cfg.Region + "/s3/aws4_request\n" + sha256HexString(method+"\n"+path+"\n"+query+"\nhost:"+s.hostURL().Host+"\n\nhost\nUNSIGNED-PAYLOAD")
+}
+
+func (s *S3Storage) deriveSigningKey(dateStamp string) []byte {
+	kSecret := []byte("AWS4" + s.cfg.SecretAccessKey)
+	kDate := hmacSHA256(kSecret, dateStamp)
+	kRegion := hmacSHA256(kDate, s.cfg.Region)
+	kService := hmacSHA256(kRegion, "s3")
+	return hmacSHA256(kService, "aws4_request")
+}
+
+func headerKey(lower string) string {
+	switch lower {
+	case "host":
+		return "Host"
+	case "content-type":
+		return "Content-Type"
+	case "content-length":
+		return "Content-Length"
+	case "x-amz-content-sha256":
+		return "X-Amz-Content-Sha256"
+	case "x-amz-date":
+		return "X-Amz-Date"
+	case "cache-control":
+		return "Cache-Control"
+	case "x-amz-acl":
+		return "X-Amz-Acl"
+	case "x-amz-security-token":
+		return "X-Amz-Security-Token"
+	default:
+		if strings.HasPrefix(lower, "x-amz-meta-") {
+			return "X-Amz-Meta-" + strings.TrimPrefix(lower, "x-amz-meta-")
+		}
+		return lower
+	}
+}
+
+func sha256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+func sha256HexString(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+func hmacSHA256(key []byte, data string) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(data))
+	return mac.Sum(nil)
+}
+
+type s3ListResponse struct {
+	Contents []s3ListContents `json:"Contents"`
+}
+
+type s3ListContents struct {
+	Key          string `json:"Key"`
+	Size         int64  `json:"Size"`
+	LastModified string `json:"LastModified"`
+}
+
+func parseS3ListResponse(body []byte, baseURL string) ([]*StorageObject, error) {
+	var result s3ListResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return parseS3ListXML(body, baseURL)
+	}
+
+	objects := make([]*StorageObject, 0, len(result.Contents))
+	for _, c := range result.Contents {
+		objURL := baseURL + c.Key
+		objects = append(objects, &StorageObject{
+			Key:  c.Key,
+			Size: c.Size,
+			URL:  objURL,
+		})
+	}
+
+	return objects, nil
+}
+
+func parseS3ListXML(body []byte, baseURL string) ([]*StorageObject, error) {
+	var objects []*StorageObject
+
+	contentTag := "<Contents>"
+	endTag := "</Contents>"
+	keyTag := "<Key>"
+	keyEndTag := "</Key>"
+	sizeTag := "<Size>"
+	sizeEndTag := "</Size>"
+	lmTag := "<LastModified>"
+	lmEndTag := "</LastModified>"
+
+	pos := 0
+	for {
+		idx := bytes.Index(body[pos:], []byte(contentTag))
+		if idx == -1 {
+			break
+		}
+		start := pos + idx + len(contentTag)
+		endIdx := bytes.Index(body[start:], []byte(endTag))
+		if endIdx == -1 {
+			break
+		}
+		content := body[start : start+endIdx]
+
+		obj := &StorageObject{URL: baseURL}
+
+		keyIdx := bytes.Index(content, []byte(keyTag))
+		if keyIdx >= 0 {
+			keyStart := keyIdx + len(keyTag)
+			keyEnd := bytes.Index(content[keyStart:], []byte(keyEndTag))
+			if keyEnd >= 0 {
+				obj.Key = string(content[keyStart : keyStart+keyEnd])
+			}
+		}
+
+		sizeIdx := bytes.Index(content, []byte(sizeTag))
+		if sizeIdx >= 0 {
+			sizeStart := sizeIdx + len(sizeTag)
+			sizeEnd := bytes.Index(content[sizeStart:], []byte(sizeEndTag))
+			if sizeEnd >= 0 {
+				fmt.Sscanf(string(content[sizeStart:sizeStart+sizeEnd]), "%d", &obj.Size)
+			}
+		}
+
+		lmIdx := bytes.Index(content, []byte(lmTag))
+		if lmIdx >= 0 {
+			lmStart := lmIdx + len(lmTag)
+			lmEnd := bytes.Index(content[lmStart:], []byte(lmEndTag))
+			if lmEnd >= 0 {
+				if t, err := time.Parse(time.RFC3339, string(content[lmStart:lmStart+lmEnd])); err == nil {
+					obj.LastModified = t
+				}
+			}
+		}
+
+		if obj.Key != "" {
+			objects = append(objects, obj)
+		}
+
+		pos = start + endIdx + len(endTag)
+	}
+
+	return objects, nil
+}
+
+type StorageManager struct {
+	mu        sync.RWMutex
+	backends  map[StorageBackendType]StorageBackend
+	defaultBE StorageBackendType
+}
+
+func NewStorageManager() *StorageManager {
+	return &StorageManager{
+		backends: make(map[StorageBackendType]StorageBackend),
+	}
+}
+
+func (sm *StorageManager) Register(backend StorageBackend) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.backends[backend.Type()] = backend
+	if sm.defaultBE == "" {
+		sm.defaultBE = backend.Type()
+	}
+}
+
+func (sm *StorageManager) SetDefault(t StorageBackendType) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.defaultBE = t
+}
+
+func (sm *StorageManager) Backend(t StorageBackendType) StorageBackend {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.backends[t]
+}
+
+func (sm *StorageManager) Default() StorageBackend {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.backends[sm.defaultBE]
+}
+
+func (sm *StorageManager) Put(ctx context.Context, key string, data []byte, opts StoragePutOptions) (*StorageObject, error) {
+	be := sm.Default()
+	if be == nil {
+		return nil, fmt.Errorf("no storage backend configured")
+	}
+	return be.Put(ctx, key, data, opts)
+}
+
+func (sm *StorageManager) Get(ctx context.Context, key string) (*StorageObject, error) {
+	be := sm.Default()
+	if be == nil {
+		return nil, fmt.Errorf("no storage backend configured")
+	}
+	return be.Get(ctx, key)
+}
+
+func (sm *StorageManager) Delete(ctx context.Context, key string) error {
+	be := sm.Default()
+	if be == nil {
+		return fmt.Errorf("no storage backend configured")
+	}
+	return be.Delete(ctx, key)
+}
+
+func (sm *StorageManager) Exists(ctx context.Context, key string) (bool, error) {
+	be := sm.Default()
+	if be == nil {
+		return false, fmt.Errorf("no storage backend configured")
+	}
+	return be.Exists(ctx, key)
+}
+
+func (sm *StorageManager) List(ctx context.Context, prefix string) ([]*StorageObject, error) {
+	be := sm.Default()
+	if be == nil {
+		return nil, fmt.Errorf("no storage backend configured")
+	}
+	return be.List(ctx, prefix)
+}
+
+func (sm *StorageManager) URL(ctx context.Context, key string, expires time.Duration) (string, error) {
+	be := sm.Default()
+	if be == nil {
+		return "", fmt.Errorf("no storage backend configured")
+	}
+	return be.URL(ctx, key, expires)
+}

--- a/pkg/media/storage.go
+++ b/pkg/media/storage.go
@@ -76,11 +76,45 @@ func (s *LocalStorage) Type() StorageBackendType {
 	return StorageLocal
 }
 
+func (s *LocalStorage) resolveKeyPath(key string) (string, string, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", "", fmt.Errorf("invalid storage key")
+	}
+	if filepath.IsAbs(key) || filepath.VolumeName(key) != "" {
+		return "", "", fmt.Errorf("invalid storage key: absolute paths are not allowed")
+	}
+
+	cleanKey := filepath.Clean(key)
+	if cleanKey == "." || cleanKey == ".." {
+		return "", "", fmt.Errorf("invalid storage key: %s", key)
+	}
+
+	basePath, err := filepath.Abs(s.basePath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve base path: %w", err)
+	}
+
+	resolvedPath := filepath.Join(basePath, cleanKey)
+	rel, err := filepath.Rel(basePath, resolvedPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve storage key: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", "", fmt.Errorf("invalid storage key: path escapes storage root")
+	}
+
+	return filepath.ToSlash(cleanKey), resolvedPath, nil
+}
+
 func (s *LocalStorage) Put(ctx context.Context, key string, data []byte, opts StoragePutOptions) (*StorageObject, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	path := filepath.Join(s.basePath, key)
+	cleanKey, path, err := s.resolveKeyPath(key)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return nil, fmt.Errorf("create directory: %w", err)
@@ -96,7 +130,7 @@ func (s *LocalStorage) Put(ctx context.Context, key string, data []byte, opts St
 	}
 
 	obj := &StorageObject{
-		Key:          key,
+		Key:          cleanKey,
 		Size:         info.Size(),
 		MimeType:     opts.MimeType,
 		LastModified: info.ModTime(),
@@ -104,7 +138,7 @@ func (s *LocalStorage) Put(ctx context.Context, key string, data []byte, opts St
 	}
 
 	if s.baseURL != "" {
-		obj.URL = strings.TrimRight(s.baseURL, "/") + "/" + key
+		obj.URL = strings.TrimRight(s.baseURL, "/") + "/" + cleanKey
 	} else {
 		obj.URL = "file://" + path
 	}
@@ -116,7 +150,10 @@ func (s *LocalStorage) Get(ctx context.Context, key string) (*StorageObject, err
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	path := filepath.Join(s.basePath, key)
+	cleanKey, path, err := s.resolveKeyPath(key)
+	if err != nil {
+		return nil, err
+	}
 
 	info, err := os.Stat(path)
 	if err != nil {
@@ -131,13 +168,13 @@ func (s *LocalStorage) Get(ctx context.Context, key string) (*StorageObject, err
 		return nil, fmt.Errorf("read file: %w", err)
 	}
 
-	mimeType := mime.TypeByExtension(filepath.Ext(key))
+	mimeType := mime.TypeByExtension(filepath.Ext(cleanKey))
 	if mimeType == "" {
 		mimeType = "application/octet-stream"
 	}
 
 	obj := &StorageObject{
-		Key:          key,
+		Key:          cleanKey,
 		Size:         info.Size(),
 		MimeType:     mimeType,
 		LastModified: info.ModTime(),
@@ -145,7 +182,7 @@ func (s *LocalStorage) Get(ctx context.Context, key string) (*StorageObject, err
 	}
 
 	if s.baseURL != "" {
-		obj.URL = strings.TrimRight(s.baseURL, "/") + "/" + key
+		obj.URL = strings.TrimRight(s.baseURL, "/") + "/" + cleanKey
 	} else {
 		obj.URL = "file://" + path
 	}
@@ -157,7 +194,10 @@ func (s *LocalStorage) Delete(ctx context.Context, key string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	path := filepath.Join(s.basePath, key)
+	_, path, err := s.resolveKeyPath(key)
+	if err != nil {
+		return err
+	}
 
 	if err := os.Remove(path); err != nil {
 		if os.IsNotExist(err) {
@@ -173,9 +213,12 @@ func (s *LocalStorage) Exists(ctx context.Context, key string) (bool, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	path := filepath.Join(s.basePath, key)
+	_, path, err := s.resolveKeyPath(key)
+	if err != nil {
+		return false, err
+	}
 
-	_, err := os.Stat(path)
+	_, err = os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
@@ -191,8 +234,19 @@ func (s *LocalStorage) List(ctx context.Context, prefix string) ([]*StorageObjec
 	defer s.mu.RUnlock()
 
 	searchDir := s.basePath
+	keyDir := ""
+	basePrefix := ""
 	if prefix != "" {
-		searchDir = filepath.Join(s.basePath, filepath.Dir(prefix))
+		cleanPrefix, resolvedPrefix, err := s.resolveKeyPath(prefix)
+		if err != nil {
+			return nil, err
+		}
+		basePrefix = filepath.Base(cleanPrefix)
+		searchDir = filepath.Dir(resolvedPrefix)
+		keyDir = filepath.Dir(cleanPrefix)
+		if keyDir == "." {
+			keyDir = ""
+		}
 	}
 
 	entries, err := os.ReadDir(searchDir)
@@ -209,11 +263,8 @@ func (s *LocalStorage) List(ctx context.Context, prefix string) ([]*StorageObjec
 			continue
 		}
 		name := entry.Name()
-		if prefix != "" {
-			basePrefix := filepath.Base(prefix)
-			if basePrefix != "." && !strings.HasPrefix(name, basePrefix) {
-				continue
-			}
+		if basePrefix != "" && !strings.HasPrefix(name, basePrefix) {
+			continue
 		}
 
 		info, err := entry.Info()
@@ -222,9 +273,10 @@ func (s *LocalStorage) List(ctx context.Context, prefix string) ([]*StorageObjec
 		}
 
 		key := name
-		if prefix != "" {
-			key = filepath.Join(filepath.Dir(prefix), name)
+		if keyDir != "" {
+			key = filepath.Join(keyDir, name)
 		}
+		key = filepath.ToSlash(key)
 		objURL := ""
 		if s.baseURL != "" {
 			objURL = strings.TrimRight(s.baseURL, "/") + "/" + key
@@ -242,10 +294,14 @@ func (s *LocalStorage) List(ctx context.Context, prefix string) ([]*StorageObjec
 }
 
 func (s *LocalStorage) URL(ctx context.Context, key string, expires time.Duration) (string, error) {
-	if s.baseURL != "" {
-		return strings.TrimRight(s.baseURL, "/") + "/" + key, nil
+	cleanKey, path, err := s.resolveKeyPath(key)
+	if err != nil {
+		return "", err
 	}
-	return "file://" + filepath.Join(s.basePath, key), nil
+	if s.baseURL != "" {
+		return strings.TrimRight(s.baseURL, "/") + "/" + cleanKey, nil
+	}
+	return "file://" + path, nil
 }
 
 type S3Config struct {

--- a/pkg/media/storage_test.go
+++ b/pkg/media/storage_test.go
@@ -1,0 +1,1057 @@
+package media
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLocalStorage_PutAndGet(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+	})
+
+	ctx := context.Background()
+	data := []byte("test media content")
+
+	obj, err := store.Put(ctx, "test/file.txt", data, StoragePutOptions{
+		MimeType: "text/plain",
+	})
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	if obj.Key != "test/file.txt" {
+		t.Errorf("expected key test/file.txt, got %s", obj.Key)
+	}
+	if obj.Size != int64(len(data)) {
+		t.Errorf("expected size %d, got %d", len(data), obj.Size)
+	}
+	if obj.MimeType != "text/plain" {
+		t.Errorf("expected mime text/plain, got %s", obj.MimeType)
+	}
+
+	got, err := store.Get(ctx, "test/file.txt")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.Key != "test/file.txt" {
+		t.Errorf("expected key test/file.txt, got %s", got.Key)
+	}
+	if got.Size != int64(len(data)) {
+		t.Errorf("expected size %d, got %d", len(data), got.Size)
+	}
+}
+
+func TestLocalStorage_Delete(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+	})
+
+	ctx := context.Background()
+	_, err := store.Put(ctx, "to-delete.txt", []byte("delete me"), StoragePutOptions{})
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	err = store.Delete(ctx, "to-delete.txt")
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	exists, err := store.Exists(ctx, "to-delete.txt")
+	if err != nil {
+		t.Fatalf("exists: %v", err)
+	}
+	if exists {
+		t.Error("expected file to be deleted")
+	}
+}
+
+func TestLocalStorage_DeleteNotFound(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+	})
+
+	ctx := context.Background()
+	err := store.Delete(ctx, "nonexistent.txt")
+	if err == nil {
+		t.Fatal("expected error for deleting nonexistent file")
+	}
+}
+
+func TestLocalStorage_Exists(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+	})
+
+	ctx := context.Background()
+
+	exists, err := store.Exists(ctx, "missing.txt")
+	if err != nil {
+		t.Fatalf("exists: %v", err)
+	}
+	if exists {
+		t.Error("expected false for missing file")
+	}
+
+	_, err = store.Put(ctx, "present.txt", []byte("hello"), StoragePutOptions{})
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	exists, err = store.Exists(ctx, "present.txt")
+	if err != nil {
+		t.Fatalf("exists: %v", err)
+	}
+	if !exists {
+		t.Error("expected true for existing file")
+	}
+}
+
+func TestLocalStorage_List(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+	})
+
+	ctx := context.Background()
+
+	_, _ = store.Put(ctx, "img1.jpg", []byte("img1"), StoragePutOptions{})
+	_, _ = store.Put(ctx, "img2.jpg", []byte("img2"), StoragePutOptions{})
+	_, _ = store.Put(ctx, "doc.pdf", []byte("doc"), StoragePutOptions{})
+
+	objects, err := store.List(ctx, "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(objects) != 3 {
+		t.Errorf("expected 3 objects, got %d", len(objects))
+	}
+}
+
+func TestLocalStorage_URL(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://example.com/media",
+	})
+
+	ctx := context.Background()
+
+	objURL, err := store.URL(ctx, "photo.jpg", 0)
+	if err != nil {
+		t.Fatalf("url: %v", err)
+	}
+
+	expected := "https://example.com/media/photo.jpg"
+	if objURL != expected {
+		t.Errorf("expected URL %s, got %s", expected, objURL)
+	}
+}
+
+func TestLocalStorage_URL_NoBaseURL(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+	})
+
+	ctx := context.Background()
+
+	objURL, err := store.URL(ctx, "photo.jpg", 0)
+	if err != nil {
+		t.Fatalf("url: %v", err)
+	}
+
+	expected := "file://" + filepath.Join(dir, "photo.jpg")
+	if objURL != expected {
+		t.Errorf("expected URL %s, got %s", expected, objURL)
+	}
+}
+
+func TestLocalStorage_Type(t *testing.T) {
+	store := NewLocalStorage(LocalStorageConfig{})
+	if store.Type() != StorageLocal {
+		t.Errorf("expected StorageLocal, got %s", store.Type())
+	}
+}
+
+func TestLocalStorage_PutWithMetadata(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+	})
+
+	ctx := context.Background()
+	_, err := store.Put(ctx, "meta.txt", []byte("data"), StoragePutOptions{
+		MimeType: "text/plain",
+		Metadata: map[string]string{
+			"author": "test",
+			"title":  "example",
+		},
+	})
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	obj, err := store.Get(ctx, "meta.txt")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if !strings.HasPrefix(obj.MimeType, "text/plain") {
+		t.Errorf("expected mime starting with text/plain, got %s", obj.MimeType)
+	}
+
+	if len(obj.Metadata) == 0 {
+		t.Error("expected metadata to be populated")
+	}
+}
+
+func TestS3Storage_Type(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:   "us-east-1",
+		Bucket:   "test-bucket",
+		Endpoint: "s3.us-east-1.amazonaws.com",
+	})
+
+	if store.Type() != StorageS3 {
+		t.Errorf("expected StorageS3, got %s", store.Type())
+	}
+}
+
+func TestS3Storage_HostURL_VirtualHosted(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:   "us-east-1",
+		Bucket:   "my-bucket",
+		Endpoint: "s3.us-east-1.amazonaws.com",
+	})
+
+	host := store.hostURL()
+	if host.Host != "my-bucket.s3.us-east-1.amazonaws.com" {
+		t.Errorf("expected my-bucket.s3.us-east-1.amazonaws.com, got %s", host.Host)
+	}
+}
+
+func TestS3Storage_HostURL_PathStyle(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:         "us-east-1",
+		Bucket:         "my-bucket",
+		Endpoint:       "http://localhost:9000",
+		ForcePathStyle: true,
+	})
+
+	host := store.hostURL()
+	if host.Host != "localhost:9000" {
+		t.Errorf("expected localhost:9000, got %s", host.Host)
+	}
+}
+
+func TestS3Storage_ObjectURL_VirtualHosted(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:   "us-east-1",
+		Bucket:   "my-bucket",
+		Endpoint: "s3.us-east-1.amazonaws.com",
+	})
+
+	objURL := store.objectURL("photos/img.jpg")
+	expected := "https://my-bucket.s3.us-east-1.amazonaws.com/photos/img.jpg"
+	if objURL != expected {
+		t.Errorf("expected %s, got %s", expected, objURL)
+	}
+}
+
+func TestS3Storage_ObjectURL_PathStyle(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:         "us-east-1",
+		Bucket:         "my-bucket",
+		Endpoint:       "http://localhost:9000",
+		ForcePathStyle: true,
+	})
+
+	objURL := store.objectURL("photos/img.jpg")
+	expected := "http://localhost:9000/my-bucket/photos/img.jpg"
+	if objURL != expected {
+		t.Errorf("expected %s, got %s", expected, objURL)
+	}
+}
+
+func TestS3Storage_Put_NoCredentials(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:   "us-east-1",
+		Bucket:   "test-bucket",
+		Endpoint: "s3.us-east-1.amazonaws.com",
+	})
+
+	ctx := context.Background()
+	_, err := store.Put(ctx, "test.txt", []byte("data"), StoragePutOptions{})
+	if err == nil {
+		t.Fatal("expected error with no credentials")
+	}
+}
+
+func TestS3Storage_Get_NoCredentials(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:   "us-east-1",
+		Bucket:   "test-bucket",
+		Endpoint: "s3.us-east-1.amazonaws.com",
+	})
+
+	ctx := context.Background()
+	_, err := store.Get(ctx, "test.txt")
+	if err == nil {
+		t.Fatal("expected error with no credentials")
+	}
+}
+
+func TestS3Storage_Delete_NoCredentials(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:   "us-east-1",
+		Bucket:   "test-bucket",
+		Endpoint: "s3.us-east-1.amazonaws.com",
+	})
+
+	ctx := context.Background()
+	err := store.Delete(ctx, "test.txt")
+	if err == nil {
+		t.Fatal("expected error with no credentials")
+	}
+}
+
+func TestS3Storage_Exists_NoCredentials(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:   "us-east-1",
+		Bucket:   "test-bucket",
+		Endpoint: "s3.us-east-1.amazonaws.com",
+	})
+
+	ctx := context.Background()
+	_, err := store.Exists(ctx, "test.txt")
+	if err == nil {
+		t.Fatal("expected error with no credentials")
+	}
+}
+
+func TestS3Storage_List_NoCredentials(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:   "us-east-1",
+		Bucket:   "test-bucket",
+		Endpoint: "s3.us-east-1.amazonaws.com",
+	})
+
+	ctx := context.Background()
+	_, err := store.List(ctx, "")
+	if err == nil {
+		t.Fatal("expected error with no credentials")
+	}
+}
+
+func TestS3Storage_URL_Presigned(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:          "us-east-1",
+		Bucket:          "my-bucket",
+		Endpoint:        "s3.us-east-1.amazonaws.com",
+		AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+		SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+	})
+
+	ctx := context.Background()
+	presignedURL, err := store.URL(ctx, "photos/img.jpg", time.Hour)
+	if err != nil {
+		t.Fatalf("presigned URL: %v", err)
+	}
+
+	if presignedURL == "" {
+		t.Fatal("presigned URL is empty")
+	}
+}
+
+func TestStorageManager_RegisterAndGet(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewStorageManager()
+
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+	sm.Register(local)
+
+	got := sm.Backend(StorageLocal)
+	if got != local {
+		t.Error("expected local backend")
+	}
+}
+
+func TestStorageManager_Default(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewStorageManager()
+
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+	sm.Register(local)
+
+	if sm.Default() != local {
+		t.Error("expected local as default")
+	}
+}
+
+func TestStorageManager_SetDefault(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewStorageManager()
+
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+	sm.Register(local)
+
+	s3 := NewS3Storage(S3Config{
+		Region:   "us-east-1",
+		Bucket:   "test",
+		Endpoint: "s3.us-east-1.amazonaws.com",
+	})
+	sm.Register(s3)
+	sm.SetDefault(StorageS3)
+
+	if sm.Default() != s3 {
+		t.Error("expected S3 as default")
+	}
+}
+
+func TestStorageManager_NoBackend(t *testing.T) {
+	sm := NewStorageManager()
+
+	ctx := context.Background()
+	_, err := sm.Put(ctx, "key", []byte("data"), StoragePutOptions{})
+	if err == nil {
+		t.Fatal("expected error with no backend")
+	}
+
+	_, err = sm.Get(ctx, "key")
+	if err == nil {
+		t.Fatal("expected error with no backend")
+	}
+
+	err = sm.Delete(ctx, "key")
+	if err == nil {
+		t.Fatal("expected error with no backend")
+	}
+
+	_, err = sm.Exists(ctx, "key")
+	if err == nil {
+		t.Fatal("expected error with no backend")
+	}
+
+	_, err = sm.List(ctx, "")
+	if err == nil {
+		t.Fatal("expected error with no backend")
+	}
+
+	_, err = sm.URL(ctx, "key", 0)
+	if err == nil {
+		t.Fatal("expected error with no backend")
+	}
+}
+
+func TestProcessor_SetStorage(t *testing.T) {
+	dir := t.TempDir()
+	proc := NewProcessor("")
+
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+	proc.SetStorage(local)
+
+	if proc.Storage() != local {
+		t.Error("storage not set")
+	}
+}
+
+func TestProcessor_Upload_LocalStorage(t *testing.T) {
+	dir := t.TempDir()
+	proc := NewProcessor("")
+
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+	proc.SetStorage(local)
+
+	ctx := context.Background()
+	media := &Media{
+		ID:       "upload-test",
+		Type:     TypeImage,
+		Data:     []byte("image data"),
+		MimeType: "image/jpeg",
+		Name:     "test.jpg",
+	}
+
+	url, err := proc.Upload(ctx, media)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+
+	if url == "" {
+		t.Error("upload returned empty URL")
+	}
+
+	if media.URL != url {
+		t.Errorf("media URL not updated")
+	}
+}
+
+func TestProcessor_Save_LocalStorage(t *testing.T) {
+	dir := t.TempDir()
+	proc := NewProcessor("")
+
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+	proc.SetStorage(local)
+
+	ctx := context.Background()
+	media := &Media{
+		ID:       "save-test",
+		Type:     TypeDoc,
+		Data:     []byte("document content"),
+		MimeType: "application/pdf",
+		Name:     "report.pdf",
+	}
+
+	url, err := proc.Save(ctx, media)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	if url == "" {
+		t.Error("save returned empty URL")
+	}
+}
+
+func TestProcessor_Load_LocalStorage(t *testing.T) {
+	dir := t.TempDir()
+	proc := NewProcessor("")
+
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+	proc.SetStorage(local)
+
+	ctx := context.Background()
+	original := &Media{
+		ID:       "load-test",
+		Type:     TypeDoc,
+		Data:     []byte("loadable content"),
+		MimeType: "text/plain",
+		Name:     "load.txt",
+	}
+
+	_, err := proc.Save(ctx, original)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := proc.Load(ctx, "load.txt")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if string(loaded.Data) != "loadable content" {
+		t.Errorf("expected loadable content, got %s", string(loaded.Data))
+	}
+}
+
+func TestProcessor_Delete_LocalStorage(t *testing.T) {
+	dir := t.TempDir()
+	proc := NewProcessor("")
+
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+	proc.SetStorage(local)
+
+	ctx := context.Background()
+	media := &Media{
+		ID:   "delete-test",
+		Data: []byte("to delete"),
+		Name: "delete.txt",
+	}
+
+	_, err := proc.Save(ctx, media)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	err = proc.Delete(ctx, "delete.txt")
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	exists, err := proc.Exists(ctx, "delete.txt")
+	if err != nil {
+		t.Fatalf("exists: %v", err)
+	}
+	if exists {
+		t.Error("expected file to be deleted")
+	}
+}
+
+func TestProcessor_List_LocalStorage(t *testing.T) {
+	dir := t.TempDir()
+	proc := NewProcessor("")
+
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+	proc.SetStorage(local)
+
+	ctx := context.Background()
+	_, _ = proc.Save(ctx, &Media{ID: "1", Data: []byte("a"), Name: "a.txt"})
+	_, _ = proc.Save(ctx, &Media{ID: "2", Data: []byte("b"), Name: "b.txt"})
+
+	objects, err := proc.List(ctx, "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(objects) < 2 {
+		t.Errorf("expected at least 2 objects, got %d", len(objects))
+	}
+}
+
+func TestProcessor_PresignURL_LocalStorage(t *testing.T) {
+	dir := t.TempDir()
+	proc := NewProcessor("")
+
+	local := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://example.com",
+	})
+	proc.SetStorage(local)
+
+	ctx := context.Background()
+	media := &Media{
+		ID:   "presign-test",
+		Data: []byte("presignable"),
+		Name: "presign.txt",
+	}
+
+	_, err := proc.Save(ctx, media)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	presignedURL, err := proc.PresignURL(ctx, "presign.txt", time.Hour)
+	if err != nil {
+		t.Fatalf("presign: %v", err)
+	}
+
+	if presignedURL != "https://example.com/presign.txt" {
+		t.Errorf("expected https://example.com/presign.txt, got %s", presignedURL)
+	}
+}
+
+func TestProcessor_NoStorageBackend(t *testing.T) {
+	proc := NewProcessor("")
+
+	ctx := context.Background()
+	media := &Media{
+		ID:   "no-storage",
+		Data: []byte("data"),
+	}
+
+	_, err := proc.Upload(ctx, media)
+	if err == nil {
+		t.Fatal("expected error with no storage")
+	}
+
+	_, err = proc.Save(ctx, media)
+	if err == nil {
+		t.Fatal("expected error with no storage")
+	}
+
+	_, err = proc.Load(ctx, "key")
+	if err == nil {
+		t.Fatal("expected error with no storage")
+	}
+
+	err = proc.Delete(ctx, "key")
+	if err == nil {
+		t.Fatal("expected error with no storage")
+	}
+
+	_, err = proc.Exists(ctx, "key")
+	if err == nil {
+		t.Fatal("expected error with no storage")
+	}
+
+	_, err = proc.List(ctx, "")
+	if err == nil {
+		t.Fatal("expected error with no storage")
+	}
+
+	_, err = proc.PresignURL(ctx, "key", 0)
+	if err == nil {
+		t.Fatal("expected error with no storage")
+	}
+}
+
+func TestMediaPipeline_SaveToStorage(t *testing.T) {
+	dir := t.TempDir()
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Storage = local
+
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	media := &Media{
+		ID:       "pipeline-save",
+		Type:     TypeImage,
+		Data:     []byte("image data"),
+		MimeType: "image/jpeg",
+	}
+
+	url, err := p.SaveToStorage(ctx, media)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	if url == "" {
+		t.Error("save returned empty URL")
+	}
+}
+
+func TestMediaPipeline_LoadFromStorage(t *testing.T) {
+	dir := t.TempDir()
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Storage = local
+
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	media := &Media{
+		ID:       "pipeline-load",
+		Type:     TypeDoc,
+		Data:     []byte("loadable data"),
+		MimeType: "text/plain",
+	}
+
+	_, err := p.SaveToStorage(ctx, media)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := p.LoadFromStorage(ctx, media.ID+".bin")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if string(loaded.Data) != "loadable data" {
+		t.Errorf("expected loadable data, got %s", string(loaded.Data))
+	}
+}
+
+func TestMediaPipeline_DeleteFromStorage(t *testing.T) {
+	dir := t.TempDir()
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Storage = local
+
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	media := &Media{
+		ID:   "pipeline-delete",
+		Data: []byte("delete me"),
+	}
+
+	_, err := p.SaveToStorage(ctx, media)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	err = p.DeleteFromStorage(ctx, media.ID+".bin")
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+}
+
+func TestMediaPipeline_AutoSave(t *testing.T) {
+	dir := t.TempDir()
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Storage = local
+	cfg.AutoSave = true
+
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	_, err := p.Download(ctx, "http://localhost:1/media.txt")
+	if err == nil {
+		t.Log("auto-save attempted (expected failure due to no server)")
+	}
+}
+
+func TestMediaPipeline_StorageURL(t *testing.T) {
+	dir := t.TempDir()
+	local := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://cdn.example.com",
+	})
+
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Storage = local
+
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+	objURL, err := p.StorageURL(ctx, "photo.jpg", 0)
+	if err != nil {
+		t.Fatalf("storage URL: %v", err)
+	}
+
+	expected := "https://cdn.example.com/photo.jpg"
+	if objURL != expected {
+		t.Errorf("expected %s, got %s", expected, objURL)
+	}
+}
+
+func TestMediaPipeline_NoStorageConfigured(t *testing.T) {
+	cfg := DefaultMediaPipelineConfig()
+	p := NewMediaPipeline(cfg)
+
+	ctx := context.Background()
+
+	_, err := p.SaveToStorage(ctx, &Media{})
+	if err == nil {
+		t.Fatal("expected error with no storage")
+	}
+
+	_, err = p.LoadFromStorage(ctx, "key")
+	if err == nil {
+		t.Fatal("expected error with no storage")
+	}
+
+	err = p.DeleteFromStorage(ctx, "key")
+	if err == nil {
+		t.Fatal("expected error with no storage")
+	}
+
+	_, err = p.StorageURL(ctx, "key", 0)
+	if err == nil {
+		t.Fatal("expected error with no storage")
+	}
+}
+
+func TestLocalStorage_PutCreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+	})
+
+	ctx := context.Background()
+	_, err := store.Put(ctx, "deep/nested/path/file.txt", []byte("data"), StoragePutOptions{})
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	exists, err := store.Exists(ctx, "deep/nested/path/file.txt")
+	if err != nil {
+		t.Fatalf("exists: %v", err)
+	}
+	if !exists {
+		t.Error("expected file to exist in nested directory")
+	}
+}
+
+func TestLocalStorage_GetNotFound(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+	})
+
+	ctx := context.Background()
+	_, err := store.Get(ctx, "nonexistent.txt")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestLocalStorage_ListEmpty(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+	})
+
+	ctx := context.Background()
+	objects, err := store.List(ctx, "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(objects) != 0 {
+		t.Errorf("expected 0 objects, got %d", len(objects))
+	}
+}
+
+func TestLocalStorage_ListWithPrefix(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+	})
+
+	ctx := context.Background()
+	_, _ = store.Put(ctx, "img_photo1.jpg", []byte("1"), StoragePutOptions{})
+	_, _ = store.Put(ctx, "img_photo2.jpg", []byte("2"), StoragePutOptions{})
+	_, _ = store.Put(ctx, "doc_report.pdf", []byte("3"), StoragePutOptions{})
+
+	objects, err := store.List(ctx, "img")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(objects) != 2 {
+		t.Errorf("expected 2 objects with img prefix, got %d", len(objects))
+	}
+}
+
+func TestStorageManager_PutGetDelete(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewStorageManager()
+
+	local := NewLocalStorage(LocalStorageConfig{BasePath: dir})
+	sm.Register(local)
+
+	ctx := context.Background()
+
+	obj, err := sm.Put(ctx, "manager-test.txt", []byte("manager data"), StoragePutOptions{
+		MimeType: "text/plain",
+	})
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	if obj.Key != "manager-test.txt" {
+		t.Errorf("expected key manager-test.txt, got %s", obj.Key)
+	}
+
+	got, err := sm.Get(ctx, "manager-test.txt")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.Key != "manager-test.txt" {
+		t.Errorf("expected key manager-test.txt, got %s", got.Key)
+	}
+
+	err = sm.Delete(ctx, "manager-test.txt")
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	exists, err := sm.Exists(ctx, "manager-test.txt")
+	if err != nil {
+		t.Fatalf("exists: %v", err)
+	}
+	if exists {
+		t.Error("expected file to be deleted")
+	}
+}
+
+func TestS3Storage_PutWithSessionToken(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:          "us-east-1",
+		Bucket:          "test-bucket",
+		Endpoint:        "s3.us-east-1.amazonaws.com",
+		AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+		SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		SessionToken:    "FwoGZXIvYXdzEBY...",
+	})
+
+	ctx := context.Background()
+	_, err := store.Put(ctx, "test.txt", []byte("data"), StoragePutOptions{})
+	if err == nil {
+		t.Fatal("expected error (no real S3)")
+	}
+}
+
+func TestS3Storage_PutWithACL(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:          "us-east-1",
+		Bucket:          "test-bucket",
+		Endpoint:        "s3.us-east-1.amazonaws.com",
+		AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+		SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+	})
+
+	ctx := context.Background()
+	_, err := store.Put(ctx, "acl-test.txt", []byte("data"), StoragePutOptions{
+		ACL: "private",
+	})
+	if err == nil {
+		t.Fatal("expected error (no real S3)")
+	}
+}
+
+func TestS3Storage_PutWithCacheControl(t *testing.T) {
+	store := NewS3Storage(S3Config{
+		Region:          "us-east-1",
+		Bucket:          "test-bucket",
+		Endpoint:        "s3.us-east-1.amazonaws.com",
+		AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+		SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+	})
+
+	ctx := context.Background()
+	_, err := store.Put(ctx, "cache-test.txt", []byte("data"), StoragePutOptions{
+		CacheControl: "max-age=3600",
+	})
+	if err == nil {
+		t.Fatal("expected error (no real S3)")
+	}
+}
+
+func TestLocalStorage_BaseURL_TrailingSlash(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+		BaseURL:  "https://example.com/media/",
+	})
+
+	ctx := context.Background()
+	objURL, err := store.URL(ctx, "photo.jpg", 0)
+	if err != nil {
+		t.Fatalf("url: %v", err)
+	}
+
+	expected := "https://example.com/media/photo.jpg"
+	if objURL != expected {
+		t.Errorf("expected %s, got %s", expected, objURL)
+	}
+}
+
+func TestLocalStorage_GetDataIntegrity(t *testing.T) {
+	dir := t.TempDir()
+	store := NewLocalStorage(LocalStorageConfig{
+		BasePath: dir,
+	})
+
+	ctx := context.Background()
+	original := []byte("integrity test content with special chars: !@#$%^&*()")
+
+	_, err := store.Put(ctx, "integrity.txt", original, StoragePutOptions{})
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	obj, err := store.Get(ctx, "integrity.txt")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	retrieved, err := os.ReadFile(filepath.Join(dir, "integrity.txt"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	if string(retrieved) != string(original) {
+		t.Errorf("data integrity check failed")
+	}
+
+	_ = obj
+}

--- a/pkg/media/storage_test.go
+++ b/pkg/media/storage_test.go
@@ -1055,3 +1055,83 @@ func TestLocalStorage_GetDataIntegrity(t *testing.T) {
 
 	_ = obj
 }
+
+func TestLocalStorage_RejectsEscapingRelativeKeys(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "storage-root")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	store := NewLocalStorage(LocalStorageConfig{BasePath: root})
+	ctx := context.Background()
+	escapeKey := filepath.Join("..", "outside.txt")
+	outsidePath := filepath.Join(parent, "outside.txt")
+
+	if _, err := store.Put(ctx, escapeKey, []byte("escape"), StoragePutOptions{}); err == nil {
+		t.Fatal("expected put to reject escaping key")
+	}
+	if _, err := os.Stat(outsidePath); !os.IsNotExist(err) {
+		t.Fatalf("expected no file outside storage root, stat err=%v", err)
+	}
+
+	if _, err := store.Get(ctx, escapeKey); err == nil {
+		t.Fatal("expected get to reject escaping key")
+	}
+
+	if err := store.Delete(ctx, escapeKey); err == nil {
+		t.Fatal("expected delete to reject escaping key")
+	}
+
+	if _, err := store.Exists(ctx, escapeKey); err == nil {
+		t.Fatal("expected exists to reject escaping key")
+	}
+
+	if _, err := store.List(ctx, escapeKey); err == nil {
+		t.Fatal("expected list to reject escaping prefix")
+	}
+
+	if _, err := store.URL(ctx, escapeKey, 0); err == nil {
+		t.Fatal("expected url to reject escaping key")
+	}
+}
+
+func TestLocalStorage_RejectsAbsoluteKeys(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "storage-root")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	absoluteKey := filepath.Join(parent, "outside.txt")
+	if err := os.WriteFile(absoluteKey, []byte("outside"), 0644); err != nil {
+		t.Fatalf("seed outside file: %v", err)
+	}
+
+	store := NewLocalStorage(LocalStorageConfig{BasePath: root})
+	ctx := context.Background()
+
+	if _, err := store.Get(ctx, absoluteKey); err == nil {
+		t.Fatal("expected get to reject absolute key")
+	}
+
+	if err := store.Delete(ctx, absoluteKey); err == nil {
+		t.Fatal("expected delete to reject absolute key")
+	}
+
+	if _, err := store.Exists(ctx, absoluteKey); err == nil {
+		t.Fatal("expected exists to reject absolute key")
+	}
+
+	if _, err := store.URL(ctx, absoluteKey, 0); err == nil {
+		t.Fatal("expected url to reject absolute key")
+	}
+
+	data, err := os.ReadFile(absoluteKey)
+	if err != nil {
+		t.Fatalf("read outside file: %v", err)
+	}
+	if string(data) != "outside" {
+		t.Fatalf("expected outside file to remain unchanged, got %q", string(data))
+	}
+}

--- a/pkg/media/transcoder.go
+++ b/pkg/media/transcoder.go
@@ -1,0 +1,632 @@
+package media
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"image"
+	"image/color"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"os"
+	"os/exec"
+)
+
+type ImageQuality int
+
+const (
+	QualityLow      ImageQuality = 30
+	QualityMedium   ImageQuality = 60
+	QualityHigh     ImageQuality = 85
+	QualityLossless ImageQuality = 100
+)
+
+type ImageResizeMode string
+
+const (
+	ResizeFit       ImageResizeMode = "fit"
+	ResizeFill      ImageResizeMode = "fill"
+	ResizeStretch   ImageResizeMode = "stretch"
+	ResizeThumbnail ImageResizeMode = "thumbnail"
+)
+
+type ImageOptions struct {
+	Format        Format
+	Quality       int
+	MaxWidth      int
+	MaxHeight     int
+	ResizeMode    ImageResizeMode
+	StripMetadata bool
+}
+
+func DefaultImageOptions() ImageOptions {
+	return ImageOptions{
+		Format:     FormatUnknown,
+		Quality:    int(QualityHigh),
+		ResizeMode: ResizeFit,
+	}
+}
+
+type AudioOptions struct {
+	Format     Format
+	Bitrate    int
+	SampleRate int
+	Channels   int
+	Codec      string
+}
+
+func DefaultAudioOptions() AudioOptions {
+	return AudioOptions{
+		Format:     FormatMP3,
+		Bitrate:    128,
+		SampleRate: 44100,
+		Channels:   2,
+	}
+}
+
+type VideoOptions struct {
+	Format     Format
+	VideoCodec string
+	AudioCodec string
+	Bitrate    string
+	CRF        int
+	MaxWidth   int
+	MaxHeight  int
+	FPS        float64
+	Preset     string
+}
+
+func DefaultVideoOptions() VideoOptions {
+	return VideoOptions{
+		Format:     FormatMP4,
+		VideoCodec: "libx264",
+		AudioCodec: "aac",
+		CRF:        23,
+		Preset:     "medium",
+	}
+}
+
+type Transcoder struct {
+	ffmpegPath  string
+	ffprobePath string
+}
+
+func NewTranscoder() *Transcoder {
+	return &Transcoder{
+		ffmpegPath:  "ffmpeg",
+		ffprobePath: "ffprobe",
+	}
+}
+
+func (t *Transcoder) SetFFmpegPath(path string) {
+	t.ffmpegPath = path
+}
+
+func (t *Transcoder) SetFFprobePath(path string) {
+	t.ffprobePath = path
+}
+
+func (t *Transcoder) CompressImage(data []byte, opts ImageOptions) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty image data")
+	}
+
+	img, format, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("decode image: %w", err)
+	}
+
+	if opts.MaxWidth > 0 || opts.MaxHeight > 0 {
+		img = resizeImage(img, opts.MaxWidth, opts.MaxHeight, opts.ResizeMode)
+	}
+
+	targetFormat := opts.Format
+	if targetFormat == FormatUnknown {
+		targetFormat = formatFromString(format)
+	}
+
+	return encodeImage(img, targetFormat, opts.Quality)
+}
+
+func (t *Transcoder) ConvertImage(data []byte, targetFormat Format) ([]byte, error) {
+	return t.CompressImage(data, ImageOptions{
+		Format:  targetFormat,
+		Quality: int(QualityHigh),
+	})
+}
+
+func (t *Transcoder) ResizeImage(data []byte, width, height int, mode ImageResizeMode) ([]byte, error) {
+	img, format, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("decode image: %w", err)
+	}
+
+	resized := resizeImage(img, width, height, mode)
+	return encodeImage(resized, formatFromString(format), int(QualityHigh))
+}
+
+func (t *Transcoder) StripImageMetadata(data []byte, format Format) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty image data")
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("decode image: %w", err)
+	}
+
+	targetFormat := format
+	if targetFormat == FormatUnknown {
+		detected := DetectMediaType(data, "", "")
+		if detected.Format != FormatUnknown {
+			targetFormat = detected.Format
+		} else {
+			targetFormat = FormatPNG
+		}
+	}
+
+	return encodeImage(img, targetFormat, int(QualityLossless))
+}
+
+func (t *Transcoder) TranscodeAudio(ctx context.Context, data []byte, opts AudioOptions) ([]byte, error) {
+	if !t.isFFmpegAvailable(ctx) {
+		return nil, fmt.Errorf("ffmpeg not available for audio transcoding")
+	}
+
+	tmpIn, err := t.writeTempFile(data, "input")
+	if err != nil {
+		return nil, fmt.Errorf("create temp input: %w", err)
+	}
+	defer os.Remove(tmpIn)
+
+	outExt := formatToExt(opts.Format)
+	if outExt == "" {
+		outExt = ".mp3"
+	}
+
+	tmpOut, err := t.createTempFile("output" + outExt)
+	if err != nil {
+		return nil, fmt.Errorf("create temp output: %w", err)
+	}
+	outPath := tmpOut.Name()
+	tmpOut.Close()
+	defer os.Remove(outPath)
+
+	args := t.buildAudioArgs(tmpIn, outPath, opts)
+
+	cmd := exec.CommandContext(ctx, t.ffmpegPath, args...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("ffmpeg audio transcode: %w", err)
+	}
+
+	result, err := os.ReadFile(outPath)
+	if err != nil {
+		return nil, fmt.Errorf("read transcoded audio: %w", err)
+	}
+
+	return result, nil
+}
+
+func (t *Transcoder) TranscodeVideo(ctx context.Context, data []byte, opts VideoOptions) ([]byte, error) {
+	if !t.isFFmpegAvailable(ctx) {
+		return nil, fmt.Errorf("ffmpeg not available for video transcoding")
+	}
+
+	tmpIn, err := t.writeTempFile(data, "input")
+	if err != nil {
+		return nil, fmt.Errorf("create temp input: %w", err)
+	}
+	defer os.Remove(tmpIn)
+
+	outExt := formatToExt(opts.Format)
+	if outExt == "" {
+		outExt = ".mp4"
+	}
+
+	tmpOut, err := t.createTempFile("output" + outExt)
+	if err != nil {
+		return nil, fmt.Errorf("create temp output: %w", err)
+	}
+	outPath := tmpOut.Name()
+	tmpOut.Close()
+	defer os.Remove(outPath)
+
+	args := t.buildVideoArgs(tmpIn, outPath, opts)
+
+	cmd := exec.CommandContext(ctx, t.ffmpegPath, args...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("ffmpeg video transcode: %w", err)
+	}
+
+	result, err := os.ReadFile(outPath)
+	if err != nil {
+		return nil, fmt.Errorf("read transcoded video: %w", err)
+	}
+
+	return result, nil
+}
+
+func (t *Transcoder) CompressAudio(ctx context.Context, data []byte, bitrate int) ([]byte, error) {
+	opts := DefaultAudioOptions()
+	opts.Bitrate = bitrate
+	return t.TranscodeAudio(ctx, data, opts)
+}
+
+func (t *Transcoder) CompressVideo(ctx context.Context, data []byte, crf int) ([]byte, error) {
+	opts := DefaultVideoOptions()
+	opts.CRF = crf
+	return t.TranscodeVideo(ctx, data, opts)
+}
+
+func (t *Transcoder) ExtractThumbnail(ctx context.Context, videoData []byte, timestamp string) ([]byte, error) {
+	if !t.isFFmpegAvailable(ctx) {
+		return nil, fmt.Errorf("ffmpeg not available for thumbnail extraction")
+	}
+
+	if timestamp == "" {
+		timestamp = "00:00:01"
+	}
+
+	tmpIn, err := t.writeTempFile(videoData, "video")
+	if err != nil {
+		return nil, fmt.Errorf("create temp input: %w", err)
+	}
+	defer os.Remove(tmpIn)
+
+	tmpOut, err := t.createTempFile("thumb.jpg")
+	if err != nil {
+		return nil, fmt.Errorf("create temp output: %w", err)
+	}
+	outPath := tmpOut.Name()
+	tmpOut.Close()
+	defer os.Remove(outPath)
+
+	args := []string{
+		"-i", tmpIn,
+		"-ss", timestamp,
+		"-vframes", "1",
+		"-q:v", "2",
+		"-y",
+		outPath,
+	}
+
+	cmd := exec.CommandContext(ctx, t.ffmpegPath, args...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("ffmpeg thumbnail: %w", err)
+	}
+
+	return os.ReadFile(outPath)
+}
+
+func (t *Transcoder) ProbeMedia(ctx context.Context, data []byte) (map[string]any, error) {
+	if !t.isFFmpegAvailable(ctx) {
+		return nil, fmt.Errorf("ffprobe not available")
+	}
+
+	tmpIn, err := t.writeTempFile(data, "probe")
+	if err != nil {
+		return nil, fmt.Errorf("create temp input: %w", err)
+	}
+	defer os.Remove(tmpIn)
+
+	args := []string{
+		"-v", "quiet",
+		"-print_format", "json",
+		"-show_format",
+		"-show_streams",
+		tmpIn,
+	}
+
+	cmd := exec.CommandContext(ctx, t.ffprobePath, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ffprobe: %w", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(output, &result); err != nil {
+		return nil, fmt.Errorf("parse ffprobe output: %w", err)
+	}
+
+	return result, nil
+}
+
+func (t *Transcoder) IsFFmpegAvailable(ctx context.Context) bool {
+	return t.isFFmpegAvailable(ctx)
+}
+
+func (t *Transcoder) isFFmpegAvailable(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, t.ffmpegPath, "-version")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run() == nil
+}
+
+func (t *Transcoder) buildAudioArgs(input, output string, opts AudioOptions) []string {
+	args := []string{
+		"-i", input,
+		"-y",
+	}
+
+	if opts.Codec != "" {
+		args = append(args, "-acodec", opts.Codec)
+	} else {
+		args = append(args, "-acodec", audioCodecForFormat(opts.Format))
+	}
+
+	if opts.Bitrate > 0 {
+		args = append(args, "-b:a", fmt.Sprintf("%dk", opts.Bitrate))
+	}
+
+	if opts.SampleRate > 0 {
+		args = append(args, "-ar", fmt.Sprintf("%d", opts.SampleRate))
+	}
+
+	if opts.Channels > 0 {
+		args = append(args, "-ac", fmt.Sprintf("%d", opts.Channels))
+	}
+
+	args = append(args, output)
+	return args
+}
+
+func (t *Transcoder) buildVideoArgs(input, output string, opts VideoOptions) []string {
+	args := []string{
+		"-i", input,
+		"-y",
+	}
+
+	if opts.VideoCodec != "" {
+		args = append(args, "-c:v", opts.VideoCodec)
+	}
+
+	if opts.AudioCodec != "" {
+		args = append(args, "-c:a", opts.AudioCodec)
+	}
+
+	if opts.CRF > 0 && opts.VideoCodec == "libx264" {
+		args = append(args, "-crf", fmt.Sprintf("%d", opts.CRF))
+	}
+
+	if opts.Preset != "" && opts.VideoCodec == "libx264" {
+		args = append(args, "-preset", opts.Preset)
+	}
+
+	if opts.Bitrate != "" {
+		args = append(args, "-b:v", opts.Bitrate)
+	}
+
+	if opts.MaxWidth > 0 || opts.MaxHeight > 0 {
+		w := opts.MaxWidth
+		h := opts.MaxHeight
+		if w == 0 {
+			w = -2
+		}
+		if h == 0 {
+			h = -2
+		}
+		args = append(args, "-vf", fmt.Sprintf("scale=%d:%d", w, h))
+	}
+
+	if opts.FPS > 0 {
+		args = append(args, "-r", fmt.Sprintf("%.2f", opts.FPS))
+	}
+
+	args = append(args, output)
+	return args
+}
+
+func (t *Transcoder) writeTempFile(data []byte, prefix string) (string, error) {
+	f, err := t.createTempFile(prefix)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+
+	return f.Name(), nil
+}
+
+func (t *Transcoder) createTempFile(pattern string) (*os.File, error) {
+	dir := os.TempDir()
+	return os.CreateTemp(dir, fmt.Sprintf("anyclaw-media-%s-*", pattern))
+}
+
+func resizeImage(img image.Image, maxWidth, maxHeight int, mode ImageResizeMode) image.Image {
+	bounds := img.Bounds()
+	origW := bounds.Dx()
+	origH := bounds.Dy()
+
+	if maxWidth <= 0 {
+		maxWidth = origW
+	}
+	if maxHeight <= 0 {
+		maxHeight = origH
+	}
+
+	var newW, newH int
+
+	switch mode {
+	case ResizeFit:
+		scale := float64(maxWidth) / float64(origW)
+		if float64(origH)*scale > float64(maxHeight) {
+			scale = float64(maxHeight) / float64(origH)
+		}
+		newW = int(float64(origW) * scale)
+		newH = int(float64(origH) * scale)
+	case ResizeFill:
+		scaleX := float64(maxWidth) / float64(origW)
+		scaleY := float64(maxHeight) / float64(origH)
+		scale := scaleX
+		if scaleY > scaleX {
+			scale = scaleY
+		}
+		newW = int(float64(origW) * scale)
+		newH = int(float64(origH) * scale)
+	case ResizeStretch:
+		newW = maxWidth
+		newH = maxHeight
+	case ResizeThumbnail:
+		size := maxWidth
+		if maxHeight < maxWidth {
+			size = maxHeight
+		}
+		scale := float64(size) / float64(origW)
+		if float64(origH)*scale > float64(size) {
+			scale = float64(size) / float64(origH)
+		}
+		newW = int(float64(origW) * scale)
+		newH = int(float64(origH) * scale)
+	default:
+		return img
+	}
+
+	if newW <= 0 || newH <= 0 {
+		return img
+	}
+
+	if newW == origW && newH == origH {
+		return img
+	}
+
+	return scaleImageBilinear(img, newW, newH)
+}
+
+func scaleImageBilinear(src image.Image, newW, newH int) image.Image {
+	dst := image.NewRGBA(image.Rect(0, 0, newW, newH))
+	bounds := src.Bounds()
+	srcW := bounds.Dx()
+	srcH := bounds.Dy()
+
+	if srcW == 0 || srcH == 0 {
+		return dst
+	}
+
+	xRatio := float64(srcW) / float64(newW)
+	yRatio := float64(srcH) / float64(newH)
+
+	for y := 0; y < newH; y++ {
+		for x := 0; x < newW; x++ {
+			srcX := int(float64(x) * xRatio)
+			srcY := int(float64(y) * yRatio)
+
+			if srcX >= srcW {
+				srcX = srcW - 1
+			}
+			if srcY >= srcH {
+				srcY = srcH - 1
+			}
+
+			r, g, b, a := src.At(bounds.Min.X+srcX, bounds.Min.Y+srcY).RGBA()
+			dst.Set(x, y, color.RGBA{
+				R: uint8(r >> 8),
+				G: uint8(g >> 8),
+				B: uint8(b >> 8),
+				A: uint8(a >> 8),
+			})
+		}
+	}
+
+	return dst
+}
+
+func encodeImage(img image.Image, format Format, quality int) ([]byte, error) {
+	var buf bytes.Buffer
+
+	switch format {
+	case FormatJPEG:
+		if quality <= 0 {
+			quality = int(QualityHigh)
+		}
+		err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: quality})
+		return buf.Bytes(), err
+	case FormatPNG:
+		encoder := &png.Encoder{
+			CompressionLevel: png.DefaultCompression,
+		}
+		err := encoder.Encode(&buf, img)
+		return buf.Bytes(), err
+	case FormatGIF:
+		err := gif.Encode(&buf, img, &gif.Options{NumColors: 256})
+		return buf.Bytes(), err
+	default:
+		err := png.Encode(&buf, img)
+		return buf.Bytes(), err
+	}
+}
+
+func formatFromString(goFormat string) Format {
+	switch goFormat {
+	case "jpeg":
+		return FormatJPEG
+	case "png":
+		return FormatPNG
+	case "gif":
+		return FormatGIF
+	default:
+		return FormatPNG
+	}
+}
+
+func formatToExt(format Format) string {
+	switch format {
+	case FormatMP3:
+		return ".mp3"
+	case FormatWAV:
+		return ".wav"
+	case FormatOGG:
+		return ".ogg"
+	case FormatFLAC:
+		return ".flac"
+	case FormatAAC:
+		return ".aac"
+	case FormatM4A:
+		return ".m4a"
+	case FormatMP4:
+		return ".mp4"
+	case FormatWebM:
+		return ".webm"
+	case FormatAVI:
+		return ".avi"
+	case FormatMKV:
+		return ".mkv"
+	case FormatMOV:
+		return ".mov"
+	case Format3GP:
+		return ".3gp"
+	default:
+		return ""
+	}
+}
+
+func audioCodecForFormat(format Format) string {
+	switch format {
+	case FormatMP3:
+		return "libmp3lame"
+	case FormatWAV:
+		return "pcm_s16le"
+	case FormatOGG:
+		return "libvorbis"
+	case FormatFLAC:
+		return "flac"
+	case FormatAAC, FormatM4A:
+		return "aac"
+	default:
+		return "libmp3lame"
+	}
+}

--- a/pkg/media/transcoder_test.go
+++ b/pkg/media/transcoder_test.go
@@ -1,0 +1,542 @@
+package media
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+)
+
+func createTestImage(width, height int) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{
+				R: uint8(x % 256),
+				G: uint8(y % 256),
+				B: 128,
+				A: 255,
+			})
+		}
+	}
+	var buf bytes.Buffer
+	_ = png.Encode(&buf, img)
+	return buf.Bytes()
+}
+
+func TestTranscoder_CompressImage_JPEG(t *testing.T) {
+	imgData := createTestImage(100, 100)
+	tr := NewTranscoder()
+
+	compressed, err := tr.CompressImage(imgData, ImageOptions{
+		Format:  FormatJPEG,
+		Quality: int(QualityMedium),
+	})
+	if err != nil {
+		t.Fatalf("compress image: %v", err)
+	}
+
+	if len(compressed) == 0 {
+		t.Fatal("compressed data is empty")
+	}
+
+	result := DetectMediaType(compressed, "", "")
+	if result.Format != FormatJPEG {
+		t.Errorf("expected FormatJPEG, got %s", result.Format)
+	}
+}
+
+func TestTranscoder_CompressImage_QualityLevels(t *testing.T) {
+	imgData := createTestImage(200, 200)
+	tr := NewTranscoder()
+
+	sizes := map[string]int{
+		"low":    int(QualityLow),
+		"medium": int(QualityMedium),
+		"high":   int(QualityHigh),
+	}
+
+	var lastSize int64
+	for name, quality := range sizes {
+		compressed, err := tr.CompressImage(imgData, ImageOptions{
+			Format:  FormatJPEG,
+			Quality: quality,
+		})
+		if err != nil {
+			t.Fatalf("[%s] compress: %v", name, err)
+		}
+
+		if int64(len(compressed)) <= 0 {
+			t.Errorf("[%s] compressed data empty", name)
+		}
+
+		if lastSize > 0 && quality > int(QualityMedium) {
+			if int64(len(compressed)) < lastSize {
+				t.Logf("[%s] size=%d (expected larger for higher quality, got smaller)", name, len(compressed))
+			}
+		}
+		lastSize = int64(len(compressed))
+	}
+}
+
+func TestTranscoder_ConvertImage_PNGToJPEG(t *testing.T) {
+	imgData := createTestImage(50, 50)
+	tr := NewTranscoder()
+
+	converted, err := tr.ConvertImage(imgData, FormatJPEG)
+	if err != nil {
+		t.Fatalf("convert to JPEG: %v", err)
+	}
+
+	result := DetectMediaType(converted, "", "")
+	if result.Format != FormatJPEG {
+		t.Errorf("expected FormatJPEG, got %s", result.Format)
+	}
+	if result.Type != TypeImage {
+		t.Errorf("expected TypeImage, got %s", result.Type)
+	}
+}
+
+func TestTranscoder_ConvertImage_JPEGToPNG(t *testing.T) {
+	jpegData := createTestImage(50, 50)
+	tr := NewTranscoder()
+
+	converted, err := tr.ConvertImage(jpegData, FormatPNG)
+	if err != nil {
+		t.Fatalf("convert to PNG: %v", err)
+	}
+
+	result := DetectMediaType(converted, "", "")
+	if result.Format != FormatPNG {
+		t.Errorf("expected FormatPNG, got %s", result.Format)
+	}
+}
+
+func TestTranscoder_ConvertImage_PNGToGIF(t *testing.T) {
+	imgData := createTestImage(50, 50)
+	tr := NewTranscoder()
+
+	converted, err := tr.ConvertImage(imgData, FormatGIF)
+	if err != nil {
+		t.Fatalf("convert to GIF: %v", err)
+	}
+
+	result := DetectMediaType(converted, "", "")
+	if result.Format != FormatGIF {
+		t.Errorf("expected FormatGIF, got %s", result.Format)
+	}
+}
+
+func TestTranscoder_ResizeImage_Fit(t *testing.T) {
+	imgData := createTestImage(200, 100)
+	tr := NewTranscoder()
+
+	resized, err := tr.ResizeImage(imgData, 100, 50, ResizeFit)
+	if err != nil {
+		t.Fatalf("resize image: %v", err)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(resized))
+	if err != nil {
+		t.Fatalf("decode resized image: %v", err)
+	}
+
+	bounds := img.Bounds()
+	if bounds.Dx() != 100 {
+		t.Errorf("expected width 100, got %d", bounds.Dx())
+	}
+	if bounds.Dy() != 50 {
+		t.Errorf("expected height 50, got %d", bounds.Dy())
+	}
+}
+
+func TestTranscoder_ResizeImage_Stretch(t *testing.T) {
+	imgData := createTestImage(200, 100)
+	tr := NewTranscoder()
+
+	resized, err := tr.ResizeImage(imgData, 80, 80, ResizeStretch)
+	if err != nil {
+		t.Fatalf("resize image: %v", err)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(resized))
+	if err != nil {
+		t.Fatalf("decode resized image: %v", err)
+	}
+
+	bounds := img.Bounds()
+	if bounds.Dx() != 80 {
+		t.Errorf("expected width 80, got %d", bounds.Dx())
+	}
+	if bounds.Dy() != 80 {
+		t.Errorf("expected height 80, got %d", bounds.Dy())
+	}
+}
+
+func TestTranscoder_ResizeImage_Thumbnail(t *testing.T) {
+	imgData := createTestImage(300, 200)
+	tr := NewTranscoder()
+
+	resized, err := tr.ResizeImage(imgData, 64, 64, ResizeThumbnail)
+	if err != nil {
+		t.Fatalf("resize image: %v", err)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(resized))
+	if err != nil {
+		t.Fatalf("decode resized image: %v", err)
+	}
+
+	bounds := img.Bounds()
+	if bounds.Dx() > 64 {
+		t.Errorf("expected width <= 64, got %d", bounds.Dx())
+	}
+	if bounds.Dy() > 64 {
+		t.Errorf("expected height <= 64, got %d", bounds.Dy())
+	}
+}
+
+func TestTranscoder_StripImageMetadata(t *testing.T) {
+	imgData := createTestImage(100, 100)
+	tr := NewTranscoder()
+
+	stripped, err := tr.StripImageMetadata(imgData, FormatPNG)
+	if err != nil {
+		t.Fatalf("strip metadata: %v", err)
+	}
+
+	if len(stripped) == 0 {
+		t.Fatal("stripped data is empty")
+	}
+
+	result := DetectMediaType(stripped, "", "")
+	if result.Format != FormatPNG {
+		t.Errorf("expected FormatPNG, got %s", result.Format)
+	}
+}
+
+func TestTranscoder_CompressImage_EmptyData(t *testing.T) {
+	tr := NewTranscoder()
+
+	_, err := tr.CompressImage([]byte{}, ImageOptions{})
+	if err == nil {
+		t.Fatal("expected error for empty data")
+	}
+}
+
+func TestTranscoder_CompressImage_InvalidData(t *testing.T) {
+	tr := NewTranscoder()
+
+	_, err := tr.CompressImage([]byte("not an image"), ImageOptions{})
+	if err == nil {
+		t.Fatal("expected error for invalid image data")
+	}
+}
+
+func TestTranscoder_ResizeImage_NoResize(t *testing.T) {
+	imgData := createTestImage(100, 100)
+	tr := NewTranscoder()
+
+	resized, err := tr.ResizeImage(imgData, 0, 0, ResizeFit)
+	if err != nil {
+		t.Fatalf("resize image: %v", err)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(resized))
+	if err != nil {
+		t.Fatalf("decode resized image: %v", err)
+	}
+
+	bounds := img.Bounds()
+	if bounds.Dx() != 100 {
+		t.Errorf("expected width 100, got %d", bounds.Dx())
+	}
+	if bounds.Dy() != 100 {
+		t.Errorf("expected height 100, got %d", bounds.Dy())
+	}
+}
+
+func TestTranscoder_IsFFmpegAvailable(t *testing.T) {
+	tr := NewTranscoder()
+	ctx := context.Background()
+
+	_ = tr.IsFFmpegAvailable(ctx)
+}
+
+func TestTranscoder_TranscodeAudio_NoFFmpeg(t *testing.T) {
+	tr := NewTranscoder()
+	tr.SetFFmpegPath("nonexistent-ffmpeg")
+	ctx := context.Background()
+
+	_, err := tr.TranscodeAudio(ctx, []byte("fake audio"), DefaultAudioOptions())
+	if err == nil {
+		t.Fatal("expected error when ffmpeg not available")
+	}
+}
+
+func TestTranscoder_TranscodeVideo_NoFFmpeg(t *testing.T) {
+	tr := NewTranscoder()
+	tr.SetFFmpegPath("nonexistent-ffmpeg")
+	ctx := context.Background()
+
+	_, err := tr.TranscodeVideo(ctx, []byte("fake video"), DefaultVideoOptions())
+	if err == nil {
+		t.Fatal("expected error when ffmpeg not available")
+	}
+}
+
+func TestTranscoder_ExtractThumbnail_NoFFmpeg(t *testing.T) {
+	tr := NewTranscoder()
+	tr.SetFFmpegPath("nonexistent-ffmpeg")
+	ctx := context.Background()
+
+	_, err := tr.ExtractThumbnail(ctx, []byte("fake video"), "00:00:01")
+	if err == nil {
+		t.Fatal("expected error when ffmpeg not available")
+	}
+}
+
+func TestTranscoder_ProbeMedia_NoFFmpeg(t *testing.T) {
+	tr := NewTranscoder()
+	tr.SetFFprobePath("nonexistent-ffprobe")
+	ctx := context.Background()
+
+	_, err := tr.ProbeMedia(ctx, []byte("fake media"))
+	if err == nil {
+		t.Fatal("expected error when ffprobe not available")
+	}
+}
+
+func TestTranscoder_CompressAudio_NoFFmpeg(t *testing.T) {
+	tr := NewTranscoder()
+	tr.SetFFmpegPath("nonexistent-ffmpeg")
+	ctx := context.Background()
+
+	_, err := tr.CompressAudio(ctx, []byte("fake audio"), 64)
+	if err == nil {
+		t.Fatal("expected error when ffmpeg not available")
+	}
+}
+
+func TestTranscoder_CompressVideo_NoFFmpeg(t *testing.T) {
+	tr := NewTranscoder()
+	tr.SetFFmpegPath("nonexistent-ffmpeg")
+	ctx := context.Background()
+
+	_, err := tr.CompressVideo(ctx, []byte("fake video"), 28)
+	if err == nil {
+		t.Fatal("expected error when ffmpeg not available")
+	}
+}
+
+func TestTranscoder_FormatToExt(t *testing.T) {
+	tests := []struct {
+		format Format
+		want   string
+	}{
+		{FormatMP3, ".mp3"},
+		{FormatWAV, ".wav"},
+		{FormatOGG, ".ogg"},
+		{FormatFLAC, ".flac"},
+		{FormatAAC, ".aac"},
+		{FormatM4A, ".m4a"},
+		{FormatMP4, ".mp4"},
+		{FormatWebM, ".webm"},
+		{FormatAVI, ".avi"},
+		{FormatMKV, ".mkv"},
+		{FormatMOV, ".mov"},
+		{Format3GP, ".3gp"},
+		{FormatUnknown, ""},
+	}
+
+	for _, tt := range tests {
+		got := formatToExt(tt.format)
+		if got != tt.want {
+			t.Errorf("formatToExt(%s) = %q, want %q", tt.format, got, tt.want)
+		}
+	}
+}
+
+func TestTranscoder_AudioCodecForFormat(t *testing.T) {
+	tests := []struct {
+		format Format
+		want   string
+	}{
+		{FormatMP3, "libmp3lame"},
+		{FormatWAV, "pcm_s16le"},
+		{FormatOGG, "libvorbis"},
+		{FormatFLAC, "flac"},
+		{FormatAAC, "aac"},
+		{FormatM4A, "aac"},
+		{FormatUnknown, "libmp3lame"},
+	}
+
+	for _, tt := range tests {
+		got := audioCodecForFormat(tt.format)
+		if got != tt.want {
+			t.Errorf("audioCodecForFormat(%s) = %q, want %q", tt.format, got, tt.want)
+		}
+	}
+}
+
+func TestProcessor_Compress_Image(t *testing.T) {
+	imgData := createTestImage(200, 200)
+	proc := NewProcessor("")
+
+	media := &Media{
+		ID:       "test-1",
+		Type:     TypeImage,
+		Data:     imgData,
+		MimeType: "image/png",
+		Name:     "test.png",
+	}
+
+	compressed, err := proc.Compress(context.Background(), media, ImageOptions{
+		Format:  FormatJPEG,
+		Quality: int(QualityMedium),
+	})
+	if err != nil {
+		t.Fatalf("compress: %v", err)
+	}
+
+	if compressed.Size <= 0 {
+		t.Error("compressed media has no size")
+	}
+
+	if compressed.MimeType != "image/jpeg" {
+		t.Errorf("expected mimeType image/jpeg, got %s", compressed.MimeType)
+	}
+}
+
+func TestProcessor_Convert_Image(t *testing.T) {
+	imgData := createTestImage(100, 100)
+	proc := NewProcessor("")
+
+	media := &Media{
+		ID:       "test-2",
+		Type:     TypeImage,
+		Data:     imgData,
+		MimeType: "image/png",
+		Name:     "test.png",
+	}
+
+	converted, err := proc.Convert(context.Background(), media, FormatJPEG)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	if converted.MimeType != "image/jpeg" {
+		t.Errorf("expected mimeType image/jpeg, got %s", converted.MimeType)
+	}
+
+	if converted.Metadata["format"] != "jpeg" {
+		t.Errorf("expected format jpeg in metadata, got %v", converted.Metadata["format"])
+	}
+}
+
+func TestProcessor_Compress_UnsupportedType(t *testing.T) {
+	proc := NewProcessor("")
+
+	media := &Media{
+		ID:   "test-3",
+		Type: TypeDoc,
+		Data: []byte("document"),
+	}
+
+	_, err := proc.Compress(context.Background(), media, ImageOptions{})
+	if err == nil {
+		t.Fatal("expected error for unsupported type")
+	}
+}
+
+func TestProcessor_Convert_UnsupportedType(t *testing.T) {
+	proc := NewProcessor("")
+
+	media := &Media{
+		ID:   "test-4",
+		Type: TypeDoc,
+		Data: []byte("document"),
+	}
+
+	_, err := proc.Convert(context.Background(), media, FormatPDF)
+	if err == nil {
+		t.Fatal("expected error for unsupported type")
+	}
+}
+
+func TestTranscoder_CompressImage_ResizeAndCompress(t *testing.T) {
+	imgData := createTestImage(500, 500)
+	tr := NewTranscoder()
+
+	compressed, err := tr.CompressImage(imgData, ImageOptions{
+		Format:     FormatJPEG,
+		Quality:    int(QualityLow),
+		MaxWidth:   100,
+		MaxHeight:  100,
+		ResizeMode: ResizeFit,
+	})
+	if err != nil {
+		t.Fatalf("compress and resize: %v", err)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(compressed))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	bounds := img.Bounds()
+	if bounds.Dx() > 100 || bounds.Dy() > 100 {
+		t.Errorf("expected dimensions <= 100, got %dx%d", bounds.Dx(), bounds.Dy())
+	}
+
+	result := DetectMediaType(compressed, "", "")
+	if result.Format != FormatJPEG {
+		t.Errorf("expected FormatJPEG, got %s", result.Format)
+	}
+}
+
+func TestProcessor_Transcoder_GetSet(t *testing.T) {
+	proc := NewProcessor("")
+
+	tr := proc.Transcoder()
+	if tr == nil {
+		t.Fatal("expected default transcoder")
+	}
+
+	newTr := NewTranscoder()
+	proc.SetTranscoder(newTr)
+
+	if proc.Transcoder() != newTr {
+		t.Error("transcoder not updated")
+	}
+}
+
+func TestMediaPipeline_TranscodeConfig(t *testing.T) {
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Transcode = true
+	cfg.ImageOptions = ImageOptions{
+		Format:  FormatJPEG,
+		Quality: int(QualityMedium),
+	}
+
+	p := NewMediaPipeline(cfg)
+	if !p.config.Transcode {
+		t.Error("transcode not enabled")
+	}
+
+	if p.config.ImageOptions.Format != FormatJPEG {
+		t.Errorf("expected FormatJPEG, got %s", p.config.ImageOptions.Format)
+	}
+}
+
+func TestMediaPipeline_TranscodeDisabled(t *testing.T) {
+	cfg := DefaultMediaPipelineConfig()
+	cfg.Transcode = false
+
+	p := NewMediaPipeline(cfg)
+	if p.config.Transcode {
+		t.Error("transcode should be disabled")
+	}
+}


### PR DESCRIPTION
## 概要

补充媒体处理基础能力，引入 `pkg/media` 统一封装媒体类型识别、下载缓存、存储签名和转码处理，为后续视觉、工作流和上层运行时能力提供可复用的媒体基础设施。

## 本次变更

- 新增媒体基础模型与处理入口
  - `media.go`
  - 定义 `Media`、`Processor` 和基础元数据提取流程
- 新增媒体类型识别能力
  - `detector.go`
  - 支持从字节内容、MIME type 和文件扩展名推断媒体类型与格式
- 新增媒体下载与处理流水线
  - `pipeline.go`
  - 支持下载、重试、缓存、批量处理、自动保存和签名 URL 生成
- 新增媒体缓存能力
  - `cache.go`
  - 支持内存缓存、磁盘回填和缓存统计
- 新增媒体存储与签名能力
  - `storage.go`
  - `signer.go`
  - 提供本地存储后端、对象保存/读取/删除以及带过期时间的签名 URL
- 新增媒体转码能力
  - `transcoder.go`
  - 支持图片压缩/转换、音频转码、视频转码和缩略图提取
- 新增对应测试
  - `detector_test.go`
  - `pipeline_test.go`
  - `storage_test.go`
  - `signer_test.go`
  - `transcoder_test.go`

## 影响

这条 PR 只引入 `pkg/media` 这一组独立媒体能力，不包含上层工作流编排、vision 分析或 runtime 装配逻辑。

这样拆分的目标是先把媒体下载、缓存、存储、签名和转码这些基础模块独立合入，降低后续更高层多媒体能力 PR 的耦合和 review 成本。

## 验证

已执行：

- `go test ./pkg/media`
