### PR TITLE
feat(canvas): add a2ui renderer and canvas store

### DIFF
--- a/pkg/canvas/a2ui.go
+++ b/pkg/canvas/a2ui.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -125,7 +126,7 @@ func (r *A2UIRenderer) renderComponent(comp A2UIComponent, indent string) (strin
 }
 
 func (r *A2UIRenderer) renderContainer(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "", "")
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%s<div%s>\n", indent, attrs))
 	childIndent := indent + "  "
@@ -141,9 +142,9 @@ func (r *A2UIRenderer) renderContainer(comp A2UIComponent, indent string) (strin
 }
 
 func (r *A2UIRenderer) renderSection(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "a2ui-section", "")
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%s<section class=\"a2ui-section\"%s>\n", indent, attrs))
+	sb.WriteString(fmt.Sprintf("%s<section%s>\n", indent, attrs))
 	childIndent := indent + "  "
 	if title, ok := comp.Props["title"].(string); ok && strings.TrimSpace(title) != "" {
 		sb.WriteString(fmt.Sprintf("%s  <h2>%s</h2>\n", indent, template.HTMLEscapeString(title)))
@@ -163,7 +164,6 @@ func (r *A2UIRenderer) renderSection(comp A2UIComponent, indent string) (string,
 }
 
 func (r *A2UIRenderer) renderStack(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
 	direction := "column"
 	if value, ok := comp.Props["direction"].(string); ok && strings.TrimSpace(value) != "" {
 		direction = value
@@ -176,9 +176,10 @@ func (r *A2UIRenderer) renderStack(comp A2UIComponent, indent string) (string, e
 	if value, ok := comp.Props["align"].(string); ok && strings.TrimSpace(value) != "" {
 		align = value
 	}
-	style := fmt.Sprintf(" style=\"display:flex;flex-direction:%s;gap:%s;align-items:%s;\"", template.HTMLEscapeString(direction), template.HTMLEscapeString(gap), template.HTMLEscapeString(align))
+	style := fmt.Sprintf("display:flex;flex-direction:%s;gap:%s;align-items:%s;", direction, gap, align)
+	attrs := r.buildAttributes(comp, "a2ui-stack", style)
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%s<div class=\"a2ui-stack\"%s%s>\n", indent, style, attrs))
+	sb.WriteString(fmt.Sprintf("%s<div%s>\n", indent, attrs))
 	childIndent := indent + "  "
 	for _, child := range comp.Children {
 		html, err := r.renderComponent(child, childIndent)
@@ -196,7 +197,7 @@ func (r *A2UIRenderer) renderText(comp A2UIComponent, indent string) (string, er
 	if comp.Type == "span" {
 		tag = "span"
 	}
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "", "")
 	content := template.HTMLEscapeString(comp.Content)
 	return fmt.Sprintf("%s<%s%s>%s</%s>\n", indent, tag, attrs, content, tag), nil
 }
@@ -210,13 +211,13 @@ func (r *A2UIRenderer) renderHeading(comp A2UIComponent, indent string) (string,
 		}
 		tag = fmt.Sprintf("h%d", int(level))
 	}
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "", "")
 	content := template.HTMLEscapeString(comp.Content)
 	return fmt.Sprintf("%s<%s%s>%s</%s>\n", indent, tag, attrs, content, tag), nil
 }
 
 func (r *A2UIRenderer) renderButton(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "", "")
 	content := template.HTMLEscapeString(comp.Content)
 	if content == "" {
 		content = "Button"
@@ -225,7 +226,7 @@ func (r *A2UIRenderer) renderButton(comp A2UIComponent, indent string) (string, 
 }
 
 func (r *A2UIRenderer) renderInput(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "", "")
 	inputType := "text"
 	if t, ok := comp.Props["inputType"].(string); ok {
 		inputType = t
@@ -239,7 +240,7 @@ func (r *A2UIRenderer) renderInput(comp A2UIComponent, indent string) (string, e
 }
 
 func (r *A2UIRenderer) renderTextarea(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "", "")
 	rows := "4"
 	if value, ok := comp.Props["rows"].(string); ok && strings.TrimSpace(value) != "" {
 		rows = value
@@ -254,7 +255,7 @@ func (r *A2UIRenderer) renderTextarea(comp A2UIComponent, indent string) (string
 }
 
 func (r *A2UIRenderer) renderImage(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "", "")
 	src := ""
 	if s, ok := comp.Props["src"].(string); ok {
 		src = template.HTMLEscapeString(s)
@@ -267,7 +268,7 @@ func (r *A2UIRenderer) renderImage(comp A2UIComponent, indent string) (string, e
 }
 
 func (r *A2UIRenderer) renderLink(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "", "")
 	href := "#"
 	if value, ok := comp.Props["href"].(string); ok && strings.TrimSpace(value) != "" {
 		href = value
@@ -284,7 +285,7 @@ func (r *A2UIRenderer) renderList(comp A2UIComponent, indent string) (string, er
 	if comp.Type == "ol" {
 		tag = "ol"
 	}
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "", "")
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%s<%s%s>\n", indent, tag, attrs))
 	for _, child := range comp.Children {
@@ -296,9 +297,9 @@ func (r *A2UIRenderer) renderList(comp A2UIComponent, indent string) (string, er
 }
 
 func (r *A2UIRenderer) renderCard(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "a2ui-card", "")
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%s<div class=\"a2ui-card\"%s>\n", indent, attrs))
+	sb.WriteString(fmt.Sprintf("%s<div%s>\n", indent, attrs))
 	childIndent := indent + "  "
 	for _, child := range comp.Children {
 		html, err := r.renderComponent(child, childIndent)
@@ -312,15 +313,14 @@ func (r *A2UIRenderer) renderCard(comp A2UIComponent, indent string) (string, er
 }
 
 func (r *A2UIRenderer) renderGrid(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
 	cols := "3"
 	if c, ok := comp.Props["columns"].(string); ok {
 		cols = c
 	}
-	cols = template.HTMLEscapeString(cols)
-	style := fmt.Sprintf(" style=\"display:grid;grid-template-columns:repeat(%s,1fr);gap:16px;\"", cols)
+	style := fmt.Sprintf("display:grid;grid-template-columns:repeat(%s,1fr);gap:16px;", cols)
+	attrs := r.buildAttributes(comp, "a2ui-grid", style)
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%s<div class=\"a2ui-grid\"%s%s>\n", indent, style, attrs))
+	sb.WriteString(fmt.Sprintf("%s<div%s>\n", indent, attrs))
 	childIndent := indent + "  "
 	for _, child := range comp.Children {
 		html, err := r.renderComponent(child, childIndent)
@@ -334,15 +334,15 @@ func (r *A2UIRenderer) renderGrid(comp A2UIComponent, indent string) (string, er
 }
 
 func (r *A2UIRenderer) renderCode(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "a2ui-code", "")
 	content := template.HTMLEscapeString(comp.Content)
-	return fmt.Sprintf("%s<pre class=\"a2ui-code\"%s><code>%s</code></pre>\n", indent, attrs, content), nil
+	return fmt.Sprintf("%s<pre%s><code>%s</code></pre>\n", indent, attrs, content), nil
 }
 
 func (r *A2UIRenderer) renderTable(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "a2ui-table", "")
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%s<table class=\"a2ui-table\"%s>\n", indent, attrs))
+	sb.WriteString(fmt.Sprintf("%s<table%s>\n", indent, attrs))
 
 	if headers, ok := comp.Props["headers"].([]any); ok {
 		sb.WriteString(fmt.Sprintf("%s  <thead><tr>\n", indent))
@@ -371,7 +371,7 @@ func (r *A2UIRenderer) renderTable(comp A2UIComponent, indent string) (string, e
 }
 
 func (r *A2UIRenderer) renderProgress(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "", "")
 	value := "0"
 	if v, ok := comp.Props["value"].(string); ok {
 		value = v
@@ -386,20 +386,19 @@ func (r *A2UIRenderer) renderProgress(comp A2UIComponent, indent string) (string
 }
 
 func (r *A2UIRenderer) renderBadge(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "a2ui-badge", "")
 	content := template.HTMLEscapeString(comp.Content)
-	return fmt.Sprintf("%s<span class=\"a2ui-badge\"%s>%s</span>\n", indent, attrs, content), nil
+	return fmt.Sprintf("%s<span%s>%s</span>\n", indent, attrs, content), nil
 }
 
 func (r *A2UIRenderer) renderAlert(comp A2UIComponent, indent string) (string, error) {
-	attrs := r.buildAttributes(comp)
 	level := "info"
 	if l, ok := comp.Props["level"].(string); ok {
 		level = l
 	}
-	level = template.HTMLEscapeString(level)
+	attrs := r.buildAttributes(comp, fmt.Sprintf("a2ui-alert a2ui-alert-%s", level), "")
 	content := template.HTMLEscapeString(comp.Content)
-	return fmt.Sprintf("%s<div class=\"a2ui-alert a2ui-alert-%s\"%s>%s</div>\n", indent, level, attrs, content), nil
+	return fmt.Sprintf("%s<div%s>%s</div>\n", indent, attrs, content), nil
 }
 
 func (r *A2UIRenderer) renderGeneric(comp A2UIComponent, indent string) (string, error) {
@@ -409,28 +408,22 @@ func (r *A2UIRenderer) renderGeneric(comp A2UIComponent, indent string) (string,
 			tag = t
 		}
 	}
-	attrs := r.buildAttributes(comp)
+	attrs := r.buildAttributes(comp, "", "")
 	content := template.HTMLEscapeString(comp.Content)
 	return fmt.Sprintf("%s<%s%s>%s</%s>\n", indent, tag, attrs, content, tag), nil
 }
 
-func (r *A2UIRenderer) buildAttributes(comp A2UIComponent) string {
+func (r *A2UIRenderer) buildAttributes(comp A2UIComponent, baseClass string, baseStyle string) string {
 	var sb strings.Builder
 
-	if comp.Styles != nil && len(comp.Styles) > 0 {
-		sb.WriteString(" style=\"")
-		for k, v := range comp.Styles {
-			if !isSafeCSSName(k) {
-				continue
-			}
-			sb.WriteString(fmt.Sprintf("%s:%s;", template.HTMLEscapeString(k), template.HTMLEscapeString(v)))
-		}
-		sb.WriteString("\"")
+	if style := buildStyleValue(baseStyle, comp.Styles); style != "" {
+		sb.WriteString(fmt.Sprintf(" style=\"%s\"", style))
 	}
 
 	if comp.Attributes != nil {
-		for k, v := range comp.Attributes {
-			if k == "style" || !isSafeAttributeName(k) {
+		for _, k := range sortedAttributeKeys(comp.Attributes) {
+			v := comp.Attributes[k]
+			if k == "style" || k == "class" || !isSafeAttributeName(k) {
 				continue
 			}
 			sb.WriteString(fmt.Sprintf(" %s=\"%s\"", k, template.HTMLEscapeString(fmt.Sprintf("%v", v))))
@@ -446,11 +439,74 @@ func (r *A2UIRenderer) buildAttributes(comp A2UIComponent) string {
 		sb.WriteString(fmt.Sprintf(" id=\"%s\"", template.HTMLEscapeString(id)))
 	}
 
-	if className, ok := comp.Props["className"].(string); ok {
-		sb.WriteString(fmt.Sprintf(" class=\"%s\"", template.HTMLEscapeString(className)))
+	if classValue := buildClassValue(baseClass, comp); classValue != "" {
+		sb.WriteString(fmt.Sprintf(" class=\"%s\"", classValue))
 	}
 
 	return sb.String()
+}
+
+func buildStyleValue(baseStyle string, styles map[string]string) string {
+	var sb strings.Builder
+	baseStyle = strings.TrimSpace(baseStyle)
+	if baseStyle != "" {
+		sb.WriteString(template.HTMLEscapeString(baseStyle))
+		if !strings.HasSuffix(baseStyle, ";") {
+			sb.WriteString(";")
+		}
+	}
+
+	if len(styles) > 0 {
+		keys := make([]string, 0, len(styles))
+		for k := range styles {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := styles[k]
+			if !isSafeCSSName(k) {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("%s:%s;", template.HTMLEscapeString(k), template.HTMLEscapeString(v)))
+		}
+	}
+
+	return sb.String()
+}
+
+func buildClassValue(baseClass string, comp A2UIComponent) string {
+	classes := make([]string, 0, 3)
+	baseClass = strings.TrimSpace(baseClass)
+	if baseClass != "" {
+		classes = append(classes, baseClass)
+	}
+	if comp.Attributes != nil {
+		if value, ok := comp.Attributes["class"]; ok {
+			className := strings.TrimSpace(fmt.Sprintf("%v", value))
+			if className != "" {
+				classes = append(classes, className)
+			}
+		}
+	}
+	if className, ok := comp.Props["className"].(string); ok {
+		className = strings.TrimSpace(className)
+		if className != "" {
+			classes = append(classes, className)
+		}
+	}
+	if len(classes) == 0 {
+		return ""
+	}
+	return template.HTMLEscapeString(strings.Join(classes, " "))
+}
+
+func sortedAttributeKeys(attrs map[string]any) []string {
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func isSafeHTMLName(name string) bool {

--- a/pkg/canvas/a2ui.go
+++ b/pkg/canvas/a2ui.go
@@ -1,0 +1,609 @@
+package canvas
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"strings"
+)
+
+type A2UIComponent struct {
+	Type       string            `json:"type"`
+	Props      map[string]any    `json:"props,omitempty"`
+	Children   []A2UIComponent   `json:"children,omitempty"`
+	Content    string            `json:"content,omitempty"`
+	Attributes map[string]any    `json:"attributes,omitempty"`
+	Events     map[string]string `json:"events,omitempty"`
+	Styles     map[string]string `json:"styles,omitempty"`
+}
+
+type A2UIDocument struct {
+	Version     string            `json:"version"`
+	Title       string            `json:"title,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Theme       string            `json:"theme,omitempty"`
+	ThemeVars   map[string]string `json:"theme_vars,omitempty"`
+	Components  []A2UIComponent   `json:"components"`
+	Metadata    map[string]any    `json:"metadata,omitempty"`
+}
+
+type A2UIRenderer struct {
+	themeStyles map[string]string
+}
+
+func NewA2UIRenderer() *A2UIRenderer {
+	return &A2UIRenderer{
+		themeStyles: defaultThemeStyles(),
+	}
+}
+
+func (r *A2UIRenderer) Render(doc *A2UIDocument) (string, error) {
+	if doc == nil {
+		return "", fmt.Errorf("document is nil")
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<!DOCTYPE html>\n<html>\n<head>\n")
+	sb.WriteString("<meta charset=\"UTF-8\">\n")
+	sb.WriteString("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n")
+
+	title := "A2UI Canvas"
+	if doc.Title != "" {
+		title = doc.Title
+	}
+	sb.WriteString(fmt.Sprintf("<title>%s</title>\n", template.HTMLEscapeString(title)))
+	if strings.TrimSpace(doc.Description) != "" {
+		sb.WriteString(fmt.Sprintf("<meta name=\"description\" content=\"%s\">\n", template.HTMLEscapeString(doc.Description)))
+	}
+
+	sb.WriteString("<style>\n")
+	sb.WriteString(r.themeStyles[doc.Theme])
+	sb.WriteString(r.themeVariableStyles(doc))
+	sb.WriteString(r.componentStyles())
+	sb.WriteString("</style>\n")
+	sb.WriteString("</head>\n")
+	sb.WriteString(fmt.Sprintf("<body data-a2ui-theme=\"%s\">\n", template.HTMLEscapeString(firstNonEmptyTheme(doc.Theme, "light"))))
+
+	for _, comp := range doc.Components {
+		html, err := r.renderComponent(comp, "")
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(html)
+	}
+
+	sb.WriteString("\n</body>\n</html>")
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderComponent(comp A2UIComponent, indent string) (string, error) {
+	switch comp.Type {
+	case "container", "div":
+		return r.renderContainer(comp, indent)
+	case "section":
+		return r.renderSection(comp, indent)
+	case "stack":
+		return r.renderStack(comp, indent)
+	case "text", "p", "span":
+		return r.renderText(comp, indent)
+	case "heading", "h1", "h2", "h3", "h4", "h5", "h6":
+		return r.renderHeading(comp, indent)
+	case "button":
+		return r.renderButton(comp, indent)
+	case "input":
+		return r.renderInput(comp, indent)
+	case "textarea":
+		return r.renderTextarea(comp, indent)
+	case "image", "img":
+		return r.renderImage(comp, indent)
+	case "link", "a":
+		return r.renderLink(comp, indent)
+	case "list", "ul", "ol":
+		return r.renderList(comp, indent)
+	case "card":
+		return r.renderCard(comp, indent)
+	case "grid":
+		return r.renderGrid(comp, indent)
+	case "divider", "hr":
+		return indent + "<hr>\n", nil
+	case "code":
+		return r.renderCode(comp, indent)
+	case "table":
+		return r.renderTable(comp, indent)
+	case "progress":
+		return r.renderProgress(comp, indent)
+	case "badge":
+		return r.renderBadge(comp, indent)
+	case "alert":
+		return r.renderAlert(comp, indent)
+	default:
+		return r.renderGeneric(comp, indent)
+	}
+}
+
+func (r *A2UIRenderer) renderContainer(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<div%s>\n", indent, attrs))
+	childIndent := indent + "  "
+	for _, child := range comp.Children {
+		html, err := r.renderComponent(child, childIndent)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(html)
+	}
+	sb.WriteString(fmt.Sprintf("%s</div>\n", indent))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderSection(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<section class=\"a2ui-section\"%s>\n", indent, attrs))
+	childIndent := indent + "  "
+	if title, ok := comp.Props["title"].(string); ok && strings.TrimSpace(title) != "" {
+		sb.WriteString(fmt.Sprintf("%s  <h2>%s</h2>\n", indent, template.HTMLEscapeString(title)))
+	}
+	if description, ok := comp.Props["description"].(string); ok && strings.TrimSpace(description) != "" {
+		sb.WriteString(fmt.Sprintf("%s  <p class=\"a2ui-section-description\">%s</p>\n", indent, template.HTMLEscapeString(description)))
+	}
+	for _, child := range comp.Children {
+		html, err := r.renderComponent(child, childIndent)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(html)
+	}
+	sb.WriteString(fmt.Sprintf("%s</section>\n", indent))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderStack(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	direction := "column"
+	if value, ok := comp.Props["direction"].(string); ok && strings.TrimSpace(value) != "" {
+		direction = value
+	}
+	gap := "12px"
+	if value, ok := comp.Props["gap"].(string); ok && strings.TrimSpace(value) != "" {
+		gap = value
+	}
+	align := "stretch"
+	if value, ok := comp.Props["align"].(string); ok && strings.TrimSpace(value) != "" {
+		align = value
+	}
+	style := fmt.Sprintf(" style=\"display:flex;flex-direction:%s;gap:%s;align-items:%s;\"", template.HTMLEscapeString(direction), template.HTMLEscapeString(gap), template.HTMLEscapeString(align))
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<div class=\"a2ui-stack\"%s%s>\n", indent, style, attrs))
+	childIndent := indent + "  "
+	for _, child := range comp.Children {
+		html, err := r.renderComponent(child, childIndent)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(html)
+	}
+	sb.WriteString(fmt.Sprintf("%s</div>\n", indent))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderText(comp A2UIComponent, indent string) (string, error) {
+	tag := "p"
+	if comp.Type == "span" {
+		tag = "span"
+	}
+	attrs := r.buildAttributes(comp)
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<%s%s>%s</%s>\n", indent, tag, attrs, content, tag), nil
+}
+
+func (r *A2UIRenderer) renderHeading(comp A2UIComponent, indent string) (string, error) {
+	tag := comp.Type
+	if tag == "heading" {
+		level, _ := comp.Props["level"].(float64)
+		if level == 0 {
+			level = 2
+		}
+		tag = fmt.Sprintf("h%d", int(level))
+	}
+	attrs := r.buildAttributes(comp)
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<%s%s>%s</%s>\n", indent, tag, attrs, content, tag), nil
+}
+
+func (r *A2UIRenderer) renderButton(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	content := template.HTMLEscapeString(comp.Content)
+	if content == "" {
+		content = "Button"
+	}
+	return fmt.Sprintf("%s<button%s>%s</button>\n", indent, attrs, content), nil
+}
+
+func (r *A2UIRenderer) renderInput(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	inputType := "text"
+	if t, ok := comp.Props["inputType"].(string); ok {
+		inputType = t
+	}
+	placeholder := ""
+	if p, ok := comp.Props["placeholder"].(string); ok {
+		placeholder = fmt.Sprintf(" placeholder=\"%s\"", template.HTMLEscapeString(p))
+	}
+	return fmt.Sprintf("%s<input type=\"%s\"%s%s>\n", indent, inputType, placeholder, attrs), nil
+}
+
+func (r *A2UIRenderer) renderTextarea(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	rows := "4"
+	if value, ok := comp.Props["rows"].(string); ok && strings.TrimSpace(value) != "" {
+		rows = value
+	}
+	placeholder := ""
+	if p, ok := comp.Props["placeholder"].(string); ok {
+		placeholder = fmt.Sprintf(" placeholder=\"%s\"", template.HTMLEscapeString(p))
+	}
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<textarea rows=\"%s\"%s%s>%s</textarea>\n", indent, rows, placeholder, attrs, content), nil
+}
+
+func (r *A2UIRenderer) renderImage(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	src := ""
+	if s, ok := comp.Props["src"].(string); ok {
+		src = template.HTMLEscapeString(s)
+	}
+	alt := ""
+	if a, ok := comp.Props["alt"].(string); ok {
+		alt = template.HTMLEscapeString(a)
+	}
+	return fmt.Sprintf("%s<img src=\"%s\" alt=\"%s\"%s>\n", indent, src, alt, attrs), nil
+}
+
+func (r *A2UIRenderer) renderLink(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	href := "#"
+	if value, ok := comp.Props["href"].(string); ok && strings.TrimSpace(value) != "" {
+		href = value
+	}
+	content := template.HTMLEscapeString(comp.Content)
+	if content == "" {
+		content = template.HTMLEscapeString(href)
+	}
+	return fmt.Sprintf("%s<a href=\"%s\"%s>%s</a>\n", indent, template.HTMLEscapeString(href), attrs, content), nil
+}
+
+func (r *A2UIRenderer) renderList(comp A2UIComponent, indent string) (string, error) {
+	tag := "ul"
+	if comp.Type == "ol" {
+		tag = "ol"
+	}
+	attrs := r.buildAttributes(comp)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<%s%s>\n", indent, tag, attrs))
+	for _, child := range comp.Children {
+		itemContent := template.HTMLEscapeString(child.Content)
+		sb.WriteString(fmt.Sprintf("%s  <li>%s</li>\n", indent, itemContent))
+	}
+	sb.WriteString(fmt.Sprintf("%s</%s>\n", indent, tag))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderCard(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<div class=\"a2ui-card\"%s>\n", indent, attrs))
+	childIndent := indent + "  "
+	for _, child := range comp.Children {
+		html, err := r.renderComponent(child, childIndent)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(html)
+	}
+	sb.WriteString(fmt.Sprintf("%s</div>\n", indent))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderGrid(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	cols := "3"
+	if c, ok := comp.Props["columns"].(string); ok {
+		cols = c
+	}
+	style := fmt.Sprintf(" style=\"display:grid;grid-template-columns:repeat(%s,1fr);gap:16px;\"", cols)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<div class=\"a2ui-grid\"%s%s>\n", indent, style, attrs))
+	childIndent := indent + "  "
+	for _, child := range comp.Children {
+		html, err := r.renderComponent(child, childIndent)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(html)
+	}
+	sb.WriteString(fmt.Sprintf("%s</div>\n", indent))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderCode(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<pre class=\"a2ui-code\"%s><code>%s</code></pre>\n", indent, attrs, content), nil
+}
+
+func (r *A2UIRenderer) renderTable(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<table class=\"a2ui-table\"%s>\n", indent, attrs))
+
+	if headers, ok := comp.Props["headers"].([]any); ok {
+		sb.WriteString(fmt.Sprintf("%s  <thead><tr>\n", indent))
+		for _, h := range headers {
+			sb.WriteString(fmt.Sprintf("%s    <th>%s</th>\n", indent, template.HTMLEscapeString(fmt.Sprintf("%v", h))))
+		}
+		sb.WriteString(fmt.Sprintf("%s  </tr></thead>\n", indent))
+	}
+
+	if rows, ok := comp.Props["rows"].([]any); ok {
+		sb.WriteString(fmt.Sprintf("%s  <tbody>\n", indent))
+		for _, row := range rows {
+			sb.WriteString(fmt.Sprintf("%s    <tr>\n", indent))
+			if cells, ok := row.([]any); ok {
+				for _, cell := range cells {
+					sb.WriteString(fmt.Sprintf("%s      <td>%s</td>\n", indent, template.HTMLEscapeString(fmt.Sprintf("%v", cell))))
+				}
+			}
+			sb.WriteString(fmt.Sprintf("%s    </tr>\n", indent))
+		}
+		sb.WriteString(fmt.Sprintf("%s  </tbody>\n", indent))
+	}
+
+	sb.WriteString(fmt.Sprintf("%s</table>\n", indent))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderProgress(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	value := "0"
+	if v, ok := comp.Props["value"].(string); ok {
+		value = v
+	}
+	max := "100"
+	if m, ok := comp.Props["max"].(string); ok {
+		max = m
+	}
+	return fmt.Sprintf("%s<progress value=\"%s\" max=\"%s\"%s></progress>\n", indent, value, max, attrs), nil
+}
+
+func (r *A2UIRenderer) renderBadge(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<span class=\"a2ui-badge\"%s>%s</span>\n", indent, attrs, content), nil
+}
+
+func (r *A2UIRenderer) renderAlert(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp)
+	level := "info"
+	if l, ok := comp.Props["level"].(string); ok {
+		level = l
+	}
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<div class=\"a2ui-alert a2ui-alert-%s\"%s>%s</div>\n", indent, level, attrs, content), nil
+}
+
+func (r *A2UIRenderer) renderGeneric(comp A2UIComponent, indent string) (string, error) {
+	tag := "div"
+	if t, ok := comp.Props["tag"].(string); ok {
+		tag = t
+	}
+	attrs := r.buildAttributes(comp)
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<%s%s>%s</%s>\n", indent, tag, attrs, content, tag), nil
+}
+
+func (r *A2UIRenderer) buildAttributes(comp A2UIComponent) string {
+	var sb strings.Builder
+
+	if comp.Styles != nil && len(comp.Styles) > 0 {
+		sb.WriteString(" style=\"")
+		for k, v := range comp.Styles {
+			sb.WriteString(fmt.Sprintf("%s:%s;", k, v))
+		}
+		sb.WriteString("\"")
+	}
+
+	if comp.Attributes != nil {
+		for k, v := range comp.Attributes {
+			if k == "style" {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf(" %s=\"%v\"", k, v))
+		}
+	}
+
+	if comp.Events != nil && len(comp.Events) > 0 {
+		eventsJSON, _ := json.Marshal(comp.Events)
+		sb.WriteString(fmt.Sprintf(" data-a2ui-events=\"%s\"", template.HTMLEscapeString(string(eventsJSON))))
+	}
+
+	if id, ok := comp.Props["id"].(string); ok {
+		sb.WriteString(fmt.Sprintf(" id=\"%s\"", template.HTMLEscapeString(id)))
+	}
+
+	if className, ok := comp.Props["className"].(string); ok {
+		sb.WriteString(fmt.Sprintf(" class=\"%s\"", template.HTMLEscapeString(className)))
+	}
+
+	return sb.String()
+}
+
+func (r *A2UIRenderer) componentStyles() string {
+	return `
+.a2ui-section {
+  margin-bottom: 24px;
+}
+.a2ui-section-description {
+  color: #5b5249;
+  margin-top: -8px;
+}
+.a2ui-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  margin-bottom: 16px;
+}
+.a2ui-code {
+  background: #1e1e1e;
+  color: #d4d4d4;
+  padding: 16px;
+  border-radius: 8px;
+  overflow-x: auto;
+  font-family: 'Cascadia Code', Consolas, monospace;
+  font-size: 14px;
+}
+.a2ui-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+.a2ui-table th, .a2ui-table td {
+  padding: 10px 14px;
+  text-align: left;
+  border-bottom: 1px solid #e5e7eb;
+}
+.a2ui-table th {
+  background: #f9fafb;
+  font-weight: 600;
+}
+.a2ui-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #e0e7ff;
+  color: #3730a3;
+}
+.a2ui-alert {
+  padding: 14px 18px;
+  border-radius: 10px;
+  margin: 12px 0;
+  font-size: 14px;
+}
+.a2ui-alert-info {
+  background: #eff6ff;
+  color: #1e40af;
+  border: 1px solid #bfdbfe;
+}
+.a2ui-alert-success {
+  background: #f0fdf4;
+  color: #166534;
+  border: 1px solid #bbf7d0;
+}
+.a2ui-alert-warning {
+  background: #fffbeb;
+  color: #92400e;
+  border: 1px solid #fde68a;
+}
+.a2ui-alert-error {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+}
+body {
+  font-family: 'Aptos', 'Segoe UI Variable', 'Segoe UI', sans-serif;
+  color: #1c1a18;
+  background: #f7f1e6;
+  padding: 24px;
+  line-height: 1.6;
+}
+button {
+  padding: 10px 18px;
+  border-radius: 10px;
+  border: none;
+  background: linear-gradient(135deg, #0f766e, #115e59);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+button:hover {
+  transform: translateY(-1px);
+}
+input {
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  font: inherit;
+  width: 100%;
+  max-width: 400px;
+}
+textarea {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid #d1d5db;
+  font: inherit;
+  width: 100%;
+  min-height: 120px;
+  resize: vertical;
+}
+a {
+  color: #0f766e;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+`
+}
+
+func defaultThemeStyles() map[string]string {
+	return map[string]string{
+		"":        "",
+		"light":   "",
+		"dark":    "body { background: #1a1a2e; color: #e0e0e0; } .a2ui-card { background: #16213e; } .a2ui-table th { background: #0f3460; } .a2ui-table td { border-color: #1a1a2e; }",
+		"minimal": "body { background: #fff; color: #333; padding: 16px; } .a2ui-card { box-shadow: none; border: 1px solid #eee; }",
+	}
+}
+
+func (r *A2UIRenderer) themeVariableStyles(doc *A2UIDocument) string {
+	if doc == nil || len(doc.ThemeVars) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString(":root{")
+	for key, value := range doc.ThemeVars {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		sb.WriteString(fmt.Sprintf("--%s:%s;", template.HTMLEscapeString(key), template.HTMLEscapeString(value)))
+	}
+	sb.WriteString("}\n")
+	return sb.String()
+}
+
+func firstNonEmptyTheme(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func ParseA2UI(content string) (*A2UIDocument, error) {
+	var doc A2UIDocument
+	if err := json.Unmarshal([]byte(content), &doc); err != nil {
+		return nil, fmt.Errorf("parse a2ui: %w", err)
+	}
+	if doc.Version == "" {
+		doc.Version = "1.0"
+	}
+	return &doc, nil
+}

--- a/pkg/canvas/a2ui.go
+++ b/pkg/canvas/a2ui.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -258,20 +259,20 @@ func (r *A2UIRenderer) renderImage(comp A2UIComponent, indent string) (string, e
 	attrs := r.buildAttributes(comp, "", "")
 	src := ""
 	if s, ok := comp.Props["src"].(string); ok {
-		src = template.HTMLEscapeString(s)
+		src = sanitizeImageURL(s)
 	}
 	alt := ""
 	if a, ok := comp.Props["alt"].(string); ok {
 		alt = template.HTMLEscapeString(a)
 	}
-	return fmt.Sprintf("%s<img src=\"%s\" alt=\"%s\"%s>\n", indent, src, alt, attrs), nil
+	return fmt.Sprintf("%s<img src=\"%s\" alt=\"%s\"%s>\n", indent, template.HTMLEscapeString(src), alt, attrs), nil
 }
 
 func (r *A2UIRenderer) renderLink(comp A2UIComponent, indent string) (string, error) {
 	attrs := r.buildAttributes(comp, "", "")
 	href := "#"
 	if value, ok := comp.Props["href"].(string); ok && strings.TrimSpace(value) != "" {
-		href = value
+		href = sanitizeLinkURL(value)
 	}
 	content := template.HTMLEscapeString(comp.Content)
 	if content == "" {
@@ -683,6 +684,50 @@ func firstNonEmptyTheme(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func sanitizeLinkURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "#"
+	}
+	if isSafeA2UIURL(raw, map[string]bool{
+		"http":   true,
+		"https":  true,
+		"mailto": true,
+	}) {
+		return raw
+	}
+	return "#"
+}
+
+func sanitizeImageURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if isSafeA2UIURL(raw, map[string]bool{
+		"http":  true,
+		"https": true,
+	}) {
+		return raw
+	}
+	return ""
+}
+
+func isSafeA2UIURL(raw string, allowedSchemes map[string]bool) bool {
+	if strings.ContainsAny(raw, "\x00\r\n\t") {
+		return false
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if parsed.Scheme == "" {
+		return parsed.Host == ""
+	}
+	return allowedSchemes[strings.ToLower(parsed.Scheme)]
 }
 
 func ParseA2UI(content string) (*A2UIDocument, error) {

--- a/pkg/canvas/a2ui.go
+++ b/pkg/canvas/a2ui.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"regexp"
 	"strings"
 )
 
@@ -30,6 +31,8 @@ type A2UIDocument struct {
 type A2UIRenderer struct {
 	themeStyles map[string]string
 }
+
+var htmlNamePattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9:_-]*$`)
 
 func NewA2UIRenderer() *A2UIRenderer {
 	return &A2UIRenderer{
@@ -227,6 +230,7 @@ func (r *A2UIRenderer) renderInput(comp A2UIComponent, indent string) (string, e
 	if t, ok := comp.Props["inputType"].(string); ok {
 		inputType = t
 	}
+	inputType = template.HTMLEscapeString(inputType)
 	placeholder := ""
 	if p, ok := comp.Props["placeholder"].(string); ok {
 		placeholder = fmt.Sprintf(" placeholder=\"%s\"", template.HTMLEscapeString(p))
@@ -240,6 +244,7 @@ func (r *A2UIRenderer) renderTextarea(comp A2UIComponent, indent string) (string
 	if value, ok := comp.Props["rows"].(string); ok && strings.TrimSpace(value) != "" {
 		rows = value
 	}
+	rows = template.HTMLEscapeString(rows)
 	placeholder := ""
 	if p, ok := comp.Props["placeholder"].(string); ok {
 		placeholder = fmt.Sprintf(" placeholder=\"%s\"", template.HTMLEscapeString(p))
@@ -312,6 +317,7 @@ func (r *A2UIRenderer) renderGrid(comp A2UIComponent, indent string) (string, er
 	if c, ok := comp.Props["columns"].(string); ok {
 		cols = c
 	}
+	cols = template.HTMLEscapeString(cols)
 	style := fmt.Sprintf(" style=\"display:grid;grid-template-columns:repeat(%s,1fr);gap:16px;\"", cols)
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%s<div class=\"a2ui-grid\"%s%s>\n", indent, style, attrs))
@@ -370,10 +376,12 @@ func (r *A2UIRenderer) renderProgress(comp A2UIComponent, indent string) (string
 	if v, ok := comp.Props["value"].(string); ok {
 		value = v
 	}
+	value = template.HTMLEscapeString(value)
 	max := "100"
 	if m, ok := comp.Props["max"].(string); ok {
 		max = m
 	}
+	max = template.HTMLEscapeString(max)
 	return fmt.Sprintf("%s<progress value=\"%s\" max=\"%s\"%s></progress>\n", indent, value, max, attrs), nil
 }
 
@@ -389,6 +397,7 @@ func (r *A2UIRenderer) renderAlert(comp A2UIComponent, indent string) (string, e
 	if l, ok := comp.Props["level"].(string); ok {
 		level = l
 	}
+	level = template.HTMLEscapeString(level)
 	content := template.HTMLEscapeString(comp.Content)
 	return fmt.Sprintf("%s<div class=\"a2ui-alert a2ui-alert-%s\"%s>%s</div>\n", indent, level, attrs, content), nil
 }
@@ -396,7 +405,9 @@ func (r *A2UIRenderer) renderAlert(comp A2UIComponent, indent string) (string, e
 func (r *A2UIRenderer) renderGeneric(comp A2UIComponent, indent string) (string, error) {
 	tag := "div"
 	if t, ok := comp.Props["tag"].(string); ok {
-		tag = t
+		if isSafeHTMLName(t) {
+			tag = t
+		}
 	}
 	attrs := r.buildAttributes(comp)
 	content := template.HTMLEscapeString(comp.Content)
@@ -409,17 +420,20 @@ func (r *A2UIRenderer) buildAttributes(comp A2UIComponent) string {
 	if comp.Styles != nil && len(comp.Styles) > 0 {
 		sb.WriteString(" style=\"")
 		for k, v := range comp.Styles {
-			sb.WriteString(fmt.Sprintf("%s:%s;", k, v))
+			if !isSafeCSSName(k) {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("%s:%s;", template.HTMLEscapeString(k), template.HTMLEscapeString(v)))
 		}
 		sb.WriteString("\"")
 	}
 
 	if comp.Attributes != nil {
 		for k, v := range comp.Attributes {
-			if k == "style" {
+			if k == "style" || !isSafeAttributeName(k) {
 				continue
 			}
-			sb.WriteString(fmt.Sprintf(" %s=\"%v\"", k, v))
+			sb.WriteString(fmt.Sprintf(" %s=\"%s\"", k, template.HTMLEscapeString(fmt.Sprintf("%v", v))))
 		}
 	}
 
@@ -437,6 +451,24 @@ func (r *A2UIRenderer) buildAttributes(comp A2UIComponent) string {
 	}
 
 	return sb.String()
+}
+
+func isSafeHTMLName(name string) bool {
+	name = strings.TrimSpace(name)
+	return htmlNamePattern.MatchString(name)
+}
+
+func isSafeAttributeName(name string) bool {
+	name = strings.TrimSpace(name)
+	return isSafeHTMLName(name) && !strings.HasPrefix(strings.ToLower(name), "on")
+}
+
+func isSafeCSSName(name string) bool {
+	name = strings.TrimSpace(name)
+	if strings.HasPrefix(name, "--") {
+		return htmlNamePattern.MatchString("x" + name)
+	}
+	return htmlNamePattern.MatchString(name)
 }
 
 func (r *A2UIRenderer) componentStyles() string {

--- a/pkg/canvas/store.go
+++ b/pkg/canvas/store.go
@@ -1,0 +1,352 @@
+package canvas
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type CanvasEntry struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Content   string    `json:"content"`
+	Type      string    `json:"type"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Version   int       `json:"version"`
+}
+
+type CanvasVersion struct {
+	Version   int       `json:"version"`
+	Content   string    `json:"content"`
+	Timestamp time.Time `json:"timestamp"`
+	Agent     string    `json:"agent,omitempty"`
+}
+
+type CanvasStore struct {
+	mu          sync.RWMutex
+	baseDir     string
+	entries     map[string]*CanvasEntry
+	versions    map[string][]*CanvasVersion
+	maxVersions int
+}
+
+const (
+	EntryTypeHTML = "html"
+	EntryTypeA2UI = "a2ui"
+	EntryTypeMD   = "markdown"
+	EntryTypeJSON = "json"
+	EntryTypeText = "text"
+)
+
+func NewStore(baseDir string, maxVersions int) (*CanvasStore, error) {
+	if maxVersions <= 0 {
+		maxVersions = 20
+	}
+	canvasDir := filepath.Join(baseDir, "canvas")
+	if err := os.MkdirAll(canvasDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create canvas dir: %w", err)
+	}
+
+	store := &CanvasStore{
+		baseDir:     canvasDir,
+		entries:     make(map[string]*CanvasEntry),
+		versions:    make(map[string][]*CanvasVersion),
+		maxVersions: maxVersions,
+	}
+
+	if err := store.load(); err != nil {
+		return nil, fmt.Errorf("load canvas store: %w", err)
+	}
+
+	return store, nil
+}
+
+func (s *CanvasStore) entryDir() string {
+	return filepath.Join(s.baseDir, "entries")
+}
+
+func (s *CanvasStore) versionDir(id string) string {
+	return filepath.Join(s.baseDir, "versions", id)
+}
+
+func (s *CanvasStore) load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entryDir := s.entryDir()
+	if _, err := os.Stat(entryDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	entries, err := os.ReadDir(entryDir)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(entryDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		var ce CanvasEntry
+		if err := json.Unmarshal(data, &ce); err != nil {
+			continue
+		}
+		s.entries[ce.ID] = &ce
+		s.loadVersions(ce.ID)
+	}
+
+	return nil
+}
+
+func (s *CanvasStore) loadVersions(id string) {
+	vDir := s.versionDir(id)
+	entries, err := os.ReadDir(vDir)
+	if err != nil {
+		return
+	}
+
+	versions := make([]*CanvasVersion, 0)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(vDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var v CanvasVersion
+		if err := json.Unmarshal(data, &v); err != nil {
+			continue
+		}
+		versions = append(versions, &v)
+	}
+
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].Version < versions[j].Version
+	})
+	s.versions[id] = versions
+}
+
+func (s *CanvasStore) Push(id string, name string, content string, contentType string, agent string) (*CanvasEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC()
+
+	if strings.TrimSpace(id) == "" {
+		id = fmt.Sprintf("canvas-%d", now.UnixMilli())
+	}
+
+	if strings.TrimSpace(contentType) == "" {
+		contentType = EntryTypeHTML
+	}
+
+	entry, exists := s.entries[id]
+	if exists {
+		s.saveVersionLocked(entry, agent)
+		entry.Content = content
+		entry.UpdatedAt = now
+		entry.Version++
+	} else {
+		if strings.TrimSpace(name) == "" {
+			name = id
+		}
+		entry = &CanvasEntry{
+			ID:        id,
+			Name:      name,
+			Content:   content,
+			Type:      contentType,
+			CreatedAt: now,
+			UpdatedAt: now,
+			Version:   1,
+		}
+		s.entries[id] = entry
+	}
+
+	if err := s.saveEntry(entry); err != nil {
+		return nil, err
+	}
+
+	return cloneEntry(entry), nil
+}
+
+func (s *CanvasStore) saveVersionLocked(entry *CanvasEntry, agent string) {
+	vDir := s.versionDir(entry.ID)
+	if err := os.MkdirAll(vDir, 0o755); err != nil {
+		return
+	}
+
+	version := &CanvasVersion{
+		Version:   entry.Version,
+		Content:   entry.Content,
+		Timestamp: time.Now().UTC(),
+		Agent:     agent,
+	}
+
+	data, err := json.MarshalIndent(version, "", "  ")
+	if err != nil {
+		return
+	}
+
+	versionFile := filepath.Join(vDir, fmt.Sprintf("v%d.json", entry.Version))
+	_ = os.WriteFile(versionFile, data, 0o644)
+
+	if s.versions[entry.ID] == nil {
+		s.versions[entry.ID] = make([]*CanvasVersion, 0)
+	}
+	s.versions[entry.ID] = append(s.versions[entry.ID], version)
+
+	s.pruneVersions(entry.ID)
+}
+
+func (s *CanvasStore) pruneVersions(id string) {
+	versions := s.versions[id]
+	if len(versions) <= s.maxVersions {
+		return
+	}
+
+	vDir := s.versionDir(id)
+	toRemove := versions[:len(versions)-s.maxVersions]
+	for _, v := range toRemove {
+		_ = os.Remove(filepath.Join(vDir, fmt.Sprintf("v%d.json", v.Version)))
+	}
+	s.versions[id] = versions[len(toRemove):]
+}
+
+func (s *CanvasStore) saveEntry(entry *CanvasEntry) error {
+	entryDir := s.entryDir()
+	if err := os.MkdirAll(entryDir, 0o755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(entryDir, entry.ID+".json"), data, 0o644)
+}
+
+func (s *CanvasStore) Get(id string) (*CanvasEntry, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.entries[id]
+	if !ok {
+		return nil, false
+	}
+	return cloneEntry(entry), true
+}
+
+func (s *CanvasStore) List() []*CanvasEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := make([]*CanvasEntry, 0, len(s.entries))
+	for _, entry := range s.entries {
+		items = append(items, cloneEntry(entry))
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].UpdatedAt.After(items[j].UpdatedAt)
+	})
+
+	return items
+}
+
+func (s *CanvasStore) GetVersions(id string, limit int) []*CanvasVersion {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	versions := s.versions[id]
+	if len(versions) == 0 {
+		return nil
+	}
+
+	result := make([]*CanvasVersion, len(versions))
+	for i, v := range versions {
+		result[i] = cloneVersion(v)
+	}
+
+	if limit > 0 && len(result) > limit {
+		result = result[len(result)-limit:]
+	}
+
+	return result
+}
+
+func (s *CanvasStore) GetVersion(id string, version int) (*CanvasVersion, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	versions := s.versions[id]
+	for _, v := range versions {
+		if v.Version == version {
+			return cloneVersion(v), true
+		}
+	}
+	return nil, false
+}
+
+func (s *CanvasStore) Reset(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.entries[id]
+	if !ok {
+		return fmt.Errorf("canvas entry not found: %s", id)
+	}
+
+	s.saveVersionLocked(entry, "system")
+
+	entry.Content = ""
+	entry.UpdatedAt = time.Now().UTC()
+	entry.Version++
+
+	return s.saveEntry(entry)
+}
+
+func (s *CanvasStore) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.entries, id)
+
+	entryDir := s.entryDir()
+	_ = os.Remove(filepath.Join(entryDir, id+".json"))
+
+	vDir := s.versionDir(id)
+	_ = os.RemoveAll(vDir)
+	delete(s.versions, id)
+
+	return nil
+}
+
+func (s *CanvasStore) BaseDir() string {
+	return s.baseDir
+}
+
+func cloneEntry(e *CanvasEntry) *CanvasEntry {
+	if e == nil {
+		return nil
+	}
+	clone := *e
+	return &clone
+}
+
+func cloneVersion(v *CanvasVersion) *CanvasVersion {
+	if v == nil {
+		return nil
+	}
+	clone := *v
+	return &clone
+}

--- a/pkg/canvas/store.go
+++ b/pkg/canvas/store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -43,6 +44,8 @@ const (
 	EntryTypeJSON = "json"
 	EntryTypeText = "text"
 )
+
+var canvasIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
 func NewStore(baseDir string, maxVersions int) (*CanvasStore, error) {
 	if maxVersions <= 0 {
@@ -101,6 +104,9 @@ func (s *CanvasStore) load() error {
 		if err := json.Unmarshal(data, &ce); err != nil {
 			continue
 		}
+		if err := validateCanvasID(ce.ID); err != nil {
+			continue
+		}
 		s.entries[ce.ID] = &ce
 		s.loadVersions(ce.ID)
 	}
@@ -145,6 +151,9 @@ func (s *CanvasStore) Push(id string, name string, content string, contentType s
 
 	if strings.TrimSpace(id) == "" {
 		id = fmt.Sprintf("canvas-%d", now.UnixMilli())
+	}
+	if err := validateCanvasID(id); err != nil {
+		return nil, err
 	}
 
 	if strings.TrimSpace(contentType) == "" {
@@ -224,6 +233,10 @@ func (s *CanvasStore) pruneVersions(id string) {
 }
 
 func (s *CanvasStore) saveEntry(entry *CanvasEntry) error {
+	if err := validateCanvasID(entry.ID); err != nil {
+		return err
+	}
+
 	entryDir := s.entryDir()
 	if err := os.MkdirAll(entryDir, 0o755); err != nil {
 		return err
@@ -301,6 +314,10 @@ func (s *CanvasStore) Reset(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if err := validateCanvasID(id); err != nil {
+		return err
+	}
+
 	entry, ok := s.entries[id]
 	if !ok {
 		return fmt.Errorf("canvas entry not found: %s", id)
@@ -318,6 +335,10 @@ func (s *CanvasStore) Reset(id string) error {
 func (s *CanvasStore) Delete(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if err := validateCanvasID(id); err != nil {
+		return err
+	}
 
 	delete(s.entries, id)
 
@@ -349,4 +370,15 @@ func cloneVersion(v *CanvasVersion) *CanvasVersion {
 	}
 	clone := *v
 	return &clone
+}
+
+func validateCanvasID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return fmt.Errorf("canvas id is required")
+	}
+	if id == "." || id == ".." || !canvasIDPattern.MatchString(id) {
+		return fmt.Errorf("invalid canvas id: %q", id)
+	}
+	return nil
 }

--- a/pkg/canvas/store.go
+++ b/pkg/canvas/store.go
@@ -168,7 +168,9 @@ func (s *CanvasStore) Push(id string, name string, content string, contentType s
 
 	entry, exists := s.entries[id]
 	if exists {
-		s.saveVersionLocked(entry, agent)
+		if err := s.saveVersionLocked(entry, agent); err != nil {
+			return nil, err
+		}
 		entry.Content = content
 		entry.UpdatedAt = now
 		entry.Version++
@@ -195,10 +197,10 @@ func (s *CanvasStore) Push(id string, name string, content string, contentType s
 	return cloneEntry(entry), nil
 }
 
-func (s *CanvasStore) saveVersionLocked(entry *CanvasEntry, agent string) {
+func (s *CanvasStore) saveVersionLocked(entry *CanvasEntry, agent string) error {
 	vDir := s.versionDir(entry.ID)
 	if err := os.MkdirAll(vDir, 0o755); err != nil {
-		return
+		return fmt.Errorf("create canvas version dir: %w", err)
 	}
 
 	version := &CanvasVersion{
@@ -210,11 +212,13 @@ func (s *CanvasStore) saveVersionLocked(entry *CanvasEntry, agent string) {
 
 	data, err := json.MarshalIndent(version, "", "  ")
 	if err != nil {
-		return
+		return fmt.Errorf("marshal canvas version: %w", err)
 	}
 
 	versionFile := filepath.Join(vDir, fmt.Sprintf("v%d.json", entry.Version))
-	_ = os.WriteFile(versionFile, data, 0o644)
+	if err := os.WriteFile(versionFile, data, 0o644); err != nil {
+		return fmt.Errorf("write canvas version: %w", err)
+	}
 
 	if s.versions[entry.ID] == nil {
 		s.versions[entry.ID] = make([]*CanvasVersion, 0)
@@ -222,6 +226,7 @@ func (s *CanvasStore) saveVersionLocked(entry *CanvasEntry, agent string) {
 	s.versions[entry.ID] = append(s.versions[entry.ID], version)
 
 	s.pruneVersions(entry.ID)
+	return nil
 }
 
 func (s *CanvasStore) pruneVersions(id string) {
@@ -329,7 +334,9 @@ func (s *CanvasStore) Reset(id string) error {
 		return fmt.Errorf("canvas entry not found: %s", id)
 	}
 
-	s.saveVersionLocked(entry, "system")
+	if err := s.saveVersionLocked(entry, "system"); err != nil {
+		return err
+	}
 
 	entry.Content = ""
 	entry.UpdatedAt = time.Now().UTC()

--- a/pkg/canvas/store.go
+++ b/pkg/canvas/store.go
@@ -1,6 +1,8 @@
 package canvas
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -150,7 +152,11 @@ func (s *CanvasStore) Push(id string, name string, content string, contentType s
 	now := time.Now().UTC()
 
 	if strings.TrimSpace(id) == "" {
-		id = fmt.Sprintf("canvas-%d", now.UnixMilli())
+		generatedID, err := generateCanvasID(now)
+		if err != nil {
+			return nil, err
+		}
+		id = generatedID
 	}
 	if err := validateCanvasID(id); err != nil {
 		return nil, err
@@ -381,4 +387,12 @@ func validateCanvasID(id string) error {
 		return fmt.Errorf("invalid canvas id: %q", id)
 	}
 	return nil
+}
+
+func generateCanvasID(now time.Time) (string, error) {
+	var suffix [8]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return "", fmt.Errorf("generate canvas id: %w", err)
+	}
+	return fmt.Sprintf("canvas-%d-%s", now.UnixMilli(), hex.EncodeToString(suffix[:])), nil
 }

--- a/pkg/canvas/store_test.go
+++ b/pkg/canvas/store_test.go
@@ -446,6 +446,94 @@ func TestA2UIEscapesAttributesAndRejectsUnsafeNames(t *testing.T) {
 	}
 }
 
+func TestA2UIMergesBuiltInAndCallerAttributes(t *testing.T) {
+	renderer := NewA2UIRenderer()
+	html, err := renderer.Render(&A2UIDocument{
+		Title: "Attributes",
+		Components: []A2UIComponent{
+			{
+				Type: "stack",
+				Props: map[string]any{
+					"className": "custom-stack",
+					"gap":       "4px",
+				},
+				Styles: map[string]string{
+					"color": "red",
+				},
+			},
+			{
+				Type: "grid",
+				Props: map[string]any{
+					"className": "custom-grid",
+					"columns":   "2",
+				},
+				Styles: map[string]string{
+					"margin": "0",
+				},
+			},
+			{
+				Type: "card",
+				Props: map[string]any{
+					"className": "prop-card",
+				},
+				Attributes: map[string]any{
+					"class": "attr-card",
+				},
+			},
+			{
+				Type: "badge",
+				Props: map[string]any{
+					"className": "custom-badge",
+				},
+				Content: "Badge",
+			},
+			{
+				Type: "alert",
+				Props: map[string]any{
+					"className": "custom-alert",
+					"level":     "warning",
+				},
+				Content: "Alert",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		needle    string
+		wantClass string
+		wantStyle bool
+	}{
+		{name: "stack", needle: "a2ui-stack", wantClass: `class="a2ui-stack custom-stack"`, wantStyle: true},
+		{name: "grid", needle: "a2ui-grid", wantClass: `class="a2ui-grid custom-grid"`, wantStyle: true},
+		{name: "card", needle: "a2ui-card", wantClass: `class="a2ui-card attr-card prop-card"`},
+		{name: "badge", needle: "a2ui-badge", wantClass: `class="a2ui-badge custom-badge"`},
+		{name: "alert", needle: "a2ui-alert-warning", wantClass: `class="a2ui-alert a2ui-alert-warning custom-alert"`},
+	}
+
+	for _, tc := range cases {
+		line := lineContaining(html, tc.needle)
+		if line == "" {
+			t.Fatalf("%s: expected rendered line containing %q:\n%s", tc.name, tc.needle, html)
+		}
+		if strings.Count(line, ` class=`) != 1 {
+			t.Fatalf("%s: expected one class attribute, got line:\n%s", tc.name, line)
+		}
+		if !strings.Contains(line, tc.wantClass) {
+			t.Fatalf("%s: expected merged class %s, got line:\n%s", tc.name, tc.wantClass, line)
+		}
+		if tc.wantStyle && strings.Count(line, ` style=`) != 1 {
+			t.Fatalf("%s: expected one style attribute, got line:\n%s", tc.name, line)
+		}
+		if !tc.wantStyle && strings.Count(line, ` style=`) != 0 {
+			t.Fatalf("%s: expected no style attribute, got line:\n%s", tc.name, line)
+		}
+	}
+}
+
 func containsAll(value string, snippets []string) bool {
 	for _, snippet := range snippets {
 		if !strings.Contains(value, snippet) {
@@ -453,4 +541,13 @@ func containsAll(value string, snippets []string) bool {
 		}
 	}
 	return true
+}
+
+func lineContaining(value string, needle string) string {
+	for _, line := range strings.Split(value, "\n") {
+		if strings.Contains(line, "<") && strings.Contains(line, needle) {
+			return line
+		}
+	}
+	return ""
 }

--- a/pkg/canvas/store_test.go
+++ b/pkg/canvas/store_test.go
@@ -446,6 +446,106 @@ func TestA2UIEscapesAttributesAndRejectsUnsafeNames(t *testing.T) {
 	}
 }
 
+func TestA2UIValidatesRenderedURISchemes(t *testing.T) {
+	renderer := NewA2UIRenderer()
+	html, err := renderer.Render(&A2UIDocument{
+		Title: "Links",
+		Components: []A2UIComponent{
+			{
+				Type:    "link",
+				Content: "Safe HTTP",
+				Props: map[string]any{
+					"href": "https://example.com/docs",
+				},
+			},
+			{
+				Type:    "link",
+				Content: "Safe Mail",
+				Props: map[string]any{
+					"href": "mailto:hello@example.com",
+				},
+			},
+			{
+				Type:    "link",
+				Content: "Safe Relative",
+				Props: map[string]any{
+					"href": "/docs/getting-started#intro",
+				},
+			},
+			{
+				Type:    "link",
+				Content: "Unsafe JS",
+				Props: map[string]any{
+					"href": "javascript:alert(1)",
+				},
+			},
+			{
+				Type:    "link",
+				Content: "Unsafe Data",
+				Props: map[string]any{
+					"href": "data:text/html,<script>alert(1)</script>",
+				},
+			},
+			{
+				Type:    "link",
+				Content: "Protocol Relative",
+				Props: map[string]any{
+					"href": "//example.com/path",
+				},
+			},
+			{
+				Type: "image",
+				Props: map[string]any{
+					"src": "https://example.com/image.png",
+					"alt": "safe",
+				},
+			},
+			{
+				Type: "image",
+				Props: map[string]any{
+					"src": "./images/local.png",
+					"alt": "relative",
+				},
+			},
+			{
+				Type: "image",
+				Props: map[string]any{
+					"src": "javascript:alert(1)",
+					"alt": "bad js",
+				},
+			},
+			{
+				Type: "image",
+				Props: map[string]any{
+					"src": "data:text/html,<script>alert(1)</script>",
+					"alt": "bad data",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	if !containsAll(html, []string{
+		`<a href="https://example.com/docs">Safe HTTP</a>`,
+		`<a href="mailto:hello@example.com">Safe Mail</a>`,
+		`<a href="/docs/getting-started#intro">Safe Relative</a>`,
+		`<a href="#">Unsafe JS</a>`,
+		`<a href="#">Unsafe Data</a>`,
+		`<a href="#">Protocol Relative</a>`,
+		`<img src="https://example.com/image.png" alt="safe">`,
+		`<img src="./images/local.png" alt="relative">`,
+		`<img src="" alt="bad js">`,
+		`<img src="" alt="bad data">`,
+	}) {
+		t.Fatalf("rendered HTML missing expected safe URI output:\n%s", html)
+	}
+	if strings.Contains(html, "javascript:") || strings.Contains(html, "data:text/html") || strings.Contains(html, "//example.com/path") {
+		t.Fatalf("rendered HTML leaked unsafe URI:\n%s", html)
+	}
+}
+
 func TestA2UIMergesBuiltInAndCallerAttributes(t *testing.T) {
 	renderer := NewA2UIRenderer()
 	html, err := renderer.Render(&A2UIDocument{

--- a/pkg/canvas/store_test.go
+++ b/pkg/canvas/store_test.go
@@ -180,6 +180,68 @@ func TestVersionPruning(t *testing.T) {
 	}
 }
 
+func TestPushSurfacesVersionPersistenceFailure(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, err = store.Push("test-1", "Test", "v1", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("initial Push failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(store.BaseDir(), "versions"), []byte("not-a-dir"), 0o600); err != nil {
+		t.Fatalf("create versions path conflict: %v", err)
+	}
+
+	if _, err := store.Push("test-1", "Test", "v2", EntryTypeHTML, "agent-1"); err == nil {
+		t.Fatal("expected version persistence failure")
+	}
+
+	entry, ok := store.Get("test-1")
+	if !ok {
+		t.Fatal("entry missing after failed update")
+	}
+	if entry.Content != "v1" {
+		t.Fatalf("expected content to remain v1 after failed version save, got %q", entry.Content)
+	}
+	if entry.Version != 1 {
+		t.Fatalf("expected version to remain 1 after failed version save, got %d", entry.Version)
+	}
+}
+
+func TestResetSurfacesVersionPersistenceFailure(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, err = store.Push("test-1", "Test", "content", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(store.BaseDir(), "versions"), []byte("not-a-dir"), 0o600); err != nil {
+		t.Fatalf("create versions path conflict: %v", err)
+	}
+
+	if err := store.Reset("test-1"); err == nil {
+		t.Fatal("expected version persistence failure")
+	}
+
+	entry, ok := store.Get("test-1")
+	if !ok {
+		t.Fatal("entry missing after failed reset")
+	}
+	if entry.Content != "content" {
+		t.Fatalf("expected content to remain after failed reset, got %q", entry.Content)
+	}
+	if entry.Version != 1 {
+		t.Fatalf("expected version to remain 1 after failed reset, got %d", entry.Version)
+	}
+}
+
 func TestStorePersistence(t *testing.T) {
 	dir := t.TempDir()
 

--- a/pkg/canvas/store_test.go
+++ b/pkg/canvas/store_test.go
@@ -271,6 +271,34 @@ func TestAutoIDGeneration(t *testing.T) {
 	}
 }
 
+func TestAutoIDGenerationDoesNotOverwriteSameMillisecondEntries(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		entry, err := store.Push("", "Auto", "content", EntryTypeHTML, "agent-1")
+		if err != nil {
+			t.Fatalf("Push failed: %v", err)
+		}
+		if seen[entry.ID] {
+			t.Fatalf("duplicate auto-generated ID: %s", entry.ID)
+		}
+		seen[entry.ID] = true
+		if entry.Version != 1 {
+			t.Fatalf("expected auto-created entry version 1, got %d", entry.Version)
+		}
+	}
+
+	items := store.List()
+	if len(items) != 100 {
+		t.Fatalf("expected 100 independently created entries, got %d", len(items))
+	}
+}
+
 func TestPathTraversalProtection(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewStore(dir, 5)

--- a/pkg/canvas/store_test.go
+++ b/pkg/canvas/store_test.go
@@ -278,6 +278,19 @@ func TestPathTraversalProtection(t *testing.T) {
 		t.Fatalf("NewStore failed: %v", err)
 	}
 
+	if _, err := store.Push("../escape", "Escape", "content", EntryTypeHTML, "agent-1"); err == nil {
+		t.Fatal("expected path traversal id to be rejected")
+	}
+	if _, err := store.Push(`nested\escape`, "Escape", "content", EntryTypeHTML, "agent-1"); err == nil {
+		t.Fatal("expected backslash path id to be rejected")
+	}
+	if err := store.Delete("../escape"); err == nil {
+		t.Fatal("expected invalid delete id to be rejected")
+	}
+	if err := store.Reset("../escape"); err == nil {
+		t.Fatal("expected invalid reset id to be rejected")
+	}
+
 	entryDir := filepath.Join(store.BaseDir(), "entries")
 	if err := os.MkdirAll(entryDir, 0o755); err != nil {
 		t.Fatalf("mkdir failed: %v", err)
@@ -289,6 +302,57 @@ func TestPathTraversalProtection(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Fatalf("expected empty entries dir, got %d files", len(entries))
+	}
+}
+
+func TestA2UIEscapesAttributesAndRejectsUnsafeNames(t *testing.T) {
+	renderer := NewA2UIRenderer()
+	html, err := renderer.Render(&A2UIDocument{
+		Title: "Unsafe",
+		Components: []A2UIComponent{
+			{
+				Type:    "input",
+				Content: "ignored",
+				Props: map[string]any{
+					"inputType": `text" autofocus`,
+				},
+				Attributes: map[string]any{
+					`onclick`:       "alert(1)",
+					`bad name`:      "bad",
+					`data-title`:    `hello "quoted"`,
+					`x" onfocus="x`: "bad",
+				},
+				Styles: map[string]string{
+					"color":       `red";background:url(x)`,
+					`bad name`:    "bad",
+					"--accent":    "#0f766e",
+					"font-weight": "700",
+				},
+			},
+			{
+				Type: "unknown",
+				Props: map[string]any{
+					"tag": `script onclick="bad"`,
+				},
+				Content: `<hello>`,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	if strings.Contains(html, "bad name") || strings.Contains(html, `x" onfocus`) {
+		t.Fatalf("expected unsafe attribute/style names to be skipped:\n%s", html)
+	}
+	if !strings.Contains(html, `data-title="hello &#34;quoted&#34;"`) {
+		t.Fatalf("expected attribute value to be escaped:\n%s", html)
+	}
+	if strings.Contains(html, `<script`) {
+		t.Fatalf("expected unsafe generic tag to fall back to div:\n%s", html)
+	}
+	if !strings.Contains(html, `&lt;hello&gt;`) {
+		t.Fatalf("expected generic content to be escaped:\n%s", html)
 	}
 }
 

--- a/pkg/canvas/store_test.go
+++ b/pkg/canvas/store_test.go
@@ -1,0 +1,302 @@
+package canvas
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewStore(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	if store == nil {
+		t.Fatal("store is nil")
+	}
+	if store.BaseDir() == "" {
+		t.Fatal("base dir is empty")
+	}
+}
+
+func TestPushAndGet(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	entry, err := store.Push("test-1", "Test Canvas", "<h1>Hello</h1>", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	if entry.ID != "test-1" {
+		t.Fatalf("expected id test-1, got %s", entry.ID)
+	}
+	if entry.Version != 1 {
+		t.Fatalf("expected version 1, got %d", entry.Version)
+	}
+
+	got, ok := store.Get("test-1")
+	if !ok {
+		t.Fatal("entry not found")
+	}
+	if got.Content != "<h1>Hello</h1>" {
+		t.Fatalf("expected content <h1>Hello</h1>, got %s", got.Content)
+	}
+}
+
+func TestPushUpdatesVersion(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, err = store.Push("test-1", "Test", "v1", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("first push failed: %v", err)
+	}
+
+	entry, err := store.Push("test-1", "Test", "v2", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("second push failed: %v", err)
+	}
+	if entry.Version != 2 {
+		t.Fatalf("expected version 2, got %d", entry.Version)
+	}
+	if entry.Content != "v2" {
+		t.Fatalf("expected content v2, got %s", entry.Content)
+	}
+}
+
+func TestReset(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, err = store.Push("test-1", "Test", "content", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	if err := store.Reset("test-1"); err != nil {
+		t.Fatalf("Reset failed: %v", err)
+	}
+
+	entry, ok := store.Get("test-1")
+	if !ok {
+		t.Fatal("entry not found after reset")
+	}
+	if entry.Content != "" {
+		t.Fatalf("expected empty content, got %s", entry.Content)
+	}
+	if entry.Version != 2 {
+		t.Fatalf("expected version 2 after reset, got %d", entry.Version)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, err = store.Push("test-1", "Test", "content", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	if err := store.Delete("test-1"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	_, ok := store.Get("test-1")
+	if ok {
+		t.Fatal("entry still exists after delete")
+	}
+}
+
+func TestList(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, _ = store.Push("a", "A", "content", EntryTypeHTML, "agent-1")
+	_, _ = store.Push("b", "B", "content", EntryTypeHTML, "agent-1")
+
+	items := store.List()
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+}
+
+func TestVersions(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, _ = store.Push("test-1", "Test", "v1", EntryTypeHTML, "agent-1")
+	_, _ = store.Push("test-1", "Test", "v2", EntryTypeHTML, "agent-1")
+	_, _ = store.Push("test-1", "Test", "v3", EntryTypeHTML, "agent-1")
+
+	versions := store.GetVersions("test-1", 0)
+	if len(versions) != 2 {
+		t.Fatalf("expected 2 versions (v1 and v2 saved before v3 push), got %d", len(versions))
+	}
+
+	v, ok := store.GetVersion("test-1", 2)
+	if !ok {
+		t.Fatal("version 2 not found")
+	}
+	if v.Content != "v2" {
+		t.Fatalf("expected v2 content, got %s", v.Content)
+	}
+}
+
+func TestVersionPruning(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 3)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	for i := 1; i <= 5; i++ {
+		_, _ = store.Push("test-1", "Test", "v", EntryTypeHTML, "agent-1")
+	}
+
+	versions := store.GetVersions("test-1", 0)
+	if len(versions) > 3 {
+		t.Fatalf("expected at most 3 versions, got %d", len(versions))
+	}
+}
+
+func TestStorePersistence(t *testing.T) {
+	dir := t.TempDir()
+
+	store1, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	_, _ = store1.Push("persist-1", "Persist", "content", EntryTypeHTML, "agent-1")
+
+	store2, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore reload failed: %v", err)
+	}
+
+	entry, ok := store2.Get("persist-1")
+	if !ok {
+		t.Fatal("entry not found after reload")
+	}
+	if entry.Content != "content" {
+		t.Fatalf("expected content 'content', got %s", entry.Content)
+	}
+}
+
+func TestA2UIParseAndRender(t *testing.T) {
+	content := `{
+		"version": "1.0",
+		"title": "Test Page",
+		"description": "Demo description",
+		"theme": "light",
+		"theme_vars": {
+			"accent": "#0f766e"
+		},
+		"components": [
+			{"type": "heading", "content": "Hello World", "props": {"level": 1}},
+			{"type": "text", "content": "This is a test."},
+			{"type": "button", "content": "Click Me"},
+			{"type": "section", "props": {"title": "Details", "description": "More context"}, "children": [
+				{"type": "stack", "props": {"gap": "8px"}, "children": [
+					{"type": "textarea", "props": {"rows": "6", "placeholder": "Write here"}, "content": "Draft"},
+					{"type": "link", "content": "AnyClaw", "props": {"href": "https://github.com/1024XEngineer/anyclaw"}}
+				]}
+			]}
+		]
+	}`
+
+	doc, err := ParseA2UI(content)
+	if err != nil {
+		t.Fatalf("ParseA2UI failed: %v", err)
+	}
+	if doc.Title != "Test Page" {
+		t.Fatalf("expected title 'Test Page', got %s", doc.Title)
+	}
+	if len(doc.Components) != 4 {
+		t.Fatalf("expected 4 components, got %d", len(doc.Components))
+	}
+
+	renderer := NewA2UIRenderer()
+	html, err := renderer.Render(doc)
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if len(html) == 0 {
+		t.Fatal("rendered HTML is empty")
+	}
+	if !containsAll(html, []string{
+		`meta name="description" content="Demo description"`,
+		`--accent:#0f766e`,
+		`<section class="a2ui-section"`,
+		`<textarea rows="6" placeholder="Write here">Draft</textarea>`,
+		`<a href="https://github.com/1024XEngineer/anyclaw">AnyClaw</a>`,
+	}) {
+		t.Fatalf("rendered HTML missing expected upgraded A2UI content:\n%s", html)
+	}
+}
+
+func TestAutoIDGeneration(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	entry, err := store.Push("", "Auto", "content", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	if entry.ID == "" {
+		t.Fatal("auto-generated ID is empty")
+	}
+}
+
+func TestPathTraversalProtection(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	entryDir := filepath.Join(store.BaseDir(), "entries")
+	if err := os.MkdirAll(entryDir, 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+
+	entries, err := os.ReadDir(entryDir)
+	if err != nil {
+		t.Fatalf("readdir failed: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty entries dir, got %d files", len(entries))
+	}
+}
+
+func containsAll(value string, snippets []string) bool {
+	for _, snippet := range snippets {
+		if !strings.Contains(value, snippet) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## 概要

新增 canvas 基础模块，提供 A2UI 文档渲染和本地 canvas 内容存储能力，为后续运行时 UI/画布类能力提供基础组件。

## 本次变更

- 新增 `pkg/canvas/a2ui.go`
  - 定义 A2UI document/component 数据结构
  - 支持将 A2UI JSON 渲染为独立 HTML
  - 支持常见组件：container、section、stack、text、heading、button、input、textarea、image、link、list、card、grid、table、progress、badge、alert 等
  - 支持主题变量、基础样式和 HTML 转义
- 新增 `pkg/canvas/store.go`
  - 提供本地 canvas store
  - 支持创建、更新、读取、列表、重置和删除 canvas entry
  - 支持版本历史记录、版本查询和版本数量裁剪
  - 持久化保存 entry 和 version 数据
- 新增 `pkg/canvas/store_test.go`
  - 覆盖 store 创建、写入、更新、读取、列表、重置、删除和持久化
  - 覆盖版本记录和版本裁剪
  - 覆盖 A2UI 解析与渲染
  - 覆盖 canvas ID 路径安全和 A2UI 属性转义行为

## 安全性说明

- canvas ID 会校验为安全文件名，避免路径穿越写入
- A2UI renderer 会跳过不安全属性名，并对属性值和文本内容进行 HTML 转义

## 验证

已执行：

- `go test ./pkg/canvas`
- `go test ./pkg/canvas -cover`

当前 `pkg/canvas` 覆盖率为 `64.0%`。