### PR TITLE
feat(vision): add media understanding and analysis toolkit

### DIFF
--- a/pkg/vision/analyze.go
+++ b/pkg/vision/analyze.go
@@ -423,13 +423,25 @@ func (p *LLMVisionProvider) Name() string {
 	return "llm-vision"
 }
 
+func (p *LLMVisionProvider) requireClient() (LLMVisionClient, error) {
+	if p == nil || p.cfg.Client == nil {
+		return nil, fmt.Errorf("no LLM vision client configured")
+	}
+	return p.cfg.Client, nil
+}
+
 func (p *LLMVisionProvider) AnalyzeImage(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+	client, err := p.requireClient()
+	if err != nil {
+		return nil, err
+	}
+
 	prompt := p.cfg.Prompt
 	if prompt == "" {
 		prompt = "Describe this image in detail."
 	}
 
-	description, err := p.cfg.Client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
+	description, err := client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
 	if err != nil {
 		return nil, fmt.Errorf("LLM vision analysis: %w", err)
 	}
@@ -462,8 +474,13 @@ func (p *LLMVisionProvider) AnalyzeImageURL(ctx context.Context, imageURL string
 }
 
 func (p *LLMVisionProvider) OCR(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error) {
+	client, err := p.requireClient()
+	if err != nil {
+		return nil, err
+	}
+
 	prompt := "Extract all text from this image. Return only the text content, preserving line breaks."
-	description, err := p.cfg.Client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
+	description, err := client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
 	if err != nil {
 		return nil, err
 	}
@@ -474,8 +491,13 @@ func (p *LLMVisionProvider) OCR(ctx context.Context, imageData []byte, mimeType 
 }
 
 func (p *LLMVisionProvider) LabelImage(ctx context.Context, imageData []byte, mimeType string) ([]Label, error) {
+	client, err := p.requireClient()
+	if err != nil {
+		return nil, err
+	}
+
 	prompt := "List the main objects and concepts in this image as a comma-separated list. Format each as 'name:confidence' where confidence is 0.0-1.0."
-	description, err := p.cfg.Client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
+	description, err := client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
 	if err != nil {
 		return nil, err
 	}
@@ -500,8 +522,13 @@ func (p *LLMVisionProvider) LabelImage(ctx context.Context, imageData []byte, mi
 }
 
 func (p *LLMVisionProvider) DetectObjects(ctx context.Context, imageData []byte, mimeType string) ([]DetectedObject, error) {
+	client, err := p.requireClient()
+	if err != nil {
+		return nil, err
+	}
+
 	prompt := "List all visible objects in this image. For each, provide name and approximate bounding box as x,y,width,height."
-	_, err := p.cfg.Client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
+	_, err = client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vision/analyze.go
+++ b/pkg/vision/analyze.go
@@ -1,0 +1,591 @@
+package vision
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type AnalysisResult struct {
+	Description string           `json:"description"`
+	Labels      []Label          `json:"labels"`
+	Objects     []DetectedObject `json:"objects"`
+	Text        []DetectedText   `json:"text"`
+	Faces       []DetectedFace   `json:"faces"`
+	SafeSearch  SafeSearchResult `json:"safe_search"`
+	ImageProps  ImageProperties  `json:"image_properties"`
+	Metadata    map[string]any   `json:"metadata"`
+}
+
+type Label struct {
+	Name        string  `json:"name"`
+	Confidence  float64 `json:"confidence"`
+	Description string  `json:"description"`
+}
+
+type DetectedObject struct {
+	Name       string  `json:"name"`
+	Confidence float64 `json:"confidence"`
+	Bounds     Bounds  `json:"bounds"`
+}
+
+type DetectedText struct {
+	Text       string  `json:"text"`
+	Confidence float64 `json:"confidence"`
+	Bounds     Bounds  `json:"bounds"`
+	Language   string  `json:"language"`
+}
+
+type DetectedFace struct {
+	Confidence float64            `json:"confidence"`
+	Bounds     Bounds             `json:"bounds"`
+	Emotions   map[string]float64 `json:"emotions"`
+}
+
+type Bounds struct {
+	X      int `json:"x"`
+	Y      int `json:"y"`
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+type SafeSearchResult struct {
+	Adult    float64 `json:"adult"`
+	Violence float64 `json:"violence"`
+	Medical  float64 `json:"medical"`
+	Spoof    float64 `json:"spoof"`
+}
+
+type ImageProperties struct {
+	DominantColors []string `json:"dominant_colors"`
+	Width          int      `json:"width"`
+	Height         int      `json:"height"`
+	Format         string   `json:"format"`
+}
+
+type VisionProvider interface {
+	Name() string
+	AnalyzeImage(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error)
+	AnalyzeImageURL(ctx context.Context, imageURL string) (*AnalysisResult, error)
+	OCR(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error)
+	LabelImage(ctx context.Context, imageData []byte, mimeType string) ([]Label, error)
+	DetectObjects(ctx context.Context, imageData []byte, mimeType string) ([]DetectedObject, error)
+}
+
+type GoogleVisionConfig struct {
+	APIKey     string
+	Endpoint   string
+	Features   []string
+	MaxResults int
+	Timeout    time.Duration
+}
+
+func DefaultGoogleVisionConfig() GoogleVisionConfig {
+	return GoogleVisionConfig{
+		Endpoint:   "https://vision.googleapis.com/v1",
+		Features:   []string{"LABEL_DETECTION", "TEXT_DETECTION", "OBJECT_LOCALIZATION", "FACE_DETECTION", "SAFE_SEARCH_DETECTION", "IMAGE_PROPERTIES"},
+		MaxResults: 10,
+		Timeout:    30 * time.Second,
+	}
+}
+
+type GoogleVisionProvider struct {
+	cfg    GoogleVisionConfig
+	client *http.Client
+}
+
+func NewGoogleVisionProvider(cfg GoogleVisionConfig) *GoogleVisionProvider {
+	return &GoogleVisionProvider{
+		cfg: cfg,
+		client: &http.Client{
+			Timeout: cfg.Timeout,
+		},
+	}
+}
+
+func (p *GoogleVisionProvider) Name() string {
+	return "google-vision"
+}
+
+func (p *GoogleVisionProvider) AnalyzeImage(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+	encoded := base64.StdEncoding.EncodeToString(imageData)
+
+	requests := []map[string]any{}
+	features := make([]map[string]any, 0, len(p.cfg.Features))
+	for _, f := range p.cfg.Features {
+		features = append(features, map[string]any{
+			"type":       f,
+			"maxResults": p.cfg.MaxResults,
+		})
+	}
+
+	requests = append(requests, map[string]any{
+		"image":    map[string]any{"content": encoded},
+		"features": features,
+	})
+
+	body := map[string]any{"requests": requests}
+	jsonBody, _ := json.Marshal(body)
+
+	url := fmt.Sprintf("%s/images:annotate?key=%s", p.cfg.Endpoint, p.cfg.APIKey)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Google Vision API error: %s - %s", resp.Status, string(respBody))
+	}
+
+	var apiResp struct {
+		Responses []struct {
+			LabelAnnotations          []gcpAnnotation `json:"labelAnnotations"`
+			TextAnnotations           []gcpAnnotation `json:"textAnnotations"`
+			ObjectLocalizations       []gcpObjectAnn  `json:"objectLocalizations"`
+			FaceAnnotations           []gcpFaceAnn    `json:"faceAnnotations"`
+			SafeSearchAnnotation      gcpSafeSearch   `json:"safeSearchAnnotation"`
+			ImagePropertiesAnnotation gcpImageProps   `json:"imagePropertiesAnnotation"`
+			Error                     *struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		} `json:"responses"`
+	}
+
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	if len(apiResp.Responses) == 0 {
+		return nil, fmt.Errorf("empty response from Google Vision API")
+	}
+
+	r := apiResp.Responses[0]
+	if r.Error != nil {
+		return nil, fmt.Errorf("Google Vision API error: %s", r.Error.Message)
+	}
+
+	result := &AnalysisResult{Metadata: make(map[string]any)}
+
+	for _, ann := range r.LabelAnnotations {
+		result.Labels = append(result.Labels, Label{
+			Name:       ann.Description,
+			Confidence: float64(ann.Score),
+		})
+	}
+
+	if len(result.Labels) > 0 {
+		result.Description = result.Labels[0].Name
+	}
+
+	for _, ann := range r.TextAnnotations {
+		dt := DetectedText{
+			Text:       ann.Description,
+			Confidence: float64(ann.Score),
+		}
+		if ann.BoundingPoly != nil && len(ann.BoundingPoly.Vertices) >= 2 {
+			dt.Bounds = Bounds{
+				X:      ann.BoundingPoly.Vertices[0].X,
+				Y:      ann.BoundingPoly.Vertices[0].Y,
+				Width:  ann.BoundingPoly.Vertices[1].X - ann.BoundingPoly.Vertices[0].X,
+				Height: ann.BoundingPoly.Vertices[2].Y - ann.BoundingPoly.Vertices[0].Y,
+			}
+		}
+		result.Text = append(result.Text, dt)
+	}
+
+	for _, obj := range r.ObjectLocalizations {
+		detObj := DetectedObject{
+			Name:       obj.Name,
+			Confidence: float64(obj.Score),
+		}
+		if obj.BoundingPoly != nil && len(obj.BoundingPoly.Vertices) >= 2 {
+			detObj.Bounds = Bounds{
+				X:      obj.BoundingPoly.Vertices[0].X,
+				Y:      obj.BoundingPoly.Vertices[0].Y,
+				Width:  obj.BoundingPoly.Vertices[1].X - obj.BoundingPoly.Vertices[0].X,
+				Height: obj.BoundingPoly.Vertices[2].Y - obj.BoundingPoly.Vertices[0].Y,
+			}
+		}
+		result.Objects = append(result.Objects, detObj)
+	}
+
+	for _, face := range r.FaceAnnotations {
+		emotions := make(map[string]float64)
+		emotions["joy"] = likelihoodToFloat(face.JoyLikelihood)
+		emotions["sorrow"] = likelihoodToFloat(face.SorrowLikelihood)
+		emotions["anger"] = likelihoodToFloat(face.AngerLikelihood)
+		emotions["surprise"] = likelihoodToFloat(face.SurpriseLikelihood)
+
+		detFace := DetectedFace{
+			Confidence: float64(face.DetectionConfidence),
+			Emotions:   emotions,
+		}
+		if face.BoundingPoly != nil && len(face.BoundingPoly.Vertices) >= 2 {
+			detFace.Bounds = Bounds{
+				X:      face.BoundingPoly.Vertices[0].X,
+				Y:      face.BoundingPoly.Vertices[0].Y,
+				Width:  face.BoundingPoly.Vertices[1].X - face.BoundingPoly.Vertices[0].X,
+				Height: face.BoundingPoly.Vertices[2].Y - face.BoundingPoly.Vertices[0].Y,
+			}
+		}
+		result.Faces = append(result.Faces, detFace)
+	}
+
+	result.SafeSearch = SafeSearchResult{
+		Adult:    likelihoodToFloat(r.SafeSearchAnnotation.Adult),
+		Violence: likelihoodToFloat(r.SafeSearchAnnotation.Violence),
+		Medical:  likelihoodToFloat(r.SafeSearchAnnotation.Medical),
+		Spoof:    likelihoodToFloat(r.SafeSearchAnnotation.Spoof),
+	}
+
+	if len(r.ImagePropertiesAnnotation.DominantColors.Colors) > 0 {
+		for _, c := range r.ImagePropertiesAnnotation.DominantColors.Colors {
+			result.ImageProps.DominantColors = append(result.ImageProps.DominantColors,
+				fmt.Sprintf("#%02X%02X%02X", c.Color.Red, c.Color.Green, c.Color.Blue))
+		}
+	}
+
+	return result, nil
+}
+
+func (p *GoogleVisionProvider) AnalyzeImageURL(ctx context.Context, imageURL string) (*AnalysisResult, error) {
+	resp, err := p.client.Get(imageURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetch image: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 20*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read image: %w", err)
+	}
+
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "image/jpeg"
+	}
+
+	return p.AnalyzeImage(ctx, data, mimeType)
+}
+
+func (p *GoogleVisionProvider) OCR(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error) {
+	result, err := p.AnalyzeImage(ctx, imageData, mimeType)
+	if err != nil {
+		return nil, err
+	}
+	return result.Text, nil
+}
+
+func (p *GoogleVisionProvider) LabelImage(ctx context.Context, imageData []byte, mimeType string) ([]Label, error) {
+	result, err := p.AnalyzeImage(ctx, imageData, mimeType)
+	if err != nil {
+		return nil, err
+	}
+	return result.Labels, nil
+}
+
+func (p *GoogleVisionProvider) DetectObjects(ctx context.Context, imageData []byte, mimeType string) ([]DetectedObject, error) {
+	result, err := p.AnalyzeImage(ctx, imageData, mimeType)
+	if err != nil {
+		return nil, err
+	}
+	return result.Objects, nil
+}
+
+type gcpAnnotation struct {
+	Mid          string  `json:"mid"`
+	Description  string  `json:"description"`
+	Score        float32 `json:"score"`
+	Confidence   float32 `json:"confidence"`
+	Topicality   float32 `json:"topicality"`
+	BoundingPoly *struct {
+		Vertices []struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+		} `json:"vertices"`
+	} `json:"boundingPoly"`
+}
+
+type gcpObjectAnn struct {
+	Name         string  `json:"name"`
+	Score        float32 `json:"score"`
+	BoundingPoly *struct {
+		Vertices []struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+		} `json:"vertices"`
+	} `json:"boundingPoly"`
+}
+
+type gcpFaceAnn struct {
+	BoundingPoly *struct {
+		Vertices []struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+		} `json:"vertices"`
+	} `json:"boundingPoly"`
+	DetectionConfidence   float32 `json:"detectionConfidence"`
+	LandmarkingConfidence float32 `json:"landmarkingConfidence"`
+	JoyLikelihood         string  `json:"joyLikelihood"`
+	SorrowLikelihood      string  `json:"sorrowLikelihood"`
+	AngerLikelihood       string  `json:"angerLikelihood"`
+	SurpriseLikelihood    string  `json:"surpriseLikelihood"`
+}
+
+type gcpSafeSearch struct {
+	Adult    string `json:"adult"`
+	Spoof    string `json:"spoof"`
+	Medical  string `json:"medical"`
+	Violence string `json:"violence"`
+	Racy     string `json:"racy"`
+}
+
+type gcpImageProps struct {
+	DominantColors struct {
+		Colors []struct {
+			Color struct {
+				Red   int `json:"red"`
+				Green int `json:"green"`
+				Blue  int `json:"blue"`
+			} `json:"color"`
+			Score float32 `json:"score"`
+		} `json:"colors"`
+	} `json:"dominantColors"`
+}
+
+func likelihoodToFloat(l string) float64 {
+	switch strings.ToLower(l) {
+	case "very_likely":
+		return 0.9
+	case "likely":
+		return 0.7
+	case "possible":
+		return 0.5
+	case "unlikely":
+		return 0.3
+	case "very_unlikely":
+		return 0.1
+	default:
+		return 0
+	}
+}
+
+type LLMVisionConfig struct {
+	Client      LLMVisionClient
+	Prompt      string
+	MaxTokens   int
+	Temperature float64
+}
+
+func DefaultLLMVisionConfig() LLMVisionConfig {
+	return LLMVisionConfig{
+		Prompt:      "Describe this image in detail. Include objects, text, people, actions, colors, and overall scene.",
+		MaxTokens:   1024,
+		Temperature: 0.3,
+	}
+}
+
+type LLMVisionClient interface {
+	AnalyzeImageWithPrompt(ctx context.Context, imageData []byte, mimeType string, prompt string) (string, error)
+}
+
+type LLMVisionProvider struct {
+	cfg LLMVisionConfig
+}
+
+func NewLLMVisionProvider(cfg LLMVisionConfig) *LLMVisionProvider {
+	return &LLMVisionProvider{cfg: cfg}
+}
+
+func (p *LLMVisionProvider) Name() string {
+	return "llm-vision"
+}
+
+func (p *LLMVisionProvider) AnalyzeImage(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+	prompt := p.cfg.Prompt
+	if prompt == "" {
+		prompt = "Describe this image in detail."
+	}
+
+	description, err := p.cfg.Client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
+	if err != nil {
+		return nil, fmt.Errorf("LLM vision analysis: %w", err)
+	}
+
+	return &AnalysisResult{
+		Description: description,
+		Metadata:    map[string]any{"provider": "llm-vision", "prompt": prompt},
+	}, nil
+}
+
+func (p *LLMVisionProvider) AnalyzeImageURL(ctx context.Context, imageURL string) (*AnalysisResult, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(imageURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetch image: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 20*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read image: %w", err)
+	}
+
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "image/jpeg"
+	}
+
+	return p.AnalyzeImage(ctx, data, mimeType)
+}
+
+func (p *LLMVisionProvider) OCR(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error) {
+	prompt := "Extract all text from this image. Return only the text content, preserving line breaks."
+	description, err := p.cfg.Client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	return []DetectedText{
+		{Text: description, Confidence: 1.0},
+	}, nil
+}
+
+func (p *LLMVisionProvider) LabelImage(ctx context.Context, imageData []byte, mimeType string) ([]Label, error) {
+	prompt := "List the main objects and concepts in this image as a comma-separated list. Format each as 'name:confidence' where confidence is 0.0-1.0."
+	description, err := p.cfg.Client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	var labels []Label
+	lines := strings.Split(description, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		name := strings.TrimSpace(parts[0])
+		confidence := 0.8
+		if len(parts) == 2 {
+			fmt.Sscanf(strings.TrimSpace(parts[1]), "%f", &confidence)
+		}
+		labels = append(labels, Label{Name: name, Confidence: confidence})
+	}
+
+	return labels, nil
+}
+
+func (p *LLMVisionProvider) DetectObjects(ctx context.Context, imageData []byte, mimeType string) ([]DetectedObject, error) {
+	prompt := "List all visible objects in this image. For each, provide name and approximate bounding box as x,y,width,height."
+	_, err := p.cfg.Client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, fmt.Errorf("object detection not supported via LLM vision")
+}
+
+func AnalyzeImageFile(ctx context.Context, provider VisionProvider, path string) (*AnalysisResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read image file: %w", err)
+	}
+
+	mimeType := mimeTypeFromPath(path)
+	if mimeType == "" {
+		mimeType = "image/jpeg"
+	}
+
+	return provider.AnalyzeImage(ctx, data, mimeType)
+}
+
+func mimeTypeFromPath(path string) string {
+	ext := strings.ToLower(path)
+	switch {
+	case strings.HasSuffix(ext, ".jpg"), strings.HasSuffix(ext, ".jpeg"):
+		return "image/jpeg"
+	case strings.HasSuffix(ext, ".png"):
+		return "image/png"
+	case strings.HasSuffix(ext, ".gif"):
+		return "image/gif"
+	case strings.HasSuffix(ext, ".webp"):
+		return "image/webp"
+	case strings.HasSuffix(ext, ".bmp"):
+		return "image/bmp"
+	default:
+		return ""
+	}
+}
+
+func UploadImageForAnalysis(ctx context.Context, endpoint string, apiKey string, imageData []byte, mimeType string) (*AnalysisResult, error) {
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	part, err := writer.CreateFormFile("image", "upload")
+	if err != nil {
+		return nil, fmt.Errorf("create form file: %w", err)
+	}
+	part.Write(imageData)
+
+	if mimeType != "" {
+		writer.WriteField("mime_type", mimeType)
+	}
+
+	writer.Close()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, &buf)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("upload failed: %s - %s", resp.Status, string(body))
+	}
+
+	var result AnalysisResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/pkg/vision/analyze.go
+++ b/pkg/vision/analyze.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
+	"net/netip"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -271,7 +274,7 @@ func (p *GoogleVisionProvider) AnalyzeImage(ctx context.Context, imageData []byt
 }
 
 func (p *GoogleVisionProvider) AnalyzeImageURL(ctx context.Context, imageURL string) (*AnalysisResult, error) {
-	resp, err := p.client.Get(imageURL)
+	resp, err := fetchImageURL(ctx, p.client, imageURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetch image: %w", err)
 	}
@@ -312,6 +315,133 @@ func (p *GoogleVisionProvider) DetectObjects(ctx context.Context, imageData []by
 		return nil, err
 	}
 	return result.Objects, nil
+}
+
+func fetchImageURL(ctx context.Context, client *http.Client, imageURL string) (*http.Response, error) {
+	if err := validateImageFetchURL(ctx, imageURL); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create image request: %w", err)
+	}
+
+	return imageFetchHTTPClient(client).Do(req)
+}
+
+func imageFetchHTTPClient(client *http.Client) *http.Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	next := *client
+	previousCheckRedirect := client.CheckRedirect
+	next.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		if err := validateImageFetchURL(req.Context(), req.URL.String()); err != nil {
+			return err
+		}
+		if previousCheckRedirect != nil {
+			return previousCheckRedirect(req, via)
+		}
+		return nil
+	}
+
+	return &next
+}
+
+func validateImageFetchURL(ctx context.Context, rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid image URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("unsafe image URL scheme: %s", parsed.Scheme)
+	}
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("image URL host is required")
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("image URL must not include credentials")
+	}
+	return validateImageFetchHost(ctx, parsed.Hostname())
+}
+
+func validateImageFetchHost(ctx context.Context, host string) error {
+	normalized := strings.TrimSuffix(strings.ToLower(host), ".")
+	if normalized == "" {
+		return fmt.Errorf("image URL host is required")
+	}
+	if normalized == "localhost" || strings.HasSuffix(normalized, ".localhost") {
+		return fmt.Errorf("unsafe image URL host: %s", host)
+	}
+
+	if addr, err := netip.ParseAddr(normalized); err == nil {
+		return validateImageFetchAddr(host, addr)
+	}
+
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return fmt.Errorf("resolve image URL host %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("resolve image URL host %q: no addresses", host)
+	}
+	for _, ip := range ips {
+		addr, ok := netip.AddrFromSlice(ip.IP)
+		if !ok {
+			return fmt.Errorf("resolve image URL host %q: invalid address %s", host, ip.IP)
+		}
+		if err := validateImageFetchAddr(host, addr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateImageFetchAddr(host string, addr netip.Addr) error {
+	addr = addr.Unmap()
+	if !addr.IsValid() || !addr.IsGlobalUnicast() || addr.IsPrivate() || addr.IsLoopback() || addr.IsLinkLocalUnicast() || addr.IsMulticast() || isSpecialImageFetchAddr(addr) {
+		return fmt.Errorf("unsafe image URL host %q resolves to non-public address %s", host, addr)
+	}
+	return nil
+}
+
+func isSpecialImageFetchAddr(addr netip.Addr) bool {
+	for _, prefix := range blockedImageFetchPrefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+var blockedImageFetchPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("224.0.0.0/4"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("::/128"),
+	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("64:ff9b::/96"),
+	netip.MustParsePrefix("100::/64"),
+	netip.MustParsePrefix("2001::/23"),
+	netip.MustParsePrefix("2001:2::/48"),
+	netip.MustParsePrefix("2001:db8::/32"),
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+	netip.MustParsePrefix("ff00::/8"),
 }
 
 type gcpAnnotation struct {
@@ -453,8 +583,12 @@ func (p *LLMVisionProvider) AnalyzeImage(ctx context.Context, imageData []byte, 
 }
 
 func (p *LLMVisionProvider) AnalyzeImageURL(ctx context.Context, imageURL string) (*AnalysisResult, error) {
+	if _, err := p.requireClient(); err != nil {
+		return nil, err
+	}
+
 	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Get(imageURL)
+	resp, err := fetchImageURL(ctx, client, imageURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetch image: %w", err)
 	}

--- a/pkg/vision/analyze_test.go
+++ b/pkg/vision/analyze_test.go
@@ -1,0 +1,92 @@
+package vision
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type testLLMVisionClient struct {
+	analyzeFunc func(ctx context.Context, imageData []byte, mimeType string, prompt string) (string, error)
+}
+
+func (c *testLLMVisionClient) AnalyzeImageWithPrompt(ctx context.Context, imageData []byte, mimeType string, prompt string) (string, error) {
+	if c.analyzeFunc != nil {
+		return c.analyzeFunc(ctx, imageData, mimeType, prompt)
+	}
+	return "ok", nil
+}
+
+func TestLLMVisionProviderRejectsMissingClient(t *testing.T) {
+	t.Run("AnalyzeImage", func(t *testing.T) {
+		provider := NewLLMVisionProvider(LLMVisionConfig{})
+		_, err := provider.AnalyzeImage(context.Background(), []byte("img"), "image/png")
+		assertMissingLLMClientError(t, err)
+	})
+
+	t.Run("OCR", func(t *testing.T) {
+		provider := NewLLMVisionProvider(LLMVisionConfig{})
+		_, err := provider.OCR(context.Background(), []byte("img"), "image/png")
+		assertMissingLLMClientError(t, err)
+	})
+
+	t.Run("LabelImage", func(t *testing.T) {
+		provider := NewLLMVisionProvider(LLMVisionConfig{})
+		_, err := provider.LabelImage(context.Background(), []byte("img"), "image/png")
+		assertMissingLLMClientError(t, err)
+	})
+
+	t.Run("DetectObjects", func(t *testing.T) {
+		provider := NewLLMVisionProvider(LLMVisionConfig{})
+		_, err := provider.DetectObjects(context.Background(), []byte("img"), "image/png")
+		assertMissingLLMClientError(t, err)
+	})
+}
+
+func TestLLMVisionProviderAnalyzeImageURLRejectsMissingClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("img"))
+	}))
+	defer server.Close()
+
+	provider := NewLLMVisionProvider(LLMVisionConfig{})
+	_, err := provider.AnalyzeImageURL(context.Background(), server.URL)
+	assertMissingLLMClientError(t, err)
+}
+
+func TestLLMVisionProviderAnalyzeImageUsesConfiguredClient(t *testing.T) {
+	provider := NewLLMVisionProvider(LLMVisionConfig{
+		Client: &testLLMVisionClient{
+			analyzeFunc: func(ctx context.Context, imageData []byte, mimeType string, prompt string) (string, error) {
+				if mimeType != "image/png" {
+					t.Fatalf("expected mime type image/png, got %s", mimeType)
+				}
+				if prompt == "" {
+					t.Fatal("expected prompt to be populated")
+				}
+				return "analyzed", nil
+			},
+		},
+	})
+
+	result, err := provider.AnalyzeImage(context.Background(), []byte("img"), "image/png")
+	if err != nil {
+		t.Fatalf("AnalyzeImage: %v", err)
+	}
+	if result.Description != "analyzed" {
+		t.Fatalf("expected description %q, got %q", "analyzed", result.Description)
+	}
+}
+
+func assertMissingLLMClientError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected missing client error")
+	}
+	if !strings.Contains(err.Error(), "no LLM vision client configured") {
+		t.Fatalf("expected missing client error, got %v", err)
+	}
+}

