### PR TITLE
feat(api): add vector search HTTP server

### DIFF
--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type ErrorResponse struct {
+	Error   string `json:"error"`
+	Code    int    `json:"code"`
+	Details string `json:"details,omitempty"`
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, ErrorResponse{
+		Error: message,
+		Code:  status,
+	})
+}
+
+func writeErrorDetail(w http.ResponseWriter, status int, message, details string) {
+	writeJSON(w, status, ErrorResponse{
+		Error:   message,
+		Code:    status,
+		Details: details,
+	})
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1,0 +1,676 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/embedding"
+	"github.com/1024XEngineer/anyclaw/pkg/index"
+	"github.com/1024XEngineer/anyclaw/pkg/vec"
+)
+
+type Server struct {
+	mux                 *http.ServeMux
+	im                  *index.IndexManager
+	embedder            embedding.Provider
+	batchProc           *embedding.BatchProcessor
+	addr                string
+	maxRequestBodyBytes int64
+}
+
+type ServerConfig struct {
+	Addr                string
+	IndexMgr            *index.IndexManager
+	Embedder            embedding.Provider
+	BatchConfig         *embedding.BatchConfig
+	MaxRequestBodyBytes int64
+}
+
+func NewServer(cfg ServerConfig) *Server {
+	s := &Server{
+		mux:                 http.NewServeMux(),
+		im:                  cfg.IndexMgr,
+		embedder:            cfg.Embedder,
+		addr:                cfg.Addr,
+		maxRequestBodyBytes: cfg.MaxRequestBodyBytes,
+	}
+	if s.addr == "" {
+		s.addr = ":8080"
+	}
+	if s.maxRequestBodyBytes <= 0 {
+		s.maxRequestBodyBytes = 8 << 20
+	}
+	if cfg.Embedder != nil {
+		mgr, _ := embedding.NewManager([]embedding.Provider{cfg.Embedder}, nil)
+		batchCfg := embedding.DefaultBatchConfig()
+		if cfg.BatchConfig != nil {
+			batchCfg = *cfg.BatchConfig
+		}
+		s.batchProc = embedding.NewBatchProcessor(mgr, batchCfg)
+	}
+	s.registerRoutes()
+	return s
+}
+
+func (s *Server) registerRoutes() {
+	s.mux.HandleFunc("POST /v1/search", s.handleSearch)
+	s.mux.HandleFunc("POST /v1/search/text", s.handleSearchText)
+	s.mux.HandleFunc("POST /v1/pure-search", s.handlePureSearch)
+	s.mux.HandleFunc("POST /v1/embed", s.handleEmbed)
+	s.mux.HandleFunc("POST /v1/embed/batch", s.handleEmbedBatch)
+	s.mux.HandleFunc("GET /v1/indexes", s.handleListIndexes)
+	s.mux.HandleFunc("POST /v1/indexes", s.handleCreateIndex)
+	s.mux.HandleFunc("GET /v1/indexes/{name}", s.handleGetIndex)
+	s.mux.HandleFunc("DELETE /v1/indexes/{name}", s.handleDeleteIndex)
+	s.mux.HandleFunc("POST /v1/indexes/{name}/rebuild", s.handleRebuildIndex)
+	s.mux.HandleFunc("GET /v1/health", s.handleHealth)
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+func (s *Server) Start() error {
+	return s.newHTTPServer().ListenAndServe()
+}
+
+func (s *Server) StartWithContext(ctx context.Context) error {
+	server := s.newHTTPServer()
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	return server.ListenAndServe()
+}
+
+func (s *Server) newHTTPServer() *http.Server {
+	return &http.Server{
+		Addr:              s.addr,
+		Handler:           s,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+}
+
+type SearchRequest struct {
+	Index     string         `json:"index"`
+	Vector    []float32      `json:"vector"`
+	Limit     int            `json:"limit"`
+	Threshold float64        `json:"threshold"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+type SearchResult struct {
+	ID       any            `json:"id"`
+	Distance float64        `json:"distance"`
+	Score    float64        `json:"score"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+type SearchResponse struct {
+	Results  []SearchResult `json:"results"`
+	Count    int            `json:"count"`
+	Index    string         `json:"index"`
+	Duration string         `json:"duration"`
+}
+
+type EmbedRequest struct {
+	Text string `json:"text"`
+}
+
+type EmbedResponse struct {
+	Vector    []float32 `json:"vector"`
+	Dimension int       `json:"dimension"`
+	Provider  string    `json:"provider"`
+}
+
+type CreateIndexRequest struct {
+	Name       string             `json:"name"`
+	Dimensions int                `json:"dimensions"`
+	Distance   vec.DistanceMetric `json:"distance"`
+	Metadata   []string           `json:"metadata"`
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{
+		"status":  "ok",
+		"service": "vector-search",
+	})
+}
+
+func (s *Server) decodeJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, s.maxRequestBodyBytes)
+
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(dst); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return false
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return false
+	}
+	return true
+}
+
+func (s *Server) requireIndexManager(w http.ResponseWriter) bool {
+	if s.im == nil {
+		writeError(w, http.StatusServiceUnavailable, "index manager not configured")
+		return false
+	}
+	return true
+}
+
+func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
+	if !s.requireIndexManager(w) {
+		return
+	}
+
+	var req SearchRequest
+	if !s.decodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Index == "" {
+		writeError(w, http.StatusBadRequest, "index is required")
+		return
+	}
+	if len(req.Vector) == 0 {
+		writeError(w, http.StatusBadRequest, "vector is required")
+		return
+	}
+
+	if req.Limit <= 0 {
+		req.Limit = 10
+	}
+
+	start := time.Now()
+
+	ctx := r.Context()
+	results, err := s.im.Search(ctx, req.Index, req.Vector, req.Limit)
+	if err != nil {
+		writeErrorDetail(w, http.StatusBadRequest, "search failed", err.Error())
+		return
+	}
+
+	searchResults := make([]SearchResult, 0, len(results))
+	for _, r := range results {
+		if req.Threshold > 0 && r.Distance > req.Threshold {
+			continue
+		}
+
+		score := 1.0 - r.Distance
+		if score < 0 {
+			score = 0
+		}
+
+		searchResults = append(searchResults, SearchResult{
+			ID:       r.ID,
+			Distance: r.Distance,
+			Score:    math.Round(score*10000) / 10000,
+			Metadata: r.Metadata,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, SearchResponse{
+		Results:  searchResults,
+		Count:    len(searchResults),
+		Index:    req.Index,
+		Duration: time.Since(start).String(),
+	})
+}
+
+func (s *Server) handleSearchText(w http.ResponseWriter, r *http.Request) {
+	if !s.requireIndexManager(w) {
+		return
+	}
+	if s.embedder == nil {
+		writeError(w, http.StatusBadGateway, "no embedder configured")
+		return
+	}
+
+	var req struct {
+		Index     string         `json:"index"`
+		Text      string         `json:"text"`
+		Limit     int            `json:"limit"`
+		Threshold float64        `json:"threshold"`
+		Metadata  map[string]any `json:"metadata,omitempty"`
+	}
+	if !s.decodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Index == "" {
+		writeError(w, http.StatusBadRequest, "index is required")
+		return
+	}
+	if req.Text == "" {
+		writeError(w, http.StatusBadRequest, "text is required")
+		return
+	}
+
+	if req.Limit <= 0 {
+		req.Limit = 10
+	}
+
+	start := time.Now()
+
+	ctx := r.Context()
+	results, err := s.im.SearchByText(ctx, req.Index, req.Text, req.Limit)
+	if err != nil {
+		writeErrorDetail(w, http.StatusBadRequest, "search failed", err.Error())
+		return
+	}
+
+	searchResults := make([]SearchResult, 0, len(results))
+	for _, r := range results {
+		if req.Threshold > 0 && r.Distance > req.Threshold {
+			continue
+		}
+
+		score := 1.0 - r.Distance
+		if score < 0 {
+			score = 0
+		}
+
+		searchResults = append(searchResults, SearchResult{
+			ID:       r.ID,
+			Distance: r.Distance,
+			Score:    math.Round(score*10000) / 10000,
+			Metadata: r.Metadata,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, SearchResponse{
+		Results:  searchResults,
+		Count:    len(searchResults),
+		Index:    req.Index,
+		Duration: time.Since(start).String(),
+	})
+}
+
+func (s *Server) handleEmbed(w http.ResponseWriter, r *http.Request) {
+	if s.embedder == nil {
+		writeError(w, http.StatusBadGateway, "no embedder configured")
+		return
+	}
+
+	var req EmbedRequest
+	if !s.decodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Text == "" {
+		writeError(w, http.StatusBadRequest, "text is required")
+		return
+	}
+
+	ctx := r.Context()
+	vector, err := s.embedder.Embed(ctx, req.Text)
+	if err != nil {
+		writeErrorDetail(w, http.StatusInternalServerError, "embedding failed", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, EmbedResponse{
+		Vector:    vector,
+		Dimension: len(vector),
+		Provider:  s.embedder.Name(),
+	})
+}
+
+type EmbedBatchRequest struct {
+	Texts       []string `json:"texts"`
+	Concurrency int      `json:"concurrency"`
+	ChunkSize   int      `json:"chunk_size"`
+	MaxRetries  int      `json:"max_retries"`
+	RateLimit   int      `json:"rate_limit"`
+}
+
+type EmbedBatchResponse struct {
+	Embeddings [][]float32  `json:"embeddings"`
+	Errors     []BatchError `json:"errors,omitempty"`
+	Total      int          `json:"total"`
+	Succeeded  int          `json:"succeeded"`
+	Failed     int          `json:"failed"`
+	Duration   string       `json:"duration"`
+	Provider   string       `json:"provider"`
+}
+
+type BatchError struct {
+	Index int    `json:"index"`
+	Text  string `json:"text"`
+	Error string `json:"error"`
+}
+
+func (s *Server) handleEmbedBatch(w http.ResponseWriter, r *http.Request) {
+	if s.batchProc == nil {
+		writeError(w, http.StatusBadGateway, "batch processing not configured")
+		return
+	}
+
+	var req EmbedBatchRequest
+	if !s.decodeJSON(w, r, &req) {
+		return
+	}
+
+	if len(req.Texts) == 0 {
+		writeError(w, http.StatusBadRequest, "texts array is required")
+		return
+	}
+	if len(req.Texts) > 10000 {
+		writeError(w, http.StatusBadRequest, "maximum 10000 texts per batch")
+		return
+	}
+
+	bp := s.batchProc
+	if req.Concurrency > 0 || req.ChunkSize > 0 || req.MaxRetries >= 0 || req.RateLimit > 0 {
+		cfg := s.batchProc.Config()
+		if req.Concurrency > 0 {
+			cfg.Concurrency = req.Concurrency
+		}
+		if req.ChunkSize > 0 {
+			cfg.ChunkSize = req.ChunkSize
+		}
+		if req.MaxRetries >= 0 {
+			cfg.MaxRetries = req.MaxRetries
+		}
+		if req.RateLimit > 0 {
+			cfg.RateLimitPerSec = req.RateLimit
+		}
+		bp = embedding.NewBatchProcessor(s.batchProc.Manager(), cfg)
+	}
+
+	ctx := r.Context()
+	result, err := bp.Process(ctx, req.Texts)
+	if err != nil {
+		writeErrorDetail(w, http.StatusInternalServerError, "batch processing failed", err.Error())
+		return
+	}
+
+	batchErrors := make([]BatchError, len(result.Errors))
+	for i, e := range result.Errors {
+		batchErrors[i] = BatchError{
+			Index: e.Index,
+			Text:  e.Text,
+			Error: e.Err.Error(),
+		}
+	}
+
+	writeJSON(w, http.StatusOK, EmbedBatchResponse{
+		Embeddings: result.Embeddings,
+		Errors:     batchErrors,
+		Total:      result.Total,
+		Succeeded:  result.Succeeded,
+		Failed:     result.Failed,
+		Duration:   result.Duration.String(),
+		Provider:   s.embedder.Name(),
+	})
+}
+
+func (s *Server) handleListIndexes(w http.ResponseWriter, r *http.Request) {
+	if !s.requireIndexManager(w) {
+		return
+	}
+
+	indexes := s.im.List()
+	writeJSON(w, http.StatusOK, indexes)
+}
+
+func (s *Server) handleCreateIndex(w http.ResponseWriter, r *http.Request) {
+	if !s.requireIndexManager(w) {
+		return
+	}
+
+	var req CreateIndexRequest
+	if !s.decodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if req.Dimensions <= 0 {
+		writeError(w, http.StatusBadRequest, "dimensions must be positive")
+		return
+	}
+
+	if req.Distance == "" {
+		req.Distance = vec.DistanceCosine
+	}
+
+	ctx := r.Context()
+	info, err := s.im.Create(ctx, index.Config{
+		Name:       req.Name,
+		Dimensions: req.Dimensions,
+		Distance:   req.Distance,
+		Metadata:   req.Metadata,
+	})
+	if err != nil {
+		writeErrorDetail(w, http.StatusConflict, "create index failed", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, info)
+}
+
+func (s *Server) handleGetIndex(w http.ResponseWriter, r *http.Request) {
+	if !s.requireIndexManager(w) {
+		return
+	}
+
+	name := r.PathValue("name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "index name is required")
+		return
+	}
+
+	info, err := s.im.Get(name)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, info)
+}
+
+func (s *Server) handleDeleteIndex(w http.ResponseWriter, r *http.Request) {
+	if !s.requireIndexManager(w) {
+		return
+	}
+
+	name := r.PathValue("name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "index name is required")
+		return
+	}
+
+	ctx := r.Context()
+	if err := s.im.Delete(ctx, name); err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted", "index": name})
+}
+
+func (s *Server) handleRebuildIndex(w http.ResponseWriter, r *http.Request) {
+	if !s.requireIndexManager(w) {
+		return
+	}
+
+	name := r.PathValue("name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "index name is required")
+		return
+	}
+
+	ctx := r.Context()
+	result, err := s.im.Rebuild(ctx, name, nil)
+	if err != nil {
+		writeErrorDetail(w, http.StatusBadRequest, "rebuild failed", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) HandleIndex(ctx context.Context, indexName string, items []index.IndexItem, progress index.ProgressFunc) (*index.IndexResult, error) {
+	if s.im == nil {
+		return nil, fmt.Errorf("index manager not configured")
+	}
+	return s.im.Index(ctx, indexName, items, progress)
+}
+
+func (s *Server) RemoveVectors(ctx context.Context, indexName string, ids []any) (int, error) {
+	if s.im == nil {
+		return 0, fmt.Errorf("index manager not configured")
+	}
+	return s.im.RemoveVectors(ctx, indexName, ids)
+}
+
+func (s *Server) CosineSimilarity(a, b []float32) float64 {
+	return vec.CosineSimilarity(a, b)
+}
+
+func (s *Server) CosineDistance(a, b []float32) float64 {
+	return vec.CosineDistance(a, b)
+}
+
+type scoredEntry struct {
+	index    int
+	distance float64
+	score    float64
+}
+
+type PureSearchRequest struct {
+	Vectors   [][]float32 `json:"vectors"`
+	Query     []float32   `json:"query"`
+	Limit     int         `json:"limit"`
+	TopK      int         `json:"top_k"`
+	Threshold float64     `json:"threshold"`
+	Metric    string      `json:"metric"`
+}
+
+type PureSearchResult struct {
+	Index    int     `json:"index"`
+	Distance float64 `json:"distance"`
+	Score    float64 `json:"score"`
+}
+
+type PureSearchResponse struct {
+	Results  []PureSearchResult `json:"results"`
+	Count    int                `json:"count"`
+	Metric   string             `json:"metric"`
+	Duration string             `json:"duration"`
+}
+
+func (s *Server) handlePureSearch(w http.ResponseWriter, r *http.Request) {
+	var req PureSearchRequest
+	if !s.decodeJSON(w, r, &req) {
+		return
+	}
+
+	if len(req.Query) == 0 {
+		writeError(w, http.StatusBadRequest, "query vector is required")
+		return
+	}
+
+	vectors := req.Vectors
+	if len(vectors) == 0 {
+		writeError(w, http.StatusBadRequest, "vectors are required")
+		return
+	}
+
+	if req.Limit <= 0 {
+		req.Limit = 10
+	}
+	if req.TopK > 0 && req.TopK < req.Limit {
+		req.Limit = req.TopK
+	}
+
+	metric := req.Metric
+	if metric == "" {
+		metric = "cosine"
+	}
+
+	start := time.Now()
+
+	type scored struct {
+		index    int
+		distance float64
+		score    float64
+	}
+
+	var scoredResults []scoredEntry
+	for i, v := range vectors {
+		var distance float64
+		switch metric {
+		case "cosine":
+			distance = vec.CosineDistance(req.Query, v)
+		case "l2", "euclidean":
+			distance = vec.L2Distance(req.Query, v)
+		default:
+			distance = vec.CosineDistance(req.Query, v)
+		}
+
+		score := 1.0 - distance
+		if score < 0 {
+			score = 0
+		}
+
+		if req.Threshold > 0 && distance > req.Threshold {
+			continue
+		}
+
+		scoredResults = append(scoredResults, scoredEntry{
+			index:    i,
+			distance: distance,
+			score:    math.Round(score*10000) / 10000,
+		})
+	}
+
+	sortByScore(scoredResults)
+
+	if len(scoredResults) > req.Limit {
+		scoredResults = scoredResults[:req.Limit]
+	}
+
+	results := make([]PureSearchResult, len(scoredResults))
+	for i, sr := range scoredResults {
+		results[i] = PureSearchResult{
+			Index:    sr.index,
+			Distance: sr.distance,
+			Score:    sr.score,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, PureSearchResponse{
+		Results:  results,
+		Count:    len(results),
+		Metric:   metric,
+		Duration: time.Since(start).String(),
+	})
+}
+
+func sortByScore(results []scoredEntry) {
+	for i := 0; i < len(results); i++ {
+		for j := i + 1; j < len(results); j++ {
+			if results[j].score > results[i].score {
+				results[i], results[j] = results[j], results[i]
+			}
+		}
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -362,10 +362,10 @@ func (s *Server) handleEmbed(w http.ResponseWriter, r *http.Request) {
 
 type EmbedBatchRequest struct {
 	Texts       []string `json:"texts"`
-	Concurrency int      `json:"concurrency"`
-	ChunkSize   int      `json:"chunk_size"`
-	MaxRetries  int      `json:"max_retries"`
-	RateLimit   int      `json:"rate_limit"`
+	Concurrency *int     `json:"concurrency"`
+	ChunkSize   *int     `json:"chunk_size"`
+	MaxRetries  *int     `json:"max_retries"`
+	RateLimit   *int     `json:"rate_limit"`
 }
 
 type EmbedBatchResponse struct {
@@ -405,19 +405,19 @@ func (s *Server) handleEmbedBatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	bp := s.batchProc
-	if req.Concurrency > 0 || req.ChunkSize > 0 || req.MaxRetries >= 0 || req.RateLimit > 0 {
+	if req.Concurrency != nil || req.ChunkSize != nil || req.MaxRetries != nil || req.RateLimit != nil {
 		cfg := s.batchProc.Config()
-		if req.Concurrency > 0 {
-			cfg.Concurrency = req.Concurrency
+		if req.Concurrency != nil && *req.Concurrency > 0 {
+			cfg.Concurrency = *req.Concurrency
 		}
-		if req.ChunkSize > 0 {
-			cfg.ChunkSize = req.ChunkSize
+		if req.ChunkSize != nil && *req.ChunkSize > 0 {
+			cfg.ChunkSize = *req.ChunkSize
 		}
-		if req.MaxRetries >= 0 {
-			cfg.MaxRetries = req.MaxRetries
+		if req.MaxRetries != nil && *req.MaxRetries >= 0 {
+			cfg.MaxRetries = *req.MaxRetries
 		}
-		if req.RateLimit > 0 {
-			cfg.RateLimitPerSec = req.RateLimit
+		if req.RateLimit != nil && *req.RateLimit > 0 {
+			cfg.RateLimitPerSec = *req.RateLimit
 		}
 		bp = embedding.NewBatchProcessor(s.batchProc.Manager(), cfg)
 	}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/1024XEngineer/anyclaw/pkg/embedding"
@@ -172,6 +173,27 @@ func (s *Server) requireIndexManager(w http.ResponseWriter) bool {
 	return true
 }
 
+func requestMetadataFilter(w http.ResponseWriter, metadata map[string]any) (map[string]string, bool) {
+	if len(metadata) == 0 {
+		return nil, true
+	}
+
+	filter := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		if strings.TrimSpace(key) == "" {
+			writeError(w, http.StatusBadRequest, "metadata keys must be non-empty")
+			return nil, false
+		}
+		text, ok := value.(string)
+		if !ok {
+			writeError(w, http.StatusBadRequest, "metadata filter values must be strings")
+			return nil, false
+		}
+		filter[key] = text
+	}
+	return filter, true
+}
+
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	if !s.requireIndexManager(w) {
 		return
@@ -195,10 +217,15 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		req.Limit = 10
 	}
 
+	metadataFilter, ok := requestMetadataFilter(w, req.Metadata)
+	if !ok {
+		return
+	}
+
 	start := time.Now()
 
 	ctx := r.Context()
-	results, err := s.im.Search(ctx, req.Index, req.Vector, req.Limit)
+	results, err := s.im.SearchWithFilter(ctx, req.Index, req.Vector, req.Limit, req.Threshold, metadataFilter)
 	if err != nil {
 		writeErrorDetail(w, http.StatusBadRequest, "search failed", err.Error())
 		return
@@ -206,10 +233,6 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 
 	searchResults := make([]SearchResult, 0, len(results))
 	for _, r := range results {
-		if req.Threshold > 0 && r.Distance > req.Threshold {
-			continue
-		}
-
 		score := 1.0 - r.Distance
 		if score < 0 {
 			score = 0
@@ -264,6 +287,11 @@ func (s *Server) handleSearchText(w http.ResponseWriter, r *http.Request) {
 		req.Limit = 10
 	}
 
+	metadataFilter, ok := requestMetadataFilter(w, req.Metadata)
+	if !ok {
+		return
+	}
+
 	start := time.Now()
 
 	ctx := r.Context()
@@ -273,7 +301,7 @@ func (s *Server) handleSearchText(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results, err := s.im.Search(ctx, req.Index, vector, req.Limit)
+	results, err := s.im.SearchWithFilter(ctx, req.Index, vector, req.Limit, req.Threshold, metadataFilter)
 	if err != nil {
 		writeErrorDetail(w, http.StatusBadRequest, "search failed", err.Error())
 		return
@@ -281,10 +309,6 @@ func (s *Server) handleSearchText(w http.ResponseWriter, r *http.Request) {
 
 	searchResults := make([]SearchResult, 0, len(results))
 	for _, r := range results {
-		if req.Threshold > 0 && r.Distance > req.Threshold {
-			continue
-		}
-
 		score := 1.0 - r.Distance
 		if score < 0 {
 			score = 0

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -267,7 +267,13 @@ func (s *Server) handleSearchText(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 
 	ctx := r.Context()
-	results, err := s.im.SearchByText(ctx, req.Index, req.Text, req.Limit)
+	vector, err := s.embedder.Embed(ctx, req.Text)
+	if err != nil {
+		writeErrorDetail(w, http.StatusInternalServerError, "embedding failed", err.Error())
+		return
+	}
+
+	results, err := s.im.Search(ctx, req.Index, vector, req.Limit)
 	if err != nil {
 		writeErrorDetail(w, http.StatusBadRequest, "search failed", err.Error())
 		return

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -1,0 +1,667 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite/vec"
+
+	"github.com/1024XEngineer/anyclaw/pkg/index"
+)
+
+func setupTestServer(t *testing.T) (*Server, *mockEmbedder) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	embedder := &mockEmbedder{dim: 4}
+	im := index.NewIndexManager(db, embedder, index.WithVectorDir(t.TempDir()))
+	if err := im.Init(context.Background()); err != nil {
+		t.Fatalf("init index manager: %v", err)
+	}
+
+	if _, err := im.Create(context.Background(), index.Config{
+		Name:       "test_index",
+		Dimensions: 4,
+		Distance:   "cosine",
+	}); err != nil {
+		t.Fatalf("create test index: %v", err)
+	}
+
+	if _, err := im.Index(context.Background(), "test_index", []index.IndexItem{
+		{ID: 1, Vector: []float32{0.1, 0.2, 0.3, 0.4}},
+		{ID: 2, Vector: []float32{0.5, 0.6, 0.7, 0.8}},
+		{ID: 3, Vector: []float32{0.9, 1.0, 0.1, 0.2}},
+	}, nil); err != nil {
+		t.Fatalf("seed test index: %v", err)
+	}
+
+	server := NewServer(ServerConfig{
+		IndexMgr: im,
+		Embedder: embedder,
+	})
+
+	return server, embedder
+}
+
+func doRequest(t *testing.T, s *Server, method, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var reqBody []byte
+	if body != nil {
+		reqBody, _ = json.Marshal(body)
+	}
+	req := httptest.NewRequest(method, path, bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	return w
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	s, _ := setupTestServer(t)
+	w := doRequest(t, s, "GET", "/v1/health", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "ok" {
+		t.Errorf("expected status ok, got %s", resp["status"])
+	}
+}
+
+func TestIndexRoutesRejectMissingIndexManager(t *testing.T) {
+	s := NewServer(ServerConfig{})
+	w := doRequest(t, s, "GET", "/v1/indexes", nil)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRejectsOversizedRequestBody(t *testing.T) {
+	s, _ := setupTestServer(t)
+	s.maxRequestBodyBytes = 8
+
+	w := doRequest(t, s, "POST", "/v1/pure-search", map[string]any{
+		"query":   []float32{0.1, 0.2, 0.3, 0.4},
+		"vectors": [][]float32{{0.1, 0.2, 0.3, 0.4}},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRejectsMultipleJSONValues(t *testing.T) {
+	s, _ := setupTestServer(t)
+	req := httptest.NewRequest("POST", "/v1/embed", bytes.NewBufferString(`{"text":"hello"}{"text":"again"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSearchEndpoint(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := map[string]any{
+		"index":  "test_index",
+		"vector": []float32{0.1, 0.2, 0.3, 0.4},
+		"limit":  10,
+	}
+
+	w := doRequest(t, s, "POST", "/v1/search", reqBody)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp SearchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp.Count != 3 {
+		t.Errorf("expected 3 results, got %d", resp.Count)
+	}
+	if resp.Index != "test_index" {
+		t.Errorf("expected index test_index, got %s", resp.Index)
+	}
+	if resp.Duration == "" {
+		t.Error("expected non-empty duration")
+	}
+
+	if resp.Results[0].Score < 0.99 {
+		t.Errorf("expected first result score ~1.0, got %f", resp.Results[0].Score)
+	}
+}
+
+func TestSearchWithThreshold(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := map[string]any{
+		"index":     "test_index",
+		"vector":    []float32{0.1, 0.2, 0.3, 0.4},
+		"limit":     10,
+		"threshold": 0.01,
+	}
+
+	w := doRequest(t, s, "POST", "/v1/search", reqBody)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp SearchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp.Count < 1 {
+		t.Errorf("expected at least 1 result with threshold, got %d", resp.Count)
+	}
+}
+
+func TestSearchMissingIndex(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := map[string]any{
+		"index":  "nonexistent",
+		"vector": []float32{0.1, 0.2, 0.3, 0.4},
+	}
+
+	w := doRequest(t, s, "POST", "/v1/search", reqBody)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestSearchMissingVector(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := map[string]any{
+		"index": "test_index",
+	}
+
+	w := doRequest(t, s, "POST", "/v1/search", reqBody)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestSearchTextEndpoint(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := map[string]any{
+		"index": "test_index",
+		"text":  "search query",
+		"limit": 10,
+	}
+
+	w := doRequest(t, s, "POST", "/v1/search/text", reqBody)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp SearchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp.Count != 3 {
+		t.Errorf("expected 3 results, got %d", resp.Count)
+	}
+}
+
+func TestSearchTextMissingText(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := map[string]any{
+		"index": "test_index",
+	}
+
+	w := doRequest(t, s, "POST", "/v1/search/text", reqBody)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestEmbedEndpoint(t *testing.T) {
+	s, embedder := setupTestServer(t)
+
+	reqBody := map[string]any{
+		"text": "hello world",
+	}
+
+	w := doRequest(t, s, "POST", "/v1/embed", reqBody)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp EmbedResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp.Dimension != 4 {
+		t.Errorf("expected dimension 4, got %d", resp.Dimension)
+	}
+	if resp.Provider != "mock" {
+		t.Errorf("expected provider mock, got %s", resp.Provider)
+	}
+	if len(resp.Vector) != 4 {
+		t.Errorf("expected 4 vector elements, got %d", len(resp.Vector))
+	}
+	if embedder.callCount.Load() != 1 {
+		t.Errorf("expected 1 embed call, got %d", embedder.callCount.Load())
+	}
+}
+
+func TestEmbedMissingText(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := map[string]any{}
+
+	w := doRequest(t, s, "POST", "/v1/embed", reqBody)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestListIndexes(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	w := doRequest(t, s, "GET", "/v1/indexes", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var indexes []map[string]any
+	json.Unmarshal(w.Body.Bytes(), &indexes)
+
+	if len(indexes) != 1 {
+		t.Errorf("expected 1 index, got %d", len(indexes))
+	}
+}
+
+func TestGetIndex(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	w := doRequest(t, s, "GET", "/v1/indexes/test_index", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var info map[string]any
+	json.Unmarshal(w.Body.Bytes(), &info)
+
+	if info["name"] != "test_index" {
+		t.Errorf("expected name test_index, got %v", info["name"])
+	}
+}
+
+func TestGetIndexNotFound(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	w := doRequest(t, s, "GET", "/v1/indexes/nonexistent", nil)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestCreateIndex(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := map[string]any{
+		"name":       "new_index",
+		"dimensions": 8,
+		"distance":   "cosine",
+		"metadata":   []string{"category"},
+	}
+
+	w := doRequest(t, s, "POST", "/v1/indexes", reqBody)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var info map[string]any
+	json.Unmarshal(w.Body.Bytes(), &info)
+
+	if info["name"] != "new_index" {
+		t.Errorf("expected name new_index, got %v", info["name"])
+	}
+}
+
+func TestCreateIndexDuplicate(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := map[string]any{
+		"name":       "test_index",
+		"dimensions": 4,
+	}
+
+	w := doRequest(t, s, "POST", "/v1/indexes", reqBody)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+}
+
+func TestDeleteIndex(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	w := doRequest(t, s, "DELETE", "/v1/indexes/test_index", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "deleted" {
+		t.Errorf("expected status deleted, got %s", resp["status"])
+	}
+}
+
+func TestRebuildIndex(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	w := doRequest(t, s, "POST", "/v1/indexes/test_index/rebuild", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPureSearchCosine(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := PureSearchRequest{
+		Vectors: [][]float32{
+			{0.1, 0.2, 0.3, 0.4},
+			{0.5, 0.6, 0.7, 0.8},
+			{0.9, 1.0, 0.1, 0.2},
+		},
+		Query:  []float32{0.1, 0.2, 0.3, 0.4},
+		Limit:  10,
+		Metric: "cosine",
+	}
+
+	w := doRequest(t, s, "POST", "/v1/pure-search", reqBody)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp PureSearchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp.Count != 3 {
+		t.Errorf("expected 3 results, got %d", resp.Count)
+	}
+	if resp.Metric != "cosine" {
+		t.Errorf("expected metric cosine, got %s", resp.Metric)
+	}
+	if resp.Results[0].Index != 0 {
+		t.Errorf("expected first result index 0, got %d", resp.Results[0].Index)
+	}
+	if resp.Results[0].Score < 0.99 {
+		t.Errorf("expected first result score ~1.0, got %f", resp.Results[0].Score)
+	}
+}
+
+func TestPureSearchL2(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := PureSearchRequest{
+		Vectors: [][]float32{
+			{0.0, 0.0, 0.0, 0.0},
+			{3.0, 4.0, 0.0, 0.0},
+		},
+		Query:  []float32{0.0, 0.0, 0.0, 0.0},
+		Limit:  10,
+		Metric: "l2",
+	}
+
+	w := doRequest(t, s, "POST", "/v1/pure-search", reqBody)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp PureSearchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp.Count != 2 {
+		t.Errorf("expected 2 results, got %d", resp.Count)
+	}
+	if resp.Results[0].Distance > 0.01 {
+		t.Errorf("expected first result distance ~0, got %f", resp.Results[0].Distance)
+	}
+}
+
+func TestPureSearchThreshold(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := PureSearchRequest{
+		Vectors: [][]float32{
+			{0.1, 0.2, 0.3, 0.4},
+			{0.5, 0.6, 0.7, 0.8},
+			{0.9, 1.0, 0.1, 0.2},
+		},
+		Query:     []float32{0.1, 0.2, 0.3, 0.4},
+		Limit:     10,
+		Threshold: 0.01,
+	}
+
+	w := doRequest(t, s, "POST", "/v1/pure-search", reqBody)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp PureSearchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp.Count < 1 {
+		t.Errorf("expected at least 1 result with threshold, got %d", resp.Count)
+	}
+}
+
+func TestPureSearchLimit(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := PureSearchRequest{
+		Vectors: [][]float32{
+			{0.1, 0.2, 0.3, 0.4},
+			{0.5, 0.6, 0.7, 0.8},
+			{0.9, 1.0, 0.1, 0.2},
+		},
+		Query: []float32{0.1, 0.2, 0.3, 0.4},
+		Limit: 1,
+	}
+
+	w := doRequest(t, s, "POST", "/v1/pure-search", reqBody)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp PureSearchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp.Count != 1 {
+		t.Errorf("expected 1 result with limit=1, got %d", resp.Count)
+	}
+}
+
+func TestEmbedBatchEndpoint(t *testing.T) {
+	s, embedder := setupTestServer(t)
+
+	reqBody := map[string]any{
+		"texts":       []string{"hello", "world", "batch test"},
+		"concurrency": 2,
+		"chunk_size":  2,
+	}
+
+	w := doRequest(t, s, "POST", "/v1/embed/batch", reqBody)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp EmbedBatchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp.Total != 3 {
+		t.Errorf("expected total 3, got %d", resp.Total)
+	}
+	if resp.Succeeded != 3 {
+		t.Errorf("expected succeeded 3, got %d", resp.Succeeded)
+	}
+	if resp.Failed != 0 {
+		t.Errorf("expected failed 0, got %d", resp.Failed)
+	}
+	if len(resp.Embeddings) != 3 {
+		t.Errorf("expected 3 embeddings, got %d", len(resp.Embeddings))
+	}
+	if embedder.callCount.Load() != 3 {
+		t.Errorf("expected 3 embed calls, got %d", embedder.callCount.Load())
+	}
+}
+
+func TestEmbedBatchEmptyTexts(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := map[string]any{
+		"texts": []string{},
+	}
+
+	w := doRequest(t, s, "POST", "/v1/embed/batch", reqBody)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestEmbedBatchTooMany(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	texts := make([]string, 10001)
+	for i := range texts {
+		texts[i] = "text"
+	}
+
+	reqBody := map[string]any{
+		"texts": texts,
+	}
+
+	w := doRequest(t, s, "POST", "/v1/embed/batch", reqBody)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestEmbedBatchWithRateLimit(t *testing.T) {
+	s, embedder := setupTestServer(t)
+
+	reqBody := map[string]any{
+		"texts":       []string{"a", "b", "c", "d", "e"},
+		"rate_limit":  100,
+		"chunk_size":  2,
+		"concurrency": 1,
+	}
+
+	w := doRequest(t, s, "POST", "/v1/embed/batch", reqBody)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp EmbedBatchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp.Succeeded != 5 {
+		t.Errorf("expected 5 succeeded, got %d", resp.Succeeded)
+	}
+	if embedder.callCount.Load() != 5+5 {
+		t.Logf("embed call count: %d", embedder.callCount.Load())
+	}
+}
+
+func TestEmbedBatchResponseStructure(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	reqBody := map[string]any{
+		"texts": []string{"test1", "test2"},
+	}
+
+	w := doRequest(t, s, "POST", "/v1/embed/batch", reqBody)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp EmbedBatchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp.Provider == "" {
+		t.Error("expected non-empty provider")
+	}
+	if resp.Duration == "" {
+		t.Error("expected non-empty duration")
+	}
+	if resp.Errors != nil && len(resp.Errors) > 0 {
+		t.Errorf("expected no errors, got %d", len(resp.Errors))
+	}
+}
+
+type mockEmbedder struct {
+	dim       int
+	callCount atomic.Int32
+}
+
+func (m *mockEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	m.callCount.Add(1)
+	result := make([]float32, m.dim)
+	for i := range result {
+		result[i] = float32(len(text)) / float32(m.dim)
+	}
+	return result, nil
+}
+
+func (m *mockEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	var results [][]float32
+	for _, text := range texts {
+		emb, err := m.Embed(ctx, text)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, emb)
+	}
+	return results, nil
+}
+
+func (m *mockEmbedder) Name() string   { return "mock" }
+func (m *mockEmbedder) Dimension() int { return m.dim }

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -35,14 +35,15 @@ func setupTestServer(t *testing.T) (*Server, *mockEmbedder) {
 		Name:       "test_index",
 		Dimensions: 4,
 		Distance:   "cosine",
+		Metadata:   []string{"category"},
 	}); err != nil {
 		t.Fatalf("create test index: %v", err)
 	}
 
 	if _, err := im.Index(context.Background(), "test_index", []index.IndexItem{
-		{ID: 1, Vector: []float32{0.1, 0.2, 0.3, 0.4}},
-		{ID: 2, Vector: []float32{0.5, 0.6, 0.7, 0.8}},
-		{ID: 3, Vector: []float32{0.9, 1.0, 0.1, 0.2}},
+		{ID: 1, Vector: []float32{0.1, 0.2, 0.3, 0.4}, Metadata: map[string]string{"category": "docs"}},
+		{ID: 2, Vector: []float32{0.5, 0.6, 0.7, 0.8}, Metadata: map[string]string{"category": "media"}},
+		{ID: 3, Vector: []float32{0.9, 1.0, 0.1, 0.2}, Metadata: map[string]string{"category": "docs"}},
 	}, nil); err != nil {
 		t.Fatalf("seed test index: %v", err)
 	}
@@ -176,6 +177,50 @@ func TestSearchWithThreshold(t *testing.T) {
 	}
 }
 
+func TestSearchWithMetadataFilter(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	w := doRequest(t, s, "POST", "/v1/search", map[string]any{
+		"index": "test_index",
+		"vector": []float32{
+			0.1, 0.2, 0.3, 0.4,
+		},
+		"limit": 10,
+		"metadata": map[string]any{
+			"category": "media",
+		},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp SearchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Count != 1 {
+		t.Fatalf("expected 1 filtered result, got %d", resp.Count)
+	}
+	if resp.Results[0].Metadata["category"] != "media" {
+		t.Fatalf("expected media metadata, got %+v", resp.Results[0].Metadata)
+	}
+}
+
+func TestSearchRejectsNonStringMetadataFilter(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	w := doRequest(t, s, "POST", "/v1/search", map[string]any{
+		"index":  "test_index",
+		"vector": []float32{0.1, 0.2, 0.3, 0.4},
+		"metadata": map[string]any{
+			"category": 123,
+		},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestSearchMissingIndex(t *testing.T) {
 	s, _ := setupTestServer(t)
 
@@ -275,6 +320,34 @@ func TestSearchTextUsesServerEmbedder(t *testing.T) {
 	}
 	if embedder.callCount.Load() != 1 {
 		t.Fatalf("expected server embedder to be called once, got %d", embedder.callCount.Load())
+	}
+}
+
+func TestSearchTextWithMetadataFilter(t *testing.T) {
+	s, _ := setupTestServer(t)
+
+	w := doRequest(t, s, "POST", "/v1/search/text", map[string]any{
+		"index": "test_index",
+		"text":  "search query",
+		"limit": 10,
+		"metadata": map[string]any{
+			"category": "docs",
+		},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp SearchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Count != 2 {
+		t.Fatalf("expected 2 filtered results, got %d", resp.Count)
+	}
+	for _, result := range resp.Results {
+		if result.Metadata["category"] != "docs" {
+			t.Fatalf("expected docs metadata, got %+v", result.Metadata)
+		}
 	}
 }
 

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -5,14 +5,17 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 	_ "modernc.org/sqlite/vec"
 
+	"github.com/1024XEngineer/anyclaw/pkg/embedding"
 	"github.com/1024XEngineer/anyclaw/pkg/index"
 )
 
@@ -733,6 +736,67 @@ func TestEmbedBatchWithRateLimit(t *testing.T) {
 	}
 }
 
+func TestEmbedBatchPreservesConfiguredRetriesWhenOmitted(t *testing.T) {
+	cfg := embedding.DefaultBatchConfig()
+	cfg.Concurrency = 1
+	cfg.MaxRetries = 1
+	cfg.RetryDelay = time.Millisecond
+
+	embedder := &transientEmbedder{dim: 4, failFirst: 1}
+	s := NewServer(ServerConfig{
+		Embedder:    embedder,
+		BatchConfig: &cfg,
+	})
+
+	w := doRequest(t, s, "POST", "/v1/embed/batch", map[string]any{
+		"texts": []string{"retry me"},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp EmbedBatchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Succeeded != 1 || resp.Failed != 0 {
+		t.Fatalf("expected retry to succeed, got succeeded=%d failed=%d errors=%v", resp.Succeeded, resp.Failed, resp.Errors)
+	}
+	if embedder.callCount.Load() != 2 {
+		t.Fatalf("expected one retry after transient failure, got %d calls", embedder.callCount.Load())
+	}
+}
+
+func TestEmbedBatchExplicitZeroRetriesOverridesConfig(t *testing.T) {
+	cfg := embedding.DefaultBatchConfig()
+	cfg.Concurrency = 1
+	cfg.MaxRetries = 1
+	cfg.RetryDelay = time.Millisecond
+
+	embedder := &transientEmbedder{dim: 4, failFirst: 1}
+	s := NewServer(ServerConfig{
+		Embedder:    embedder,
+		BatchConfig: &cfg,
+	})
+
+	w := doRequest(t, s, "POST", "/v1/embed/batch", map[string]any{
+		"texts":       []string{"do not retry"},
+		"max_retries": 0,
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp EmbedBatchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Succeeded != 0 || resp.Failed != 1 {
+		t.Fatalf("expected explicit zero retries to fail once, got succeeded=%d failed=%d", resp.Succeeded, resp.Failed)
+	}
+	if embedder.callCount.Load() != 1 {
+		t.Fatalf("expected no retry when max_retries is explicitly zero, got %d calls", embedder.callCount.Load())
+	}
+}
+
 func TestEmbedBatchResponseStructure(t *testing.T) {
 	s, _ := setupTestServer(t)
 
@@ -788,3 +852,37 @@ func (m *mockEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]floa
 
 func (m *mockEmbedder) Name() string   { return "mock" }
 func (m *mockEmbedder) Dimension() int { return m.dim }
+
+type transientEmbedder struct {
+	dim       int
+	failFirst int32
+	callCount atomic.Int32
+}
+
+func (m *transientEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	call := m.callCount.Add(1)
+	if call <= m.failFirst {
+		return nil, errors.New("transient embedding failure")
+	}
+
+	result := make([]float32, m.dim)
+	for i := range result {
+		result[i] = float32(len(text)) / float32(m.dim)
+	}
+	return result, nil
+}
+
+func (m *transientEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	var results [][]float32
+	for _, text := range texts {
+		emb, err := m.Embed(ctx, text)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, emb)
+	}
+	return results, nil
+}
+
+func (m *transientEmbedder) Name() string   { return "transient" }
+func (m *transientEmbedder) Dimension() int { return m.dim }

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -228,6 +228,56 @@ func TestSearchTextEndpoint(t *testing.T) {
 	}
 }
 
+func TestSearchTextUsesServerEmbedder(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	im := index.NewIndexManager(db, nil, index.WithVectorDir(t.TempDir()))
+	if err := im.Init(context.Background()); err != nil {
+		t.Fatalf("init index manager: %v", err)
+	}
+	if _, err := im.Create(context.Background(), index.Config{
+		Name:       "server_embedder_index",
+		Dimensions: 4,
+		Distance:   "cosine",
+	}); err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+	if _, err := im.Index(context.Background(), "server_embedder_index", []index.IndexItem{
+		{ID: "doc-1", Vector: []float32{0.25, 0.25, 0.25, 0.25}},
+	}, nil); err != nil {
+		t.Fatalf("seed index: %v", err)
+	}
+
+	embedder := &mockEmbedder{dim: 4}
+	s := NewServer(ServerConfig{
+		IndexMgr: im,
+		Embedder: embedder,
+	})
+
+	w := doRequest(t, s, "POST", "/v1/search/text", map[string]any{
+		"index": "server_embedder_index",
+		"text":  "a",
+		"limit": 1,
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp SearchResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Count != 1 {
+		t.Fatalf("expected 1 result, got %d", resp.Count)
+	}
+	if embedder.callCount.Load() != 1 {
+		t.Fatalf("expected server embedder to be called once, got %d", embedder.callCount.Load())
+	}
+}
+
 func TestSearchTextMissingText(t *testing.T) {
 	s, _ := setupTestServer(t)
 

--- a/pkg/canvas/a2ui.go
+++ b/pkg/canvas/a2ui.go
@@ -1,0 +1,742 @@
+package canvas
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type A2UIComponent struct {
+	Type       string            `json:"type"`
+	Props      map[string]any    `json:"props,omitempty"`
+	Children   []A2UIComponent   `json:"children,omitempty"`
+	Content    string            `json:"content,omitempty"`
+	Attributes map[string]any    `json:"attributes,omitempty"`
+	Events     map[string]string `json:"events,omitempty"`
+	Styles     map[string]string `json:"styles,omitempty"`
+}
+
+type A2UIDocument struct {
+	Version     string            `json:"version"`
+	Title       string            `json:"title,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Theme       string            `json:"theme,omitempty"`
+	ThemeVars   map[string]string `json:"theme_vars,omitempty"`
+	Components  []A2UIComponent   `json:"components"`
+	Metadata    map[string]any    `json:"metadata,omitempty"`
+}
+
+type A2UIRenderer struct {
+	themeStyles map[string]string
+}
+
+var htmlNamePattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9:_-]*$`)
+
+func NewA2UIRenderer() *A2UIRenderer {
+	return &A2UIRenderer{
+		themeStyles: defaultThemeStyles(),
+	}
+}
+
+func (r *A2UIRenderer) Render(doc *A2UIDocument) (string, error) {
+	if doc == nil {
+		return "", fmt.Errorf("document is nil")
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<!DOCTYPE html>\n<html>\n<head>\n")
+	sb.WriteString("<meta charset=\"UTF-8\">\n")
+	sb.WriteString("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n")
+
+	title := "A2UI Canvas"
+	if doc.Title != "" {
+		title = doc.Title
+	}
+	sb.WriteString(fmt.Sprintf("<title>%s</title>\n", template.HTMLEscapeString(title)))
+	if strings.TrimSpace(doc.Description) != "" {
+		sb.WriteString(fmt.Sprintf("<meta name=\"description\" content=\"%s\">\n", template.HTMLEscapeString(doc.Description)))
+	}
+
+	sb.WriteString("<style>\n")
+	sb.WriteString(r.themeStyles[doc.Theme])
+	sb.WriteString(r.themeVariableStyles(doc))
+	sb.WriteString(r.componentStyles())
+	sb.WriteString("</style>\n")
+	sb.WriteString("</head>\n")
+	sb.WriteString(fmt.Sprintf("<body data-a2ui-theme=\"%s\">\n", template.HTMLEscapeString(firstNonEmptyTheme(doc.Theme, "light"))))
+
+	for _, comp := range doc.Components {
+		html, err := r.renderComponent(comp, "")
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(html)
+	}
+
+	sb.WriteString("\n</body>\n</html>")
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderComponent(comp A2UIComponent, indent string) (string, error) {
+	switch comp.Type {
+	case "container", "div":
+		return r.renderContainer(comp, indent)
+	case "section":
+		return r.renderSection(comp, indent)
+	case "stack":
+		return r.renderStack(comp, indent)
+	case "text", "p", "span":
+		return r.renderText(comp, indent)
+	case "heading", "h1", "h2", "h3", "h4", "h5", "h6":
+		return r.renderHeading(comp, indent)
+	case "button":
+		return r.renderButton(comp, indent)
+	case "input":
+		return r.renderInput(comp, indent)
+	case "textarea":
+		return r.renderTextarea(comp, indent)
+	case "image", "img":
+		return r.renderImage(comp, indent)
+	case "link", "a":
+		return r.renderLink(comp, indent)
+	case "list", "ul", "ol":
+		return r.renderList(comp, indent)
+	case "card":
+		return r.renderCard(comp, indent)
+	case "grid":
+		return r.renderGrid(comp, indent)
+	case "divider", "hr":
+		return indent + "<hr>\n", nil
+	case "code":
+		return r.renderCode(comp, indent)
+	case "table":
+		return r.renderTable(comp, indent)
+	case "progress":
+		return r.renderProgress(comp, indent)
+	case "badge":
+		return r.renderBadge(comp, indent)
+	case "alert":
+		return r.renderAlert(comp, indent)
+	default:
+		return r.renderGeneric(comp, indent)
+	}
+}
+
+func (r *A2UIRenderer) renderContainer(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp, "", "")
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<div%s>\n", indent, attrs))
+	childIndent := indent + "  "
+	for _, child := range comp.Children {
+		html, err := r.renderComponent(child, childIndent)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(html)
+	}
+	sb.WriteString(fmt.Sprintf("%s</div>\n", indent))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderSection(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp, "a2ui-section", "")
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<section%s>\n", indent, attrs))
+	childIndent := indent + "  "
+	if title, ok := comp.Props["title"].(string); ok && strings.TrimSpace(title) != "" {
+		sb.WriteString(fmt.Sprintf("%s  <h2>%s</h2>\n", indent, template.HTMLEscapeString(title)))
+	}
+	if description, ok := comp.Props["description"].(string); ok && strings.TrimSpace(description) != "" {
+		sb.WriteString(fmt.Sprintf("%s  <p class=\"a2ui-section-description\">%s</p>\n", indent, template.HTMLEscapeString(description)))
+	}
+	for _, child := range comp.Children {
+		html, err := r.renderComponent(child, childIndent)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(html)
+	}
+	sb.WriteString(fmt.Sprintf("%s</section>\n", indent))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderStack(comp A2UIComponent, indent string) (string, error) {
+	direction := "column"
+	if value, ok := comp.Props["direction"].(string); ok && strings.TrimSpace(value) != "" {
+		direction = value
+	}
+	gap := "12px"
+	if value, ok := comp.Props["gap"].(string); ok && strings.TrimSpace(value) != "" {
+		gap = value
+	}
+	align := "stretch"
+	if value, ok := comp.Props["align"].(string); ok && strings.TrimSpace(value) != "" {
+		align = value
+	}
+	style := fmt.Sprintf("display:flex;flex-direction:%s;gap:%s;align-items:%s;", direction, gap, align)
+	attrs := r.buildAttributes(comp, "a2ui-stack", style)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<div%s>\n", indent, attrs))
+	childIndent := indent + "  "
+	for _, child := range comp.Children {
+		html, err := r.renderComponent(child, childIndent)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(html)
+	}
+	sb.WriteString(fmt.Sprintf("%s</div>\n", indent))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderText(comp A2UIComponent, indent string) (string, error) {
+	tag := "p"
+	if comp.Type == "span" {
+		tag = "span"
+	}
+	attrs := r.buildAttributes(comp, "", "")
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<%s%s>%s</%s>\n", indent, tag, attrs, content, tag), nil
+}
+
+func (r *A2UIRenderer) renderHeading(comp A2UIComponent, indent string) (string, error) {
+	tag := comp.Type
+	if tag == "heading" {
+		level, _ := comp.Props["level"].(float64)
+		if level == 0 {
+			level = 2
+		}
+		tag = fmt.Sprintf("h%d", int(level))
+	}
+	attrs := r.buildAttributes(comp, "", "")
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<%s%s>%s</%s>\n", indent, tag, attrs, content, tag), nil
+}
+
+func (r *A2UIRenderer) renderButton(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp, "", "")
+	content := template.HTMLEscapeString(comp.Content)
+	if content == "" {
+		content = "Button"
+	}
+	return fmt.Sprintf("%s<button%s>%s</button>\n", indent, attrs, content), nil
+}
+
+func (r *A2UIRenderer) renderInput(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp, "", "")
+	inputType := "text"
+	if t, ok := comp.Props["inputType"].(string); ok {
+		inputType = t
+	}
+	inputType = template.HTMLEscapeString(inputType)
+	placeholder := ""
+	if p, ok := comp.Props["placeholder"].(string); ok {
+		placeholder = fmt.Sprintf(" placeholder=\"%s\"", template.HTMLEscapeString(p))
+	}
+	return fmt.Sprintf("%s<input type=\"%s\"%s%s>\n", indent, inputType, placeholder, attrs), nil
+}
+
+func (r *A2UIRenderer) renderTextarea(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp, "", "")
+	rows := "4"
+	if value, ok := comp.Props["rows"].(string); ok && strings.TrimSpace(value) != "" {
+		rows = value
+	}
+	rows = template.HTMLEscapeString(rows)
+	placeholder := ""
+	if p, ok := comp.Props["placeholder"].(string); ok {
+		placeholder = fmt.Sprintf(" placeholder=\"%s\"", template.HTMLEscapeString(p))
+	}
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<textarea rows=\"%s\"%s%s>%s</textarea>\n", indent, rows, placeholder, attrs, content), nil
+}
+
+func (r *A2UIRenderer) renderImage(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp, "", "")
+	src := ""
+	if s, ok := comp.Props["src"].(string); ok {
+		src = sanitizeImageURL(s)
+	}
+	alt := ""
+	if a, ok := comp.Props["alt"].(string); ok {
+		alt = template.HTMLEscapeString(a)
+	}
+	return fmt.Sprintf("%s<img src=\"%s\" alt=\"%s\"%s>\n", indent, template.HTMLEscapeString(src), alt, attrs), nil
+}
+
+func (r *A2UIRenderer) renderLink(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp, "", "")
+	href := "#"
+	if value, ok := comp.Props["href"].(string); ok && strings.TrimSpace(value) != "" {
+		href = sanitizeLinkURL(value)
+	}
+	content := template.HTMLEscapeString(comp.Content)
+	if content == "" {
+		content = template.HTMLEscapeString(href)
+	}
+	return fmt.Sprintf("%s<a href=\"%s\"%s>%s</a>\n", indent, template.HTMLEscapeString(href), attrs, content), nil
+}
+
+func (r *A2UIRenderer) renderList(comp A2UIComponent, indent string) (string, error) {
+	tag := "ul"
+	if comp.Type == "ol" {
+		tag = "ol"
+	}
+	attrs := r.buildAttributes(comp, "", "")
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<%s%s>\n", indent, tag, attrs))
+	for _, child := range comp.Children {
+		itemContent := template.HTMLEscapeString(child.Content)
+		sb.WriteString(fmt.Sprintf("%s  <li>%s</li>\n", indent, itemContent))
+	}
+	sb.WriteString(fmt.Sprintf("%s</%s>\n", indent, tag))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderCard(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp, "a2ui-card", "")
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<div%s>\n", indent, attrs))
+	childIndent := indent + "  "
+	for _, child := range comp.Children {
+		html, err := r.renderComponent(child, childIndent)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(html)
+	}
+	sb.WriteString(fmt.Sprintf("%s</div>\n", indent))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderGrid(comp A2UIComponent, indent string) (string, error) {
+	cols := "3"
+	if c, ok := comp.Props["columns"].(string); ok {
+		cols = c
+	}
+	style := fmt.Sprintf("display:grid;grid-template-columns:repeat(%s,1fr);gap:16px;", cols)
+	attrs := r.buildAttributes(comp, "a2ui-grid", style)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<div%s>\n", indent, attrs))
+	childIndent := indent + "  "
+	for _, child := range comp.Children {
+		html, err := r.renderComponent(child, childIndent)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(html)
+	}
+	sb.WriteString(fmt.Sprintf("%s</div>\n", indent))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderCode(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp, "a2ui-code", "")
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<pre%s><code>%s</code></pre>\n", indent, attrs, content), nil
+}
+
+func (r *A2UIRenderer) renderTable(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp, "a2ui-table", "")
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s<table%s>\n", indent, attrs))
+
+	if headers, ok := comp.Props["headers"].([]any); ok {
+		sb.WriteString(fmt.Sprintf("%s  <thead><tr>\n", indent))
+		for _, h := range headers {
+			sb.WriteString(fmt.Sprintf("%s    <th>%s</th>\n", indent, template.HTMLEscapeString(fmt.Sprintf("%v", h))))
+		}
+		sb.WriteString(fmt.Sprintf("%s  </tr></thead>\n", indent))
+	}
+
+	if rows, ok := comp.Props["rows"].([]any); ok {
+		sb.WriteString(fmt.Sprintf("%s  <tbody>\n", indent))
+		for _, row := range rows {
+			sb.WriteString(fmt.Sprintf("%s    <tr>\n", indent))
+			if cells, ok := row.([]any); ok {
+				for _, cell := range cells {
+					sb.WriteString(fmt.Sprintf("%s      <td>%s</td>\n", indent, template.HTMLEscapeString(fmt.Sprintf("%v", cell))))
+				}
+			}
+			sb.WriteString(fmt.Sprintf("%s    </tr>\n", indent))
+		}
+		sb.WriteString(fmt.Sprintf("%s  </tbody>\n", indent))
+	}
+
+	sb.WriteString(fmt.Sprintf("%s</table>\n", indent))
+	return sb.String(), nil
+}
+
+func (r *A2UIRenderer) renderProgress(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp, "", "")
+	value := "0"
+	if v, ok := comp.Props["value"].(string); ok {
+		value = v
+	}
+	value = template.HTMLEscapeString(value)
+	max := "100"
+	if m, ok := comp.Props["max"].(string); ok {
+		max = m
+	}
+	max = template.HTMLEscapeString(max)
+	return fmt.Sprintf("%s<progress value=\"%s\" max=\"%s\"%s></progress>\n", indent, value, max, attrs), nil
+}
+
+func (r *A2UIRenderer) renderBadge(comp A2UIComponent, indent string) (string, error) {
+	attrs := r.buildAttributes(comp, "a2ui-badge", "")
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<span%s>%s</span>\n", indent, attrs, content), nil
+}
+
+func (r *A2UIRenderer) renderAlert(comp A2UIComponent, indent string) (string, error) {
+	level := "info"
+	if l, ok := comp.Props["level"].(string); ok {
+		level = l
+	}
+	attrs := r.buildAttributes(comp, fmt.Sprintf("a2ui-alert a2ui-alert-%s", level), "")
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<div%s>%s</div>\n", indent, attrs, content), nil
+}
+
+func (r *A2UIRenderer) renderGeneric(comp A2UIComponent, indent string) (string, error) {
+	tag := "div"
+	if t, ok := comp.Props["tag"].(string); ok {
+		if isSafeHTMLName(t) {
+			tag = t
+		}
+	}
+	attrs := r.buildAttributes(comp, "", "")
+	content := template.HTMLEscapeString(comp.Content)
+	return fmt.Sprintf("%s<%s%s>%s</%s>\n", indent, tag, attrs, content, tag), nil
+}
+
+func (r *A2UIRenderer) buildAttributes(comp A2UIComponent, baseClass string, baseStyle string) string {
+	var sb strings.Builder
+
+	if style := buildStyleValue(baseStyle, comp.Styles); style != "" {
+		sb.WriteString(fmt.Sprintf(" style=\"%s\"", style))
+	}
+
+	if comp.Attributes != nil {
+		for _, k := range sortedAttributeKeys(comp.Attributes) {
+			v := comp.Attributes[k]
+			if k == "style" || k == "class" || !isSafeAttributeName(k) {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf(" %s=\"%s\"", k, template.HTMLEscapeString(fmt.Sprintf("%v", v))))
+		}
+	}
+
+	if comp.Events != nil && len(comp.Events) > 0 {
+		eventsJSON, _ := json.Marshal(comp.Events)
+		sb.WriteString(fmt.Sprintf(" data-a2ui-events=\"%s\"", template.HTMLEscapeString(string(eventsJSON))))
+	}
+
+	if id, ok := comp.Props["id"].(string); ok {
+		sb.WriteString(fmt.Sprintf(" id=\"%s\"", template.HTMLEscapeString(id)))
+	}
+
+	if classValue := buildClassValue(baseClass, comp); classValue != "" {
+		sb.WriteString(fmt.Sprintf(" class=\"%s\"", classValue))
+	}
+
+	return sb.String()
+}
+
+func buildStyleValue(baseStyle string, styles map[string]string) string {
+	var sb strings.Builder
+	baseStyle = strings.TrimSpace(baseStyle)
+	if baseStyle != "" {
+		sb.WriteString(template.HTMLEscapeString(baseStyle))
+		if !strings.HasSuffix(baseStyle, ";") {
+			sb.WriteString(";")
+		}
+	}
+
+	if len(styles) > 0 {
+		keys := make([]string, 0, len(styles))
+		for k := range styles {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := styles[k]
+			if !isSafeCSSName(k) {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("%s:%s;", template.HTMLEscapeString(k), template.HTMLEscapeString(v)))
+		}
+	}
+
+	return sb.String()
+}
+
+func buildClassValue(baseClass string, comp A2UIComponent) string {
+	classes := make([]string, 0, 3)
+	baseClass = strings.TrimSpace(baseClass)
+	if baseClass != "" {
+		classes = append(classes, baseClass)
+	}
+	if comp.Attributes != nil {
+		if value, ok := comp.Attributes["class"]; ok {
+			className := strings.TrimSpace(fmt.Sprintf("%v", value))
+			if className != "" {
+				classes = append(classes, className)
+			}
+		}
+	}
+	if className, ok := comp.Props["className"].(string); ok {
+		className = strings.TrimSpace(className)
+		if className != "" {
+			classes = append(classes, className)
+		}
+	}
+	if len(classes) == 0 {
+		return ""
+	}
+	return template.HTMLEscapeString(strings.Join(classes, " "))
+}
+
+func sortedAttributeKeys(attrs map[string]any) []string {
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func isSafeHTMLName(name string) bool {
+	name = strings.TrimSpace(name)
+	return htmlNamePattern.MatchString(name)
+}
+
+func isSafeAttributeName(name string) bool {
+	name = strings.TrimSpace(name)
+	return isSafeHTMLName(name) && !strings.HasPrefix(strings.ToLower(name), "on")
+}
+
+func isSafeCSSName(name string) bool {
+	name = strings.TrimSpace(name)
+	if strings.HasPrefix(name, "--") {
+		return htmlNamePattern.MatchString("x" + name)
+	}
+	return htmlNamePattern.MatchString(name)
+}
+
+func (r *A2UIRenderer) componentStyles() string {
+	return `
+.a2ui-section {
+  margin-bottom: 24px;
+}
+.a2ui-section-description {
+  color: #5b5249;
+  margin-top: -8px;
+}
+.a2ui-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  margin-bottom: 16px;
+}
+.a2ui-code {
+  background: #1e1e1e;
+  color: #d4d4d4;
+  padding: 16px;
+  border-radius: 8px;
+  overflow-x: auto;
+  font-family: 'Cascadia Code', Consolas, monospace;
+  font-size: 14px;
+}
+.a2ui-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+.a2ui-table th, .a2ui-table td {
+  padding: 10px 14px;
+  text-align: left;
+  border-bottom: 1px solid #e5e7eb;
+}
+.a2ui-table th {
+  background: #f9fafb;
+  font-weight: 600;
+}
+.a2ui-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #e0e7ff;
+  color: #3730a3;
+}
+.a2ui-alert {
+  padding: 14px 18px;
+  border-radius: 10px;
+  margin: 12px 0;
+  font-size: 14px;
+}
+.a2ui-alert-info {
+  background: #eff6ff;
+  color: #1e40af;
+  border: 1px solid #bfdbfe;
+}
+.a2ui-alert-success {
+  background: #f0fdf4;
+  color: #166534;
+  border: 1px solid #bbf7d0;
+}
+.a2ui-alert-warning {
+  background: #fffbeb;
+  color: #92400e;
+  border: 1px solid #fde68a;
+}
+.a2ui-alert-error {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+}
+body {
+  font-family: 'Aptos', 'Segoe UI Variable', 'Segoe UI', sans-serif;
+  color: #1c1a18;
+  background: #f7f1e6;
+  padding: 24px;
+  line-height: 1.6;
+}
+button {
+  padding: 10px 18px;
+  border-radius: 10px;
+  border: none;
+  background: linear-gradient(135deg, #0f766e, #115e59);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+button:hover {
+  transform: translateY(-1px);
+}
+input {
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  font: inherit;
+  width: 100%;
+  max-width: 400px;
+}
+textarea {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid #d1d5db;
+  font: inherit;
+  width: 100%;
+  min-height: 120px;
+  resize: vertical;
+}
+a {
+  color: #0f766e;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+`
+}
+
+func defaultThemeStyles() map[string]string {
+	return map[string]string{
+		"":        "",
+		"light":   "",
+		"dark":    "body { background: #1a1a2e; color: #e0e0e0; } .a2ui-card { background: #16213e; } .a2ui-table th { background: #0f3460; } .a2ui-table td { border-color: #1a1a2e; }",
+		"minimal": "body { background: #fff; color: #333; padding: 16px; } .a2ui-card { box-shadow: none; border: 1px solid #eee; }",
+	}
+}
+
+func (r *A2UIRenderer) themeVariableStyles(doc *A2UIDocument) string {
+	if doc == nil || len(doc.ThemeVars) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString(":root{")
+	for key, value := range doc.ThemeVars {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		sb.WriteString(fmt.Sprintf("--%s:%s;", template.HTMLEscapeString(key), template.HTMLEscapeString(value)))
+	}
+	sb.WriteString("}\n")
+	return sb.String()
+}
+
+func firstNonEmptyTheme(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func sanitizeLinkURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "#"
+	}
+	if isSafeA2UIURL(raw, map[string]bool{
+		"http":   true,
+		"https":  true,
+		"mailto": true,
+	}) {
+		return raw
+	}
+	return "#"
+}
+
+func sanitizeImageURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if isSafeA2UIURL(raw, map[string]bool{
+		"http":  true,
+		"https": true,
+	}) {
+		return raw
+	}
+	return ""
+}
+
+func isSafeA2UIURL(raw string, allowedSchemes map[string]bool) bool {
+	if strings.ContainsAny(raw, "\x00\r\n\t") {
+		return false
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if parsed.Scheme == "" {
+		return parsed.Host == ""
+	}
+	return allowedSchemes[strings.ToLower(parsed.Scheme)]
+}
+
+func ParseA2UI(content string) (*A2UIDocument, error) {
+	var doc A2UIDocument
+	if err := json.Unmarshal([]byte(content), &doc); err != nil {
+		return nil, fmt.Errorf("parse a2ui: %w", err)
+	}
+	if doc.Version == "" {
+		doc.Version = "1.0"
+	}
+	return &doc, nil
+}

--- a/pkg/canvas/store.go
+++ b/pkg/canvas/store.go
@@ -1,0 +1,405 @@
+package canvas
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type CanvasEntry struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Content   string    `json:"content"`
+	Type      string    `json:"type"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Version   int       `json:"version"`
+}
+
+type CanvasVersion struct {
+	Version   int       `json:"version"`
+	Content   string    `json:"content"`
+	Timestamp time.Time `json:"timestamp"`
+	Agent     string    `json:"agent,omitempty"`
+}
+
+type CanvasStore struct {
+	mu          sync.RWMutex
+	baseDir     string
+	entries     map[string]*CanvasEntry
+	versions    map[string][]*CanvasVersion
+	maxVersions int
+}
+
+const (
+	EntryTypeHTML = "html"
+	EntryTypeA2UI = "a2ui"
+	EntryTypeMD   = "markdown"
+	EntryTypeJSON = "json"
+	EntryTypeText = "text"
+)
+
+var canvasIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+func NewStore(baseDir string, maxVersions int) (*CanvasStore, error) {
+	if maxVersions <= 0 {
+		maxVersions = 20
+	}
+	canvasDir := filepath.Join(baseDir, "canvas")
+	if err := os.MkdirAll(canvasDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create canvas dir: %w", err)
+	}
+
+	store := &CanvasStore{
+		baseDir:     canvasDir,
+		entries:     make(map[string]*CanvasEntry),
+		versions:    make(map[string][]*CanvasVersion),
+		maxVersions: maxVersions,
+	}
+
+	if err := store.load(); err != nil {
+		return nil, fmt.Errorf("load canvas store: %w", err)
+	}
+
+	return store, nil
+}
+
+func (s *CanvasStore) entryDir() string {
+	return filepath.Join(s.baseDir, "entries")
+}
+
+func (s *CanvasStore) versionDir(id string) string {
+	return filepath.Join(s.baseDir, "versions", id)
+}
+
+func (s *CanvasStore) load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entryDir := s.entryDir()
+	if _, err := os.Stat(entryDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	entries, err := os.ReadDir(entryDir)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(entryDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		var ce CanvasEntry
+		if err := json.Unmarshal(data, &ce); err != nil {
+			continue
+		}
+		if err := validateCanvasID(ce.ID); err != nil {
+			continue
+		}
+		s.entries[ce.ID] = &ce
+		s.loadVersions(ce.ID)
+	}
+
+	return nil
+}
+
+func (s *CanvasStore) loadVersions(id string) {
+	vDir := s.versionDir(id)
+	entries, err := os.ReadDir(vDir)
+	if err != nil {
+		return
+	}
+
+	versions := make([]*CanvasVersion, 0)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(vDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var v CanvasVersion
+		if err := json.Unmarshal(data, &v); err != nil {
+			continue
+		}
+		versions = append(versions, &v)
+	}
+
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].Version < versions[j].Version
+	})
+	s.versions[id] = versions
+}
+
+func (s *CanvasStore) Push(id string, name string, content string, contentType string, agent string) (*CanvasEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC()
+
+	if strings.TrimSpace(id) == "" {
+		generatedID, err := generateCanvasID(now)
+		if err != nil {
+			return nil, err
+		}
+		id = generatedID
+	}
+	if err := validateCanvasID(id); err != nil {
+		return nil, err
+	}
+
+	if strings.TrimSpace(contentType) == "" {
+		contentType = EntryTypeHTML
+	}
+
+	entry, exists := s.entries[id]
+	if exists {
+		if err := s.saveVersionLocked(entry, agent); err != nil {
+			return nil, err
+		}
+		entry.Content = content
+		entry.UpdatedAt = now
+		entry.Version++
+	} else {
+		if strings.TrimSpace(name) == "" {
+			name = id
+		}
+		entry = &CanvasEntry{
+			ID:        id,
+			Name:      name,
+			Content:   content,
+			Type:      contentType,
+			CreatedAt: now,
+			UpdatedAt: now,
+			Version:   1,
+		}
+		s.entries[id] = entry
+	}
+
+	if err := s.saveEntry(entry); err != nil {
+		return nil, err
+	}
+
+	return cloneEntry(entry), nil
+}
+
+func (s *CanvasStore) saveVersionLocked(entry *CanvasEntry, agent string) error {
+	vDir := s.versionDir(entry.ID)
+	if err := os.MkdirAll(vDir, 0o755); err != nil {
+		return fmt.Errorf("create canvas version dir: %w", err)
+	}
+
+	version := &CanvasVersion{
+		Version:   entry.Version,
+		Content:   entry.Content,
+		Timestamp: time.Now().UTC(),
+		Agent:     agent,
+	}
+
+	data, err := json.MarshalIndent(version, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal canvas version: %w", err)
+	}
+
+	versionFile := filepath.Join(vDir, fmt.Sprintf("v%d.json", entry.Version))
+	if err := os.WriteFile(versionFile, data, 0o644); err != nil {
+		return fmt.Errorf("write canvas version: %w", err)
+	}
+
+	if s.versions[entry.ID] == nil {
+		s.versions[entry.ID] = make([]*CanvasVersion, 0)
+	}
+	s.versions[entry.ID] = append(s.versions[entry.ID], version)
+
+	s.pruneVersions(entry.ID)
+	return nil
+}
+
+func (s *CanvasStore) pruneVersions(id string) {
+	versions := s.versions[id]
+	if len(versions) <= s.maxVersions {
+		return
+	}
+
+	vDir := s.versionDir(id)
+	toRemove := versions[:len(versions)-s.maxVersions]
+	for _, v := range toRemove {
+		_ = os.Remove(filepath.Join(vDir, fmt.Sprintf("v%d.json", v.Version)))
+	}
+	s.versions[id] = versions[len(toRemove):]
+}
+
+func (s *CanvasStore) saveEntry(entry *CanvasEntry) error {
+	if err := validateCanvasID(entry.ID); err != nil {
+		return err
+	}
+
+	entryDir := s.entryDir()
+	if err := os.MkdirAll(entryDir, 0o755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(entryDir, entry.ID+".json"), data, 0o644)
+}
+
+func (s *CanvasStore) Get(id string) (*CanvasEntry, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.entries[id]
+	if !ok {
+		return nil, false
+	}
+	return cloneEntry(entry), true
+}
+
+func (s *CanvasStore) List() []*CanvasEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := make([]*CanvasEntry, 0, len(s.entries))
+	for _, entry := range s.entries {
+		items = append(items, cloneEntry(entry))
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].UpdatedAt.After(items[j].UpdatedAt)
+	})
+
+	return items
+}
+
+func (s *CanvasStore) GetVersions(id string, limit int) []*CanvasVersion {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	versions := s.versions[id]
+	if len(versions) == 0 {
+		return nil
+	}
+
+	result := make([]*CanvasVersion, len(versions))
+	for i, v := range versions {
+		result[i] = cloneVersion(v)
+	}
+
+	if limit > 0 && len(result) > limit {
+		result = result[len(result)-limit:]
+	}
+
+	return result
+}
+
+func (s *CanvasStore) GetVersion(id string, version int) (*CanvasVersion, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	versions := s.versions[id]
+	for _, v := range versions {
+		if v.Version == version {
+			return cloneVersion(v), true
+		}
+	}
+	return nil, false
+}
+
+func (s *CanvasStore) Reset(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := validateCanvasID(id); err != nil {
+		return err
+	}
+
+	entry, ok := s.entries[id]
+	if !ok {
+		return fmt.Errorf("canvas entry not found: %s", id)
+	}
+
+	if err := s.saveVersionLocked(entry, "system"); err != nil {
+		return err
+	}
+
+	entry.Content = ""
+	entry.UpdatedAt = time.Now().UTC()
+	entry.Version++
+
+	return s.saveEntry(entry)
+}
+
+func (s *CanvasStore) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := validateCanvasID(id); err != nil {
+		return err
+	}
+
+	delete(s.entries, id)
+
+	entryDir := s.entryDir()
+	_ = os.Remove(filepath.Join(entryDir, id+".json"))
+
+	vDir := s.versionDir(id)
+	_ = os.RemoveAll(vDir)
+	delete(s.versions, id)
+
+	return nil
+}
+
+func (s *CanvasStore) BaseDir() string {
+	return s.baseDir
+}
+
+func cloneEntry(e *CanvasEntry) *CanvasEntry {
+	if e == nil {
+		return nil
+	}
+	clone := *e
+	return &clone
+}
+
+func cloneVersion(v *CanvasVersion) *CanvasVersion {
+	if v == nil {
+		return nil
+	}
+	clone := *v
+	return &clone
+}
+
+func validateCanvasID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return fmt.Errorf("canvas id is required")
+	}
+	if id == "." || id == ".." || !canvasIDPattern.MatchString(id) {
+		return fmt.Errorf("invalid canvas id: %q", id)
+	}
+	return nil
+}
+
+func generateCanvasID(now time.Time) (string, error) {
+	var suffix [8]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return "", fmt.Errorf("generate canvas id: %w", err)
+	}
+	return fmt.Sprintf("canvas-%d-%s", now.UnixMilli(), hex.EncodeToString(suffix[:])), nil
+}

--- a/pkg/canvas/store_test.go
+++ b/pkg/canvas/store_test.go
@@ -1,0 +1,653 @@
+package canvas
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewStore(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	if store == nil {
+		t.Fatal("store is nil")
+	}
+	if store.BaseDir() == "" {
+		t.Fatal("base dir is empty")
+	}
+}
+
+func TestPushAndGet(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	entry, err := store.Push("test-1", "Test Canvas", "<h1>Hello</h1>", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	if entry.ID != "test-1" {
+		t.Fatalf("expected id test-1, got %s", entry.ID)
+	}
+	if entry.Version != 1 {
+		t.Fatalf("expected version 1, got %d", entry.Version)
+	}
+
+	got, ok := store.Get("test-1")
+	if !ok {
+		t.Fatal("entry not found")
+	}
+	if got.Content != "<h1>Hello</h1>" {
+		t.Fatalf("expected content <h1>Hello</h1>, got %s", got.Content)
+	}
+}
+
+func TestPushUpdatesVersion(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, err = store.Push("test-1", "Test", "v1", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("first push failed: %v", err)
+	}
+
+	entry, err := store.Push("test-1", "Test", "v2", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("second push failed: %v", err)
+	}
+	if entry.Version != 2 {
+		t.Fatalf("expected version 2, got %d", entry.Version)
+	}
+	if entry.Content != "v2" {
+		t.Fatalf("expected content v2, got %s", entry.Content)
+	}
+}
+
+func TestReset(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, err = store.Push("test-1", "Test", "content", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	if err := store.Reset("test-1"); err != nil {
+		t.Fatalf("Reset failed: %v", err)
+	}
+
+	entry, ok := store.Get("test-1")
+	if !ok {
+		t.Fatal("entry not found after reset")
+	}
+	if entry.Content != "" {
+		t.Fatalf("expected empty content, got %s", entry.Content)
+	}
+	if entry.Version != 2 {
+		t.Fatalf("expected version 2 after reset, got %d", entry.Version)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, err = store.Push("test-1", "Test", "content", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	if err := store.Delete("test-1"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	_, ok := store.Get("test-1")
+	if ok {
+		t.Fatal("entry still exists after delete")
+	}
+}
+
+func TestList(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, _ = store.Push("a", "A", "content", EntryTypeHTML, "agent-1")
+	_, _ = store.Push("b", "B", "content", EntryTypeHTML, "agent-1")
+
+	items := store.List()
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+}
+
+func TestVersions(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, _ = store.Push("test-1", "Test", "v1", EntryTypeHTML, "agent-1")
+	_, _ = store.Push("test-1", "Test", "v2", EntryTypeHTML, "agent-1")
+	_, _ = store.Push("test-1", "Test", "v3", EntryTypeHTML, "agent-1")
+
+	versions := store.GetVersions("test-1", 0)
+	if len(versions) != 2 {
+		t.Fatalf("expected 2 versions (v1 and v2 saved before v3 push), got %d", len(versions))
+	}
+
+	v, ok := store.GetVersion("test-1", 2)
+	if !ok {
+		t.Fatal("version 2 not found")
+	}
+	if v.Content != "v2" {
+		t.Fatalf("expected v2 content, got %s", v.Content)
+	}
+}
+
+func TestVersionPruning(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 3)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	for i := 1; i <= 5; i++ {
+		_, _ = store.Push("test-1", "Test", "v", EntryTypeHTML, "agent-1")
+	}
+
+	versions := store.GetVersions("test-1", 0)
+	if len(versions) > 3 {
+		t.Fatalf("expected at most 3 versions, got %d", len(versions))
+	}
+}
+
+func TestPushSurfacesVersionPersistenceFailure(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, err = store.Push("test-1", "Test", "v1", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("initial Push failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(store.BaseDir(), "versions"), []byte("not-a-dir"), 0o600); err != nil {
+		t.Fatalf("create versions path conflict: %v", err)
+	}
+
+	if _, err := store.Push("test-1", "Test", "v2", EntryTypeHTML, "agent-1"); err == nil {
+		t.Fatal("expected version persistence failure")
+	}
+
+	entry, ok := store.Get("test-1")
+	if !ok {
+		t.Fatal("entry missing after failed update")
+	}
+	if entry.Content != "v1" {
+		t.Fatalf("expected content to remain v1 after failed version save, got %q", entry.Content)
+	}
+	if entry.Version != 1 {
+		t.Fatalf("expected version to remain 1 after failed version save, got %d", entry.Version)
+	}
+}
+
+func TestResetSurfacesVersionPersistenceFailure(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	_, err = store.Push("test-1", "Test", "content", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(store.BaseDir(), "versions"), []byte("not-a-dir"), 0o600); err != nil {
+		t.Fatalf("create versions path conflict: %v", err)
+	}
+
+	if err := store.Reset("test-1"); err == nil {
+		t.Fatal("expected version persistence failure")
+	}
+
+	entry, ok := store.Get("test-1")
+	if !ok {
+		t.Fatal("entry missing after failed reset")
+	}
+	if entry.Content != "content" {
+		t.Fatalf("expected content to remain after failed reset, got %q", entry.Content)
+	}
+	if entry.Version != 1 {
+		t.Fatalf("expected version to remain 1 after failed reset, got %d", entry.Version)
+	}
+}
+
+func TestStorePersistence(t *testing.T) {
+	dir := t.TempDir()
+
+	store1, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	_, _ = store1.Push("persist-1", "Persist", "content", EntryTypeHTML, "agent-1")
+
+	store2, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore reload failed: %v", err)
+	}
+
+	entry, ok := store2.Get("persist-1")
+	if !ok {
+		t.Fatal("entry not found after reload")
+	}
+	if entry.Content != "content" {
+		t.Fatalf("expected content 'content', got %s", entry.Content)
+	}
+}
+
+func TestA2UIParseAndRender(t *testing.T) {
+	content := `{
+		"version": "1.0",
+		"title": "Test Page",
+		"description": "Demo description",
+		"theme": "light",
+		"theme_vars": {
+			"accent": "#0f766e"
+		},
+		"components": [
+			{"type": "heading", "content": "Hello World", "props": {"level": 1}},
+			{"type": "text", "content": "This is a test."},
+			{"type": "button", "content": "Click Me"},
+			{"type": "section", "props": {"title": "Details", "description": "More context"}, "children": [
+				{"type": "stack", "props": {"gap": "8px"}, "children": [
+					{"type": "textarea", "props": {"rows": "6", "placeholder": "Write here"}, "content": "Draft"},
+					{"type": "link", "content": "AnyClaw", "props": {"href": "https://github.com/1024XEngineer/anyclaw"}}
+				]}
+			]}
+		]
+	}`
+
+	doc, err := ParseA2UI(content)
+	if err != nil {
+		t.Fatalf("ParseA2UI failed: %v", err)
+	}
+	if doc.Title != "Test Page" {
+		t.Fatalf("expected title 'Test Page', got %s", doc.Title)
+	}
+	if len(doc.Components) != 4 {
+		t.Fatalf("expected 4 components, got %d", len(doc.Components))
+	}
+
+	renderer := NewA2UIRenderer()
+	html, err := renderer.Render(doc)
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if len(html) == 0 {
+		t.Fatal("rendered HTML is empty")
+	}
+	if !containsAll(html, []string{
+		`meta name="description" content="Demo description"`,
+		`--accent:#0f766e`,
+		`<section class="a2ui-section"`,
+		`<textarea rows="6" placeholder="Write here">Draft</textarea>`,
+		`<a href="https://github.com/1024XEngineer/anyclaw">AnyClaw</a>`,
+	}) {
+		t.Fatalf("rendered HTML missing expected upgraded A2UI content:\n%s", html)
+	}
+}
+
+func TestAutoIDGeneration(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	entry, err := store.Push("", "Auto", "content", EntryTypeHTML, "agent-1")
+	if err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	if entry.ID == "" {
+		t.Fatal("auto-generated ID is empty")
+	}
+}
+
+func TestAutoIDGenerationDoesNotOverwriteSameMillisecondEntries(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		entry, err := store.Push("", "Auto", "content", EntryTypeHTML, "agent-1")
+		if err != nil {
+			t.Fatalf("Push failed: %v", err)
+		}
+		if seen[entry.ID] {
+			t.Fatalf("duplicate auto-generated ID: %s", entry.ID)
+		}
+		seen[entry.ID] = true
+		if entry.Version != 1 {
+			t.Fatalf("expected auto-created entry version 1, got %d", entry.Version)
+		}
+	}
+
+	items := store.List()
+	if len(items) != 100 {
+		t.Fatalf("expected 100 independently created entries, got %d", len(items))
+	}
+}
+
+func TestPathTraversalProtection(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, 5)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	if _, err := store.Push("../escape", "Escape", "content", EntryTypeHTML, "agent-1"); err == nil {
+		t.Fatal("expected path traversal id to be rejected")
+	}
+	if _, err := store.Push(`nested\escape`, "Escape", "content", EntryTypeHTML, "agent-1"); err == nil {
+		t.Fatal("expected backslash path id to be rejected")
+	}
+	if err := store.Delete("../escape"); err == nil {
+		t.Fatal("expected invalid delete id to be rejected")
+	}
+	if err := store.Reset("../escape"); err == nil {
+		t.Fatal("expected invalid reset id to be rejected")
+	}
+
+	entryDir := filepath.Join(store.BaseDir(), "entries")
+	if err := os.MkdirAll(entryDir, 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+
+	entries, err := os.ReadDir(entryDir)
+	if err != nil {
+		t.Fatalf("readdir failed: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty entries dir, got %d files", len(entries))
+	}
+}
+
+func TestA2UIEscapesAttributesAndRejectsUnsafeNames(t *testing.T) {
+	renderer := NewA2UIRenderer()
+	html, err := renderer.Render(&A2UIDocument{
+		Title: "Unsafe",
+		Components: []A2UIComponent{
+			{
+				Type:    "input",
+				Content: "ignored",
+				Props: map[string]any{
+					"inputType": `text" autofocus`,
+				},
+				Attributes: map[string]any{
+					`onclick`:       "alert(1)",
+					`bad name`:      "bad",
+					`data-title`:    `hello "quoted"`,
+					`x" onfocus="x`: "bad",
+				},
+				Styles: map[string]string{
+					"color":       `red";background:url(x)`,
+					`bad name`:    "bad",
+					"--accent":    "#0f766e",
+					"font-weight": "700",
+				},
+			},
+			{
+				Type: "unknown",
+				Props: map[string]any{
+					"tag": `script onclick="bad"`,
+				},
+				Content: `<hello>`,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	if strings.Contains(html, "bad name") || strings.Contains(html, `x" onfocus`) {
+		t.Fatalf("expected unsafe attribute/style names to be skipped:\n%s", html)
+	}
+	if !strings.Contains(html, `data-title="hello &#34;quoted&#34;"`) {
+		t.Fatalf("expected attribute value to be escaped:\n%s", html)
+	}
+	if strings.Contains(html, `<script`) {
+		t.Fatalf("expected unsafe generic tag to fall back to div:\n%s", html)
+	}
+	if !strings.Contains(html, `&lt;hello&gt;`) {
+		t.Fatalf("expected generic content to be escaped:\n%s", html)
+	}
+}
+
+func TestA2UIValidatesRenderedURISchemes(t *testing.T) {
+	renderer := NewA2UIRenderer()
+	html, err := renderer.Render(&A2UIDocument{
+		Title: "Links",
+		Components: []A2UIComponent{
+			{
+				Type:    "link",
+				Content: "Safe HTTP",
+				Props: map[string]any{
+					"href": "https://example.com/docs",
+				},
+			},
+			{
+				Type:    "link",
+				Content: "Safe Mail",
+				Props: map[string]any{
+					"href": "mailto:hello@example.com",
+				},
+			},
+			{
+				Type:    "link",
+				Content: "Safe Relative",
+				Props: map[string]any{
+					"href": "/docs/getting-started#intro",
+				},
+			},
+			{
+				Type:    "link",
+				Content: "Unsafe JS",
+				Props: map[string]any{
+					"href": "javascript:alert(1)",
+				},
+			},
+			{
+				Type:    "link",
+				Content: "Unsafe Data",
+				Props: map[string]any{
+					"href": "data:text/html,<script>alert(1)</script>",
+				},
+			},
+			{
+				Type:    "link",
+				Content: "Protocol Relative",
+				Props: map[string]any{
+					"href": "//example.com/path",
+				},
+			},
+			{
+				Type: "image",
+				Props: map[string]any{
+					"src": "https://example.com/image.png",
+					"alt": "safe",
+				},
+			},
+			{
+				Type: "image",
+				Props: map[string]any{
+					"src": "./images/local.png",
+					"alt": "relative",
+				},
+			},
+			{
+				Type: "image",
+				Props: map[string]any{
+					"src": "javascript:alert(1)",
+					"alt": "bad js",
+				},
+			},
+			{
+				Type: "image",
+				Props: map[string]any{
+					"src": "data:text/html,<script>alert(1)</script>",
+					"alt": "bad data",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	if !containsAll(html, []string{
+		`<a href="https://example.com/docs">Safe HTTP</a>`,
+		`<a href="mailto:hello@example.com">Safe Mail</a>`,
+		`<a href="/docs/getting-started#intro">Safe Relative</a>`,
+		`<a href="#">Unsafe JS</a>`,
+		`<a href="#">Unsafe Data</a>`,
+		`<a href="#">Protocol Relative</a>`,
+		`<img src="https://example.com/image.png" alt="safe">`,
+		`<img src="./images/local.png" alt="relative">`,
+		`<img src="" alt="bad js">`,
+		`<img src="" alt="bad data">`,
+	}) {
+		t.Fatalf("rendered HTML missing expected safe URI output:\n%s", html)
+	}
+	if strings.Contains(html, "javascript:") || strings.Contains(html, "data:text/html") || strings.Contains(html, "//example.com/path") {
+		t.Fatalf("rendered HTML leaked unsafe URI:\n%s", html)
+	}
+}
+
+func TestA2UIMergesBuiltInAndCallerAttributes(t *testing.T) {
+	renderer := NewA2UIRenderer()
+	html, err := renderer.Render(&A2UIDocument{
+		Title: "Attributes",
+		Components: []A2UIComponent{
+			{
+				Type: "stack",
+				Props: map[string]any{
+					"className": "custom-stack",
+					"gap":       "4px",
+				},
+				Styles: map[string]string{
+					"color": "red",
+				},
+			},
+			{
+				Type: "grid",
+				Props: map[string]any{
+					"className": "custom-grid",
+					"columns":   "2",
+				},
+				Styles: map[string]string{
+					"margin": "0",
+				},
+			},
+			{
+				Type: "card",
+				Props: map[string]any{
+					"className": "prop-card",
+				},
+				Attributes: map[string]any{
+					"class": "attr-card",
+				},
+			},
+			{
+				Type: "badge",
+				Props: map[string]any{
+					"className": "custom-badge",
+				},
+				Content: "Badge",
+			},
+			{
+				Type: "alert",
+				Props: map[string]any{
+					"className": "custom-alert",
+					"level":     "warning",
+				},
+				Content: "Alert",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		needle    string
+		wantClass string
+		wantStyle bool
+	}{
+		{name: "stack", needle: "a2ui-stack", wantClass: `class="a2ui-stack custom-stack"`, wantStyle: true},
+		{name: "grid", needle: "a2ui-grid", wantClass: `class="a2ui-grid custom-grid"`, wantStyle: true},
+		{name: "card", needle: "a2ui-card", wantClass: `class="a2ui-card attr-card prop-card"`},
+		{name: "badge", needle: "a2ui-badge", wantClass: `class="a2ui-badge custom-badge"`},
+		{name: "alert", needle: "a2ui-alert-warning", wantClass: `class="a2ui-alert a2ui-alert-warning custom-alert"`},
+	}
+
+	for _, tc := range cases {
+		line := lineContaining(html, tc.needle)
+		if line == "" {
+			t.Fatalf("%s: expected rendered line containing %q:\n%s", tc.name, tc.needle, html)
+		}
+		if strings.Count(line, ` class=`) != 1 {
+			t.Fatalf("%s: expected one class attribute, got line:\n%s", tc.name, line)
+		}
+		if !strings.Contains(line, tc.wantClass) {
+			t.Fatalf("%s: expected merged class %s, got line:\n%s", tc.name, tc.wantClass, line)
+		}
+		if tc.wantStyle && strings.Count(line, ` style=`) != 1 {
+			t.Fatalf("%s: expected one style attribute, got line:\n%s", tc.name, line)
+		}
+		if !tc.wantStyle && strings.Count(line, ` style=`) != 0 {
+			t.Fatalf("%s: expected no style attribute, got line:\n%s", tc.name, line)
+		}
+	}
+}
+
+func containsAll(value string, snippets []string) bool {
+	for _, snippet := range snippets {
+		if !strings.Contains(value, snippet) {
+			return false
+		}
+	}
+	return true
+}
+
+func lineContaining(value string, needle string) string {
+	for _, line := range strings.Split(value, "\n") {
+		if strings.Contains(line, "<") && strings.Contains(line, needle) {
+			return line
+		}
+	}
+	return ""
+}

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -592,6 +592,10 @@ func (im *IndexManager) Rebuild(ctx context.Context, indexName string, progress 
 }
 
 func (im *IndexManager) Search(ctx context.Context, indexName string, queryVector []float32, limit int) ([]vec.VecSearchResult, error) {
+	return im.SearchWithFilter(ctx, indexName, queryVector, limit, 0, nil)
+}
+
+func (im *IndexManager) SearchWithFilter(ctx context.Context, indexName string, queryVector []float32, limit int, threshold float64, metadataFilter map[string]string) ([]vec.VecSearchResult, error) {
 	im.mu.RLock()
 	info, exists := im.indexes[indexName]
 	im.mu.RUnlock()
@@ -600,7 +604,7 @@ func (im *IndexManager) Search(ctx context.Context, indexName string, queryVecto
 		return nil, fmt.Errorf("index %q not found", indexName)
 	}
 
-	return im.newVecStore(info).Search(ctx, queryVector, limit)
+	return im.newVecStore(info).SearchWithFilter(ctx, queryVector, limit, threshold, metadataFilter)
 }
 
 func (im *IndexManager) SearchByText(ctx context.Context, indexName string, queryText string, limit int) ([]vec.VecSearchResult, error) {

--- a/pkg/vision/analyze.go
+++ b/pkg/vision/analyze.go
@@ -1,0 +1,752 @@
+package vision
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+type AnalysisResult struct {
+	Description string           `json:"description"`
+	Labels      []Label          `json:"labels"`
+	Objects     []DetectedObject `json:"objects"`
+	Text        []DetectedText   `json:"text"`
+	Faces       []DetectedFace   `json:"faces"`
+	SafeSearch  SafeSearchResult `json:"safe_search"`
+	ImageProps  ImageProperties  `json:"image_properties"`
+	Metadata    map[string]any   `json:"metadata"`
+}
+
+type Label struct {
+	Name        string  `json:"name"`
+	Confidence  float64 `json:"confidence"`
+	Description string  `json:"description"`
+}
+
+type DetectedObject struct {
+	Name       string  `json:"name"`
+	Confidence float64 `json:"confidence"`
+	Bounds     Bounds  `json:"bounds"`
+}
+
+type DetectedText struct {
+	Text       string  `json:"text"`
+	Confidence float64 `json:"confidence"`
+	Bounds     Bounds  `json:"bounds"`
+	Language   string  `json:"language"`
+}
+
+type DetectedFace struct {
+	Confidence float64            `json:"confidence"`
+	Bounds     Bounds             `json:"bounds"`
+	Emotions   map[string]float64 `json:"emotions"`
+}
+
+type Bounds struct {
+	X      int `json:"x"`
+	Y      int `json:"y"`
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+type SafeSearchResult struct {
+	Adult    float64 `json:"adult"`
+	Violence float64 `json:"violence"`
+	Medical  float64 `json:"medical"`
+	Spoof    float64 `json:"spoof"`
+}
+
+type ImageProperties struct {
+	DominantColors []string `json:"dominant_colors"`
+	Width          int      `json:"width"`
+	Height         int      `json:"height"`
+	Format         string   `json:"format"`
+}
+
+type VisionProvider interface {
+	Name() string
+	AnalyzeImage(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error)
+	AnalyzeImageURL(ctx context.Context, imageURL string) (*AnalysisResult, error)
+	OCR(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error)
+	LabelImage(ctx context.Context, imageData []byte, mimeType string) ([]Label, error)
+	DetectObjects(ctx context.Context, imageData []byte, mimeType string) ([]DetectedObject, error)
+}
+
+type GoogleVisionConfig struct {
+	APIKey     string
+	Endpoint   string
+	Features   []string
+	MaxResults int
+	Timeout    time.Duration
+}
+
+func DefaultGoogleVisionConfig() GoogleVisionConfig {
+	return GoogleVisionConfig{
+		Endpoint:   "https://vision.googleapis.com/v1",
+		Features:   []string{"LABEL_DETECTION", "TEXT_DETECTION", "OBJECT_LOCALIZATION", "FACE_DETECTION", "SAFE_SEARCH_DETECTION", "IMAGE_PROPERTIES"},
+		MaxResults: 10,
+		Timeout:    30 * time.Second,
+	}
+}
+
+type GoogleVisionProvider struct {
+	cfg    GoogleVisionConfig
+	client *http.Client
+}
+
+func NewGoogleVisionProvider(cfg GoogleVisionConfig) *GoogleVisionProvider {
+	return &GoogleVisionProvider{
+		cfg: cfg,
+		client: &http.Client{
+			Timeout: cfg.Timeout,
+		},
+	}
+}
+
+func (p *GoogleVisionProvider) Name() string {
+	return "google-vision"
+}
+
+func (p *GoogleVisionProvider) AnalyzeImage(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+	encoded := base64.StdEncoding.EncodeToString(imageData)
+
+	requests := []map[string]any{}
+	features := make([]map[string]any, 0, len(p.cfg.Features))
+	for _, f := range p.cfg.Features {
+		features = append(features, map[string]any{
+			"type":       f,
+			"maxResults": p.cfg.MaxResults,
+		})
+	}
+
+	requests = append(requests, map[string]any{
+		"image":    map[string]any{"content": encoded},
+		"features": features,
+	})
+
+	body := map[string]any{"requests": requests}
+	jsonBody, _ := json.Marshal(body)
+
+	url := fmt.Sprintf("%s/images:annotate?key=%s", p.cfg.Endpoint, p.cfg.APIKey)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Google Vision API error: %s - %s", resp.Status, string(respBody))
+	}
+
+	var apiResp struct {
+		Responses []struct {
+			LabelAnnotations          []gcpAnnotation `json:"labelAnnotations"`
+			TextAnnotations           []gcpAnnotation `json:"textAnnotations"`
+			ObjectLocalizations       []gcpObjectAnn  `json:"objectLocalizations"`
+			FaceAnnotations           []gcpFaceAnn    `json:"faceAnnotations"`
+			SafeSearchAnnotation      gcpSafeSearch   `json:"safeSearchAnnotation"`
+			ImagePropertiesAnnotation gcpImageProps   `json:"imagePropertiesAnnotation"`
+			Error                     *struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		} `json:"responses"`
+	}
+
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	if len(apiResp.Responses) == 0 {
+		return nil, fmt.Errorf("empty response from Google Vision API")
+	}
+
+	r := apiResp.Responses[0]
+	if r.Error != nil {
+		return nil, fmt.Errorf("Google Vision API error: %s", r.Error.Message)
+	}
+
+	result := &AnalysisResult{Metadata: make(map[string]any)}
+
+	for _, ann := range r.LabelAnnotations {
+		result.Labels = append(result.Labels, Label{
+			Name:       ann.Description,
+			Confidence: float64(ann.Score),
+		})
+	}
+
+	if len(result.Labels) > 0 {
+		result.Description = result.Labels[0].Name
+	}
+
+	for _, ann := range r.TextAnnotations {
+		dt := DetectedText{
+			Text:       ann.Description,
+			Confidence: float64(ann.Score),
+		}
+		if ann.BoundingPoly != nil && len(ann.BoundingPoly.Vertices) >= 2 {
+			dt.Bounds = Bounds{
+				X:      ann.BoundingPoly.Vertices[0].X,
+				Y:      ann.BoundingPoly.Vertices[0].Y,
+				Width:  ann.BoundingPoly.Vertices[1].X - ann.BoundingPoly.Vertices[0].X,
+				Height: ann.BoundingPoly.Vertices[2].Y - ann.BoundingPoly.Vertices[0].Y,
+			}
+		}
+		result.Text = append(result.Text, dt)
+	}
+
+	for _, obj := range r.ObjectLocalizations {
+		detObj := DetectedObject{
+			Name:       obj.Name,
+			Confidence: float64(obj.Score),
+		}
+		if obj.BoundingPoly != nil && len(obj.BoundingPoly.Vertices) >= 2 {
+			detObj.Bounds = Bounds{
+				X:      obj.BoundingPoly.Vertices[0].X,
+				Y:      obj.BoundingPoly.Vertices[0].Y,
+				Width:  obj.BoundingPoly.Vertices[1].X - obj.BoundingPoly.Vertices[0].X,
+				Height: obj.BoundingPoly.Vertices[2].Y - obj.BoundingPoly.Vertices[0].Y,
+			}
+		}
+		result.Objects = append(result.Objects, detObj)
+	}
+
+	for _, face := range r.FaceAnnotations {
+		emotions := make(map[string]float64)
+		emotions["joy"] = likelihoodToFloat(face.JoyLikelihood)
+		emotions["sorrow"] = likelihoodToFloat(face.SorrowLikelihood)
+		emotions["anger"] = likelihoodToFloat(face.AngerLikelihood)
+		emotions["surprise"] = likelihoodToFloat(face.SurpriseLikelihood)
+
+		detFace := DetectedFace{
+			Confidence: float64(face.DetectionConfidence),
+			Emotions:   emotions,
+		}
+		if face.BoundingPoly != nil && len(face.BoundingPoly.Vertices) >= 2 {
+			detFace.Bounds = Bounds{
+				X:      face.BoundingPoly.Vertices[0].X,
+				Y:      face.BoundingPoly.Vertices[0].Y,
+				Width:  face.BoundingPoly.Vertices[1].X - face.BoundingPoly.Vertices[0].X,
+				Height: face.BoundingPoly.Vertices[2].Y - face.BoundingPoly.Vertices[0].Y,
+			}
+		}
+		result.Faces = append(result.Faces, detFace)
+	}
+
+	result.SafeSearch = SafeSearchResult{
+		Adult:    likelihoodToFloat(r.SafeSearchAnnotation.Adult),
+		Violence: likelihoodToFloat(r.SafeSearchAnnotation.Violence),
+		Medical:  likelihoodToFloat(r.SafeSearchAnnotation.Medical),
+		Spoof:    likelihoodToFloat(r.SafeSearchAnnotation.Spoof),
+	}
+
+	if len(r.ImagePropertiesAnnotation.DominantColors.Colors) > 0 {
+		for _, c := range r.ImagePropertiesAnnotation.DominantColors.Colors {
+			result.ImageProps.DominantColors = append(result.ImageProps.DominantColors,
+				fmt.Sprintf("#%02X%02X%02X", c.Color.Red, c.Color.Green, c.Color.Blue))
+		}
+	}
+
+	return result, nil
+}
+
+func (p *GoogleVisionProvider) AnalyzeImageURL(ctx context.Context, imageURL string) (*AnalysisResult, error) {
+	resp, err := fetchImageURL(ctx, p.client, imageURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetch image: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 20*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read image: %w", err)
+	}
+
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "image/jpeg"
+	}
+
+	return p.AnalyzeImage(ctx, data, mimeType)
+}
+
+func (p *GoogleVisionProvider) OCR(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error) {
+	result, err := p.AnalyzeImage(ctx, imageData, mimeType)
+	if err != nil {
+		return nil, err
+	}
+	return result.Text, nil
+}
+
+func (p *GoogleVisionProvider) LabelImage(ctx context.Context, imageData []byte, mimeType string) ([]Label, error) {
+	result, err := p.AnalyzeImage(ctx, imageData, mimeType)
+	if err != nil {
+		return nil, err
+	}
+	return result.Labels, nil
+}
+
+func (p *GoogleVisionProvider) DetectObjects(ctx context.Context, imageData []byte, mimeType string) ([]DetectedObject, error) {
+	result, err := p.AnalyzeImage(ctx, imageData, mimeType)
+	if err != nil {
+		return nil, err
+	}
+	return result.Objects, nil
+}
+
+func fetchImageURL(ctx context.Context, client *http.Client, imageURL string) (*http.Response, error) {
+	if err := validateImageFetchURL(ctx, imageURL); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create image request: %w", err)
+	}
+
+	return imageFetchHTTPClient(client).Do(req)
+}
+
+func imageFetchHTTPClient(client *http.Client) *http.Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	next := *client
+	previousCheckRedirect := client.CheckRedirect
+	next.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		if err := validateImageFetchURL(req.Context(), req.URL.String()); err != nil {
+			return err
+		}
+		if previousCheckRedirect != nil {
+			return previousCheckRedirect(req, via)
+		}
+		return nil
+	}
+
+	return &next
+}
+
+func validateImageFetchURL(ctx context.Context, rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid image URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("unsafe image URL scheme: %s", parsed.Scheme)
+	}
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("image URL host is required")
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("image URL must not include credentials")
+	}
+	return validateImageFetchHost(ctx, parsed.Hostname())
+}
+
+func validateImageFetchHost(ctx context.Context, host string) error {
+	normalized := strings.TrimSuffix(strings.ToLower(host), ".")
+	if normalized == "" {
+		return fmt.Errorf("image URL host is required")
+	}
+	if normalized == "localhost" || strings.HasSuffix(normalized, ".localhost") {
+		return fmt.Errorf("unsafe image URL host: %s", host)
+	}
+
+	if addr, err := netip.ParseAddr(normalized); err == nil {
+		return validateImageFetchAddr(host, addr)
+	}
+
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return fmt.Errorf("resolve image URL host %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("resolve image URL host %q: no addresses", host)
+	}
+	for _, ip := range ips {
+		addr, ok := netip.AddrFromSlice(ip.IP)
+		if !ok {
+			return fmt.Errorf("resolve image URL host %q: invalid address %s", host, ip.IP)
+		}
+		if err := validateImageFetchAddr(host, addr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateImageFetchAddr(host string, addr netip.Addr) error {
+	addr = addr.Unmap()
+	if !addr.IsValid() || !addr.IsGlobalUnicast() || addr.IsPrivate() || addr.IsLoopback() || addr.IsLinkLocalUnicast() || addr.IsMulticast() || isSpecialImageFetchAddr(addr) {
+		return fmt.Errorf("unsafe image URL host %q resolves to non-public address %s", host, addr)
+	}
+	return nil
+}
+
+func isSpecialImageFetchAddr(addr netip.Addr) bool {
+	for _, prefix := range blockedImageFetchPrefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+var blockedImageFetchPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("224.0.0.0/4"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("::/128"),
+	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("64:ff9b::/96"),
+	netip.MustParsePrefix("100::/64"),
+	netip.MustParsePrefix("2001::/23"),
+	netip.MustParsePrefix("2001:2::/48"),
+	netip.MustParsePrefix("2001:db8::/32"),
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+	netip.MustParsePrefix("ff00::/8"),
+}
+
+type gcpAnnotation struct {
+	Mid          string  `json:"mid"`
+	Description  string  `json:"description"`
+	Score        float32 `json:"score"`
+	Confidence   float32 `json:"confidence"`
+	Topicality   float32 `json:"topicality"`
+	BoundingPoly *struct {
+		Vertices []struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+		} `json:"vertices"`
+	} `json:"boundingPoly"`
+}
+
+type gcpObjectAnn struct {
+	Name         string  `json:"name"`
+	Score        float32 `json:"score"`
+	BoundingPoly *struct {
+		Vertices []struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+		} `json:"vertices"`
+	} `json:"boundingPoly"`
+}
+
+type gcpFaceAnn struct {
+	BoundingPoly *struct {
+		Vertices []struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+		} `json:"vertices"`
+	} `json:"boundingPoly"`
+	DetectionConfidence   float32 `json:"detectionConfidence"`
+	LandmarkingConfidence float32 `json:"landmarkingConfidence"`
+	JoyLikelihood         string  `json:"joyLikelihood"`
+	SorrowLikelihood      string  `json:"sorrowLikelihood"`
+	AngerLikelihood       string  `json:"angerLikelihood"`
+	SurpriseLikelihood    string  `json:"surpriseLikelihood"`
+}
+
+type gcpSafeSearch struct {
+	Adult    string `json:"adult"`
+	Spoof    string `json:"spoof"`
+	Medical  string `json:"medical"`
+	Violence string `json:"violence"`
+	Racy     string `json:"racy"`
+}
+
+type gcpImageProps struct {
+	DominantColors struct {
+		Colors []struct {
+			Color struct {
+				Red   int `json:"red"`
+				Green int `json:"green"`
+				Blue  int `json:"blue"`
+			} `json:"color"`
+			Score float32 `json:"score"`
+		} `json:"colors"`
+	} `json:"dominantColors"`
+}
+
+func likelihoodToFloat(l string) float64 {
+	switch strings.ToLower(l) {
+	case "very_likely":
+		return 0.9
+	case "likely":
+		return 0.7
+	case "possible":
+		return 0.5
+	case "unlikely":
+		return 0.3
+	case "very_unlikely":
+		return 0.1
+	default:
+		return 0
+	}
+}
+
+type LLMVisionConfig struct {
+	Client      LLMVisionClient
+	Prompt      string
+	MaxTokens   int
+	Temperature float64
+}
+
+func DefaultLLMVisionConfig() LLMVisionConfig {
+	return LLMVisionConfig{
+		Prompt:      "Describe this image in detail. Include objects, text, people, actions, colors, and overall scene.",
+		MaxTokens:   1024,
+		Temperature: 0.3,
+	}
+}
+
+type LLMVisionClient interface {
+	AnalyzeImageWithPrompt(ctx context.Context, imageData []byte, mimeType string, prompt string) (string, error)
+}
+
+type LLMVisionProvider struct {
+	cfg LLMVisionConfig
+}
+
+func NewLLMVisionProvider(cfg LLMVisionConfig) *LLMVisionProvider {
+	return &LLMVisionProvider{cfg: cfg}
+}
+
+func (p *LLMVisionProvider) Name() string {
+	return "llm-vision"
+}
+
+func (p *LLMVisionProvider) requireClient() (LLMVisionClient, error) {
+	if p == nil || p.cfg.Client == nil {
+		return nil, fmt.Errorf("no LLM vision client configured")
+	}
+	return p.cfg.Client, nil
+}
+
+func (p *LLMVisionProvider) AnalyzeImage(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+	client, err := p.requireClient()
+	if err != nil {
+		return nil, err
+	}
+
+	prompt := p.cfg.Prompt
+	if prompt == "" {
+		prompt = "Describe this image in detail."
+	}
+
+	description, err := client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
+	if err != nil {
+		return nil, fmt.Errorf("LLM vision analysis: %w", err)
+	}
+
+	return &AnalysisResult{
+		Description: description,
+		Metadata:    map[string]any{"provider": "llm-vision", "prompt": prompt},
+	}, nil
+}
+
+func (p *LLMVisionProvider) AnalyzeImageURL(ctx context.Context, imageURL string) (*AnalysisResult, error) {
+	if _, err := p.requireClient(); err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := fetchImageURL(ctx, client, imageURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetch image: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 20*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read image: %w", err)
+	}
+
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "image/jpeg"
+	}
+
+	return p.AnalyzeImage(ctx, data, mimeType)
+}
+
+func (p *LLMVisionProvider) OCR(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error) {
+	client, err := p.requireClient()
+	if err != nil {
+		return nil, err
+	}
+
+	prompt := "Extract all text from this image. Return only the text content, preserving line breaks."
+	description, err := client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	return []DetectedText{
+		{Text: description, Confidence: 1.0},
+	}, nil
+}
+
+func (p *LLMVisionProvider) LabelImage(ctx context.Context, imageData []byte, mimeType string) ([]Label, error) {
+	client, err := p.requireClient()
+	if err != nil {
+		return nil, err
+	}
+
+	prompt := "List the main objects and concepts in this image as a comma-separated list. Format each as 'name:confidence' where confidence is 0.0-1.0."
+	description, err := client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	var labels []Label
+	lines := strings.Split(description, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		name := strings.TrimSpace(parts[0])
+		confidence := 0.8
+		if len(parts) == 2 {
+			fmt.Sscanf(strings.TrimSpace(parts[1]), "%f", &confidence)
+		}
+		labels = append(labels, Label{Name: name, Confidence: confidence})
+	}
+
+	return labels, nil
+}
+
+func (p *LLMVisionProvider) DetectObjects(ctx context.Context, imageData []byte, mimeType string) ([]DetectedObject, error) {
+	client, err := p.requireClient()
+	if err != nil {
+		return nil, err
+	}
+
+	prompt := "List all visible objects in this image. For each, provide name and approximate bounding box as x,y,width,height."
+	_, err = client.AnalyzeImageWithPrompt(ctx, imageData, mimeType, prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, fmt.Errorf("object detection not supported via LLM vision")
+}
+
+func AnalyzeImageFile(ctx context.Context, provider VisionProvider, path string) (*AnalysisResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read image file: %w", err)
+	}
+
+	mimeType := mimeTypeFromPath(path)
+	if mimeType == "" {
+		mimeType = "image/jpeg"
+	}
+
+	return provider.AnalyzeImage(ctx, data, mimeType)
+}
+
+func mimeTypeFromPath(path string) string {
+	ext := strings.ToLower(path)
+	switch {
+	case strings.HasSuffix(ext, ".jpg"), strings.HasSuffix(ext, ".jpeg"):
+		return "image/jpeg"
+	case strings.HasSuffix(ext, ".png"):
+		return "image/png"
+	case strings.HasSuffix(ext, ".gif"):
+		return "image/gif"
+	case strings.HasSuffix(ext, ".webp"):
+		return "image/webp"
+	case strings.HasSuffix(ext, ".bmp"):
+		return "image/bmp"
+	default:
+		return ""
+	}
+}
+
+func UploadImageForAnalysis(ctx context.Context, endpoint string, apiKey string, imageData []byte, mimeType string) (*AnalysisResult, error) {
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	part, err := writer.CreateFormFile("image", "upload")
+	if err != nil {
+		return nil, fmt.Errorf("create form file: %w", err)
+	}
+	part.Write(imageData)
+
+	if mimeType != "" {
+		writer.WriteField("mime_type", mimeType)
+	}
+
+	writer.Close()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, &buf)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("upload failed: %s - %s", resp.Status, string(body))
+	}
+
+	var result AnalysisResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/pkg/vision/analyze_test.go
+++ b/pkg/vision/analyze_test.go
@@ -1,0 +1,516 @@
+package vision
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+type testLLMVisionClient struct {
+	analyzeFunc func(ctx context.Context, imageData []byte, mimeType string, prompt string) (string, error)
+}
+
+func (c *testLLMVisionClient) AnalyzeImageWithPrompt(ctx context.Context, imageData []byte, mimeType string, prompt string) (string, error) {
+	if c.analyzeFunc != nil {
+		return c.analyzeFunc(ctx, imageData, mimeType, prompt)
+	}
+	return "ok", nil
+}
+
+func TestLLMVisionProviderRejectsMissingClient(t *testing.T) {
+	t.Run("AnalyzeImage", func(t *testing.T) {
+		provider := NewLLMVisionProvider(LLMVisionConfig{})
+		_, err := provider.AnalyzeImage(context.Background(), []byte("img"), "image/png")
+		assertMissingLLMClientError(t, err)
+	})
+
+	t.Run("OCR", func(t *testing.T) {
+		provider := NewLLMVisionProvider(LLMVisionConfig{})
+		_, err := provider.OCR(context.Background(), []byte("img"), "image/png")
+		assertMissingLLMClientError(t, err)
+	})
+
+	t.Run("LabelImage", func(t *testing.T) {
+		provider := NewLLMVisionProvider(LLMVisionConfig{})
+		_, err := provider.LabelImage(context.Background(), []byte("img"), "image/png")
+		assertMissingLLMClientError(t, err)
+	})
+
+	t.Run("DetectObjects", func(t *testing.T) {
+		provider := NewLLMVisionProvider(LLMVisionConfig{})
+		_, err := provider.DetectObjects(context.Background(), []byte("img"), "image/png")
+		assertMissingLLMClientError(t, err)
+	})
+}
+
+func TestLLMVisionProviderAnalyzeImageURLRejectsMissingClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("img"))
+	}))
+	defer server.Close()
+
+	provider := NewLLMVisionProvider(LLMVisionConfig{})
+	_, err := provider.AnalyzeImageURL(context.Background(), server.URL)
+	assertMissingLLMClientError(t, err)
+}
+
+func TestAnalyzeImageURLRejectsUnsafeURL(t *testing.T) {
+	t.Run("GoogleVisionProvider", func(t *testing.T) {
+		provider := NewGoogleVisionProvider(DefaultGoogleVisionConfig())
+		_, err := provider.AnalyzeImageURL(context.Background(), "http://127.0.0.1/image.png")
+		assertUnsafeImageURLError(t, err)
+	})
+
+	t.Run("LLMVisionProvider", func(t *testing.T) {
+		provider := NewLLMVisionProvider(LLMVisionConfig{Client: &testLLMVisionClient{}})
+		_, err := provider.AnalyzeImageURL(context.Background(), "http://127.0.0.1/image.png")
+		assertUnsafeImageURLError(t, err)
+	})
+}
+
+func TestValidateImageFetchURLRejectsUnsafeInputs(t *testing.T) {
+	cases := []string{
+		"ftp://example.com/image.png",
+		"http:///image.png",
+		"https://user:pass@example.com/image.png",
+		"http://localhost/image.png",
+		"http://service.localhost/image.png",
+		"http://127.0.0.1/image.png",
+		"http://10.0.0.2/image.png",
+		"http://169.254.169.254/latest/meta-data",
+		"http://[::1]/image.png",
+		"http://[fe80::1]/image.png",
+	}
+
+	for _, rawURL := range cases {
+		err := validateImageFetchURL(context.Background(), rawURL)
+		if err == nil {
+			t.Fatalf("expected unsafe URL %q to be rejected", rawURL)
+		}
+	}
+}
+
+func TestValidateImageFetchURLAllowsPublicHTTPURLs(t *testing.T) {
+	if err := validateImageFetchURL(context.Background(), "https://8.8.8.8/image.png"); err != nil {
+		t.Fatalf("expected public URL to be accepted, got %v", err)
+	}
+}
+
+func TestImageFetchHTTPClientRejectsUnsafeRedirect(t *testing.T) {
+	client := imageFetchHTTPClient(&http.Client{})
+	req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	err = client.CheckRedirect(req, nil)
+	assertUnsafeImageURLError(t, err)
+}
+
+func TestLLMVisionProviderAnalyzeImageUsesConfiguredClient(t *testing.T) {
+	provider := NewLLMVisionProvider(LLMVisionConfig{
+		Client: &testLLMVisionClient{
+			analyzeFunc: func(ctx context.Context, imageData []byte, mimeType string, prompt string) (string, error) {
+				if mimeType != "image/png" {
+					t.Fatalf("expected mime type image/png, got %s", mimeType)
+				}
+				if prompt == "" {
+					t.Fatal("expected prompt to be populated")
+				}
+				return "analyzed", nil
+			},
+		},
+	})
+
+	result, err := provider.AnalyzeImage(context.Background(), []byte("img"), "image/png")
+	if err != nil {
+		t.Fatalf("AnalyzeImage: %v", err)
+	}
+	if result.Description != "analyzed" {
+		t.Fatalf("expected description %q, got %q", "analyzed", result.Description)
+	}
+}
+
+func TestVisionProviderNamesAndDefaults(t *testing.T) {
+	if got := NewGoogleVisionProvider(DefaultGoogleVisionConfig()).Name(); got != "google-vision" {
+		t.Fatalf("expected google provider name, got %q", got)
+	}
+	if got := NewLLMVisionProvider(DefaultLLMVisionConfig()).Name(); got != "llm-vision" {
+		t.Fatalf("expected LLM provider name, got %q", got)
+	}
+	if DefaultLLMVisionConfig().Prompt == "" {
+		t.Fatal("expected default LLM vision prompt")
+	}
+}
+
+func TestGoogleVisionProviderAnalyzeImageParsesResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.RawQuery, "key=test-key") {
+			t.Fatalf("expected API key query, got %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(googleVisionSuccessResponse))
+	}))
+	defer server.Close()
+
+	cfg := DefaultGoogleVisionConfig()
+	cfg.Endpoint = server.URL
+	cfg.APIKey = "test-key"
+	provider := NewGoogleVisionProvider(cfg)
+
+	result, err := provider.AnalyzeImage(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("AnalyzeImage: %v", err)
+	}
+	if result.Description != "cat" {
+		t.Fatalf("expected description cat, got %q", result.Description)
+	}
+	if len(result.Labels) != 1 || result.Labels[0].Name != "cat" {
+		t.Fatalf("expected parsed label, got %#v", result.Labels)
+	}
+	if len(result.Text) != 1 || result.Text[0].Text != "hello" {
+		t.Fatalf("expected parsed text, got %#v", result.Text)
+	}
+	if len(result.Objects) != 1 || result.Objects[0].Name != "cup" {
+		t.Fatalf("expected parsed object, got %#v", result.Objects)
+	}
+	if len(result.Faces) != 1 || result.Faces[0].Emotions["joy"] == 0 {
+		t.Fatalf("expected parsed face emotions, got %#v", result.Faces)
+	}
+	if len(result.ImageProps.DominantColors) != 1 || result.ImageProps.DominantColors[0] != "#010203" {
+		t.Fatalf("expected dominant color #010203, got %#v", result.ImageProps.DominantColors)
+	}
+}
+
+func TestGoogleVisionProviderAnalyzeImageErrors(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "status error", status: http.StatusBadRequest, body: "bad request"},
+		{name: "malformed json", status: http.StatusOK, body: `{invalid}`},
+		{name: "empty response", status: http.StatusOK, body: `{"responses":[]}`},
+		{name: "api response error", status: http.StatusOK, body: `{"responses":[{"error":{"code":3,"message":"bad image"}}]}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			cfg := DefaultGoogleVisionConfig()
+			cfg.Endpoint = server.URL
+			cfg.APIKey = "test-key"
+			provider := NewGoogleVisionProvider(cfg)
+
+			if _, err := provider.AnalyzeImage(context.Background(), []byte("image"), "image/png"); err == nil {
+				t.Fatal("expected AnalyzeImage to fail")
+			}
+		})
+	}
+}
+
+func TestGoogleVisionProviderDerivedMethods(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(googleVisionSuccessResponse))
+	}))
+	defer server.Close()
+
+	cfg := DefaultGoogleVisionConfig()
+	cfg.Endpoint = server.URL
+	cfg.APIKey = "test-key"
+	provider := NewGoogleVisionProvider(cfg)
+
+	texts, err := provider.OCR(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("OCR: %v", err)
+	}
+	if len(texts) != 1 || texts[0].Text != "hello" {
+		t.Fatalf("expected OCR text, got %#v", texts)
+	}
+
+	labels, err := provider.LabelImage(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("LabelImage: %v", err)
+	}
+	if len(labels) != 1 || labels[0].Name != "cat" {
+		t.Fatalf("expected label, got %#v", labels)
+	}
+
+	objects, err := provider.DetectObjects(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("DetectObjects: %v", err)
+	}
+	if len(objects) != 1 || objects[0].Name != "cup" {
+		t.Fatalf("expected object, got %#v", objects)
+	}
+}
+
+func TestLLMVisionProviderOCRLabelAndDetectObjects(t *testing.T) {
+	provider := NewLLMVisionProvider(LLMVisionConfig{
+		Client: &testLLMVisionClient{
+			analyzeFunc: func(ctx context.Context, imageData []byte, mimeType string, prompt string) (string, error) {
+				switch {
+				case strings.Contains(prompt, "Extract all text"):
+					return "invoice\n123", nil
+				case strings.Contains(prompt, "comma-separated"):
+					return "cat:0.91\ndog", nil
+				default:
+					return "objects", nil
+				}
+			},
+		},
+	})
+
+	texts, err := provider.OCR(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("OCR: %v", err)
+	}
+	if len(texts) != 1 || texts[0].Text != "invoice\n123" {
+		t.Fatalf("expected OCR output, got %#v", texts)
+	}
+
+	labels, err := provider.LabelImage(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("LabelImage: %v", err)
+	}
+	if len(labels) != 2 || labels[0].Name != "cat" || labels[1].Name != "dog" {
+		t.Fatalf("expected parsed labels, got %#v", labels)
+	}
+
+	if _, err := provider.DetectObjects(context.Background(), []byte("image"), "image/png"); err == nil {
+		t.Fatal("expected DetectObjects unsupported error")
+	}
+}
+
+func TestLLMVisionProviderReturnsClientErrors(t *testing.T) {
+	provider := NewLLMVisionProvider(LLMVisionConfig{
+		Client: &testLLMVisionClient{
+			analyzeFunc: func(ctx context.Context, imageData []byte, mimeType string, prompt string) (string, error) {
+				return "", errors.New("provider failed")
+			},
+		},
+	})
+
+	if _, err := provider.AnalyzeImage(context.Background(), []byte("image"), "image/png"); err == nil {
+		t.Fatal("expected AnalyzeImage client error")
+	}
+	if _, err := provider.OCR(context.Background(), []byte("image"), "image/png"); err == nil {
+		t.Fatal("expected OCR client error")
+	}
+	if _, err := provider.LabelImage(context.Background(), []byte("image"), "image/png"); err == nil {
+		t.Fatal("expected LabelImage client error")
+	}
+	if _, err := provider.DetectObjects(context.Background(), []byte("image"), "image/png"); err == nil {
+		t.Fatal("expected DetectObjects client error")
+	}
+}
+
+func TestAnalyzeImageFile(t *testing.T) {
+	provider := &testVisionProvider{
+		analyzeImageFunc: func(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+			if string(imageData) != "image" {
+				t.Fatalf("expected image bytes, got %q", string(imageData))
+			}
+			if mimeType != "image/png" {
+				t.Fatalf("expected image/png, got %s", mimeType)
+			}
+			return &AnalysisResult{Description: "file"}, nil
+		},
+	}
+
+	path := t.TempDir() + "/sample.png"
+	if err := os.WriteFile(path, []byte("image"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	result, err := AnalyzeImageFile(context.Background(), provider, path)
+	if err != nil {
+		t.Fatalf("AnalyzeImageFile: %v", err)
+	}
+	if result.Description != "file" {
+		t.Fatalf("expected file description, got %q", result.Description)
+	}
+
+	if _, err := AnalyzeImageFile(context.Background(), provider, path+".missing"); err == nil {
+		t.Fatal("expected read error")
+	}
+}
+
+func TestUploadImageForAnalysis(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer token" {
+			t.Fatalf("expected bearer token, got %q", r.Header.Get("Authorization"))
+		}
+		if err := r.ParseMultipartForm(1024); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"description":"uploaded","metadata":{"source":"test"}}`))
+	}))
+	defer server.Close()
+
+	result, err := UploadImageForAnalysis(context.Background(), server.URL, "token", []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("UploadImageForAnalysis: %v", err)
+	}
+	if result.Description != "uploaded" {
+		t.Fatalf("expected uploaded description, got %q", result.Description)
+	}
+}
+
+func TestUploadImageForAnalysisErrors(t *testing.T) {
+	t.Run("status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("bad gateway"))
+		}))
+		defer server.Close()
+
+		if _, err := UploadImageForAnalysis(context.Background(), server.URL, "", []byte("image"), ""); err == nil {
+			t.Fatal("expected upload status error")
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{invalid}`))
+		}))
+		defer server.Close()
+
+		if _, err := UploadImageForAnalysis(context.Background(), server.URL, "", []byte("image"), ""); err == nil {
+			t.Fatal("expected upload parse error")
+		}
+	})
+}
+
+func TestFetchImageURLUsesProvidedClient(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("image")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+
+	resp, err := fetchImageURL(context.Background(), client, "https://8.8.8.8/image.png")
+	if err != nil {
+		t.Fatalf("fetchImageURL: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if string(body) != "image" {
+		t.Fatalf("expected image body, got %q", string(body))
+	}
+}
+
+func assertMissingLLMClientError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected missing client error")
+	}
+	if !strings.Contains(err.Error(), "no LLM vision client configured") {
+		t.Fatalf("expected missing client error, got %v", err)
+	}
+}
+
+func assertUnsafeImageURLError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected unsafe image URL error")
+	}
+	if !strings.Contains(err.Error(), "unsafe image URL") && !strings.Contains(err.Error(), "image URL host is required") {
+		t.Fatalf("expected unsafe image URL error, got %v", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+const googleVisionSuccessResponse = `{
+  "responses": [
+    {
+      "labelAnnotations": [
+        {"description": "cat", "score": 0.95}
+      ],
+      "textAnnotations": [
+        {
+          "description": "hello",
+          "score": 0.80,
+          "boundingPoly": {
+            "vertices": [
+              {"x": 1, "y": 2},
+              {"x": 5, "y": 2},
+              {"x": 5, "y": 8}
+            ]
+          }
+        }
+      ],
+      "objectLocalizations": [
+        {
+          "name": "cup",
+          "score": 0.70,
+          "boundingPoly": {
+            "vertices": [
+              {"x": 2, "y": 3},
+              {"x": 7, "y": 3},
+              {"x": 7, "y": 11}
+            ]
+          }
+        }
+      ],
+      "faceAnnotations": [
+        {
+          "detectionConfidence": 0.88,
+          "joyLikelihood": "LIKELY",
+          "sorrowLikelihood": "VERY_UNLIKELY",
+          "angerLikelihood": "UNLIKELY",
+          "surpriseLikelihood": "POSSIBLE",
+          "boundingPoly": {
+            "vertices": [
+              {"x": 0, "y": 1},
+              {"x": 10, "y": 1},
+              {"x": 10, "y": 12}
+            ]
+          }
+        }
+      ],
+      "safeSearchAnnotation": {
+        "adult": "VERY_UNLIKELY",
+        "violence": "UNLIKELY",
+        "medical": "POSSIBLE",
+        "spoof": "LIKELY"
+      },
+      "imagePropertiesAnnotation": {
+        "dominantColors": {
+          "colors": [
+            {"color": {"red": 1, "green": 2, "blue": 3}, "score": 0.50}
+          ]
+        }
+      }
+    }
+  ]
+}`

--- a/pkg/vision/helpers_test.go
+++ b/pkg/vision/helpers_test.go
@@ -1,0 +1,530 @@
+package vision
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+)
+
+type testVisionProvider struct {
+	analyzeImageFunc    func(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error)
+	analyzeImageURLFunc func(ctx context.Context, imageURL string) (*AnalysisResult, error)
+	ocrFunc             func(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error)
+	analyzeImageHit     bool
+	analyzeImageURLHit  bool
+	ocrHit              bool
+}
+
+func (p *testVisionProvider) Name() string {
+	return "test"
+}
+
+func (p *testVisionProvider) AnalyzeImage(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+	p.analyzeImageHit = true
+	if p.analyzeImageFunc != nil {
+		return p.analyzeImageFunc(ctx, imageData, mimeType)
+	}
+	return &AnalysisResult{}, nil
+}
+
+func (p *testVisionProvider) AnalyzeImageURL(ctx context.Context, imageURL string) (*AnalysisResult, error) {
+	p.analyzeImageURLHit = true
+	if p.analyzeImageURLFunc != nil {
+		return p.analyzeImageURLFunc(ctx, imageURL)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (p *testVisionProvider) OCR(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error) {
+	p.ocrHit = true
+	if p.ocrFunc != nil {
+		return p.ocrFunc(ctx, imageData, mimeType)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (p *testVisionProvider) LabelImage(ctx context.Context, imageData []byte, mimeType string) ([]Label, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *testVisionProvider) DetectObjects(ctx context.Context, imageData []byte, mimeType string) ([]DetectedObject, error) {
+	return nil, errors.New("not implemented")
+}
+
+type testModelClient struct {
+	chatFunc func(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition) (*llm.Response, error)
+}
+
+func (c *testModelClient) Chat(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition) (*llm.Response, error) {
+	if c.chatFunc != nil {
+		return c.chatFunc(ctx, messages, tools)
+	}
+	return &llm.Response{Content: "described"}, nil
+}
+
+func (c *testModelClient) StreamChat(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition, onChunk func(string)) error {
+	return nil
+}
+
+func (c *testModelClient) Name() string {
+	return "test-model"
+}
+
+func TestImageDataURLRoundTrip(t *testing.T) {
+	data := []byte("image-bytes")
+	mimeType := "image/png"
+
+	dataURL := ImageToDataURL(data, mimeType)
+	if !strings.HasPrefix(dataURL, "data:image/png;base64,") {
+		t.Fatalf("unexpected data URL prefix: %s", dataURL)
+	}
+
+	decoded, gotMimeType, err := ImageFromDataURL(dataURL)
+	if err != nil {
+		t.Fatalf("ImageFromDataURL: %v", err)
+	}
+	if gotMimeType != mimeType {
+		t.Fatalf("expected mime type %s, got %s", mimeType, gotMimeType)
+	}
+	if string(decoded) != string(data) {
+		t.Fatalf("expected decoded data %q, got %q", string(data), string(decoded))
+	}
+}
+
+func TestImageFromDataURLRejectsInvalidInput(t *testing.T) {
+	if _, _, err := ImageFromDataURL("not-a-data-url"); err == nil {
+		t.Fatal("expected non-data URL to fail")
+	}
+	if _, _, err := ImageFromDataURL("data:image/png;base64"); err == nil {
+		t.Fatal("expected malformed data URL to fail")
+	}
+}
+
+func TestDetectMediaType(t *testing.T) {
+	cases := []struct {
+		mimeType string
+		want     string
+	}{
+		{mimeType: "image/jpeg", want: "image"},
+		{mimeType: "video/mp4", want: "video"},
+		{mimeType: "audio/mpeg", want: "audio"},
+		{mimeType: "application/json", want: ""},
+	}
+
+	for _, tc := range cases {
+		if got := detectMediaType(tc.mimeType); got != tc.want {
+			t.Fatalf("detectMediaType(%q) = %q, want %q", tc.mimeType, got, tc.want)
+		}
+	}
+}
+
+func TestAnalyzeMediaRejectsUnsupportedType(t *testing.T) {
+	pipeline := NewMediaUnderstandingPipeline(DefaultMediaUnderstandingConfig())
+	if _, err := AnalyzeMedia(context.Background(), pipeline, []byte("x"), "application/json"); err == nil {
+		t.Fatal("expected unsupported media type error")
+	}
+}
+
+func TestUnderstandImageRejectsOversizedEncodedImage(t *testing.T) {
+	provider := &testVisionProvider{}
+	pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+		VisionProvider: provider,
+		MaxImageSize:   4,
+		Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+	})
+
+	_, err := pipeline.UnderstandImage(context.Background(), []byte("12345"), "image/png")
+	if err == nil {
+		t.Fatal("expected oversized image to fail")
+	}
+	if !strings.Contains(err.Error(), "image too large") {
+		t.Fatalf("expected image size error, got %v", err)
+	}
+	if provider.analyzeImageHit {
+		t.Fatal("expected provider not to be called for oversized image")
+	}
+}
+
+func TestUnderstandImageCallsProviderForValidSizedImage(t *testing.T) {
+	provider := &testVisionProvider{
+		analyzeImageFunc: func(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+			return &AnalysisResult{
+				Description: "a cat",
+				Labels:      []Label{{Name: "cat"}, {Name: "pet"}},
+			}, nil
+		},
+	}
+	pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+		VisionProvider: provider,
+		MaxImageSize:   16,
+		Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+	})
+
+	result, err := pipeline.UnderstandImage(context.Background(), []byte("12345"), "image/png")
+	if err != nil {
+		t.Fatalf("UnderstandImage: %v", err)
+	}
+	if !provider.analyzeImageHit {
+		t.Fatal("expected provider to be called")
+	}
+	if result.Description != "a cat" {
+		t.Fatalf("expected description %q, got %q", "a cat", result.Description)
+	}
+	if result.Summary != "cat, pet" {
+		t.Fatalf("expected summary %q, got %q", "cat, pet", result.Summary)
+	}
+}
+
+func TestUnderstandImageWithoutProvider(t *testing.T) {
+	pipeline := NewMediaUnderstandingPipeline(DefaultMediaUnderstandingConfig())
+
+	result, err := pipeline.UnderstandImage(context.Background(), []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("UnderstandImage: %v", err)
+	}
+	if result.Description != "No vision provider configured" {
+		t.Fatalf("expected no provider description, got %q", result.Description)
+	}
+}
+
+func TestUnderstandImageFile(t *testing.T) {
+	pipeline := NewMediaUnderstandingPipeline(DefaultMediaUnderstandingConfig())
+	path := t.TempDir() + "/photo.png"
+	if err := os.WriteFile(path, []byte("image"), 0o600); err != nil {
+		t.Fatalf("write image fixture: %v", err)
+	}
+
+	result, err := pipeline.UnderstandImageFile(context.Background(), path)
+	if err != nil {
+		t.Fatalf("UnderstandImageFile: %v", err)
+	}
+	if result.Type != "image" {
+		t.Fatalf("expected image result, got %q", result.Type)
+	}
+
+	if _, err := pipeline.UnderstandImageFile(context.Background(), path+".missing"); err == nil {
+		t.Fatal("expected missing file error")
+	}
+}
+
+func TestUnderstandImageURL(t *testing.T) {
+	t.Run("missing provider", func(t *testing.T) {
+		pipeline := NewMediaUnderstandingPipeline(DefaultMediaUnderstandingConfig())
+		if _, err := pipeline.UnderstandImageURL(context.Background(), "https://example.com/image.png"); err == nil {
+			t.Fatal("expected missing provider error")
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		provider := &testVisionProvider{
+			analyzeImageURLFunc: func(ctx context.Context, imageURL string) (*AnalysisResult, error) {
+				if imageURL != "https://example.com/image.png" {
+					t.Fatalf("unexpected image URL %s", imageURL)
+				}
+				return &AnalysisResult{
+					Description: "remote",
+					Labels:      []Label{{Name: "remote"}, {Name: "image"}},
+				}, nil
+			},
+		}
+		pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+			VisionProvider: provider,
+			Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+		})
+
+		result, err := pipeline.UnderstandImageURL(context.Background(), "https://example.com/image.png")
+		if err != nil {
+			t.Fatalf("UnderstandImageURL: %v", err)
+		}
+		if result.Summary != "remote, image" {
+			t.Fatalf("expected summary, got %q", result.Summary)
+		}
+		if !provider.analyzeImageURLHit {
+			t.Fatal("expected provider AnalyzeImageURL to be called")
+		}
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		provider := &testVisionProvider{
+			analyzeImageURLFunc: func(ctx context.Context, imageURL string) (*AnalysisResult, error) {
+				return nil, errors.New("fetch failed")
+			},
+		}
+		pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+			VisionProvider: provider,
+			Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+		})
+
+		if _, err := pipeline.UnderstandImageURL(context.Background(), "https://example.com/image.png"); err == nil {
+			t.Fatal("expected provider URL error")
+		}
+	})
+}
+
+func TestOCRImage(t *testing.T) {
+	t.Run("missing provider", func(t *testing.T) {
+		pipeline := NewMediaUnderstandingPipeline(DefaultMediaUnderstandingConfig())
+		if _, err := pipeline.OCRImage(context.Background(), []byte("image"), "image/png"); err == nil {
+			t.Fatal("expected missing provider error")
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		provider := &testVisionProvider{
+			ocrFunc: func(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error) {
+				return []DetectedText{{Text: "hello"}, {Text: "world"}}, nil
+			},
+		}
+		pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+			VisionProvider: provider,
+			Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+		})
+
+		text, err := pipeline.OCRImage(context.Background(), []byte("image"), "image/png")
+		if err != nil {
+			t.Fatalf("OCRImage: %v", err)
+		}
+		if text != "hello\nworld" {
+			t.Fatalf("expected OCR text, got %q", text)
+		}
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		provider := &testVisionProvider{
+			ocrFunc: func(ctx context.Context, imageData []byte, mimeType string) ([]DetectedText, error) {
+				return nil, errors.New("ocr failed")
+			},
+		}
+		pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+			VisionProvider: provider,
+			Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+		})
+
+		if _, err := pipeline.OCRImage(context.Background(), []byte("image"), "image/png"); err == nil {
+			t.Fatal("expected OCR provider error")
+		}
+	})
+}
+
+func TestDescribeImageWithLLM(t *testing.T) {
+	pipeline := NewMediaUnderstandingPipeline(DefaultMediaUnderstandingConfig())
+
+	if _, err := pipeline.DescribeImageWithLLM(context.Background(), []byte("image"), "image/png", nil, ""); err == nil {
+		t.Fatal("expected missing LLM client error")
+	}
+
+	client := &testModelClient{
+		chatFunc: func(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition) (*llm.Response, error) {
+			if len(messages) != 1 {
+				t.Fatalf("expected one message, got %d", len(messages))
+			}
+			return &llm.Response{Content: "a detailed image"}, nil
+		},
+	}
+
+	description, err := pipeline.DescribeImageWithLLM(context.Background(), []byte("image"), "image/png", client, "")
+	if err != nil {
+		t.Fatalf("DescribeImageWithLLM: %v", err)
+	}
+	if description != "a detailed image" {
+		t.Fatalf("expected description, got %q", description)
+	}
+
+	errorClient := &testModelClient{
+		chatFunc: func(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition) (*llm.Response, error) {
+			return nil, errors.New("chat failed")
+		},
+	}
+	if _, err := pipeline.DescribeImageWithLLM(context.Background(), []byte("image"), "image/png", errorClient, "prompt"); err == nil {
+		t.Fatal("expected chat error")
+	}
+}
+
+func TestAnalyzeMediaRoutesSupportedTypes(t *testing.T) {
+	provider := &testVisionProvider{
+		analyzeImageFunc: func(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+			return &AnalysisResult{Description: "image"}, nil
+		},
+	}
+	pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+		VisionProvider: provider,
+		MaxImageSize:   100,
+		Timeout:        DefaultMediaUnderstandingConfig().Timeout,
+	})
+
+	result, err := AnalyzeMedia(context.Background(), pipeline, []byte("image"), "image/png")
+	if err != nil {
+		t.Fatalf("AnalyzeMedia image: %v", err)
+	}
+	if result.Type != "image" {
+		t.Fatalf("expected image result, got %q", result.Type)
+	}
+
+	pipeline.cfg.KeyFrameExtractor = NewKeyFrameExtractor()
+	pipeline.cfg.KeyFrameExtractor.SetFFmpegPath("definitely-missing-ffmpeg-binary")
+	if _, err := AnalyzeMedia(context.Background(), pipeline, []byte("video"), "video/mp4"); err == nil {
+		t.Fatal("expected video analysis error")
+	}
+
+	pipeline.cfg.AudioAnalyzer = NewAudioAnalyzer()
+	pipeline.cfg.AudioAnalyzer.SetFFmpegPath("definitely-missing-ffmpeg-binary")
+	if _, err := AnalyzeMedia(context.Background(), pipeline, []byte("audio"), "audio/mpeg"); err == nil {
+		t.Fatal("expected audio analysis error")
+	}
+}
+
+func TestUnderstandVideoAndAudioWithCommandOutput(t *testing.T) {
+	withFakeVisionCommands(t)
+
+	provider := &testVisionProvider{
+		analyzeImageFunc: func(ctx context.Context, imageData []byte, mimeType string) (*AnalysisResult, error) {
+			return &AnalysisResult{Description: "scene frame"}, nil
+		},
+	}
+
+	keyFrames := NewKeyFrameExtractor()
+	keyFrames.SetFFmpegPath("fake-ffmpeg")
+	keyFrames.SetFFprobePath("fake-ffprobe")
+	keyFrames.SetMaxKeyFrames(1)
+
+	audio := NewAudioAnalyzer()
+	audio.SetFFmpegPath("fake-ffmpeg")
+	audio.SetFFprobePath("fake-ffprobe")
+
+	pipeline := NewMediaUnderstandingPipeline(MediaUnderstandingConfig{
+		VisionProvider:    provider,
+		KeyFrameExtractor: keyFrames,
+		AudioAnalyzer:     audio,
+		Timeout:           DefaultMediaUnderstandingConfig().Timeout,
+	})
+
+	videoResult, err := pipeline.UnderstandVideo(context.Background(), []byte("video"))
+	if err != nil {
+		t.Fatalf("UnderstandVideo: %v", err)
+	}
+	if videoResult.Type != "video" {
+		t.Fatalf("expected video result, got %q", videoResult.Type)
+	}
+	if !strings.Contains(videoResult.Summary, "scene frame") {
+		t.Fatalf("expected scene summary, got %q", videoResult.Summary)
+	}
+
+	audioResult, err := pipeline.UnderstandAudio(context.Background(), []byte("audio"))
+	if err != nil {
+		t.Fatalf("UnderstandAudio: %v", err)
+	}
+	if audioResult.Type != "audio" {
+		t.Fatalf("expected audio result, got %q", audioResult.Type)
+	}
+	if audioResult.Metadata["duration"] != 12.5 {
+		t.Fatalf("expected audio duration metadata, got %#v", audioResult.Metadata["duration"])
+	}
+}
+
+func TestAnalysisResultToJSON(t *testing.T) {
+	result := &MediaUnderstandingResult{
+		Type:        "image",
+		Description: "desc",
+	}
+	encoded := AnalysisResultToJSON(result)
+	if !strings.Contains(encoded, `"description": "desc"`) {
+		t.Fatalf("expected JSON description, got %s", encoded)
+	}
+}
+
+func TestMimeTypeFromPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{path: "photo.jpg", want: "image/jpeg"},
+		{path: "photo.JPEG", want: "image/jpeg"},
+		{path: "photo.png", want: "image/png"},
+		{path: "photo.gif", want: "image/gif"},
+		{path: "photo.webp", want: "image/webp"},
+		{path: "photo.bmp", want: "image/bmp"},
+		{path: "photo.txt", want: ""},
+	}
+
+	for _, tc := range cases {
+		if got := mimeTypeFromPath(tc.path); got != tc.want {
+			t.Fatalf("mimeTypeFromPath(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestLikelihoodToFloat(t *testing.T) {
+	cases := []struct {
+		input string
+		want  float64
+	}{
+		{input: "VERY_UNLIKELY", want: 0.1},
+		{input: "UNLIKELY", want: 0.3},
+		{input: "POSSIBLE", want: 0.5},
+		{input: "LIKELY", want: 0.7},
+		{input: "VERY_LIKELY", want: 0.9},
+		{input: "UNKNOWN", want: 0},
+	}
+
+	for _, tc := range cases {
+		if got := likelihoodToFloat(tc.input); got != tc.want {
+			t.Fatalf("likelihoodToFloat(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestParseFPS(t *testing.T) {
+	if got := parseFPS("30000/1001"); got < 29.9 || got > 30.0 {
+		t.Fatalf("expected NTSC-ish fps, got %v", got)
+	}
+	if got := parseFPS("24"); got != 24 {
+		t.Fatalf("expected 24 fps, got %v", got)
+	}
+	if got := parseFPS("invalid"); got != 0 {
+		t.Fatalf("expected invalid input to parse as 0, got %v", got)
+	}
+}
+
+func TestAudioAnalyzerHelpers(t *testing.T) {
+	analyzer := NewAudioAnalyzer()
+
+	if got := analyzer.calcSilenceRatio([]SilenceSegment{{Duration: 2}, {Duration: 3}}, 10); got != 0.5 {
+		t.Fatalf("expected silence ratio 0.5, got %v", got)
+	}
+	if got := analyzer.calcSilenceRatio(nil, 0); got != 0 {
+		t.Fatalf("expected zero silence ratio for zero duration, got %v", got)
+	}
+
+	if got := analyzer.calcEnergyVariance([]float64{1, 2, 3}); got <= 0 {
+		t.Fatalf("expected positive variance, got %v", got)
+	}
+	if got := analyzer.calcEnergyVariance([]float64{1}); got != 0 {
+		t.Fatalf("expected zero variance for one sample, got %v", got)
+	}
+}
+
+func TestJSONUnmarshal(t *testing.T) {
+	var payload struct {
+		Name string `json:"name"`
+	}
+	if err := jsonUnmarshal([]byte(`{"name":"vision"}`), &payload); err != nil {
+		t.Fatalf("jsonUnmarshal: %v", err)
+	}
+	if payload.Name != "vision" {
+		t.Fatalf("expected parsed name, got %q", payload.Name)
+	}
+
+	if err := jsonUnmarshal([]byte(`{invalid}`), &payload); err == nil {
+		t.Fatal("expected invalid JSON to fail")
+	}
+
+	encoded, err := json.Marshal(payload)
+	if err != nil || len(encoded) == 0 {
+		t.Fatalf("expected payload to remain JSON-marshalable, err=%v", err)
+	}
+}

--- a/pkg/vision/pipeline.go
+++ b/pkg/vision/pipeline.go
@@ -1,0 +1,329 @@
+package vision
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	llm "github.com/1024XEngineer/anyclaw/pkg/capability/models"
+)
+
+type MediaUnderstandingConfig struct {
+	VisionProvider    VisionProvider
+	AudioAnalyzer     *AudioAnalyzer
+	KeyFrameExtractor *KeyFrameExtractor
+	MaxImageSize      int
+	MaxVideoDuration  float64
+	Timeout           time.Duration
+}
+
+func DefaultMediaUnderstandingConfig() MediaUnderstandingConfig {
+	return MediaUnderstandingConfig{
+		MaxImageSize:     10 * 1024 * 1024,
+		MaxVideoDuration: 300,
+		Timeout:          60 * time.Second,
+	}
+}
+
+type MediaUnderstandingResult struct {
+	Type        string         `json:"type"`
+	Description string         `json:"description"`
+	Summary     string         `json:"summary"`
+	Details     any            `json:"details"`
+	Metadata    map[string]any `json:"metadata"`
+}
+
+type MediaUnderstandingPipeline struct {
+	cfg MediaUnderstandingConfig
+}
+
+func NewMediaUnderstandingPipeline(cfg MediaUnderstandingConfig) *MediaUnderstandingPipeline {
+	return &MediaUnderstandingPipeline{cfg: cfg}
+}
+
+func (p *MediaUnderstandingPipeline) UnderstandImage(ctx context.Context, imageData []byte, mimeType string) (*MediaUnderstandingResult, error) {
+	if p.cfg.MaxImageSize > 0 && len(imageData) > p.cfg.MaxImageSize {
+		return nil, fmt.Errorf("image too large: %d bytes exceeds max %d", len(imageData), p.cfg.MaxImageSize)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
+	defer cancel()
+
+	result := &MediaUnderstandingResult{
+		Type:     "image",
+		Metadata: map[string]any{},
+	}
+
+	if p.cfg.VisionProvider != nil {
+		analysis, err := p.cfg.VisionProvider.AnalyzeImage(ctx, imageData, mimeType)
+		if err != nil {
+			return nil, fmt.Errorf("vision analysis: %w", err)
+		}
+
+		result.Description = analysis.Description
+		result.Details = analysis
+		result.Metadata["labels"] = len(analysis.Labels)
+		result.Metadata["objects"] = len(analysis.Objects)
+		result.Metadata["text_regions"] = len(analysis.Text)
+		result.Metadata["faces"] = len(analysis.Faces)
+
+		if len(analysis.Labels) > 0 {
+			labels := make([]string, 0, len(analysis.Labels))
+			for _, l := range analysis.Labels {
+				labels = append(labels, l.Name)
+			}
+			result.Summary = strings.Join(labels, ", ")
+		}
+	} else {
+		result.Description = "No vision provider configured"
+	}
+
+	return result, nil
+}
+
+func (p *MediaUnderstandingPipeline) UnderstandImageFile(ctx context.Context, path string) (*MediaUnderstandingResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read image file: %w", err)
+	}
+
+	mimeType := mimeTypeFromPath(path)
+	if mimeType == "" {
+		mimeType = "image/jpeg"
+	}
+
+	return p.UnderstandImage(ctx, data, mimeType)
+}
+
+func (p *MediaUnderstandingPipeline) UnderstandImageURL(ctx context.Context, imageURL string) (*MediaUnderstandingResult, error) {
+	if p.cfg.VisionProvider == nil {
+		return nil, fmt.Errorf("no vision provider configured")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
+	defer cancel()
+
+	analysis, err := p.cfg.VisionProvider.AnalyzeImageURL(ctx, imageURL)
+	if err != nil {
+		return nil, fmt.Errorf("vision analysis from URL: %w", err)
+	}
+
+	result := &MediaUnderstandingResult{
+		Type:        "image",
+		Description: analysis.Description,
+		Details:     analysis,
+		Metadata:    map[string]any{},
+	}
+
+	if len(analysis.Labels) > 0 {
+		labels := make([]string, 0, len(analysis.Labels))
+		for _, l := range analysis.Labels {
+			labels = append(labels, l.Name)
+		}
+		result.Summary = strings.Join(labels, ", ")
+	}
+
+	return result, nil
+}
+
+func (p *MediaUnderstandingPipeline) UnderstandVideo(ctx context.Context, videoData []byte) (*MediaUnderstandingResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
+	defer cancel()
+
+	result := &MediaUnderstandingResult{
+		Type:     "video",
+		Metadata: map[string]any{},
+	}
+
+	if p.cfg.KeyFrameExtractor == nil {
+		p.cfg.KeyFrameExtractor = NewKeyFrameExtractor()
+	}
+
+	videoAnalysis, err := p.cfg.KeyFrameExtractor.ExtractKeyFrames(ctx, videoData)
+	if err != nil {
+		return nil, fmt.Errorf("keyframe extraction: %w", err)
+	}
+
+	result.Details = videoAnalysis
+	result.Metadata["duration"] = videoAnalysis.Duration
+	result.Metadata["scenes"] = len(videoAnalysis.Scenes)
+	result.Metadata["key_frames"] = len(videoAnalysis.KeyFrames)
+	result.Metadata["resolution"] = fmt.Sprintf("%dx%d", videoAnalysis.Width, videoAnalysis.Height)
+	result.Metadata["codec"] = videoAnalysis.Codec
+
+	if len(videoAnalysis.Scenes) > 0 && p.cfg.VisionProvider != nil {
+		var sceneDescriptions []string
+		for i, scene := range videoAnalysis.Scenes {
+			if i >= 5 {
+				break
+			}
+			if len(scene.KeyFrames) > 0 {
+				kf := scene.KeyFrames[0]
+				if len(kf.FrameData) > 0 {
+					frameAnalysis, err := p.cfg.VisionProvider.AnalyzeImage(ctx, kf.FrameData, "image/jpeg")
+					if err == nil {
+						sceneDescriptions = append(sceneDescriptions, fmt.Sprintf("Scene %d (%.1fs): %s", i, scene.Start, frameAnalysis.Description))
+					}
+				}
+			}
+		}
+		if len(sceneDescriptions) > 0 {
+			result.Summary = strings.Join(sceneDescriptions, " | ")
+		}
+	}
+
+	return result, nil
+}
+
+func (p *MediaUnderstandingPipeline) UnderstandAudio(ctx context.Context, audioData []byte) (*MediaUnderstandingResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
+	defer cancel()
+
+	result := &MediaUnderstandingResult{
+		Type:     "audio",
+		Metadata: map[string]any{},
+	}
+
+	if p.cfg.AudioAnalyzer == nil {
+		p.cfg.AudioAnalyzer = NewAudioAnalyzer()
+	}
+
+	audioAnalysis, err := p.cfg.AudioAnalyzer.Analyze(ctx, audioData)
+	if err != nil {
+		return nil, fmt.Errorf("audio analysis: %w", err)
+	}
+
+	result.Details = audioAnalysis
+	result.Metadata["duration"] = audioAnalysis.Duration
+	result.Metadata["codec"] = audioAnalysis.Codec
+	result.Metadata["sample_rate"] = audioAnalysis.SampleRate
+	result.Metadata["channels"] = audioAnalysis.Channels
+	result.Metadata["is_speech"] = audioAnalysis.IsSpeech
+	result.Metadata["is_music"] = audioAnalysis.IsMusic
+	result.Metadata["speech_confidence"] = audioAnalysis.SpeechConfidence
+	result.Metadata["music_confidence"] = audioAnalysis.MusicConfidence
+	result.Metadata["silence_ratio"] = audioAnalysis.Metadata["silence_ratio"]
+
+	if audioAnalysis.IsSpeech {
+		result.Summary = fmt.Sprintf("Speech audio (%.0f%% confidence)", audioAnalysis.SpeechConfidence*100)
+	} else if audioAnalysis.IsMusic {
+		result.Summary = fmt.Sprintf("Music audio (%.0f%% confidence)", audioAnalysis.MusicConfidence*100)
+	} else {
+		result.Summary = "Unknown audio type"
+	}
+
+	return result, nil
+}
+
+func (p *MediaUnderstandingPipeline) OCRImage(ctx context.Context, imageData []byte, mimeType string) (string, error) {
+	if p.cfg.VisionProvider == nil {
+		return "", fmt.Errorf("no vision provider configured")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
+	defer cancel()
+
+	texts, err := p.cfg.VisionProvider.OCR(ctx, imageData, mimeType)
+	if err != nil {
+		return "", err
+	}
+
+	var parts []string
+	for _, t := range texts {
+		parts = append(parts, t.Text)
+	}
+
+	return strings.Join(parts, "\n"), nil
+}
+
+func (p *MediaUnderstandingPipeline) DescribeImageWithLLM(ctx context.Context, imageData []byte, mimeType string, client llm.Client, prompt string) (string, error) {
+	if client == nil {
+		return "", fmt.Errorf("no LLM client provided")
+	}
+
+	if prompt == "" {
+		prompt = "Describe this image in detail. Include objects, text, people, actions, colors, and overall scene."
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
+	defer cancel()
+
+	msg := llm.NewUserMessage(
+		llm.TextBlock(prompt),
+		llm.ImageBlockFromBase64(imageData, mimeType),
+	)
+
+	resp, err := client.Chat(ctx, []llm.Message{msg}, nil)
+	if err != nil {
+		return "", fmt.Errorf("LLM vision analysis: %w", err)
+	}
+
+	return resp.Content, nil
+}
+
+func ImageToDataURL(imageData []byte, mimeType string) string {
+	return fmt.Sprintf("data:%s;base64,%s", mimeType, base64.StdEncoding.EncodeToString(imageData))
+}
+
+func ImageFromDataURL(dataURL string) ([]byte, string, error) {
+	if !strings.HasPrefix(dataURL, "data:") {
+		return nil, "", fmt.Errorf("not a data URL")
+	}
+
+	commaIdx := strings.Index(dataURL, ",")
+	if commaIdx == -1 {
+		return nil, "", fmt.Errorf("invalid data URL format")
+	}
+
+	header := dataURL[5:commaIdx]
+	data := dataURL[commaIdx+1:]
+
+	mimeType := ""
+	if idx := strings.Index(header, ";"); idx != -1 {
+		mimeType = header[:idx]
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return nil, "", fmt.Errorf("decode base64: %w", err)
+	}
+
+	return decoded, mimeType, nil
+}
+
+func AnalyzeMedia(ctx context.Context, pipeline *MediaUnderstandingPipeline, data []byte, mimeType string) (*MediaUnderstandingResult, error) {
+	mediaType := detectMediaType(mimeType)
+
+	switch mediaType {
+	case "image":
+		return pipeline.UnderstandImage(ctx, data, mimeType)
+	case "video":
+		return pipeline.UnderstandVideo(ctx, data)
+	case "audio":
+		return pipeline.UnderstandAudio(ctx, data)
+	default:
+		return nil, fmt.Errorf("unsupported media type: %s", mimeType)
+	}
+}
+
+func detectMediaType(mimeType string) string {
+	switch {
+	case strings.HasPrefix(mimeType, "image/"):
+		return "image"
+	case strings.HasPrefix(mimeType, "video/"):
+		return "video"
+	case strings.HasPrefix(mimeType, "audio/"):
+		return "audio"
+	default:
+		return ""
+	}
+}
+
+func AnalysisResultToJSON(result *MediaUnderstandingResult) string {
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return string(data)
+}

--- a/pkg/vision/video_audio.go
+++ b/pkg/vision/video_audio.go
@@ -1,0 +1,751 @@
+package vision
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type KeyFrame struct {
+	Timestamp float64 `json:"timestamp"`
+	FrameData []byte  `json:"-"`
+	Index     int     `json:"index"`
+	SceneID   int     `json:"scene_id"`
+}
+
+type SceneInfo struct {
+	ID        int        `json:"id"`
+	Start     float64    `json:"start"`
+	End       float64    `json:"end"`
+	Duration  float64    `json:"duration"`
+	KeyFrames []KeyFrame `json:"key_frames"`
+}
+
+type VideoAnalysisResult struct {
+	Duration    float64        `json:"duration"`
+	Width       int            `json:"width"`
+	Height      int            `json:"height"`
+	FPS         float64        `json:"fps"`
+	Codec       string         `json:"codec"`
+	Scenes      []SceneInfo    `json:"scenes"`
+	KeyFrames   []KeyFrame     `json:"key_frames"`
+	TotalFrames int            `json:"total_frames"`
+	Metadata    map[string]any `json:"metadata"`
+}
+
+type KeyFrameExtractor struct {
+	ffmpegPath     string
+	ffprobePath    string
+	sceneThreshold float64
+	maxKeyFrames   int
+}
+
+var execCommandContext = exec.CommandContext
+
+func NewKeyFrameExtractor() *KeyFrameExtractor {
+	return &KeyFrameExtractor{
+		ffmpegPath:     "ffmpeg",
+		ffprobePath:    "ffprobe",
+		sceneThreshold: 30.0,
+		maxKeyFrames:   20,
+	}
+}
+
+func (e *KeyFrameExtractor) SetFFmpegPath(path string) {
+	e.ffmpegPath = path
+}
+
+func (e *KeyFrameExtractor) SetFFprobePath(path string) {
+	e.ffprobePath = path
+}
+
+func (e *KeyFrameExtractor) SetSceneThreshold(threshold float64) {
+	e.sceneThreshold = threshold
+}
+
+func (e *KeyFrameExtractor) SetMaxKeyFrames(n int) {
+	e.maxKeyFrames = n
+}
+
+func (e *KeyFrameExtractor) ExtractKeyFrames(ctx context.Context, videoData []byte) (*VideoAnalysisResult, error) {
+	if !e.isFFmpegAvailable(ctx) {
+		return nil, fmt.Errorf("ffmpeg not available")
+	}
+
+	tmpIn, err := e.writeTempFile(videoData, "video")
+	if err != nil {
+		return nil, fmt.Errorf("create temp input: %w", err)
+	}
+	defer os.Remove(tmpIn)
+
+	meta, err := e.probeVideo(ctx, tmpIn)
+	if err != nil {
+		return nil, fmt.Errorf("probe video: %w", err)
+	}
+
+	scenes, err := e.detectScenes(ctx, tmpIn, meta.Duration)
+	if err != nil {
+		scenes = []SceneInfo{
+			{ID: 0, Start: 0, End: meta.Duration, Duration: meta.Duration},
+		}
+	}
+
+	keyFrames := make([]KeyFrame, 0)
+	for i := range scenes {
+		scene := &scenes[i]
+		midTime := scene.Start + scene.Duration/2
+		frameData, err := e.extractFrameAt(ctx, tmpIn, midTime)
+		if err != nil {
+			continue
+		}
+
+		kf := KeyFrame{
+			Timestamp: midTime,
+			FrameData: frameData,
+			Index:     len(keyFrames),
+			SceneID:   scene.ID,
+		}
+		keyFrames = append(keyFrames, kf)
+		appendKeyFrameToScene(scenes, i, kf)
+
+		if len(keyFrames) >= e.maxKeyFrames {
+			break
+		}
+	}
+
+	if len(keyFrames) == 0 {
+		frameData, err := e.extractFrameAt(ctx, tmpIn, 1.0)
+		if err == nil {
+			keyFrames = append(keyFrames, KeyFrame{
+				Timestamp: 1.0,
+				FrameData: frameData,
+				Index:     0,
+				SceneID:   0,
+			})
+		}
+	}
+
+	meta.KeyFrames = keyFrames
+	meta.Scenes = scenes
+	return meta, nil
+}
+
+func (e *KeyFrameExtractor) ExtractFrameAt(ctx context.Context, videoData []byte, timestamp float64) ([]byte, error) {
+	if !e.isFFmpegAvailable(ctx) {
+		return nil, fmt.Errorf("ffmpeg not available")
+	}
+
+	tmpIn, err := e.writeTempFile(videoData, "video")
+	if err != nil {
+		return nil, fmt.Errorf("create temp input: %w", err)
+	}
+	defer os.Remove(tmpIn)
+
+	return e.extractFrameAt(ctx, tmpIn, timestamp)
+}
+
+func (e *KeyFrameExtractor) ExtractFramesAtIntervals(ctx context.Context, videoData []byte, intervalSeconds float64) ([][]byte, error) {
+	if err := validateFrameIntervalSeconds(intervalSeconds); err != nil {
+		return nil, err
+	}
+
+	if !e.isFFmpegAvailable(ctx) {
+		return nil, fmt.Errorf("ffmpeg not available")
+	}
+
+	tmpIn, err := e.writeTempFile(videoData, "video")
+	if err != nil {
+		return nil, fmt.Errorf("create temp input: %w", err)
+	}
+	defer os.Remove(tmpIn)
+
+	meta, err := e.probeVideo(ctx, tmpIn)
+	if err != nil {
+		return nil, fmt.Errorf("probe video: %w", err)
+	}
+
+	var frames [][]byte
+	for t := 0.0; t < meta.Duration; t += intervalSeconds {
+		frameData, err := e.extractFrameAt(ctx, tmpIn, t)
+		if err != nil {
+			continue
+		}
+		frames = append(frames, frameData)
+	}
+
+	return frames, nil
+}
+
+func (e *KeyFrameExtractor) detectScenes(ctx context.Context, input string, duration float64) ([]SceneInfo, error) {
+	args := []string{
+		"-i", input,
+		"-vf", fmt.Sprintf("select='gt(scene,%f)',showinfo", e.sceneThreshold/100.0),
+		"-vsync", "vfr",
+		"-f", "null",
+		"-",
+	}
+
+	cmd := execCommandContext(ctx, e.ffmpegPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("scene detection: %w", err)
+	}
+
+	var sceneChanges []float64
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "pts_time:") {
+			parts := strings.Split(line, "pts_time:")
+			if len(parts) >= 2 {
+				var t float64
+				fmt.Sscanf(strings.TrimSpace(parts[1]), "%f", &t)
+				if t > 0 {
+					sceneChanges = append(sceneChanges, t)
+				}
+			}
+		}
+	}
+
+	if len(sceneChanges) == 0 {
+		return nil, fmt.Errorf("no scene changes detected")
+	}
+
+	sort.Float64s(sceneChanges)
+
+	scenes := make([]SceneInfo, 0, len(sceneChanges)+1)
+	sceneID := 0
+	prevTime := 0.0
+
+	for _, changeTime := range sceneChanges {
+		scenes = append(scenes, SceneInfo{
+			ID:       sceneID,
+			Start:    prevTime,
+			End:      changeTime,
+			Duration: changeTime - prevTime,
+		})
+		prevTime = changeTime
+		sceneID++
+	}
+
+	if prevTime < duration {
+		scenes = append(scenes, SceneInfo{
+			ID:       sceneID,
+			Start:    prevTime,
+			End:      duration,
+			Duration: duration - prevTime,
+		})
+	}
+
+	return scenes, nil
+}
+
+func (e *KeyFrameExtractor) extractFrameAt(ctx context.Context, input string, timestamp float64) ([]byte, error) {
+	args := []string{
+		"-i", input,
+		"-ss", fmt.Sprintf("%.3f", timestamp),
+		"-vframes", "1",
+		"-q:v", "2",
+		"-f", "image2pipe",
+		"-vcodec", "mjpeg",
+		"-",
+	}
+
+	cmd := execCommandContext(ctx, e.ffmpegPath, args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = nil
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("extract frame at %.3f: %w", timestamp, err)
+	}
+
+	if out.Len() == 0 {
+		return nil, fmt.Errorf("empty frame at %.3f", timestamp)
+	}
+
+	return out.Bytes(), nil
+}
+
+func (e *KeyFrameExtractor) probeVideo(ctx context.Context, input string) (*VideoAnalysisResult, error) {
+	args := []string{
+		"-v", "quiet",
+		"-print_format", "json",
+		"-show_format",
+		"-show_streams",
+		input,
+	}
+
+	cmd := execCommandContext(ctx, e.ffprobePath, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ffprobe: %w", err)
+	}
+
+	var probeResult struct {
+		Streams []struct {
+			CodecType  string `json:"codec_type"`
+			CodecName  string `json:"codec_name"`
+			Width      int    `json:"width"`
+			Height     int    `json:"height"`
+			RFrameRate string `json:"r_frame_rate"`
+			Duration   string `json:"duration"`
+			NbFrames   string `json:"nb_frames"`
+		} `json:"streams"`
+		Format struct {
+			Duration string `json:"duration"`
+			Size     string `json:"size"`
+		} `json:"format"`
+	}
+
+	if err := jsonUnmarshal(output, &probeResult); err != nil {
+		return nil, fmt.Errorf("parse ffprobe output: %w", err)
+	}
+
+	result := &VideoAnalysisResult{Metadata: make(map[string]any)}
+
+	for _, stream := range probeResult.Streams {
+		if stream.CodecType == "video" {
+			result.Width = stream.Width
+			result.Height = stream.Height
+			result.Codec = stream.CodecName
+			result.FPS = parseFPS(stream.RFrameRate)
+			if stream.NbFrames != "" {
+				fmt.Sscanf(stream.NbFrames, "%d", &result.TotalFrames)
+			}
+		}
+	}
+
+	if probeResult.Format.Duration != "" {
+		fmt.Sscanf(probeResult.Format.Duration, "%f", &result.Duration)
+	}
+
+	return result, nil
+}
+
+func (e *KeyFrameExtractor) isFFmpegAvailable(ctx context.Context) bool {
+	cmd := execCommandContext(ctx, e.ffmpegPath, "-version")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run() == nil
+}
+
+func (e *KeyFrameExtractor) writeTempFile(data []byte, prefix string) (string, error) {
+	f, err := os.CreateTemp(os.TempDir(), fmt.Sprintf("anyclaw-vision-%s-*", prefix))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+
+	return f.Name(), nil
+}
+
+func parseFPS(fpsStr string) float64 {
+	if idx := strings.Index(fpsStr, "/"); idx > 0 {
+		var num, den float64
+		fmt.Sscanf(fpsStr[:idx], "%f", &num)
+		fmt.Sscanf(fpsStr[idx+1:], "%f", &den)
+		if den > 0 {
+			return num / den
+		}
+	}
+	var fps float64
+	fmt.Sscanf(fpsStr, "%f", &fps)
+	return fps
+}
+
+func appendKeyFrameToScene(scenes []SceneInfo, sceneIndex int, keyFrame KeyFrame) {
+	if sceneIndex < 0 || sceneIndex >= len(scenes) {
+		return
+	}
+	scenes[sceneIndex].KeyFrames = append(scenes[sceneIndex].KeyFrames, keyFrame)
+}
+
+func validateFrameIntervalSeconds(intervalSeconds float64) error {
+	if intervalSeconds <= 0 {
+		return fmt.Errorf("intervalSeconds must be > 0")
+	}
+	return nil
+}
+
+type AudioAnalysisResult struct {
+	Duration         float64          `json:"duration"`
+	SampleRate       int              `json:"sample_rate"`
+	Channels         int              `json:"channels"`
+	Codec            string           `json:"codec"`
+	Bitrate          int              `json:"bitrate"`
+	IsSpeech         bool             `json:"is_speech"`
+	SpeechConfidence float64          `json:"speech_confidence"`
+	IsMusic          bool             `json:"is_music"`
+	MusicConfidence  float64          `json:"music_confidence"`
+	EnergyProfile    []float64        `json:"energy_profile"`
+	SilenceSegments  []SilenceSegment `json:"silence_segments"`
+	Metadata         map[string]any   `json:"metadata"`
+}
+
+type SilenceSegment struct {
+	Start    float64 `json:"start"`
+	End      float64 `json:"end"`
+	Duration float64 `json:"duration"`
+}
+
+type AudioAnalyzer struct {
+	ffmpegPath  string
+	ffprobePath string
+}
+
+func NewAudioAnalyzer() *AudioAnalyzer {
+	return &AudioAnalyzer{
+		ffmpegPath:  "ffmpeg",
+		ffprobePath: "ffprobe",
+	}
+}
+
+func (a *AudioAnalyzer) SetFFmpegPath(path string) {
+	a.ffmpegPath = path
+}
+
+func (a *AudioAnalyzer) SetFFprobePath(path string) {
+	a.ffprobePath = path
+}
+
+func (a *AudioAnalyzer) Analyze(ctx context.Context, audioData []byte) (*AudioAnalysisResult, error) {
+	if !a.isFFmpegAvailable(ctx) {
+		return nil, fmt.Errorf("ffmpeg not available")
+	}
+
+	tmpIn, err := a.writeTempFile(audioData, "audio")
+	if err != nil {
+		return nil, fmt.Errorf("create temp input: %w", err)
+	}
+	defer os.Remove(tmpIn)
+
+	result := &AudioAnalysisResult{Metadata: make(map[string]any)}
+
+	meta, err := a.probeAudio(ctx, tmpIn)
+	if err != nil {
+		return nil, fmt.Errorf("probe audio: %w", err)
+	}
+
+	result.Duration = meta.Duration
+	result.SampleRate = meta.SampleRate
+	result.Channels = meta.Channels
+	result.Codec = meta.Codec
+	result.Bitrate = meta.Bitrate
+
+	energyProfile, err := a.extractEnergyProfile(ctx, tmpIn)
+	if err == nil {
+		result.EnergyProfile = energyProfile
+	}
+
+	silenceSegments, err := a.detectSilence(ctx, tmpIn)
+	if err == nil {
+		result.SilenceSegments = silenceSegments
+	}
+
+	speechConfidence, err := a.detectSpeech(ctx, tmpIn)
+	if err == nil {
+		result.SpeechConfidence = speechConfidence
+		result.IsSpeech = speechConfidence > 0.5
+	}
+
+	musicConfidence, err := a.detectMusic(ctx, tmpIn, energyProfile)
+	if err == nil {
+		result.MusicConfidence = musicConfidence
+		result.IsMusic = musicConfidence > 0.5
+	}
+
+	if result.IsSpeech && result.IsMusic {
+		if result.SpeechConfidence > result.MusicConfidence {
+			result.IsMusic = false
+		} else {
+			result.IsSpeech = false
+		}
+	}
+
+	result.Metadata["silence_ratio"] = a.calcSilenceRatio(silenceSegments, result.Duration)
+	result.Metadata["energy_variance"] = a.calcEnergyVariance(energyProfile)
+
+	return result, nil
+}
+
+func (a *AudioAnalyzer) extractEnergyProfile(ctx context.Context, input string) ([]float64, error) {
+	args := []string{
+		"-i", input,
+		"-af", "astats=metadata=1:reset=1",
+		"-f", "null",
+		"-",
+	}
+
+	cmd := execCommandContext(ctx, a.ffmpegPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("energy extraction: %w", err)
+	}
+
+	var energies []float64
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "RMS level dB") {
+			var db float64
+			fmt.Sscanf(line, "%*[^=]= %f", &db)
+			normalized := math.Pow(10, db/20.0)
+			energies = append(energies, normalized)
+		}
+	}
+
+	return energies, nil
+}
+
+func (a *AudioAnalyzer) detectSilence(ctx context.Context, input string) ([]SilenceSegment, error) {
+	args := []string{
+		"-i", input,
+		"-af", "silencedetect=noise=-30dB:d=0.5",
+		"-f", "null",
+		"-",
+	}
+
+	cmd := execCommandContext(ctx, a.ffmpegPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("silence detection: %w", err)
+	}
+
+	var segments []SilenceSegment
+	lines := strings.Split(string(output), "\n")
+
+	var currentStart float64
+	inSilence := false
+
+	for _, line := range lines {
+		if strings.Contains(line, "silence_start:") {
+			var t float64
+			fmt.Sscanf(line, "%*[^:]: %f", &t)
+			currentStart = t
+			inSilence = true
+		} else if strings.Contains(line, "silence_end:") && inSilence {
+			var end, duration float64
+			fmt.Sscanf(line, "%*[^:]: %f %*[^:]: %f", &end, &duration)
+			segments = append(segments, SilenceSegment{
+				Start:    currentStart,
+				End:      end,
+				Duration: duration,
+			})
+			inSilence = false
+		}
+	}
+
+	return segments, nil
+}
+
+func (a *AudioAnalyzer) detectSpeech(ctx context.Context, input string) (float64, error) {
+	args := []string{
+		"-i", input,
+		"-af", "highpass=f=300,lowpass=f=3000,astats=metadata=1",
+		"-f", "null",
+		"-",
+	}
+
+	cmd := execCommandContext(ctx, a.ffmpegPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("speech detection: %w", err)
+	}
+
+	var rmsValues []float64
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "RMS level dB") {
+			var db float64
+			fmt.Sscanf(line, "%*[^=]= %f", &db)
+			rmsValues = append(rmsValues, math.Pow(10, db/20.0))
+		}
+	}
+
+	if len(rmsValues) == 0 {
+		return 0, nil
+	}
+
+	avgEnergy := 0.0
+	for _, e := range rmsValues {
+		avgEnergy += e
+	}
+	avgEnergy /= float64(len(rmsValues))
+
+	if avgEnergy > 0.01 && avgEnergy < 0.5 {
+		return math.Min(1.0, avgEnergy*5), nil
+	}
+
+	return avgEnergy * 2, nil
+}
+
+func (a *AudioAnalyzer) detectMusic(ctx context.Context, input string, energyProfile []float64) (float64, error) {
+	args := []string{
+		"-i", input,
+		"-af", "highpass=f=20,astats=metadata=1",
+		"-f", "null",
+		"-",
+	}
+
+	cmd := execCommandContext(ctx, a.ffmpegPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("music detection: %w", err)
+	}
+
+	var rmsValues []float64
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "RMS level dB") {
+			var db float64
+			fmt.Sscanf(line, "%*[^=]= %f", &db)
+			rmsValues = append(rmsValues, math.Pow(10, db/20.0))
+		}
+	}
+
+	if len(rmsValues) < 2 {
+		return 0, nil
+	}
+
+	avgEnergy := 0.0
+	for _, e := range rmsValues {
+		avgEnergy += e
+	}
+	avgEnergy /= float64(len(rmsValues))
+
+	if avgEnergy > 0.05 {
+		return math.Min(1.0, avgEnergy*3), nil
+	}
+
+	return avgEnergy, nil
+}
+
+func (a *AudioAnalyzer) probeAudio(ctx context.Context, input string) (*AudioAnalysisResult, error) {
+	args := []string{
+		"-v", "quiet",
+		"-print_format", "json",
+		"-show_format",
+		"-show_streams",
+		input,
+	}
+
+	cmd := execCommandContext(ctx, a.ffprobePath, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ffprobe: %w", err)
+	}
+
+	var probeResult struct {
+		Streams []struct {
+			CodecType  string `json:"codec_type"`
+			CodecName  string `json:"codec_name"`
+			SampleRate string `json:"sample_rate"`
+			Channels   int    `json:"channels"`
+			BitRate    string `json:"bit_rate"`
+			Duration   string `json:"duration"`
+		} `json:"streams"`
+		Format struct {
+			Duration string `json:"duration"`
+			BitRate  string `json:"bit_rate"`
+		} `json:"format"`
+	}
+
+	if err := jsonUnmarshal(output, &probeResult); err != nil {
+		return nil, fmt.Errorf("parse ffprobe output: %w", err)
+	}
+
+	result := &AudioAnalysisResult{}
+
+	for _, stream := range probeResult.Streams {
+		if stream.CodecType == "audio" {
+			result.Codec = stream.CodecName
+			result.Channels = stream.Channels
+			fmt.Sscanf(stream.SampleRate, "%d", &result.SampleRate)
+			if stream.BitRate != "" {
+				fmt.Sscanf(stream.BitRate, "%d", &result.Bitrate)
+			}
+			if stream.Duration != "" {
+				fmt.Sscanf(stream.Duration, "%f", &result.Duration)
+			}
+		}
+	}
+
+	if result.Duration <= 0 && probeResult.Format.Duration != "" {
+		fmt.Sscanf(probeResult.Format.Duration, "%f", &result.Duration)
+	}
+	if result.Bitrate <= 0 && probeResult.Format.BitRate != "" {
+		fmt.Sscanf(probeResult.Format.BitRate, "%d", &result.Bitrate)
+	}
+
+	return result, nil
+}
+
+func (a *AudioAnalyzer) isFFmpegAvailable(ctx context.Context) bool {
+	cmd := execCommandContext(ctx, a.ffmpegPath, "-version")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run() == nil
+}
+
+func (a *AudioAnalyzer) writeTempFile(data []byte, prefix string) (string, error) {
+	f, err := os.CreateTemp(os.TempDir(), fmt.Sprintf("anyclaw-audio-%s-*", prefix))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+
+	return f.Name(), nil
+}
+
+func (a *AudioAnalyzer) calcSilenceRatio(segments []SilenceSegment, totalDuration float64) float64 {
+	if totalDuration <= 0 {
+		return 0
+	}
+
+	totalSilence := 0.0
+	for _, seg := range segments {
+		totalSilence += seg.Duration
+	}
+
+	return totalSilence / totalDuration
+}
+
+func (a *AudioAnalyzer) calcEnergyVariance(profile []float64) float64 {
+	if len(profile) < 2 {
+		return 0
+	}
+
+	mean := 0.0
+	for _, e := range profile {
+		mean += e
+	}
+	mean /= float64(len(profile))
+
+	variance := 0.0
+	for _, e := range profile {
+		diff := e - mean
+		variance += diff * diff
+	}
+	variance /= float64(len(profile))
+
+	return variance
+}
+
+func jsonUnmarshal(data []byte, v any) error {
+	return json.Unmarshal(data, v)
+}

--- a/pkg/vision/video_audio_test.go
+++ b/pkg/vision/video_audio_test.go
@@ -1,0 +1,307 @@
+package vision
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestAppendKeyFrameToSceneMutatesOriginalScene(t *testing.T) {
+	scenes := []SceneInfo{
+		{ID: 7, Start: 0, End: 5, Duration: 5},
+		{ID: 8, Start: 5, End: 10, Duration: 5},
+	}
+
+	first := KeyFrame{Index: 0, SceneID: 7, Timestamp: 2.5}
+	second := KeyFrame{Index: 1, SceneID: 8, Timestamp: 7.5}
+
+	appendKeyFrameToScene(scenes, 0, first)
+	appendKeyFrameToScene(scenes, 1, second)
+
+	if len(scenes[0].KeyFrames) != 1 {
+		t.Fatalf("expected first scene to keep 1 key frame, got %d", len(scenes[0].KeyFrames))
+	}
+	if len(scenes[1].KeyFrames) != 1 {
+		t.Fatalf("expected second scene to keep 1 key frame, got %d", len(scenes[1].KeyFrames))
+	}
+	if scenes[0].KeyFrames[0].SceneID != 7 {
+		t.Fatalf("expected first scene key frame scene id 7, got %d", scenes[0].KeyFrames[0].SceneID)
+	}
+	if scenes[1].KeyFrames[0].SceneID != 8 {
+		t.Fatalf("expected second scene key frame scene id 8, got %d", scenes[1].KeyFrames[0].SceneID)
+	}
+}
+
+func TestAppendKeyFrameToSceneIgnoresOutOfRangeIndex(t *testing.T) {
+	scenes := []SceneInfo{{ID: 1}}
+	appendKeyFrameToScene(scenes, -1, KeyFrame{SceneID: 1})
+	appendKeyFrameToScene(scenes, 1, KeyFrame{SceneID: 1})
+
+	if len(scenes[0].KeyFrames) != 0 {
+		t.Fatalf("expected no key frames to be appended for invalid indices, got %d", len(scenes[0].KeyFrames))
+	}
+}
+
+func TestValidateFrameIntervalSecondsRejectsNonPositiveValues(t *testing.T) {
+	cases := []float64{0, -1, -0.5}
+	for _, interval := range cases {
+		err := validateFrameIntervalSeconds(interval)
+		if err == nil {
+			t.Fatalf("expected interval %v to be rejected", interval)
+		}
+		if !strings.Contains(err.Error(), "intervalSeconds must be > 0") {
+			t.Fatalf("expected interval validation error, got %v", err)
+		}
+	}
+}
+
+func TestValidateFrameIntervalSecondsAcceptsPositiveValue(t *testing.T) {
+	if err := validateFrameIntervalSeconds(0.25); err != nil {
+		t.Fatalf("expected positive interval to be accepted, got %v", err)
+	}
+}
+
+func TestKeyFrameExtractorUsesCommandOutput(t *testing.T) {
+	withFakeVisionCommands(t)
+
+	extractor := NewKeyFrameExtractor()
+	extractor.SetFFmpegPath("fake-ffmpeg")
+	extractor.SetFFprobePath("fake-ffprobe")
+	extractor.SetSceneThreshold(25)
+	extractor.SetMaxKeyFrames(2)
+
+	result, err := extractor.ExtractKeyFrames(context.Background(), []byte("video"))
+	if err != nil {
+		t.Fatalf("ExtractKeyFrames: %v", err)
+	}
+	if result.Duration != 10 {
+		t.Fatalf("expected duration 10, got %v", result.Duration)
+	}
+	if len(result.Scenes) != 3 {
+		t.Fatalf("expected 3 scenes, got %d", len(result.Scenes))
+	}
+	if len(result.KeyFrames) != 2 {
+		t.Fatalf("expected max 2 key frames, got %d", len(result.KeyFrames))
+	}
+	if len(result.Scenes[0].KeyFrames) != 1 {
+		t.Fatalf("expected first scene to keep a key frame, got %d", len(result.Scenes[0].KeyFrames))
+	}
+}
+
+func TestKeyFrameExtractorExtractsFramesWithCommandOutput(t *testing.T) {
+	withFakeVisionCommands(t)
+
+	extractor := NewKeyFrameExtractor()
+	extractor.SetFFmpegPath("fake-ffmpeg")
+	extractor.SetFFprobePath("fake-ffprobe")
+
+	frame, err := extractor.ExtractFrameAt(context.Background(), []byte("video"), 3.5)
+	if err != nil {
+		t.Fatalf("ExtractFrameAt: %v", err)
+	}
+	if string(frame) != "JPEG-FRAME" {
+		t.Fatalf("expected fake frame bytes, got %q", string(frame))
+	}
+
+	frames, err := extractor.ExtractFramesAtIntervals(context.Background(), []byte("video"), 4)
+	if err != nil {
+		t.Fatalf("ExtractFramesAtIntervals: %v", err)
+	}
+	if len(frames) != 3 {
+		t.Fatalf("expected 3 interval frames, got %d", len(frames))
+	}
+}
+
+func TestKeyFrameExtractorReportsMissingFFmpeg(t *testing.T) {
+	extractor := NewKeyFrameExtractor()
+	extractor.SetFFmpegPath("definitely-missing-ffmpeg-binary")
+
+	if _, err := extractor.ExtractKeyFrames(context.Background(), []byte("video")); err == nil {
+		t.Fatal("expected missing ffmpeg error")
+	}
+	if _, err := extractor.ExtractFrameAt(context.Background(), []byte("video"), 1); err == nil {
+		t.Fatal("expected missing ffmpeg error")
+	}
+	if _, err := extractor.ExtractFramesAtIntervals(context.Background(), []byte("video"), 1); err == nil {
+		t.Fatal("expected missing ffmpeg error")
+	}
+}
+
+func TestAudioAnalyzerUsesCommandOutput(t *testing.T) {
+	withFakeVisionCommands(t)
+
+	analyzer := NewAudioAnalyzer()
+	analyzer.SetFFmpegPath("fake-ffmpeg")
+	analyzer.SetFFprobePath("fake-ffprobe")
+
+	result, err := analyzer.Analyze(context.Background(), []byte("audio"))
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if result.Duration != 12.5 {
+		t.Fatalf("expected duration 12.5, got %v", result.Duration)
+	}
+	if result.SampleRate != 44100 {
+		t.Fatalf("expected sample rate 44100, got %d", result.SampleRate)
+	}
+	if result.Channels != 2 {
+		t.Fatalf("expected 2 channels, got %d", result.Channels)
+	}
+	if result.Metadata == nil {
+		t.Fatal("expected metadata to be populated")
+	}
+}
+
+func TestAudioAnalyzerReportsMissingFFmpeg(t *testing.T) {
+	analyzer := NewAudioAnalyzer()
+	analyzer.SetFFmpegPath("definitely-missing-ffmpeg-binary")
+
+	if analyzer.isFFmpegAvailable(context.Background()) {
+		t.Fatal("expected missing ffmpeg to be unavailable")
+	}
+	if _, err := analyzer.Analyze(context.Background(), []byte("audio")); err == nil {
+		t.Fatal("expected missing ffmpeg error")
+	}
+}
+
+func TestVisionTempFileWriters(t *testing.T) {
+	keyExtractor := NewKeyFrameExtractor()
+	videoPath, err := keyExtractor.writeTempFile([]byte("video-data"), "unit")
+	if err != nil {
+		t.Fatalf("video writeTempFile: %v", err)
+	}
+	defer os.Remove(videoPath)
+
+	videoData, err := os.ReadFile(videoPath)
+	if err != nil {
+		t.Fatalf("read video temp file: %v", err)
+	}
+	if string(videoData) != "video-data" {
+		t.Fatalf("expected video temp contents, got %q", string(videoData))
+	}
+
+	audioAnalyzer := NewAudioAnalyzer()
+	audioPath, err := audioAnalyzer.writeTempFile([]byte("audio-data"), "unit")
+	if err != nil {
+		t.Fatalf("audio writeTempFile: %v", err)
+	}
+	defer os.Remove(audioPath)
+
+	audioData, err := os.ReadFile(audioPath)
+	if err != nil {
+		t.Fatalf("read audio temp file: %v", err)
+	}
+	if string(audioData) != "audio-data" {
+		t.Fatalf("expected audio temp contents, got %q", string(audioData))
+	}
+}
+
+func withFakeVisionCommands(t *testing.T) {
+	t.Helper()
+
+	previous := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		helperArgs := []string{"-test.run=TestVisionCommandHelperProcess", "--", name}
+		helperArgs = append(helperArgs, args...)
+		cmd := exec.CommandContext(ctx, os.Args[0], helperArgs...)
+		cmd.Env = append(os.Environ(), "GO_WANT_VISION_HELPER_PROCESS=1")
+		return cmd
+	}
+
+	t.Cleanup(func() {
+		execCommandContext = previous
+	})
+}
+
+func TestVisionCommandHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_VISION_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	separator := -1
+	for i, arg := range args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator == -1 || separator+1 >= len(args) {
+		os.Exit(2)
+	}
+
+	commandName := args[separator+1]
+	commandArgs := args[separator+2:]
+	joinedArgs := strings.Join(commandArgs, " ")
+
+	switch {
+	case strings.Contains(commandName, "ffprobe"):
+		if strings.Contains(joinedArgs, "audio") {
+			fmt.Fprint(os.Stdout, fakeAudioProbeJSON)
+		} else {
+			fmt.Fprint(os.Stdout, fakeVideoProbeJSON)
+		}
+		os.Exit(0)
+	case strings.Contains(commandName, "ffmpeg"):
+		switch {
+		case strings.Contains(joinedArgs, "-version"):
+			os.Exit(0)
+		case strings.Contains(joinedArgs, "select='gt(scene"):
+			fmt.Fprint(os.Stdout, "pts_time:2.000\npts_time:5.000\n")
+			os.Exit(0)
+		case strings.Contains(joinedArgs, "-vframes"):
+			fmt.Fprint(os.Stdout, "JPEG-FRAME")
+			os.Exit(0)
+		case strings.Contains(joinedArgs, "silencedetect"):
+			fmt.Fprint(os.Stdout, "silence_start: 1.000\nsilence_end: 3.000 | silence_duration: 2.000\n")
+			os.Exit(0)
+		case strings.Contains(joinedArgs, "highpass=f=300"):
+			fmt.Fprint(os.Stdout, "RMS level dB = -20\nRMS level dB = -18\n")
+			os.Exit(0)
+		case strings.Contains(joinedArgs, "highpass=f=20"):
+			fmt.Fprint(os.Stdout, "RMS level dB = -12\nRMS level dB = -10\n")
+			os.Exit(0)
+		case strings.Contains(joinedArgs, "astats=metadata=1:reset=1"):
+			fmt.Fprint(os.Stdout, "RMS level dB = -20\nRMS level dB = -10\n")
+			os.Exit(0)
+		}
+	}
+
+	os.Exit(2)
+}
+
+const fakeVideoProbeJSON = `{
+  "streams": [
+    {
+      "codec_type": "video",
+      "codec_name": "h264",
+      "width": 1920,
+      "height": 1080,
+      "r_frame_rate": "30000/1001",
+      "nb_frames": "300"
+    }
+  ],
+  "format": {
+    "duration": "10.0",
+    "size": "1024"
+  }
+}`
+
+const fakeAudioProbeJSON = `{
+  "streams": [
+    {
+      "codec_type": "audio",
+      "codec_name": "aac",
+      "sample_rate": "44100",
+      "channels": 2,
+      "bit_rate": "128000"
+    }
+  ],
+  "format": {
+    "duration": "12.5",
+    "bit_rate": "128000"
+  }
+}`


### PR DESCRIPTION
## 概要

新增向量搜索 HTTP API 服务，为现有 embedding、index 和 vec 能力提供统一的 REST 接口。

## 本次变更

- 新增 `pkg/api/response.go`
  - 提供统一 JSON 响应和错误响应 helper
- 新增 `pkg/api/server.go`
  - 提供 `/v1/search`
  - 提供 `/v1/search/text`
  - 提供 `/v1/pure-search`
  - 提供 `/v1/embed`
  - 提供 `/v1/embed/batch`
  - 提供 index list/create/get/delete/rebuild 接口
  - 提供 `/v1/health`
- 新增 `pkg/api/server_test.go`
  - 覆盖搜索、文本搜索、纯向量搜索、embedding、批量 embedding、index 管理和健康检查

## 额外说明

这条 PR 还补充了基础服务端保护：

- 限制 JSON request body 大小
- 拒绝单个请求体中的多个 JSON value
- 为 HTTP server 设置 timeout
- 未配置 `IndexManager` 时返回 `503`，避免空指针 panic

## 验证

已执行：

- `go test ./pkg/api`
- `go test ./pkg/api -cover`
- `go test ./pkg/api ./pkg/index ./pkg/vec ./pkg/embedding`