--- a/pkg/vision/analyze_test.go
+++ b/pkg/vision/analyze_test.go
@@ -2,8 +2,11 @@ package vision
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -134,6 +137,293 @@ func TestLLMVisionProviderAnalyzeImageUsesConfiguredClient(t *testing.T) {
 	}
 }
 
+func TestVisionProviderNamesAndDefaults(t *testing.T) {
+	if got := NewGoogleVisionProvider(DefaultGoogleVisionConfig()).Name(); got != "google-vision" {
+		t.Fatalf("expected google provider name, got %q", got)
+	}
+	if got := NewLLMVisionProvider(DefaultLLMVisionConfig()).Name(); got != "llm-vision" {
+		t.Fatalf("expected LLM provider name, got %q", got)
+	}
+	if DefaultLLMVisionConfig().Prompt == "" {
+		t.Fatal("expected default LLM vision prompt")
+	}
+}
+
+func TestGoogleVisionProviderAnalyzeImageParsesResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.RawQuery, "key=test-key") {
+			t.Fatalf("expected API key query, got %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(googleVisionSuccessResponse))
+	}))
+	defer server.Close()
+
+	cfg := DefaultGoogleVisionConfig()
+	cfg.Endpoint = server.URL
+	cfg.APIKey = "test-key"
+	provider := NewGoogleVisionProvider(cfg)
+
+	result, err := provider.AnalyzeImage(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("AnalyzeImage: %v", err)
+	}
+	if result.Description != "cat" {
+		t.Fatalf("expected description cat, got %q", result.Description)
+	}
+	if len(result.Labels) != 1 || result.Labels[0].Name != "cat" {
+		t.Fatalf("expected parsed label, got %#v", result.Labels)
+	}
+	if len(result.Text) != 1 || result.Text[0].Text != "hello" {
+		t.Fatalf("expected parsed text, got %#v", result.Text)
+	}
+	if len(result.Objects) != 1 || result.Objects[0].Name != "cup" {
+		t.Fatalf("expected parsed object, got %#v", result.Objects)
+	}
+	if len(result.Faces) != 1 || result.Faces[0].Emotions["joy"] == 0 {
+		t.Fatalf("expected parsed face emotions, got %#v", result.Faces)
+	}
+	if len(result.ImageProps.DominantColors) != 1 || result.ImageProps.DominantColors[0] != "#010203" {
+		t.Fatalf("expected dominant color #010203, got %#v", result.ImageProps.DominantColors)
+	}
+}
+
+func TestGoogleVisionProviderAnalyzeImageErrors(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "status error", status: http.StatusBadRequest, body: "bad request"},
+		{name: "malformed json", status: http.StatusOK, body: `{invalid}`},
+		{name: "empty response", status: http.StatusOK, body: `{"responses":[]}`},
+		{name: "api response error", status: http.StatusOK, body: `{"responses":[{"error":{"code":3,"message":"bad image"}}]}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			cfg := DefaultGoogleVisionConfig()
+			cfg.Endpoint = server.URL
+			cfg.APIKey = "test-key"
+			provider := NewGoogleVisionProvider(cfg)
+
+			if _, err := provider.AnalyzeImage(context.Background(), []byte("image"), "image/png"); err == nil {
+				t.Fatal("expected AnalyzeImage to fail")
+			}
+		})
+	}
+}
+
+func TestGoogleVisionProviderDerivedMethods(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(googleVisionSuccessResponse))
+	}))
+	defer server.Close()
+
+	cfg := DefaultGoogleVisionConfig()
+	cfg.Endpoint = server.URL
+	cfg.APIKey = "test-key"
+	provider := NewGoogleVisionProvider(cfg)
+
+	texts, err := provider.OCR(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("OCR: %v", err)
+	}
+	if len(texts) != 1 || texts[0].Text != "hello" {
+		t.Fatalf("expected OCR text, got %#v", texts)
+	}
+
+	labels, err := provider.LabelImage(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("LabelImage: %v", err)
+	}
+	if len(labels) != 1 || labels[0].Name != "cat" {
+		t.Fatalf("expected label, got %#v", labels)
+	}
+
+	objects, err := provider.DetectObjects(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("DetectObjects: %v", err)
+	}
+	if len(objects) != 1 || objects[0].Name != "cup" {
+		t.Fatalf("expected object, got %#v", objects)
+	}
+}
+
+func TestLLMVisionProviderOCRLabelAndDetectObjects(t *testing.T) {
+	provider := NewLLMVisionProvider(LLMVisionConfig{
+		Client: &testLLMVisionClient{
+			analyzeFunc: func(ctx context.Context, imageData []byte, mimeType string, prompt string) (string, error) {
+				switch {
+				case strings.Contains(prompt, "Extract all text"):
+					return "invoice\n123", nil
+				case strings.Contains(prompt, "comma-separated"):
+					return "cat:0.91\ndog", nil
+				default:
+					return "objects", nil
+				}
+			},
+		},
+	})
+
+	texts, err := provider.OCR(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("OCR: %v", err)
+	}
+	if len(texts) != 1 || texts[0].Text != "invoice\n123" {
+		t.Fatalf("expected OCR output, got %#v", texts)
+	}
+
+	labels, err := provider.LabelImage(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("LabelImage: %v", err)
+	}
+	if len(labels) != 2 || labels[0].Name != "cat" || labels[1].Name != "dog" {
+		t.Fatalf("expected parsed labels, got %#v", labels)
+	}
+
+	if _, err := provider.DetectObjects(context.Background(), []byte("image"), "image/png"); err == nil {
+		t.Fatal("expected DetectObjects unsupported error")
+	}
+}
+
+func TestLLMVisionProviderReturnsClientErrors(t *testing.T) {
+	provider := NewLLMVisionProvider(LLMVisionConfig{
+		Client: &testLLMVisionClient{
+			analyzeFunc: func(ctx context.Context, imageData []byte, mimeType string, prompt string) (string, error) {
+				return "", errors.New("provider failed")
+			},
+		},
+	})
+
+	if _, err := provider.AnalyzeImage(context.Background(), []byte("image"), "image/png"); err == nil {
+		t.Fatal("expected AnalyzeImage client error")
+	}
+	if _, err := provider.OCR(context.Background(), []byte("image"), "image/png"); err == nil {
+		t.Fatal("expected OCR client error")
+	}
+	if _, err := provider.LabelImage(context.Background(), []byte("image"), "image/png"); err == nil {
+		t.Fatal("expected LabelImage client error")
+	}
+	if _, err := provider.DetectObjects(context.Background(), []byte("image"), "image/png"); err == nil {
+		t.Fatal("expected DetectObjects client error")
+	}
+}
+
+func TestAnalyzeImageFile(t *testing.T) {
+	provider := &testVisionProvider{
+		analyzeImageFunc: func(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+			if string(imageData) != "image" {
+				t.Fatalf("expected image bytes, got %q", string(imageData))
+			}
+			if mimeType != "image/png" {
+				t.Fatalf("expected image/png, got %s", mimeType)
+			}
+			return &AnalysisResult{Description: "file"}, nil
+		},
+	}
+
+	path := t.TempDir() + "/sample.png"
+	if err := os.WriteFile(path, []byte("image"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	result, err := AnalyzeImageFile(context.Background(), provider, path)
+	if err != nil {
+		t.Fatalf("AnalyzeImageFile: %v", err)
+	}
+	if result.Description != "file" {
+		t.Fatalf("expected file description, got %q", result.Description)
+	}
+
+	if _, err := AnalyzeImageFile(context.Background(), provider, path+".missing"); err == nil {
+		t.Fatal("expected read error")
+	}
+}
+
+func TestUploadImageForAnalysis(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer token" {
+			t.Fatalf("expected bearer token, got %q", r.Header.Get("Authorization"))
+		}
+		if err := r.ParseMultipartForm(1024); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"description":"uploaded","metadata":{"source":"test"}}`))
+	}))
+	defer server.Close()
+
+	result, err := UploadImageForAnalysis(context.Background(), server.URL, "token", []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("UploadImageForAnalysis: %v", err)
+	}
+	if result.Description != "uploaded" {
+		t.Fatalf("expected uploaded description, got %q", result.Description)
+	}
+}
+
+func TestUploadImageForAnalysisErrors(t *testing.T) {
+	t.Run("status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("bad gateway"))
+		}))
+		defer server.Close()
+
+		if _, err := UploadImageForAnalysis(context.Background(), server.URL, "", []byte("image"), ""); err == nil {
+			t.Fatal("expected upload status error")
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{invalid}`))
+		}))
+		defer server.Close()
+
+		if _, err := UploadImageForAnalysis(context.Background(), server.URL, "", []byte("image"), ""); err == nil {
+			t.Fatal("expected upload parse error")
+		}
+	})
+}
+
+func TestFetchImageURLUsesProvidedClient(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("image")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+
+	resp, err := fetchImageURL(context.Background(), client, "https://8.8.8.8/image.png")
+	if err != nil {
+		t.Fatalf("fetchImageURL: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if string(body) != "image" {
+		t.Fatalf("expected image body, got %q", string(body))
+	}
+}
+
 func assertMissingLLMClientError(t *testing.T, err error) {
 	t.Helper()
 	if err == nil {
@@ -153,3 +443,74 @@ func assertUnsafeImageURLError(t *testing.T, err error) {
 		t.Fatalf("expected unsafe image URL error, got %v", err)
 	}
 }
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+const googleVisionSuccessResponse = `{
+  "responses": [
+    {
+      "labelAnnotations": [
+        {"description": "cat", "score": 0.95}
+      ],
+      "textAnnotations": [
+        {
+          "description": "hello",
+          "score": 0.80,
+          "boundingPoly": {
+            "vertices": [
+              {"x": 1, "y": 2},
+              {"x": 5, "y": 2},
+              {"x": 5, "y": 8}
+            ]
+          }
+        }
+      ],
+      "objectLocalizations": [
+        {
+          "name": "cup",
+          "score": 0.70,
+          "boundingPoly": {
+            "vertices": [
+              {"x": 2, "y": 3},
+              {"x": 7, "y": 3},
+              {"x": 7, "y": 11}
+            ]
+          }
+        }
+      ],
+      "faceAnnotations": [
+        {
+          "detectionConfidence": 0.88,
+          "joyLikelihood": "LIKELY",
+          "sorrowLikelihood": "VERY_UNLIKELY",
+          "angerLikelihood": "UNLIKELY",
+          "surpriseLikelihood": "POSSIBLE",
+          "boundingPoly": {
+            "vertices": [
+              {"x": 0, "y": 1},
+              {"x": 10, "y": 1},
+              {"x": 10, "y": 12}
+            ]
+          }
+        }
+      ],
+      "safeSearchAnnotation": {
+        "adult": "VERY_UNLIKELY",
+        "violence": "UNLIKELY",
+        "medical": "POSSIBLE",
+        "spoof": "LIKELY"
+      },
+      "imagePropertiesAnnotation": {
+        "dominantColors": {
+          "colors": [
+            {"color": {"red": 1, "green": 2, "blue": 3}, "score": 0.50}
+          ]
+        }
+      }
+    }
+  ]
+}`

--- a/pkg/vision/analyze_test.go
+++ b/pkg/vision/analyze_test.go
@@ -57,6 +57,59 @@ func TestLLMVisionProviderAnalyzeImageURLRejectsMissingClient(t *testing.T) {
 	assertMissingLLMClientError(t, err)
 }
 
+func TestAnalyzeImageURLRejectsUnsafeURL(t *testing.T) {
+	t.Run("GoogleVisionProvider", func(t *testing.T) {
+		provider := NewGoogleVisionProvider(DefaultGoogleVisionConfig())
+		_, err := provider.AnalyzeImageURL(context.Background(), "http://127.0.0.1/image.png")
+		assertUnsafeImageURLError(t, err)
+	})
+
+	t.Run("LLMVisionProvider", func(t *testing.T) {
+		provider := NewLLMVisionProvider(LLMVisionConfig{Client: &testLLMVisionClient{}})
+		_, err := provider.AnalyzeImageURL(context.Background(), "http://127.0.0.1/image.png")
+		assertUnsafeImageURLError(t, err)
+	})
+}
+
+func TestValidateImageFetchURLRejectsUnsafeInputs(t *testing.T) {
+	cases := []string{
+		"ftp://example.com/image.png",
+		"http:///image.png",
+		"https://user:pass@example.com/image.png",
+		"http://localhost/image.png",
+		"http://service.localhost/image.png",
+		"http://127.0.0.1/image.png",
+		"http://10.0.0.2/image.png",
+		"http://169.254.169.254/latest/meta-data",
+		"http://[::1]/image.png",
+		"http://[fe80::1]/image.png",
+	}
+
+	for _, rawURL := range cases {
+		err := validateImageFetchURL(context.Background(), rawURL)
+		if err == nil {
+			t.Fatalf("expected unsafe URL %q to be rejected", rawURL)
+		}
+	}
+}
+
+func TestValidateImageFetchURLAllowsPublicHTTPURLs(t *testing.T) {
+	if err := validateImageFetchURL(context.Background(), "https://8.8.8.8/image.png"); err != nil {
+		t.Fatalf("expected public URL to be accepted, got %v", err)
+	}
+}
+
+func TestImageFetchHTTPClientRejectsUnsafeRedirect(t *testing.T) {
+	client := imageFetchHTTPClient(&http.Client{})
+	req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	err = client.CheckRedirect(req, nil)
+	assertUnsafeImageURLError(t, err)
+}
+
 func TestLLMVisionProviderAnalyzeImageUsesConfiguredClient(t *testing.T) {
 	provider := NewLLMVisionProvider(LLMVisionConfig{
 		Client: &testLLMVisionClient{
@@ -88,5 +141,15 @@ func assertMissingLLMClientError(t *testing.T, err error) {
 	}
 	if !strings.Contains(err.Error(), "no LLM vision client configured") {
 		t.Fatalf("expected missing client error, got %v", err)
+	}
+}
+
+func assertUnsafeImageURLError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected unsafe image URL error")
+	}
+	if !strings.Contains(err.Error(), "unsafe image URL") && !strings.Contains(err.Error(), "image URL host is required") {
+		t.Fatalf("expected unsafe image URL error, got %v", err)
 	}
 }

--- a/pkg/vision/helpers_test.go
+++ b/pkg/vision/helpers_test.go
@@ -4,13 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"strings"
 	"testing"
+
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
 )
 
 type testVisionProvider struct {
-	analyzeImageFunc func(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error)
-	analyzeImageHit  bool
+	analyzeImageFunc    func(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error)
+	analyzeImageURLFunc func(ctx context.Context, imageURL string) (*AnalysisResult, error)
+	ocrFunc             func(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error)
+	analyzeImageHit     bool
+	analyzeImageURLHit  bool
+	ocrHit              bool
 }
 
 func (p *testVisionProvider) Name() string {
@@ -26,10 +33,18 @@ func (p *testVisionProvider) AnalyzeImage(ctx context.Context, imageData []byte,
 }
 
 func (p *testVisionProvider) AnalyzeImageURL(ctx context.Context, imageURL string) (*AnalysisResult, error) {
+	p.analyzeImageURLHit = true
+	if p.analyzeImageURLFunc != nil {
+		return p.analyzeImageURLFunc(ctx, imageURL)
+	}
 	return nil, errors.New("not implemented")
 }
 
 func (p *testVisionProvider) OCR(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error) {
+	p.ocrHit = true
+	if p.ocrFunc != nil {
+		return p.ocrFunc(ctx, imageData, mimeType)
+	}
 	return nil, errors.New("not implemented")
 }
 
@@ -39,6 +54,25 @@ func (p *testVisionProvider) LabelImage(ctx context.Context, imageData []byte, m
 
 func (p *testVisionProvider) DetectObjects(ctx context.Context, imageData []byte, mimeType string) ([]DetectedObject, error) {
 	return nil, errors.New("not implemented")
+}
+
+type testModelClient struct {
+	chatFunc func(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition) (*llm.Response, error)
+}
+
+func (c *testModelClient) Chat(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition) (*llm.Response, error) {
+	if c.chatFunc != nil {
+		return c.chatFunc(ctx, messages, tools)
+	}
+	return &llm.Response{Content: "described"}, nil
+}
+
+func (c *testModelClient) StreamChat(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition, onChunk func(string)) error {
+	return nil
+}
+
+func (c *testModelClient) Name() string {
+	return "test-model"
 }
 
 func TestImageDataURLRoundTrip(t *testing.T) {
@@ -143,6 +177,263 @@ func TestUnderstandImageCallsProviderForValidSizedImage(t *testing.T) {
 	}
 	if result.Summary != "cat, pet" {
 		t.Fatalf("expected summary %q, got %q", "cat, pet", result.Summary)
+	}
+}
+
+func TestUnderstandImageWithoutProvider(t *testing.T) {
+	pipeline := NewMediaUnderstandingPipeline(DefaultMediaUnderstandingConfig())
+
+	result, err := pipeline.UnderstandImage(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("UnderstandImage: %v", err)
+	}
+	if result.Description != "No vision provider configured" {
+		t.Fatalf("expected no provider description, got %q", result.Description)
+	}
+}
+
+func TestUnderstandImageFile(t *testing.T) {
+	pipeline := NewMediaUnderstandingPipeline(DefaultMediaUnderstandingConfig())
+	path := t.TempDir() + "/photo.png"
+	if err := os.WriteFile(path, []byte("image"), 0o600); err != nil {
+		t.Fatalf("write image fixture: %v", err)
+	}
+
+	result, err := pipeline.UnderstandImageFile(context.Background(), path)
+	if err != nil {
+		t.Fatalf("UnderstandImageFile: %v", err)
+	}
+	if result.Type != "image" {
+		t.Fatalf("expected image result, got %q", result.Type)
+	}
+
+	if _, err := pipeline.UnderstandImageFile(context.Background(), path+".missing"); err == nil {
+		t.Fatal("expected missing file error")
+	}
+}
+
+func TestUnderstandImageURL(t *testing.T) {
+	t.Run("missing provider", func(t *testing.T) {
+		pipeline := NewMediaUnderstandingPipeline(DefaultMediaUnderstandingConfig())
+		if _, err := pipeline.UnderstandImageURL(context.Background(), "https://example.com/image.png"); err == nil {
+			t.Fatal("expected missing provider error")
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		provider := &testVisionProvider{
+			analyzeImageURLFunc: func(ctx context.Context, imageURL string) (*AnalysisResult, error) {
+				if imageURL != "https://example.com/image.png" {
+					t.Fatalf("unexpected image URL %s", imageURL)
+				}
+				return &AnalysisResult{
+					Description: "remote",
+					Labels:      []Label{{Name: "remote"}, {Name: "image"}},
+				}, nil
+			},
+		}
+		pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+			VisionProvider: provider,
+			Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+		})
+
+		result, err := pipeline.UnderstandImageURL(context.Background(), "https://example.com/image.png")
+		if err != nil {
+			t.Fatalf("UnderstandImageURL: %v", err)
+		}
+		if result.Summary != "remote, image" {
+			t.Fatalf("expected summary, got %q", result.Summary)
+		}
+		if !provider.analyzeImageURLHit {
+			t.Fatal("expected provider AnalyzeImageURL to be called")
+		}
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		provider := &testVisionProvider{
+			analyzeImageURLFunc: func(ctx context.Context, imageURL string) (*AnalysisResult, error) {
+				return nil, errors.New("fetch failed")
+			},
+		}
+		pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+			VisionProvider: provider,
+			Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+		})
+
+		if _, err := pipeline.UnderstandImageURL(context.Background(), "https://example.com/image.png"); err == nil {
+			t.Fatal("expected provider URL error")
+		}
+	})
+}
+
+func TestOCRImage(t *testing.T) {
+	t.Run("missing provider", func(t *testing.T) {
+		pipeline := NewMediaUnderstandingPipeline(DefaultMediaUnderstandingConfig())
+		if _, err := pipeline.OCRImage(context.Background(), []byte("image"), "image/png"); err == nil {
+			t.Fatal("expected missing provider error")
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		provider := &testVisionProvider{
+			ocrFunc: func(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error) {
+				return []DetectedText{{Text: "hello"}, {Text: "world"}}, nil
+			},
+		}
+		pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+			VisionProvider: provider,
+			Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+		})
+
+		text, err := pipeline.OCRImage(context.Background(), []byte("image"), "image/png")
+		if err != nil {
+			t.Fatalf("OCRImage: %v", err)
+		}
+		if text != "hello\nworld" {
+			t.Fatalf("expected OCR text, got %q", text)
+		}
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		provider := &testVisionProvider{
+			ocrFunc: func(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error) {
+				return nil, errors.New("ocr failed")
+			},
+		}
+		pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+			VisionProvider: provider,
+			Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+		})
+
+		if _, err := pipeline.OCRImage(context.Background(), []byte("image"), "image/png"); err == nil {
+			t.Fatal("expected OCR provider error")
+		}
+	})
+}
+
+func TestDescribeImageWithLLM(t *testing.T) {
+	pipeline := NewMediaUnderstandingPipeline(DefaultMediaUnderstandingConfig())
+
+	if _, err := pipeline.DescribeImageWithLLM(context.Background(), []byte("image"), "image/png", nil, ""); err == nil {
+		t.Fatal("expected missing LLM client error")
+	}
+
+	client := &testModelClient{
+		chatFunc: func(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition) (*llm.Response, error) {
+			if len(messages) != 1 {
+				t.Fatalf("expected one message, got %d", len(messages))
+			}
+			return &llm.Response{Content: "a detailed image"}, nil
+		},
+	}
+
+	description, err := pipeline.DescribeImageWithLLM(context.Background(), []byte("image"), "image/png", client, "")
+	if err != nil {
+		t.Fatalf("DescribeImageWithLLM: %v", err)
+	}
+	if description != "a detailed image" {
+		t.Fatalf("expected description, got %q", description)
+	}
+
+	errorClient := &testModelClient{
+		chatFunc: func(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition) (*llm.Response, error) {
+			return nil, errors.New("chat failed")
+		},
+	}
+	if _, err := pipeline.DescribeImageWithLLM(context.Background(), []byte("image"), "image/png", errorClient, "prompt"); err == nil {
+		t.Fatal("expected chat error")
+	}
+}
+
+func TestAnalyzeMediaRoutesSupportedTypes(t *testing.T) {
+	provider := &testVisionProvider{
+		analyzeImageFunc: func(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+			return &AnalysisResult{Description: "image"}, nil
+		},
+	}
+	pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+		VisionProvider: provider,
+		MaxImageSize:   100,
+		Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+	})
+
+	result, err := AnalyzeMedia(context.Background(), pipeline, []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("AnalyzeMedia image: %v", err)
+	}
+	if result.Type != "image" {
+		t.Fatalf("expected image result, got %q", result.Type)
+	}
+
+	pipeline.cfg.KeyFrameExtractor = NewKeyFrameExtractor()
+	pipeline.cfg.KeyFrameExtractor.SetFFmpegPath("definitely-missing-ffmpeg-binary")
+	if _, err := AnalyzeMedia(context.Background(), pipeline, []byte("video"), "video/mp4"); err == nil {
+		t.Fatal("expected video analysis error")
+	}
+
+	pipeline.cfg.AudioAnalyzer = NewAudioAnalyzer()
+	pipeline.cfg.AudioAnalyzer.SetFFmpegPath("definitely-missing-ffmpeg-binary")
+	if _, err := AnalyzeMedia(context.Background(), pipeline, []byte("audio"), "audio/mpeg"); err == nil {
+		t.Fatal("expected audio analysis error")
+	}
+}
+
+func TestUnderstandVideoAndAudioWithCommandOutput(t *testing.T) {
+	withFakeVisionCommands(t)
+
+	provider := &testVisionProvider{
+		analyzeImageFunc: func(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+			return &AnalysisResult{Description: "scene frame"}, nil
+		},
+	}
+
+	keyFrames := NewKeyFrameExtractor()
+	keyFrames.SetFFmpegPath("fake-ffmpeg")
+	keyFrames.SetFFprobePath("fake-ffprobe")
+	keyFrames.SetMaxKeyFrames(1)
+
+	audio := NewAudioAnalyzer()
+	audio.SetFFmpegPath("fake-ffmpeg")
+	audio.SetFFprobePath("fake-ffprobe")
+
+	pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+		VisionProvider:    provider,
+		KeyFrameExtractor: keyFrames,
+		AudioAnalyzer:     audio,
+		Timeout:           DefaultMediaUnderstandingConfig().Timeout,
+	})
+
+	videoResult, err := pipeline.UnderstandVideo(context.Background(), []byte("video"))
+	if err != nil {
+		t.Fatalf("UnderstandVideo: %v", err)
+	}
+	if videoResult.Type != "video" {
+		t.Fatalf("expected video result, got %q", videoResult.Type)
+	}
+	if !strings.Contains(videoResult.Summary, "scene frame") {
+		t.Fatalf("expected scene summary, got %q", videoResult.Summary)
+	}
+
+	audioResult, err := pipeline.UnderstandAudio(context.Background(), []byte("audio"))
+	if err != nil {
+		t.Fatalf("UnderstandAudio: %v", err)
+	}
+	if audioResult.Type != "audio" {
+		t.Fatalf("expected audio result, got %q", audioResult.Type)
+	}
+	if audioResult.Metadata["duration"] != 12.5 {
+		t.Fatalf("expected audio duration metadata, got %#v", audioResult.Metadata["duration"])
+	}
+}
+
+func TestAnalysisResultToJSON(t *testing.T) {
+	result := &MediaUnderstandingResult{
+		Type:        "image",
+		Description: "desc",
+	}
+	encoded := AnalysisResultToJSON(result)
+	if !strings.Contains(encoded, `"description": "desc"`) {
+		t.Fatalf("expected JSON description, got %s", encoded)
 	}
 }
 

--- a/pkg/vision/helpers_test.go
+++ b/pkg/vision/helpers_test.go
@@ -1,0 +1,155 @@
+package vision
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestImageDataURLRoundTrip(t *testing.T) {
+	data := []byte("image-bytes")
+	mimeType := "image/png"
+
+	dataURL := ImageToDataURL(data, mimeType)
+	if !strings.HasPrefix(dataURL, "data:image/png;base64,") {
+		t.Fatalf("unexpected data URL prefix: %s", dataURL)
+	}
+
+	decoded, gotMimeType, err := ImageFromDataURL(dataURL)
+	if err != nil {
+		t.Fatalf("ImageFromDataURL: %v", err)
+	}
+	if gotMimeType != mimeType {
+		t.Fatalf("expected mime type %s, got %s", mimeType, gotMimeType)
+	}
+	if string(decoded) != string(data) {
+		t.Fatalf("expected decoded data %q, got %q", string(data), string(decoded))
+	}
+}
+
+func TestImageFromDataURLRejectsInvalidInput(t *testing.T) {
+	if _, _, err := ImageFromDataURL("not-a-data-url"); err == nil {
+		t.Fatal("expected non-data URL to fail")
+	}
+	if _, _, err := ImageFromDataURL("data:image/png;base64"); err == nil {
+		t.Fatal("expected malformed data URL to fail")
+	}
+}
+
+func TestDetectMediaType(t *testing.T) {
+	cases := []struct {
+		mimeType string
+		want     string
+	}{
+		{mimeType: "image/jpeg", want: "image"},
+		{mimeType: "video/mp4", want: "video"},
+		{mimeType: "audio/mpeg", want: "audio"},
+		{mimeType: "application/json", want: ""},
+	}
+
+	for _, tc := range cases {
+		if got := detectMediaType(tc.mimeType); got != tc.want {
+			t.Fatalf("detectMediaType(%q) = %q, want %q", tc.mimeType, got, tc.want)
+		}
+	}
+}
+
+func TestAnalyzeMediaRejectsUnsupportedType(t *testing.T) {
+	pipeline := NewMediaUnderstandingPipeline(DefaultMediaUnderstandingConfig())
+	if _, err := AnalyzeMedia(context.Background(), pipeline, []byte("x"), "application/json"); err == nil {
+		t.Fatal("expected unsupported media type error")
+	}
+}
+
+func TestMimeTypeFromPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{path: "photo.jpg", want: "image/jpeg"},
+		{path: "photo.JPEG", want: "image/jpeg"},
+		{path: "photo.png", want: "image/png"},
+		{path: "photo.gif", want: "image/gif"},
+		{path: "photo.webp", want: "image/webp"},
+		{path: "photo.bmp", want: "image/bmp"},
+		{path: "photo.txt", want: ""},
+	}
+
+	for _, tc := range cases {
+		if got := mimeTypeFromPath(tc.path); got != tc.want {
+			t.Fatalf("mimeTypeFromPath(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestLikelihoodToFloat(t *testing.T) {
+	cases := []struct {
+		input string
+		want  float64
+	}{
+		{input: "VERY_UNLIKELY", want: 0.1},
+		{input: "UNLIKELY", want: 0.3},
+		{input: "POSSIBLE", want: 0.5},
+		{input: "LIKELY", want: 0.7},
+		{input: "VERY_LIKELY", want: 0.9},
+		{input: "UNKNOWN", want: 0},
+	}
+
+	for _, tc := range cases {
+		if got := likelihoodToFloat(tc.input); got != tc.want {
+			t.Fatalf("likelihoodToFloat(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestParseFPS(t *testing.T) {
+	if got := parseFPS("30000/1001"); got < 29.9 || got > 30.0 {
+		t.Fatalf("expected NTSC-ish fps, got %v", got)
+	}
+	if got := parseFPS("24"); got != 24 {
+		t.Fatalf("expected 24 fps, got %v", got)
+	}
+	if got := parseFPS("invalid"); got != 0 {
+		t.Fatalf("expected invalid input to parse as 0, got %v", got)
+	}
+}
+
+func TestAudioAnalyzerHelpers(t *testing.T) {
+	analyzer := NewAudioAnalyzer()
+
+	if got := analyzer.calcSilenceRatio([]SilenceSegment{{Duration: 2}, {Duration: 3}}, 10); got != 0.5 {
+		t.Fatalf("expected silence ratio 0.5, got %v", got)
+	}
+	if got := analyzer.calcSilenceRatio(nil, 0); got != 0 {
+		t.Fatalf("expected zero silence ratio for zero duration, got %v", got)
+	}
+
+	if got := analyzer.calcEnergyVariance([]float64{1, 2, 3}); got <= 0 {
+		t.Fatalf("expected positive variance, got %v", got)
+	}
+	if got := analyzer.calcEnergyVariance([]float64{1}); got != 0 {
+		t.Fatalf("expected zero variance for one sample, got %v", got)
+	}
+}
+
+func TestJSONUnmarshal(t *testing.T) {
+	var payload struct {
+		Name string `json:"name"`
+	}
+	if err := jsonUnmarshal([]byte(`{"name":"vision"}`), &payload); err != nil {
+		t.Fatalf("jsonUnmarshal: %v", err)
+	}
+	if payload.Name != "vision" {
+		t.Fatalf("expected parsed name, got %q", payload.Name)
+	}
+
+	if err := jsonUnmarshal([]byte(`{invalid}`), &payload); err == nil {
+		t.Fatal("expected invalid JSON to fail")
+	}
+
+	encoded, err := json.Marshal(payload)
+	if err != nil || len(encoded) == 0 {
+		t.Fatalf("expected payload to remain JSON-marshalable, err=%v", err)
+	}
+}

--- a/pkg/vision/helpers_test.go
+++ b/pkg/vision/helpers_test.go
@@ -3,9 +3,43 @@ package vision
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 )
+
+type testVisionProvider struct {
+	analyzeImageFunc func(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error)
+	analyzeImageHit  bool
+}
+
+func (p *testVisionProvider) Name() string {
+	return "test"
+}
+
+func (p *testVisionProvider) AnalyzeImage(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+	p.analyzeImageHit = true
+	if p.analyzeImageFunc != nil {
+		return p.analyzeImageFunc(ctx, imageData, mimeType)
+	}
+	return &AnalysisResult{}, nil
+}
+
+func (p *testVisionProvider) AnalyzeImageURL(ctx context.Context, imageURL string) (*AnalysisResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *testVisionProvider) OCR(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *testVisionProvider) LabelImage(ctx context.Context, imageData []byte, mimeType string) ([]Label, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *testVisionProvider) DetectObjects(ctx context.Context, imageData []byte, mimeType string) ([]DetectedObject, error) {
+	return nil, errors.New("not implemented")
+}
 
 func TestImageDataURLRoundTrip(t *testing.T) {
 	data := []byte("image-bytes")
@@ -59,6 +93,56 @@ func TestAnalyzeMediaRejectsUnsupportedType(t *testing.T) {
 	pipeline := NewMediaUnderstandingPipeline(DefaultMediaUnderstandingConfig())
 	if _, err := AnalyzeMedia(context.Background(), pipeline, []byte("x"), "application/json"); err == nil {
 		t.Fatal("expected unsupported media type error")
+	}
+}
+
+func TestUnderstandImageRejectsOversizedEncodedImage(t *testing.T) {
+	provider := &testVisionProvider{}
+	pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+		VisionProvider: provider,
+		MaxImageSize:   4,
+		Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+	})
+
+	_, err := pipeline.UnderstandImage(context.Background(), []byte("12345"), "image/png")
+	if err == nil {
+		t.Fatal("expected oversized image to fail")
+	}
+	if !strings.Contains(err.Error(), "image too large") {
+		t.Fatalf("expected image size error, got %v", err)
+	}
+	if provider.analyzeImageHit {
+		t.Fatal("expected provider not to be called for oversized image")
+	}
+}
+
+func TestUnderstandImageCallsProviderForValidSizedImage(t *testing.T) {
+	provider := &testVisionProvider{
+		analyzeImageFunc: func(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+			return &AnalysisResult{
+				Description: "a cat",
+				Labels:      []Label{{Name: "cat"}, {Name: "pet"}},
+			}, nil
+		},
+	}
+	pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+		VisionProvider: provider,
+		MaxImageSize:   16,
+		Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+	})
+
+	result, err := pipeline.UnderstandImage(context.Background(), []byte("12345"), "image/png")
+	if err != nil {
+		t.Fatalf("UnderstandImage: %v", err)
+	}
+	if !provider.analyzeImageHit {
+		t.Fatal("expected provider to be called")
+	}
+	if result.Description != "a cat" {
+		t.Fatalf("expected description %q, got %q", "a cat", result.Description)
+	}
+	if result.Summary != "cat, pet" {
+		t.Fatalf("expected summary %q, got %q", "cat, pet", result.Summary)
 	}
 }
 

--- a/pkg/vision/pipeline.go
+++ b/pkg/vision/pipeline.go
@@ -1,0 +1,329 @@
+package vision
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+)
+
+type MediaUnderstandingConfig struct {
+	VisionProvider    VisionProvider
+	AudioAnalyzer     *AudioAnalyzer
+	KeyFrameExtractor *KeyFrameExtractor
+	MaxImageSize      int
+	MaxVideoDuration  float64
+	Timeout           time.Duration
+}
+
+func DefaultMediaUnderstandingConfig() MediaUnderstandingConfig {
+	return MediaUnderstandingConfig{
+		MaxImageSize:     10 * 1024 * 1024,
+		MaxVideoDuration: 300,
+		Timeout:          60 * time.Second,
+	}
+}
+
+type MediaUnderstandingResult struct {
+	Type        string         `json:"type"`
+	Description string         `json:"description"`
+	Summary     string         `json:"summary"`
+	Details     any            `json:"details"`
+	Metadata    map[string]any `json:"metadata"`
+}
+
+type MediaUnderstandingPipeline struct {
+	cfg MediaUnderstandingConfig
+}
+
+func NewMediaUnderstandingPipeline(cfg MediaUnderstandingConfig) *MediaUnderstandingPipeline {
+	return &MediaUnderstandingPipeline{cfg: cfg}
+}
+
+func (p *MediaUnderstandingPipeline) UnderstandImage(ctx context.Context, imageData []byte, mimeType string) (*MediaUnderstandingResult, error) {
+	if len(imageData) > p.cfg.MaxImageSize {
+		imageData = imageData[:p.cfg.MaxImageSize]
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
+	defer cancel()
+
+	result := &MediaUnderstandingResult{
+		Type:     "image",
+		Metadata: map[string]any{},
+	}
+
+	if p.cfg.VisionProvider != nil {
+		analysis, err := p.cfg.VisionProvider.AnalyzeImage(ctx, imageData, mimeType)
+		if err != nil {
+			return nil, fmt.Errorf("vision analysis: %w", err)
+		}
+
+		result.Description = analysis.Description
+		result.Details = analysis
+		result.Metadata["labels"] = len(analysis.Labels)
+		result.Metadata["objects"] = len(analysis.Objects)
+		result.Metadata["text_regions"] = len(analysis.Text)
+		result.Metadata["faces"] = len(analysis.Faces)
+
+		if len(analysis.Labels) > 0 {
+			labels := make([]string, 0, len(analysis.Labels))
+			for _, l := range analysis.Labels {
+				labels = append(labels, l.Name)
+			}
+			result.Summary = strings.Join(labels, ", ")
+		}
+	} else {
+		result.Description = "No vision provider configured"
+	}
+
+	return result, nil
+}
+
+func (p *MediaUnderstandingPipeline) UnderstandImageFile(ctx context.Context, path string) (*MediaUnderstandingResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read image file: %w", err)
+	}
+
+	mimeType := mimeTypeFromPath(path)
+	if mimeType == "" {
+		mimeType = "image/jpeg"
+	}
+
+	return p.UnderstandImage(ctx, data, mimeType)
+}
+
+func (p *MediaUnderstandingPipeline) UnderstandImageURL(ctx context.Context, imageURL string) (*MediaUnderstandingResult, error) {
+	if p.cfg.VisionProvider == nil {
+		return nil, fmt.Errorf("no vision provider configured")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
+	defer cancel()
+
+	analysis, err := p.cfg.VisionProvider.AnalyzeImageURL(ctx, imageURL)
+	if err != nil {
+		return nil, fmt.Errorf("vision analysis from URL: %w", err)
+	}
+
+	result := &MediaUnderstandingResult{
+		Type:        "image",
+		Description: analysis.Description,
+		Details:     analysis,
+		Metadata:    map[string]any{},
+	}
+
+	if len(analysis.Labels) > 0 {
+		labels := make([]string, 0, len(analysis.Labels))
+		for _, l := range analysis.Labels {
+			labels = append(labels, l.Name)
+		}
+		result.Summary = strings.Join(labels, ", ")
+	}
+
+	return result, nil
+}
+
+func (p *MediaUnderstandingPipeline) UnderstandVideo(ctx context.Context, videoData []byte) (*MediaUnderstandingResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
+	defer cancel()
+
+	result := &MediaUnderstandingResult{
+		Type:     "video",
+		Metadata: map[string]any{},
+	}
+
+	if p.cfg.KeyFrameExtractor == nil {
+		p.cfg.KeyFrameExtractor = NewKeyFrameExtractor()
+	}
+
+	videoAnalysis, err := p.cfg.KeyFrameExtractor.ExtractKeyFrames(ctx, videoData)
+	if err != nil {
+		return nil, fmt.Errorf("keyframe extraction: %w", err)
+	}
+
+	result.Details = videoAnalysis
+	result.Metadata["duration"] = videoAnalysis.Duration
+	result.Metadata["scenes"] = len(videoAnalysis.Scenes)
+	result.Metadata["key_frames"] = len(videoAnalysis.KeyFrames)
+	result.Metadata["resolution"] = fmt.Sprintf("%dx%d", videoAnalysis.Width, videoAnalysis.Height)
+	result.Metadata["codec"] = videoAnalysis.Codec
+
+	if len(videoAnalysis.Scenes) > 0 && p.cfg.VisionProvider != nil {
+		var sceneDescriptions []string
+		for i, scene := range videoAnalysis.Scenes {
+			if i >= 5 {
+				break
+			}
+			if len(scene.KeyFrames) > 0 {
+				kf := scene.KeyFrames[0]
+				if len(kf.FrameData) > 0 {
+					frameAnalysis, err := p.cfg.VisionProvider.AnalyzeImage(ctx, kf.FrameData, "image/jpeg")
+					if err == nil {
+						sceneDescriptions = append(sceneDescriptions, fmt.Sprintf("Scene %d (%.1fs): %s", i, scene.Start, frameAnalysis.Description))
+					}
+				}
+			}
+		}
+		if len(sceneDescriptions) > 0 {
+			result.Summary = strings.Join(sceneDescriptions, " | ")
+		}
+	}
+
+	return result, nil
+}
+
+func (p *MediaUnderstandingPipeline) UnderstandAudio(ctx context.Context, audioData []byte) (*MediaUnderstandingResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
+	defer cancel()
+
+	result := &MediaUnderstandingResult{
+		Type:     "audio",
+		Metadata: map[string]any{},
+	}
+
+	if p.cfg.AudioAnalyzer == nil {
+		p.cfg.AudioAnalyzer = NewAudioAnalyzer()
+	}
+
+	audioAnalysis, err := p.cfg.AudioAnalyzer.Analyze(ctx, audioData)
+	if err != nil {
+		return nil, fmt.Errorf("audio analysis: %w", err)
+	}
+
+	result.Details = audioAnalysis
+	result.Metadata["duration"] = audioAnalysis.Duration
+	result.Metadata["codec"] = audioAnalysis.Codec
+	result.Metadata["sample_rate"] = audioAnalysis.SampleRate
+	result.Metadata["channels"] = audioAnalysis.Channels
+	result.Metadata["is_speech"] = audioAnalysis.IsSpeech
+	result.Metadata["is_music"] = audioAnalysis.IsMusic
+	result.Metadata["speech_confidence"] = audioAnalysis.SpeechConfidence
+	result.Metadata["music_confidence"] = audioAnalysis.MusicConfidence
+	result.Metadata["silence_ratio"] = audioAnalysis.Metadata["silence_ratio"]
+
+	if audioAnalysis.IsSpeech {
+		result.Summary = fmt.Sprintf("Speech audio (%.0f%% confidence)", audioAnalysis.SpeechConfidence*100)
+	} else if audioAnalysis.IsMusic {
+		result.Summary = fmt.Sprintf("Music audio (%.0f%% confidence)", audioAnalysis.MusicConfidence*100)
+	} else {
+		result.Summary = "Unknown audio type"
+	}
+
+	return result, nil
+}
+
+func (p *MediaUnderstandingPipeline) OCRImage(ctx context.Context, imageData []byte, mimeType string) (string, error) {
+	if p.cfg.VisionProvider == nil {
+		return "", fmt.Errorf("no vision provider configured")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
+	defer cancel()
+
+	texts, err := p.cfg.VisionProvider.OCR(ctx, imageData, mimeType)
+	if err != nil {
+		return "", err
+	}
+
+	var parts []string
+	for _, t := range texts {
+		parts = append(parts, t.Text)
+	}
+
+	return strings.Join(parts, "\n"), nil
+}
+
+func (p *MediaUnderstandingPipeline) DescribeImageWithLLM(ctx context.Context, imageData []byte, mimeType string, client llm.Client, prompt string) (string, error) {
+	if client == nil {
+		return "", fmt.Errorf("no LLM client provided")
+	}
+
+	if prompt == "" {
+		prompt = "Describe this image in detail. Include objects, text, people, actions, colors, and overall scene."
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
+	defer cancel()
+
+	msg := llm.NewUserMessage(
+		llm.TextBlock(prompt),
+		llm.ImageBlockFromBase64(imageData, mimeType),
+	)
+
+	resp, err := client.Chat(ctx, []llm.Message{msg}, nil)
+	if err != nil {
+		return "", fmt.Errorf("LLM vision analysis: %w", err)
+	}
+
+	return resp.Content, nil
+}
+
+func ImageToDataURL(imageData []byte, mimeType string) string {
+	return fmt.Sprintf("data:%s;base64,%s", mimeType, base64.StdEncoding.EncodeToString(imageData))
+}
+
+func ImageFromDataURL(dataURL string) ([]byte, string, error) {
+	if !strings.HasPrefix(dataURL, "data:") {
+		return nil, "", fmt.Errorf("not a data URL")
+	}
+
+	commaIdx := strings.Index(dataURL, ",")
+	if commaIdx == -1 {
+		return nil, "", fmt.Errorf("invalid data URL format")
+	}
+
+	header := dataURL[5:commaIdx]
+	data := dataURL[commaIdx+1:]
+
+	mimeType := ""
+	if idx := strings.Index(header, ";"); idx != -1 {
+		mimeType = header[:idx]
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return nil, "", fmt.Errorf("decode base64: %w", err)
+	}
+
+	return decoded, mimeType, nil
+}
+
+func AnalyzeMedia(ctx context.Context, pipeline *MediaUnderstandingPipeline, data []byte, mimeType string) (*MediaUnderstandingResult, error) {
+	mediaType := detectMediaType(mimeType)
+
+	switch mediaType {
+	case "image":
+		return pipeline.UnderstandImage(ctx, data, mimeType)
+	case "video":
+		return pipeline.UnderstandVideo(ctx, data)
+	case "audio":
+		return pipeline.UnderstandAudio(ctx, data)
+	default:
+		return nil, fmt.Errorf("unsupported media type: %s", mimeType)
+	}
+}
+
+func detectMediaType(mimeType string) string {
+	switch {
+	case strings.HasPrefix(mimeType, "image/"):
+		return "image"
+	case strings.HasPrefix(mimeType, "video/"):
+		return "video"
+	case strings.HasPrefix(mimeType, "audio/"):
+		return "audio"
+	default:
+		return ""
+	}
+}
+
+func AnalysisResultToJSON(result *MediaUnderstandingResult) string {
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return string(data)
+}

--- a/pkg/vision/pipeline.go
+++ b/pkg/vision/pipeline.go
@@ -46,8 +46,8 @@ func NewMediaUnderstandingPipeline(cfg MediaUnderstandingConfig) *MediaUnderstan
 }
 
 func (p *MediaUnderstandingPipeline) UnderstandImage(ctx context.Context, imageData []byte, mimeType string) (*MediaUnderstandingResult, error) {
-	if len(imageData) > p.cfg.MaxImageSize {
-		imageData = imageData[:p.cfg.MaxImageSize]
+	if p.cfg.MaxImageSize > 0 && len(imageData) > p.cfg.MaxImageSize {
+		return nil, fmt.Errorf("image too large: %d bytes exceeds max %d", len(imageData), p.cfg.MaxImageSize)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)

--- a/pkg/vision/video_audio.go
+++ b/pkg/vision/video_audio.go
@@ -149,6 +149,10 @@ func (e *KeyFrameExtractor) ExtractFrameAt(ctx context.Context, videoData []byte
 }
 
 func (e *KeyFrameExtractor) ExtractFramesAtIntervals(ctx context.Context, videoData []byte, intervalSeconds float64) ([][]byte, error) {
+	if err := validateFrameIntervalSeconds(intervalSeconds); err != nil {
+		return nil, err
+	}
+
 	if !e.isFFmpegAvailable(ctx) {
 		return nil, fmt.Errorf("ffmpeg not available")
 	}
@@ -363,6 +367,13 @@ func appendKeyFrameToScene(scenes []SceneInfo, sceneIndex int, keyFrame KeyFrame
 		return
 	}
 	scenes[sceneIndex].KeyFrames = append(scenes[sceneIndex].KeyFrames, keyFrame)
+}
+
+func validateFrameIntervalSeconds(intervalSeconds float64) error {
+	if intervalSeconds <= 0 {
+		return fmt.Errorf("intervalSeconds must be > 0")
+	}
+	return nil
 }
 
 type AudioAnalysisResult struct {

--- a/pkg/vision/video_audio.go
+++ b/pkg/vision/video_audio.go
@@ -46,6 +46,8 @@ type KeyFrameExtractor struct {
 	maxKeyFrames   int
 }
 
+var execCommandContext = exec.CommandContext
+
 func NewKeyFrameExtractor() *KeyFrameExtractor {
 	return &KeyFrameExtractor{
 		ffmpegPath:     "ffmpeg",
@@ -189,7 +191,7 @@ func (e *KeyFrameExtractor) detectScenes(ctx context.Context, input string, dura
 		"-",
 	}
 
-	cmd := exec.CommandContext(ctx, e.ffmpegPath, args...)
+	cmd := execCommandContext(ctx, e.ffmpegPath, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("scene detection: %w", err)
@@ -254,7 +256,7 @@ func (e *KeyFrameExtractor) extractFrameAt(ctx context.Context, input string, ti
 		"-",
 	}
 
-	cmd := exec.CommandContext(ctx, e.ffmpegPath, args...)
+	cmd := execCommandContext(ctx, e.ffmpegPath, args...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = nil
@@ -279,7 +281,7 @@ func (e *KeyFrameExtractor) probeVideo(ctx context.Context, input string) (*Vide
 		input,
 	}
 
-	cmd := exec.CommandContext(ctx, e.ffprobePath, args...)
+	cmd := execCommandContext(ctx, e.ffprobePath, args...)
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("ffprobe: %w", err)
@@ -327,7 +329,7 @@ func (e *KeyFrameExtractor) probeVideo(ctx context.Context, input string) (*Vide
 }
 
 func (e *KeyFrameExtractor) isFFmpegAvailable(ctx context.Context) bool {
-	cmd := exec.CommandContext(ctx, e.ffmpegPath, "-version")
+	cmd := execCommandContext(ctx, e.ffmpegPath, "-version")
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Run() == nil
@@ -485,7 +487,7 @@ func (a *AudioAnalyzer) extractEnergyProfile(ctx context.Context, input string) 
 		"-",
 	}
 
-	cmd := exec.CommandContext(ctx, a.ffmpegPath, args...)
+	cmd := execCommandContext(ctx, a.ffmpegPath, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("energy extraction: %w", err)
@@ -513,7 +515,7 @@ func (a *AudioAnalyzer) detectSilence(ctx context.Context, input string) ([]Sile
 		"-",
 	}
 
-	cmd := exec.CommandContext(ctx, a.ffmpegPath, args...)
+	cmd := execCommandContext(ctx, a.ffmpegPath, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("silence detection: %w", err)
@@ -554,7 +556,7 @@ func (a *AudioAnalyzer) detectSpeech(ctx context.Context, input string) (float64
 		"-",
 	}
 
-	cmd := exec.CommandContext(ctx, a.ffmpegPath, args...)
+	cmd := execCommandContext(ctx, a.ffmpegPath, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return 0, fmt.Errorf("speech detection: %w", err)
@@ -595,7 +597,7 @@ func (a *AudioAnalyzer) detectMusic(ctx context.Context, input string, energyPro
 		"-",
 	}
 
-	cmd := exec.CommandContext(ctx, a.ffmpegPath, args...)
+	cmd := execCommandContext(ctx, a.ffmpegPath, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return 0, fmt.Errorf("music detection: %w", err)
@@ -637,7 +639,7 @@ func (a *AudioAnalyzer) probeAudio(ctx context.Context, input string) (*AudioAna
 		input,
 	}
 
-	cmd := exec.CommandContext(ctx, a.ffprobePath, args...)
+	cmd := execCommandContext(ctx, a.ffprobePath, args...)
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("ffprobe: %w", err)
@@ -689,7 +691,7 @@ func (a *AudioAnalyzer) probeAudio(ctx context.Context, input string) (*AudioAna
 }
 
 func (a *AudioAnalyzer) isFFmpegAvailable(ctx context.Context) bool {
-	cmd := exec.CommandContext(ctx, a.ffmpegPath, "-version")
+	cmd := execCommandContext(ctx, a.ffmpegPath, "-version")
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Run() == nil

--- a/pkg/vision/video_audio.go
+++ b/pkg/vision/video_audio.go
@@ -1,0 +1,730 @@
+package vision
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type KeyFrame struct {
+	Timestamp float64 `json:"timestamp"`
+	FrameData []byte  `json:"-"`
+	Index     int     `json:"index"`
+	SceneID   int     `json:"scene_id"`
+}
+
+type SceneInfo struct {
+	ID        int        `json:"id"`
+	Start     float64    `json:"start"`
+	End       float64    `json:"end"`
+	Duration  float64    `json:"duration"`
+	KeyFrames []KeyFrame `json:"key_frames"`
+}
+
+type VideoAnalysisResult struct {
+	Duration    float64        `json:"duration"`
+	Width       int            `json:"width"`
+	Height      int            `json:"height"`
+	FPS         float64        `json:"fps"`
+	Codec       string         `json:"codec"`
+	Scenes      []SceneInfo    `json:"scenes"`
+	KeyFrames   []KeyFrame     `json:"key_frames"`
+	TotalFrames int            `json:"total_frames"`
+	Metadata    map[string]any `json:"metadata"`
+}
+
+type KeyFrameExtractor struct {
+	ffmpegPath     string
+	ffprobePath    string
+	sceneThreshold float64
+	maxKeyFrames   int
+}
+
+func NewKeyFrameExtractor() *KeyFrameExtractor {
+	return &KeyFrameExtractor{
+		ffmpegPath:     "ffmpeg",
+		ffprobePath:    "ffprobe",
+		sceneThreshold: 30.0,
+		maxKeyFrames:   20,
+	}
+}
+
+func (e *KeyFrameExtractor) SetFFmpegPath(path string) {
+	e.ffmpegPath = path
+}
+
+func (e *KeyFrameExtractor) SetFFprobePath(path string) {
+	e.ffprobePath = path
+}
+
+func (e *KeyFrameExtractor) SetSceneThreshold(threshold float64) {
+	e.sceneThreshold = threshold
+}
+
+func (e *KeyFrameExtractor) SetMaxKeyFrames(n int) {
+	e.maxKeyFrames = n
+}
+
+func (e *KeyFrameExtractor) ExtractKeyFrames(ctx context.Context, videoData []byte) (*VideoAnalysisResult, error) {
+	if !e.isFFmpegAvailable(ctx) {
+		return nil, fmt.Errorf("ffmpeg not available")
+	}
+
+	tmpIn, err := e.writeTempFile(videoData, "video")
+	if err != nil {
+		return nil, fmt.Errorf("create temp input: %w", err)
+	}
+	defer os.Remove(tmpIn)
+
+	meta, err := e.probeVideo(ctx, tmpIn)
+	if err != nil {
+		return nil, fmt.Errorf("probe video: %w", err)
+	}
+
+	scenes, err := e.detectScenes(ctx, tmpIn, meta.Duration)
+	if err != nil {
+		scenes = []SceneInfo{
+			{ID: 0, Start: 0, End: meta.Duration, Duration: meta.Duration},
+		}
+	}
+
+	keyFrames := make([]KeyFrame, 0)
+	for _, scene := range scenes {
+		midTime := scene.Start + scene.Duration/2
+		frameData, err := e.extractFrameAt(ctx, tmpIn, midTime)
+		if err != nil {
+			continue
+		}
+
+		kf := KeyFrame{
+			Timestamp: midTime,
+			FrameData: frameData,
+			Index:     len(keyFrames),
+			SceneID:   scene.ID,
+		}
+		keyFrames = append(keyFrames, kf)
+		scene.KeyFrames = append(scene.KeyFrames, kf)
+
+		if len(keyFrames) >= e.maxKeyFrames {
+			break
+		}
+	}
+
+	if len(keyFrames) == 0 {
+		frameData, err := e.extractFrameAt(ctx, tmpIn, 1.0)
+		if err == nil {
+			keyFrames = append(keyFrames, KeyFrame{
+				Timestamp: 1.0,
+				FrameData: frameData,
+				Index:     0,
+				SceneID:   0,
+			})
+		}
+	}
+
+	meta.KeyFrames = keyFrames
+	meta.Scenes = scenes
+	return meta, nil
+}
+
+func (e *KeyFrameExtractor) ExtractFrameAt(ctx context.Context, videoData []byte, timestamp float64) ([]byte, error) {
+	if !e.isFFmpegAvailable(ctx) {
+		return nil, fmt.Errorf("ffmpeg not available")
+	}
+
+	tmpIn, err := e.writeTempFile(videoData, "video")
+	if err != nil {
+		return nil, fmt.Errorf("create temp input: %w", err)
+	}
+	defer os.Remove(tmpIn)
+
+	return e.extractFrameAt(ctx, tmpIn, timestamp)
+}
+
+func (e *KeyFrameExtractor) ExtractFramesAtIntervals(ctx context.Context, videoData []byte, intervalSeconds float64) ([][]byte, error) {
+	if !e.isFFmpegAvailable(ctx) {
+		return nil, fmt.Errorf("ffmpeg not available")
+	}
+
+	tmpIn, err := e.writeTempFile(videoData, "video")
+	if err != nil {
+		return nil, fmt.Errorf("create temp input: %w", err)
+	}
+	defer os.Remove(tmpIn)
+
+	meta, err := e.probeVideo(ctx, tmpIn)
+	if err != nil {
+		return nil, fmt.Errorf("probe video: %w", err)
+	}
+
+	var frames [][]byte
+	for t := 0.0; t < meta.Duration; t += intervalSeconds {
+		frameData, err := e.extractFrameAt(ctx, tmpIn, t)
+		if err != nil {
+			continue
+		}
+		frames = append(frames, frameData)
+	}
+
+	return frames, nil
+}
+
+func (e *KeyFrameExtractor) detectScenes(ctx context.Context, input string, duration float64) ([]SceneInfo, error) {
+	args := []string{
+		"-i", input,
+		"-vf", fmt.Sprintf("select='gt(scene,%f)',showinfo", e.sceneThreshold/100.0),
+		"-vsync", "vfr",
+		"-f", "null",
+		"-",
+	}
+
+	cmd := exec.CommandContext(ctx, e.ffmpegPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("scene detection: %w", err)
+	}
+
+	var sceneChanges []float64
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "pts_time:") {
+			parts := strings.Split(line, "pts_time:")
+			if len(parts) >= 2 {
+				var t float64
+				fmt.Sscanf(strings.TrimSpace(parts[1]), "%f", &t)
+				if t > 0 {
+					sceneChanges = append(sceneChanges, t)
+				}
+			}
+		}
+	}
+
+	if len(sceneChanges) == 0 {
+		return nil, fmt.Errorf("no scene changes detected")
+	}
+
+	sort.Float64s(sceneChanges)
+
+	scenes := make([]SceneInfo, 0, len(sceneChanges)+1)
+	sceneID := 0
+	prevTime := 0.0
+
+	for _, changeTime := range sceneChanges {
+		scenes = append(scenes, SceneInfo{
+			ID:       sceneID,
+			Start:    prevTime,
+			End:      changeTime,
+			Duration: changeTime - prevTime,
+		})
+		prevTime = changeTime
+		sceneID++
+	}
+
+	if prevTime < duration {
+		scenes = append(scenes, SceneInfo{
+			ID:       sceneID,
+			Start:    prevTime,
+			End:      duration,
+			Duration: duration - prevTime,
+		})
+	}
+
+	return scenes, nil
+}
+
+func (e *KeyFrameExtractor) extractFrameAt(ctx context.Context, input string, timestamp float64) ([]byte, error) {
+	args := []string{
+		"-i", input,
+		"-ss", fmt.Sprintf("%.3f", timestamp),
+		"-vframes", "1",
+		"-q:v", "2",
+		"-f", "image2pipe",
+		"-vcodec", "mjpeg",
+		"-",
+	}
+
+	cmd := exec.CommandContext(ctx, e.ffmpegPath, args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = nil
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("extract frame at %.3f: %w", timestamp, err)
+	}
+
+	if out.Len() == 0 {
+		return nil, fmt.Errorf("empty frame at %.3f", timestamp)
+	}
+
+	return out.Bytes(), nil
+}
+
+func (e *KeyFrameExtractor) probeVideo(ctx context.Context, input string) (*VideoAnalysisResult, error) {
+	args := []string{
+		"-v", "quiet",
+		"-print_format", "json",
+		"-show_format",
+		"-show_streams",
+		input,
+	}
+
+	cmd := exec.CommandContext(ctx, e.ffprobePath, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ffprobe: %w", err)
+	}
+
+	var probeResult struct {
+		Streams []struct {
+			CodecType  string `json:"codec_type"`
+			CodecName  string `json:"codec_name"`
+			Width      int    `json:"width"`
+			Height     int    `json:"height"`
+			RFrameRate string `json:"r_frame_rate"`
+			Duration   string `json:"duration"`
+			NbFrames   string `json:"nb_frames"`
+		} `json:"streams"`
+		Format struct {
+			Duration string `json:"duration"`
+			Size     string `json:"size"`
+		} `json:"format"`
+	}
+
+	if err := jsonUnmarshal(output, &probeResult); err != nil {
+		return nil, fmt.Errorf("parse ffprobe output: %w", err)
+	}
+
+	result := &VideoAnalysisResult{Metadata: make(map[string]any)}
+
+	for _, stream := range probeResult.Streams {
+		if stream.CodecType == "video" {
+			result.Width = stream.Width
+			result.Height = stream.Height
+			result.Codec = stream.CodecName
+			result.FPS = parseFPS(stream.RFrameRate)
+			if stream.NbFrames != "" {
+				fmt.Sscanf(stream.NbFrames, "%d", &result.TotalFrames)
+			}
+		}
+	}
+
+	if probeResult.Format.Duration != "" {
+		fmt.Sscanf(probeResult.Format.Duration, "%f", &result.Duration)
+	}
+
+	return result, nil
+}
+
+func (e *KeyFrameExtractor) isFFmpegAvailable(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, e.ffmpegPath, "-version")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run() == nil
+}
+
+func (e *KeyFrameExtractor) writeTempFile(data []byte, prefix string) (string, error) {
+	f, err := os.CreateTemp(os.TempDir(), fmt.Sprintf("anyclaw-vision-%s-*", prefix))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+
+	return f.Name(), nil
+}
+
+func parseFPS(fpsStr string) float64 {
+	if idx := strings.Index(fpsStr, "/"); idx > 0 {
+		var num, den float64
+		fmt.Sscanf(fpsStr[:idx], "%f", &num)
+		fmt.Sscanf(fpsStr[idx+1:], "%f", &den)
+		if den > 0 {
+			return num / den
+		}
+	}
+	var fps float64
+	fmt.Sscanf(fpsStr, "%f", &fps)
+	return fps
+}
+
+type AudioAnalysisResult struct {
+	Duration         float64          `json:"duration"`
+	SampleRate       int              `json:"sample_rate"`
+	Channels         int              `json:"channels"`
+	Codec            string           `json:"codec"`
+	Bitrate          int              `json:"bitrate"`
+	IsSpeech         bool             `json:"is_speech"`
+	SpeechConfidence float64          `json:"speech_confidence"`
+	IsMusic          bool             `json:"is_music"`
+	MusicConfidence  float64          `json:"music_confidence"`
+	EnergyProfile    []float64        `json:"energy_profile"`
+	SilenceSegments  []SilenceSegment `json:"silence_segments"`
+	Metadata         map[string]any   `json:"metadata"`
+}
+
+type SilenceSegment struct {
+	Start    float64 `json:"start"`
+	End      float64 `json:"end"`
+	Duration float64 `json:"duration"`
+}
+
+type AudioAnalyzer struct {
+	ffmpegPath  string
+	ffprobePath string
+}
+
+func NewAudioAnalyzer() *AudioAnalyzer {
+	return &AudioAnalyzer{
+		ffmpegPath:  "ffmpeg",
+		ffprobePath: "ffprobe",
+	}
+}
+
+func (a *AudioAnalyzer) SetFFmpegPath(path string) {
+	a.ffmpegPath = path
+}
+
+func (a *AudioAnalyzer) SetFFprobePath(path string) {
+	a.ffprobePath = path
+}
+
+func (a *AudioAnalyzer) Analyze(ctx context.Context, audioData []byte) (*AudioAnalysisResult, error) {
+	if !a.isFFmpegAvailable(ctx) {
+		return nil, fmt.Errorf("ffmpeg not available")
+	}
+
+	tmpIn, err := a.writeTempFile(audioData, "audio")
+	if err != nil {
+		return nil, fmt.Errorf("create temp input: %w", err)
+	}
+	defer os.Remove(tmpIn)
+
+	result := &AudioAnalysisResult{Metadata: make(map[string]any)}
+
+	meta, err := a.probeAudio(ctx, tmpIn)
+	if err != nil {
+		return nil, fmt.Errorf("probe audio: %w", err)
+	}
+
+	result.Duration = meta.Duration
+	result.SampleRate = meta.SampleRate
+	result.Channels = meta.Channels
+	result.Codec = meta.Codec
+	result.Bitrate = meta.Bitrate
+
+	energyProfile, err := a.extractEnergyProfile(ctx, tmpIn)
+	if err == nil {
+		result.EnergyProfile = energyProfile
+	}
+
+	silenceSegments, err := a.detectSilence(ctx, tmpIn)
+	if err == nil {
+		result.SilenceSegments = silenceSegments
+	}
+
+	speechConfidence, err := a.detectSpeech(ctx, tmpIn)
+	if err == nil {
+		result.SpeechConfidence = speechConfidence
+		result.IsSpeech = speechConfidence > 0.5
+	}
+
+	musicConfidence, err := a.detectMusic(ctx, tmpIn, energyProfile)
+	if err == nil {
+		result.MusicConfidence = musicConfidence
+		result.IsMusic = musicConfidence > 0.5
+	}
+
+	if result.IsSpeech && result.IsMusic {
+		if result.SpeechConfidence > result.MusicConfidence {
+			result.IsMusic = false
+		} else {
+			result.IsSpeech = false
+		}
+	}
+
+	result.Metadata["silence_ratio"] = a.calcSilenceRatio(silenceSegments, result.Duration)
+	result.Metadata["energy_variance"] = a.calcEnergyVariance(energyProfile)
+
+	return result, nil
+}
+
+func (a *AudioAnalyzer) extractEnergyProfile(ctx context.Context, input string) ([]float64, error) {
+	args := []string{
+		"-i", input,
+		"-af", "astats=metadata=1:reset=1",
+		"-f", "null",
+		"-",
+	}
+
+	cmd := exec.CommandContext(ctx, a.ffmpegPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("energy extraction: %w", err)
+	}
+
+	var energies []float64
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "RMS level dB") {
+			var db float64
+			fmt.Sscanf(line, "%*[^=]= %f", &db)
+			normalized := math.Pow(10, db/20.0)
+			energies = append(energies, normalized)
+		}
+	}
+
+	return energies, nil
+}
+
+func (a *AudioAnalyzer) detectSilence(ctx context.Context, input string) ([]SilenceSegment, error) {
+	args := []string{
+		"-i", input,
+		"-af", "silencedetect=noise=-30dB:d=0.5",
+		"-f", "null",
+		"-",
+	}
+
+	cmd := exec.CommandContext(ctx, a.ffmpegPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("silence detection: %w", err)
+	}
+
+	var segments []SilenceSegment
+	lines := strings.Split(string(output), "\n")
+
+	var currentStart float64
+	inSilence := false
+
+	for _, line := range lines {
+		if strings.Contains(line, "silence_start:") {
+			var t float64
+			fmt.Sscanf(line, "%*[^:]: %f", &t)
+			currentStart = t
+			inSilence = true
+		} else if strings.Contains(line, "silence_end:") && inSilence {
+			var end, duration float64
+			fmt.Sscanf(line, "%*[^:]: %f %*[^:]: %f", &end, &duration)
+			segments = append(segments, SilenceSegment{
+				Start:    currentStart,
+				End:      end,
+				Duration: duration,
+			})
+			inSilence = false
+		}
+	}
+
+	return segments, nil
+}
+
+func (a *AudioAnalyzer) detectSpeech(ctx context.Context, input string) (float64, error) {
+	args := []string{
+		"-i", input,
+		"-af", "highpass=f=300,lowpass=f=3000,astats=metadata=1",
+		"-f", "null",
+		"-",
+	}
+
+	cmd := exec.CommandContext(ctx, a.ffmpegPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("speech detection: %w", err)
+	}
+
+	var rmsValues []float64
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "RMS level dB") {
+			var db float64
+			fmt.Sscanf(line, "%*[^=]= %f", &db)
+			rmsValues = append(rmsValues, math.Pow(10, db/20.0))
+		}
+	}
+
+	if len(rmsValues) == 0 {
+		return 0, nil
+	}
+
+	avgEnergy := 0.0
+	for _, e := range rmsValues {
+		avgEnergy += e
+	}
+	avgEnergy /= float64(len(rmsValues))
+
+	if avgEnergy > 0.01 && avgEnergy < 0.5 {
+		return math.Min(1.0, avgEnergy*5), nil
+	}
+
+	return avgEnergy * 2, nil
+}
+
+func (a *AudioAnalyzer) detectMusic(ctx context.Context, input string, energyProfile []float64) (float64, error) {
+	args := []string{
+		"-i", input,
+		"-af", "highpass=f=20,astats=metadata=1",
+		"-f", "null",
+		"-",
+	}
+
+	cmd := exec.CommandContext(ctx, a.ffmpegPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("music detection: %w", err)
+	}
+
+	var rmsValues []float64
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "RMS level dB") {
+			var db float64
+			fmt.Sscanf(line, "%*[^=]= %f", &db)
+			rmsValues = append(rmsValues, math.Pow(10, db/20.0))
+		}
+	}
+
+	if len(rmsValues) < 2 {
+		return 0, nil
+	}
+
+	avgEnergy := 0.0
+	for _, e := range rmsValues {
+		avgEnergy += e
+	}
+	avgEnergy /= float64(len(rmsValues))
+
+	if avgEnergy > 0.05 {
+		return math.Min(1.0, avgEnergy*3), nil
+	}
+
+	return avgEnergy, nil
+}
+
+func (a *AudioAnalyzer) probeAudio(ctx context.Context, input string) (*AudioAnalysisResult, error) {
+	args := []string{
+		"-v", "quiet",
+		"-print_format", "json",
+		"-show_format",
+		"-show_streams",
+		input,
+	}
+
+	cmd := exec.CommandContext(ctx, a.ffprobePath, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ffprobe: %w", err)
+	}
+
+	var probeResult struct {
+		Streams []struct {
+			CodecType  string `json:"codec_type"`
+			CodecName  string `json:"codec_name"`
+			SampleRate string `json:"sample_rate"`
+			Channels   int    `json:"channels"`
+			BitRate    string `json:"bit_rate"`
+			Duration   string `json:"duration"`
+		} `json:"streams"`
+		Format struct {
+			Duration string `json:"duration"`
+			BitRate  string `json:"bit_rate"`
+		} `json:"format"`
+	}
+
+	if err := jsonUnmarshal(output, &probeResult); err != nil {
+		return nil, fmt.Errorf("parse ffprobe output: %w", err)
+	}
+
+	result := &AudioAnalysisResult{}
+
+	for _, stream := range probeResult.Streams {
+		if stream.CodecType == "audio" {
+			result.Codec = stream.CodecName
+			result.Channels = stream.Channels
+			fmt.Sscanf(stream.SampleRate, "%d", &result.SampleRate)
+			if stream.BitRate != "" {
+				fmt.Sscanf(stream.BitRate, "%d", &result.Bitrate)
+			}
+			if stream.Duration != "" {
+				fmt.Sscanf(stream.Duration, "%f", &result.Duration)
+			}
+		}
+	}
+
+	if result.Duration <= 0 && probeResult.Format.Duration != "" {
+		fmt.Sscanf(probeResult.Format.Duration, "%f", &result.Duration)
+	}
+	if result.Bitrate <= 0 && probeResult.Format.BitRate != "" {
+		fmt.Sscanf(probeResult.Format.BitRate, "%d", &result.Bitrate)
+	}
+
+	return result, nil
+}
+
+func (a *AudioAnalyzer) isFFmpegAvailable(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, a.ffmpegPath, "-version")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run() == nil
+}
+
+func (a *AudioAnalyzer) writeTempFile(data []byte, prefix string) (string, error) {
+	f, err := os.CreateTemp(os.TempDir(), fmt.Sprintf("anyclaw-audio-%s-*", prefix))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+
+	return f.Name(), nil
+}
+
+func (a *AudioAnalyzer) calcSilenceRatio(segments []SilenceSegment, totalDuration float64) float64 {
+	if totalDuration <= 0 {
+		return 0
+	}
+
+	totalSilence := 0.0
+	for _, seg := range segments {
+		totalSilence += seg.Duration
+	}
+
+	return totalSilence / totalDuration
+}
+
+func (a *AudioAnalyzer) calcEnergyVariance(profile []float64) float64 {
+	if len(profile) < 2 {
+		return 0
+	}
+
+	mean := 0.0
+	for _, e := range profile {
+		mean += e
+	}
+	mean /= float64(len(profile))
+
+	variance := 0.0
+	for _, e := range profile {
+		diff := e - mean
+		variance += diff * diff
+	}
+	variance /= float64(len(profile))
+
+	return variance
+}
+
+func jsonUnmarshal(data []byte, v any) error {
+	return json.Unmarshal(data, v)
+}

--- a/pkg/vision/video_audio.go
+++ b/pkg/vision/video_audio.go
@@ -95,7 +95,8 @@ func (e *KeyFrameExtractor) ExtractKeyFrames(ctx context.Context, videoData []by
 	}
 
 	keyFrames := make([]KeyFrame, 0)
-	for _, scene := range scenes {
+	for i := range scenes {
+		scene := &scenes[i]
 		midTime := scene.Start + scene.Duration/2
 		frameData, err := e.extractFrameAt(ctx, tmpIn, midTime)
 		if err != nil {
@@ -109,7 +110,7 @@ func (e *KeyFrameExtractor) ExtractKeyFrames(ctx context.Context, videoData []by
 			SceneID:   scene.ID,
 		}
 		keyFrames = append(keyFrames, kf)
-		scene.KeyFrames = append(scene.KeyFrames, kf)
+		appendKeyFrameToScene(scenes, i, kf)
 
 		if len(keyFrames) >= e.maxKeyFrames {
 			break
@@ -355,6 +356,13 @@ func parseFPS(fpsStr string) float64 {
 	var fps float64
 	fmt.Sscanf(fpsStr, "%f", &fps)
 	return fps
+}
+
+func appendKeyFrameToScene(scenes []SceneInfo, sceneIndex int, keyFrame KeyFrame) {
+	if sceneIndex < 0 || sceneIndex >= len(scenes) {
+		return
+	}
+	scenes[sceneIndex].KeyFrames = append(scenes[sceneIndex].KeyFrames, keyFrame)
 }
 
 type AudioAnalysisResult struct {

--- a/pkg/vision/video_audio_test.go
+++ b/pkg/vision/video_audio_test.go
@@ -1,6 +1,10 @@
 package vision
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -59,3 +63,245 @@ func TestValidateFrameIntervalSecondsAcceptsPositiveValue(t *testing.T) {
 		t.Fatalf("expected positive interval to be accepted, got %v", err)
 	}
 }
+
+func TestKeyFrameExtractorUsesCommandOutput(t *testing.T) {
+	withFakeVisionCommands(t)
+
+	extractor := NewKeyFrameExtractor()
+	extractor.SetFFmpegPath("fake-ffmpeg")
+	extractor.SetFFprobePath("fake-ffprobe")
+	extractor.SetSceneThreshold(25)
+	extractor.SetMaxKeyFrames(2)
+
+	result, err := extractor.ExtractKeyFrames(context.Background(), []byte("video"))
+	if err != nil {
+		t.Fatalf("ExtractKeyFrames: %v", err)
+	}
+	if result.Duration != 10 {
+		t.Fatalf("expected duration 10, got %v", result.Duration)
+	}
+	if len(result.Scenes) != 3 {
+		t.Fatalf("expected 3 scenes, got %d", len(result.Scenes))
+	}
+	if len(result.KeyFrames) != 2 {
+		t.Fatalf("expected max 2 key frames, got %d", len(result.KeyFrames))
+	}
+	if len(result.Scenes[0].KeyFrames) != 1 {
+		t.Fatalf("expected first scene to keep a key frame, got %d", len(result.Scenes[0].KeyFrames))
+	}
+}
+
+func TestKeyFrameExtractorExtractsFramesWithCommandOutput(t *testing.T) {
+	withFakeVisionCommands(t)
+
+	extractor := NewKeyFrameExtractor()
+	extractor.SetFFmpegPath("fake-ffmpeg")
+	extractor.SetFFprobePath("fake-ffprobe")
+
+	frame, err := extractor.ExtractFrameAt(context.Background(), []byte("video"), 3.5)
+	if err != nil {
+		t.Fatalf("ExtractFrameAt: %v", err)
+	}
+	if string(frame) != "JPEG-FRAME" {
+		t.Fatalf("expected fake frame bytes, got %q", string(frame))
+	}
+
+	frames, err := extractor.ExtractFramesAtIntervals(context.Background(), []byte("video"), 4)
+	if err != nil {
+		t.Fatalf("ExtractFramesAtIntervals: %v", err)
+	}
+	if len(frames) != 3 {
+		t.Fatalf("expected 3 interval frames, got %d", len(frames))
+	}
+}
+
+func TestKeyFrameExtractorReportsMissingFFmpeg(t *testing.T) {
+	extractor := NewKeyFrameExtractor()
+	extractor.SetFFmpegPath("definitely-missing-ffmpeg-binary")
+
+	if _, err := extractor.ExtractKeyFrames(context.Background(), []byte("video")); err == nil {
+		t.Fatal("expected missing ffmpeg error")
+	}
+	if _, err := extractor.ExtractFrameAt(context.Background(), []byte("video"), 1); err == nil {
+		t.Fatal("expected missing ffmpeg error")
+	}
+	if _, err := extractor.ExtractFramesAtIntervals(context.Background(), []byte("video"), 1); err == nil {
+		t.Fatal("expected missing ffmpeg error")
+	}
+}
+
+func TestAudioAnalyzerUsesCommandOutput(t *testing.T) {
+	withFakeVisionCommands(t)
+
+	analyzer := NewAudioAnalyzer()
+	analyzer.SetFFmpegPath("fake-ffmpeg")
+	analyzer.SetFFprobePath("fake-ffprobe")
+
+	result, err := analyzer.Analyze(context.Background(), []byte("audio"))
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if result.Duration != 12.5 {
+		t.Fatalf("expected duration 12.5, got %v", result.Duration)
+	}
+	if result.SampleRate != 44100 {
+		t.Fatalf("expected sample rate 44100, got %d", result.SampleRate)
+	}
+	if result.Channels != 2 {
+		t.Fatalf("expected 2 channels, got %d", result.Channels)
+	}
+	if result.Metadata == nil {
+		t.Fatal("expected metadata to be populated")
+	}
+}
+
+func TestAudioAnalyzerReportsMissingFFmpeg(t *testing.T) {
+	analyzer := NewAudioAnalyzer()
+	analyzer.SetFFmpegPath("definitely-missing-ffmpeg-binary")
+
+	if analyzer.isFFmpegAvailable(context.Background()) {
+		t.Fatal("expected missing ffmpeg to be unavailable")
+	}
+	if _, err := analyzer.Analyze(context.Background(), []byte("audio")); err == nil {
+		t.Fatal("expected missing ffmpeg error")
+	}
+}
+
+func TestVisionTempFileWriters(t *testing.T) {
+	keyExtractor := NewKeyFrameExtractor()
+	videoPath, err := keyExtractor.writeTempFile([]byte("video-data"), "unit")
+	if err != nil {
+		t.Fatalf("video writeTempFile: %v", err)
+	}
+	defer os.Remove(videoPath)
+
+	videoData, err := os.ReadFile(videoPath)
+	if err != nil {
+		t.Fatalf("read video temp file: %v", err)
+	}
+	if string(videoData) != "video-data" {
+		t.Fatalf("expected video temp contents, got %q", string(videoData))
+	}
+
+	audioAnalyzer := NewAudioAnalyzer()
+	audioPath, err := audioAnalyzer.writeTempFile([]byte("audio-data"), "unit")
+	if err != nil {
+		t.Fatalf("audio writeTempFile: %v", err)
+	}
+	defer os.Remove(audioPath)
+
+	audioData, err := os.ReadFile(audioPath)
+	if err != nil {
+		t.Fatalf("read audio temp file: %v", err)
+	}
+	if string(audioData) != "audio-data" {
+		t.Fatalf("expected audio temp contents, got %q", string(audioData))
+	}
+}
+
+func withFakeVisionCommands(t *testing.T) {
+	t.Helper()
+
+	previous := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		helperArgs := []string{"-test.run=TestVisionCommandHelperProcess", "--", name}
+		helperArgs = append(helperArgs, args...)
+		cmd := exec.CommandContext(ctx, os.Args[0], helperArgs...)
+		cmd.Env = append(os.Environ(), "GO_WANT_VISION_HELPER_PROCESS=1")
+		return cmd
+	}
+
+	t.Cleanup(func() {
+		execCommandContext = previous
+	})
+}
+
+func TestVisionCommandHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_VISION_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	separator := -1
+	for i, arg := range args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator == -1 || separator+1 >= len(args) {
+		os.Exit(2)
+	}
+
+	commandName := args[separator+1]
+	commandArgs := args[separator+2:]
+	joinedArgs := strings.Join(commandArgs, " ")
+
+	switch {
+	case strings.Contains(commandName, "ffprobe"):
+		if strings.Contains(joinedArgs, "audio") {
+			fmt.Fprint(os.Stdout, fakeAudioProbeJSON)
+		} else {
+			fmt.Fprint(os.Stdout, fakeVideoProbeJSON)
+		}
+		os.Exit(0)
+	case strings.Contains(commandName, "ffmpeg"):
+		switch {
+		case strings.Contains(joinedArgs, "-version"):
+			os.Exit(0)
+		case strings.Contains(joinedArgs, "select='gt(scene"):
+			fmt.Fprint(os.Stdout, "pts_time:2.000\npts_time:5.000\n")
+			os.Exit(0)
+		case strings.Contains(joinedArgs, "-vframes"):
+			fmt.Fprint(os.Stdout, "JPEG-FRAME")
+			os.Exit(0)
+		case strings.Contains(joinedArgs, "silencedetect"):
+			fmt.Fprint(os.Stdout, "silence_start: 1.000\nsilence_end: 3.000 | silence_duration: 2.000\n")
+			os.Exit(0)
+		case strings.Contains(joinedArgs, "highpass=f=300"):
+			fmt.Fprint(os.Stdout, "RMS level dB = -20\nRMS level dB = -18\n")
+			os.Exit(0)
+		case strings.Contains(joinedArgs, "highpass=f=20"):
+			fmt.Fprint(os.Stdout, "RMS level dB = -12\nRMS level dB = -10\n")
+			os.Exit(0)
+		case strings.Contains(joinedArgs, "astats=metadata=1:reset=1"):
+			fmt.Fprint(os.Stdout, "RMS level dB = -20\nRMS level dB = -10\n")
+			os.Exit(0)
+		}
+	}
+
+	os.Exit(2)
+}
+
+const fakeVideoProbeJSON = `{
+  "streams": [
+    {
+      "codec_type": "video",
+      "codec_name": "h264",
+      "width": 1920,
+      "height": 1080,
+      "r_frame_rate": "30000/1001",
+      "nb_frames": "300"
+    }
+  ],
+  "format": {
+    "duration": "10.0",
+    "size": "1024"
+  }
+}`
+
+const fakeAudioProbeJSON = `{
+  "streams": [
+    {
+      "codec_type": "audio",
+      "codec_name": "aac",
+      "sample_rate": "44100",
+      "channels": 2,
+      "bit_rate": "128000"
+    }
+  ],
+  "format": {
+    "duration": "12.5",
+    "bit_rate": "128000"
+  }
+}`

--- a/pkg/vision/video_audio_test.go
+++ b/pkg/vision/video_audio_test.go
@@ -1,6 +1,9 @@
 package vision
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestAppendKeyFrameToSceneMutatesOriginalScene(t *testing.T) {
 	scenes := []SceneInfo{
@@ -35,5 +38,24 @@ func TestAppendKeyFrameToSceneIgnoresOutOfRangeIndex(t *testing.T) {
 
 	if len(scenes[0].KeyFrames) != 0 {
 		t.Fatalf("expected no key frames to be appended for invalid indices, got %d", len(scenes[0].KeyFrames))
+	}
+}
+
+func TestValidateFrameIntervalSecondsRejectsNonPositiveValues(t *testing.T) {
+	cases := []float64{0, -1, -0.5}
+	for _, interval := range cases {
+		err := validateFrameIntervalSeconds(interval)
+		if err == nil {
+			t.Fatalf("expected interval %v to be rejected", interval)
+		}
+		if !strings.Contains(err.Error(), "intervalSeconds must be > 0") {
+			t.Fatalf("expected interval validation error, got %v", err)
+		}
+	}
+}
+
+func TestValidateFrameIntervalSecondsAcceptsPositiveValue(t *testing.T) {
+	if err := validateFrameIntervalSeconds(0.25); err != nil {
+		t.Fatalf("expected positive interval to be accepted, got %v", err)
 	}
 }

--- a/pkg/vision/video_audio_test.go
+++ b/pkg/vision/video_audio_test.go
@@ -1,0 +1,39 @@
+package vision
+
+import "testing"
+
+func TestAppendKeyFrameToSceneMutatesOriginalScene(t *testing.T) {
+	scenes := []SceneInfo{
+		{ID: 7, Start: 0, End: 5, Duration: 5},
+		{ID: 8, Start: 5, End: 10, Duration: 5},
+	}
+
+	first := KeyFrame{Index: 0, SceneID: 7, Timestamp: 2.5}
+	second := KeyFrame{Index: 1, SceneID: 8, Timestamp: 7.5}
+
+	appendKeyFrameToScene(scenes, 0, first)
+	appendKeyFrameToScene(scenes, 1, second)
+
+	if len(scenes[0].KeyFrames) != 1 {
+		t.Fatalf("expected first scene to keep 1 key frame, got %d", len(scenes[0].KeyFrames))
+	}
+	if len(scenes[1].KeyFrames) != 1 {
+		t.Fatalf("expected second scene to keep 1 key frame, got %d", len(scenes[1].KeyFrames))
+	}
+	if scenes[0].KeyFrames[0].SceneID != 7 {
+		t.Fatalf("expected first scene key frame scene id 7, got %d", scenes[0].KeyFrames[0].SceneID)
+	}
+	if scenes[1].KeyFrames[0].SceneID != 8 {
+		t.Fatalf("expected second scene key frame scene id 8, got %d", scenes[1].KeyFrames[0].SceneID)
+	}
+}
+
+func TestAppendKeyFrameToSceneIgnoresOutOfRangeIndex(t *testing.T) {
+	scenes := []SceneInfo{{ID: 1}}
+	appendKeyFrameToScene(scenes, -1, KeyFrame{SceneID: 1})
+	appendKeyFrameToScene(scenes, 1, KeyFrame{SceneID: 1})
+
+	if len(scenes[0].KeyFrames) != 0 {
+		t.Fatalf("expected no key frames to be appended for invalid indices, got %d", len(scenes[0].KeyFrames))
+	}
+}


### PR DESCRIPTION
## 概要

补充视觉与多媒体理解基础能力，引入 `pkg/vision` 统一封装图像分析、媒体理解流水线以及视频/音频辅助分析能力，为后续更高层的视觉、工作流和多模态能力提供基础组件。

## 本次变更

- 新增图像分析能力
  - `analyze.go`
  - 定义视觉分析结果结构
  - 提供 Google Vision 与 LLM Vision 两类 provider 抽象及基础实现
  - 提供图片文件分析和上传分析辅助方法
- 新增媒体理解流水线
  - `pipeline.go`
  - 提供 image / video / audio 三类媒体的统一理解入口
  - 支持 OCR、data URL 编解码和基础媒体类型判断
  - 支持结合 LLM client 做图片描述
- 新增视频与音频辅助分析能力
  - `video_audio.go`
  - 提供关键帧提取、场景检测、视频元信息探测
  - 提供音频分析、静音检测、语音/音乐置信度估算等辅助能力
- 新增基础测试
  - `helpers_test.go`
  - 覆盖 data URL 编解码、MIME 推断、media type 判断、FPS 解析、音频 helper 和 JSON 解析等基础路径
- 修复一个实现问题
  - 将 `jsonUnmarshal` 从空实现改为真实 JSON 解析，避免音视频探测结果被静默吞掉

## 影响

这条 PR 只引入 `pkg/vision` 这一组独立视觉与媒体理解能力，不包含上层工作流编排、runtime 装配或 UI 集成逻辑。

这样拆分的目标是先把图像分析、媒体理解和音视频辅助能力独立合入，降低后续多模态与视觉相关 PR 的耦合和 review 成本。

## 验证

已执行：

- `go test ./pkg/vision/...`
