### PR TITLE
feat(sqlite): add backup and repair helpers

### DIFF
--- a/pkg/sqlite/backup.go
+++ b/pkg/sqlite/backup.go
@@ -1,0 +1,347 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type BackupConfig struct {
+	BackupDir     string
+	MaxBackups    int
+	Interval      time.Duration
+	Compress      bool
+	OnBackupStart func(path string)
+	OnBackupDone  func(path string, size int64, duration time.Duration)
+	OnBackupError func(err error)
+}
+
+func DefaultBackupConfig(backupDir string) BackupConfig {
+	return BackupConfig{
+		BackupDir:  backupDir,
+		MaxBackups: 10,
+		Interval:   1 * time.Hour,
+		Compress:   false,
+	}
+}
+
+type BackupInfo struct {
+	Path      string    `json:"path"`
+	Timestamp time.Time `json:"timestamp"`
+	Size      int64     `json:"size"`
+	Name      string    `json:"name"`
+}
+
+type BackupManager struct {
+	mu      sync.Mutex
+	cfg     BackupConfig
+	running bool
+	stopCh  chan struct{}
+	doneCh  chan struct{}
+	counter int64
+}
+
+func NewBackupManager(cfg BackupConfig) *BackupManager {
+	cfg = normalizeBackupConfig(cfg)
+	return &BackupManager{
+		cfg: cfg,
+	}
+}
+
+func (bm *BackupManager) Start(ctx context.Context, db *DB) error {
+	if err := os.MkdirAll(bm.cfg.BackupDir, 0o755); err != nil {
+		return fmt.Errorf("sqlite: create backup dir: %w", err)
+	}
+
+	bm.mu.Lock()
+	if bm.running {
+		bm.mu.Unlock()
+		return fmt.Errorf("sqlite: backup manager already running")
+	}
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	bm.stopCh = stopCh
+	bm.doneCh = doneCh
+	bm.running = true
+	bm.mu.Unlock()
+
+	go bm.runLoop(ctx, db, stopCh, doneCh)
+
+	return nil
+}
+
+func (bm *BackupManager) Stop() {
+	bm.mu.Lock()
+	if !bm.running {
+		bm.mu.Unlock()
+		return
+	}
+	stopCh := bm.stopCh
+	doneCh := bm.doneCh
+	bm.running = false
+	close(stopCh)
+	bm.mu.Unlock()
+
+	if doneCh != nil {
+		<-doneCh
+	}
+}
+
+func (bm *BackupManager) Wait() {
+	bm.mu.Lock()
+	doneCh := bm.doneCh
+	bm.mu.Unlock()
+
+	if doneCh != nil {
+		<-doneCh
+	}
+}
+
+func (bm *BackupManager) BackupOnce(ctx context.Context, db *DB) (string, error) {
+	bm.mu.Lock()
+	cfg := bm.cfg
+	bm.counter++
+	counter := bm.counter
+	bm.mu.Unlock()
+
+	if err := os.MkdirAll(cfg.BackupDir, 0o755); err != nil {
+		return "", fmt.Errorf("sqlite: create backup dir: %w", err)
+	}
+
+	start := time.Now()
+	timestamp := start.Format("20060102_150405")
+	backupPath := filepath.Join(cfg.BackupDir, fmt.Sprintf("backup_%s_%03d.db", timestamp, counter))
+
+	if cfg.OnBackupStart != nil {
+		cfg.OnBackupStart(backupPath)
+	}
+
+	if err := bm.performBackup(ctx, db, backupPath); err != nil {
+		if cfg.OnBackupError != nil {
+			cfg.OnBackupError(err)
+		}
+		return "", fmt.Errorf("sqlite: backup: %w", err)
+	}
+
+	info, err := os.Stat(backupPath)
+	if err != nil {
+		return "", err
+	}
+
+	if cfg.OnBackupDone != nil {
+		cfg.OnBackupDone(backupPath, info.Size(), time.Since(start))
+	}
+
+	if err := pruneOldBackups(cfg); err != nil {
+		return backupPath, fmt.Errorf("sqlite: prune backups: %w", err)
+	}
+
+	return backupPath, nil
+}
+
+func (bm *BackupManager) performBackup(ctx context.Context, db *DB, backupPath string) error {
+	if err := db.Checkpoint(ctx, "TRUNCATE"); err != nil {
+		return fmt.Errorf("checkpoint before backup: %w", err)
+	}
+
+	srcDB := db.DSN()
+	if srcDB == "" || srcDB == ":memory:" {
+		return fmt.Errorf("sqlite: cannot backup in-memory database")
+	}
+
+	srcFile, err := os.Open(srcDB)
+	if err != nil {
+		return fmt.Errorf("open source db: %w", err)
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(backupPath)
+	if err != nil {
+		return fmt.Errorf("create backup file: %w", err)
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return fmt.Errorf("copy to backup: %w", err)
+	}
+
+	if err := dstFile.Sync(); err != nil {
+		return fmt.Errorf("sync backup: %w", err)
+	}
+
+	return nil
+}
+
+func (bm *BackupManager) ListBackups() ([]BackupInfo, error) {
+	bm.mu.Lock()
+	cfg := bm.cfg
+	bm.mu.Unlock()
+
+	return listBackups(cfg)
+}
+
+func listBackups(cfg BackupConfig) ([]BackupInfo, error) {
+	entries, err := os.ReadDir(cfg.BackupDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var backups []BackupInfo
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, "backup_") || !strings.HasSuffix(name, ".db") {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
+		base := strings.TrimSuffix(strings.TrimPrefix(name, "backup_"), ".db")
+		parts := strings.SplitN(base, "_", 3)
+		if len(parts) < 2 {
+			continue
+		}
+		tsStr := parts[0] + "_" + parts[1]
+		ts, err := time.Parse("20060102_150405", tsStr)
+		if err != nil {
+			continue
+		}
+
+		backups = append(backups, BackupInfo{
+			Path:      filepath.Join(cfg.BackupDir, name),
+			Timestamp: ts,
+			Size:      info.Size(),
+			Name:      name,
+		})
+	}
+
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].Timestamp.After(backups[j].Timestamp)
+	})
+
+	return backups, nil
+}
+
+func (bm *BackupManager) LatestBackup() (*BackupInfo, error) {
+	backups, err := bm.ListBackups()
+	if err != nil {
+		return nil, err
+	}
+	if len(backups) == 0 {
+		return nil, fmt.Errorf("sqlite: no backups found")
+	}
+	return &backups[0], nil
+}
+
+func (bm *BackupManager) RestoreFromBackup(ctx context.Context, db *DB, backupPath string) error {
+	bm.mu.Lock()
+	defer bm.mu.Unlock()
+
+	if !db.isClosed() {
+		return fmt.Errorf("sqlite: close database before restore")
+	}
+
+	if _, err := os.Stat(backupPath); err != nil {
+		return fmt.Errorf("sqlite: backup file not found: %w", err)
+	}
+
+	srcFile, err := os.Open(backupPath)
+	if err != nil {
+		return fmt.Errorf("sqlite: open backup file: %w", err)
+	}
+	defer srcFile.Close()
+
+	dstPath := db.DSN()
+	if dstPath == "" || dstPath == ":memory:" {
+		return fmt.Errorf("sqlite: cannot restore to in-memory database")
+	}
+
+	dstFile, err := os.Create(dstPath)
+	if err != nil {
+		return fmt.Errorf("sqlite: create database file: %w", err)
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return fmt.Errorf("sqlite: restore database: %w", err)
+	}
+
+	if err := dstFile.Sync(); err != nil {
+		return fmt.Errorf("sqlite: sync restored database: %w", err)
+	}
+
+	return nil
+}
+
+func pruneOldBackups(cfg BackupConfig) error {
+	backups, err := listBackups(cfg)
+	if err != nil {
+		return err
+	}
+
+	if len(backups) <= cfg.MaxBackups {
+		return nil
+	}
+
+	toDelete := backups[cfg.MaxBackups:]
+	for _, backup := range toDelete {
+		if err := os.Remove(backup.Path); err != nil {
+			return fmt.Errorf("remove old backup %s: %w", backup.Path, err)
+		}
+	}
+
+	return nil
+}
+
+func (bm *BackupManager) runLoop(ctx context.Context, db *DB, stopCh <-chan struct{}, doneCh chan<- struct{}) {
+	defer func() {
+		close(doneCh)
+		bm.mu.Lock()
+		if bm.stopCh == stopCh {
+			bm.running = false
+		}
+		bm.mu.Unlock()
+	}()
+
+	ticker := time.NewTicker(bm.cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-stopCh:
+			return
+		case <-ticker.C:
+			if _, err := bm.BackupOnce(ctx, db); err != nil {
+				if bm.cfg.OnBackupError != nil {
+					bm.cfg.OnBackupError(err)
+				}
+			}
+		}
+	}
+}
+
+func normalizeBackupConfig(cfg BackupConfig) BackupConfig {
+	if cfg.BackupDir == "" {
+		cfg.BackupDir = ".anyclaw/backups"
+	}
+	if cfg.MaxBackups <= 0 {
+		cfg.MaxBackups = 10
+	}
+	if cfg.Interval <= 0 {
+		cfg.Interval = time.Hour
+	}
+	return cfg
+}

--- a/pkg/sqlite/backup.go
+++ b/pkg/sqlite/backup.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"io"
 	"os"
@@ -146,36 +147,11 @@ func (bm *BackupManager) BackupOnce(ctx context.Context, db *DB) (string, error)
 }
 
 func (bm *BackupManager) performBackup(ctx context.Context, db *DB, backupPath string) error {
-	if err := db.Checkpoint(ctx, "TRUNCATE"); err != nil {
-		return fmt.Errorf("checkpoint before backup: %w", err)
+	if _, err := sqliteFilePathFromDSN(db.DSN()); err != nil {
+		return err
 	}
 
-	srcDB := db.DSN()
-	if srcDB == "" || srcDB == ":memory:" {
-		return fmt.Errorf("sqlite: cannot backup in-memory database")
-	}
-
-	srcFile, err := os.Open(srcDB)
-	if err != nil {
-		return fmt.Errorf("open source db: %w", err)
-	}
-	defer srcFile.Close()
-
-	dstFile, err := os.Create(backupPath)
-	if err != nil {
-		return fmt.Errorf("create backup file: %w", err)
-	}
-	defer dstFile.Close()
-
-	if _, err := io.Copy(dstFile, srcFile); err != nil {
-		return fmt.Errorf("copy to backup: %w", err)
-	}
-
-	if err := dstFile.Sync(); err != nil {
-		return fmt.Errorf("sync backup: %w", err)
-	}
-
-	return nil
+	return sqliteBackupInto(ctx, db.DB, backupPath)
 }
 
 func (bm *BackupManager) ListBackups() ([]BackupInfo, error) {
@@ -256,32 +232,12 @@ func (bm *BackupManager) RestoreFromBackup(ctx context.Context, db *DB, backupPa
 		return fmt.Errorf("sqlite: backup file not found: %w", err)
 	}
 
-	srcFile, err := os.Open(backupPath)
+	dstPath, err := sqliteFilePathFromDSN(db.DSN())
 	if err != nil {
-		return fmt.Errorf("sqlite: open backup file: %w", err)
-	}
-	defer srcFile.Close()
-
-	dstPath := db.DSN()
-	if dstPath == "" || dstPath == ":memory:" {
-		return fmt.Errorf("sqlite: cannot restore to in-memory database")
+		return err
 	}
 
-	dstFile, err := os.Create(dstPath)
-	if err != nil {
-		return fmt.Errorf("sqlite: create database file: %w", err)
-	}
-	defer dstFile.Close()
-
-	if _, err := io.Copy(dstFile, srcFile); err != nil {
-		return fmt.Errorf("sqlite: restore database: %w", err)
-	}
-
-	if err := dstFile.Sync(); err != nil {
-		return fmt.Errorf("sqlite: sync restored database: %w", err)
-	}
-
-	return nil
+	return copyFile(backupPath, dstPath)
 }
 
 func pruneOldBackups(cfg BackupConfig) error {
@@ -344,4 +300,71 @@ func normalizeBackupConfig(cfg BackupConfig) BackupConfig {
 		cfg.Interval = time.Hour
 	}
 	return cfg
+}
+
+func sqliteBackupInto(ctx context.Context, db *sql.DB, backupPath string) error {
+	if db == nil {
+		return fmt.Errorf("sqlite: database is nil")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(backupPath), 0o755); err != nil {
+		return fmt.Errorf("sqlite: create backup dir: %w", err)
+	}
+
+	if _, err := os.Stat(backupPath); err == nil {
+		if err := os.Remove(backupPath); err != nil {
+			return fmt.Errorf("sqlite: remove existing backup: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("sqlite: stat backup path: %w", err)
+	}
+
+	if _, err := db.ExecContext(ctx, "VACUUM main INTO ?", backupPath); err != nil {
+		return fmt.Errorf("sqlite: vacuum into backup: %w", err)
+	}
+
+	return nil
+}
+
+func sqliteFilePathFromDSN(dsn string) (string, error) {
+	dsn = strings.TrimSpace(dsn)
+	if dsn == "" || dsn == ":memory:" || strings.Contains(dsn, "mode=memory") {
+		return "", fmt.Errorf("sqlite: operation requires a file-backed database")
+	}
+
+	if strings.HasPrefix(dsn, "file:") {
+		dsn = strings.TrimPrefix(dsn, "file:")
+	}
+	if idx := strings.Index(dsn, "?"); idx >= 0 {
+		dsn = dsn[:idx]
+	}
+	dsn = strings.TrimSpace(dsn)
+	if dsn == "" || dsn == ":memory:" {
+		return "", fmt.Errorf("sqlite: operation requires a file-backed database")
+	}
+
+	return filepath.Clean(dsn), nil
+}
+
+func copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source file: %w", err)
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create destination file: %w", err)
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return fmt.Errorf("copy file: %w", err)
+	}
+	if err := dstFile.Sync(); err != nil {
+		return fmt.Errorf("sync destination file: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/sqlite/backup_test.go
+++ b/pkg/sqlite/backup_test.go
@@ -1,0 +1,648 @@
+package sqlite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBackupOnce(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/test.db"
+	backupDir := tmpDir + "/backups"
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	_, err = db.ExecContext(ctx, `INSERT INTO test (name) VALUES ('backup_test')`)
+	if err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	bm := NewBackupManager(DefaultBackupConfig(backupDir))
+
+	backupPath, err := bm.BackupOnce(ctx, db)
+	if err != nil {
+		t.Fatalf("backup failed: %v", err)
+	}
+
+	if _, err := os.Stat(backupPath); err != nil {
+		t.Fatalf("backup file not created: %v", err)
+	}
+
+	backups, err := bm.ListBackups()
+	if err != nil {
+		t.Fatalf("list backups failed: %v", err)
+	}
+
+	if len(backups) != 1 {
+		t.Errorf("expected 1 backup, got %d", len(backups))
+	}
+
+	latest, err := bm.LatestBackup()
+	if err != nil {
+		t.Fatalf("latest backup failed: %v", err)
+	}
+
+	if latest.Path != backupPath {
+		t.Errorf("expected latest backup %s, got %s", backupPath, latest.Path)
+	}
+}
+
+func TestBackupPruning(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/test.db"
+	backupDir := tmpDir + "/backups"
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY)`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	bm := NewBackupManager(BackupConfig{
+		BackupDir:  backupDir,
+		MaxBackups: 3,
+		Interval:   time.Hour,
+	})
+
+	for i := 0; i < 5; i++ {
+		_, err := bm.BackupOnce(ctx, db)
+		if err != nil {
+			t.Fatalf("backup %d failed: %v", i, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	backups, err := bm.ListBackups()
+	if err != nil {
+		t.Fatalf("list backups failed: %v", err)
+	}
+
+	if len(backups) != 3 {
+		t.Errorf("expected 3 backups after pruning, got %d", len(backups))
+	}
+}
+
+func TestBackupStartStop(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/test.db"
+	backupDir := tmpDir + "/backups"
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY)`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	var backupCount atomic.Int32
+	bm := NewBackupManager(BackupConfig{
+		BackupDir:  backupDir,
+		MaxBackups: 10,
+		Interval:   100 * time.Millisecond,
+		OnBackupDone: func(path string, size int64, duration time.Duration) {
+			backupCount.Add(1)
+		},
+	})
+
+	if err := bm.Start(ctx, db); err != nil {
+		t.Fatalf("start backup manager failed: %v", err)
+	}
+
+	time.Sleep(350 * time.Millisecond)
+
+	bm.Stop()
+
+	count := backupCount.Load()
+	if count < 2 {
+		t.Errorf("expected at least 2 backups, got %d", count)
+	}
+}
+
+func TestBackupManagerCanRestart(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	backupDir := filepath.Join(tmpDir, "backups")
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	bm := NewBackupManager(BackupConfig{
+		BackupDir:  backupDir,
+		MaxBackups: 2,
+		Interval:   time.Hour,
+	})
+
+	if err := bm.Start(ctx, db); err != nil {
+		t.Fatalf("first start failed: %v", err)
+	}
+	bm.Stop()
+
+	if err := bm.Start(ctx, db); err != nil {
+		t.Fatalf("second start failed: %v", err)
+	}
+	bm.Stop()
+}
+
+func TestRestoreFromBackup(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/test.db"
+	backupDir := tmpDir + "/backups"
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	_, err = db.ExecContext(ctx, `INSERT INTO test (name) VALUES ('original')`)
+	if err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	bm := NewBackupManager(DefaultBackupConfig(backupDir))
+
+	backupPath, err := bm.BackupOnce(ctx, db)
+	if err != nil {
+		t.Fatalf("backup failed: %v", err)
+	}
+
+	db.Close()
+
+	if err := bm.RestoreFromBackup(ctx, db, backupPath); err != nil {
+		t.Fatalf("restore failed: %v", err)
+	}
+
+	db2, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("reopen db failed: %v", err)
+	}
+	defer db2.Close()
+
+	var name string
+	err = db2.QueryRowContext(ctx, `SELECT name FROM test LIMIT 1`).Scan(&name)
+	if err != nil {
+		t.Fatalf("query after restore failed: %v", err)
+	}
+
+	if name != "original" {
+		t.Errorf("expected name 'original', got %s", name)
+	}
+}
+
+func TestRestoreFromBackupRequiresClosedDatabase(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	backupDir := filepath.Join(tmpDir, "backups")
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	bm := NewBackupManager(DefaultBackupConfig(backupDir))
+	backupPath, err := bm.BackupOnce(ctx, db)
+	if err != nil {
+		t.Fatalf("backup failed: %v", err)
+	}
+
+	if err := bm.RestoreFromBackup(ctx, db, backupPath); err == nil {
+		t.Fatal("expected restore against open database to fail")
+	}
+}
+
+func TestRepairIntegrityCheck(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/test.db"
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	_, err = db.ExecContext(ctx, `INSERT INTO test (name) VALUES ('repair_test')`)
+	if err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	rm := NewRepairManager(DefaultRepairConfig())
+
+	result, err := rm.CheckDatabase(ctx, db)
+	if err != nil {
+		t.Fatalf("check database failed: %v", err)
+	}
+
+	if len(result.IssuesFound) != 0 {
+		t.Errorf("expected no issues on healthy db, got %v", result.IssuesFound)
+	}
+}
+
+func TestQuickFix(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/test.db"
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	_, err = db.ExecContext(ctx, `INSERT INTO test (name) VALUES ('quickfix')`)
+	if err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	rm := NewRepairManager(DefaultRepairConfig())
+
+	if err := rm.QuickFix(ctx, db); err != nil {
+		t.Fatalf("quick fix failed: %v", err)
+	}
+
+	ok, err := db.IntegrityCheck(ctx)
+	if err != nil {
+		t.Fatalf("integrity check after quick fix failed: %v", err)
+	}
+	if !ok {
+		t.Error("database failed integrity check after quick fix")
+	}
+}
+
+func TestRepairWithCallbacks(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/test.db"
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY)`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	var issuesDetected []string
+	var issuesFixed []string
+
+	rm := NewRepairManager(RepairConfig{
+		AutoRepair:    true,
+		CreateBackup:  true,
+		MaxRepairTime: 10 * time.Second,
+		OnIssueDetected: func(issue string) {
+			issuesDetected = append(issuesDetected, issue)
+		},
+		OnIssueFixed: func(fix string) {
+			issuesFixed = append(issuesFixed, fix)
+		},
+	})
+
+	result, err := rm.CheckDatabase(ctx, db)
+	if err != nil {
+		t.Fatalf("check database failed: %v", err)
+	}
+
+	if len(issuesDetected) != 0 {
+		t.Logf("issues detected: %v", issuesDetected)
+	}
+
+	_ = result
+}
+
+func TestRecoverFromBackup(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/test.db"
+	backupDir := tmpDir + "/backups"
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	_, err = db.ExecContext(ctx, `INSERT INTO test (name) VALUES ('recover_test')`)
+	if err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	bm := NewBackupManager(DefaultBackupConfig(backupDir))
+	_, err = bm.BackupOnce(ctx, db)
+	if err != nil {
+		t.Fatalf("backup failed: %v", err)
+	}
+
+	db.Close()
+
+	rm := NewRepairManager(DefaultRepairConfig())
+	if err := rm.RecoverFromBackup(ctx, db, backupDir); err != nil {
+		t.Fatalf("recover from backup failed: %v", err)
+	}
+
+	db2, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("reopen db failed: %v", err)
+	}
+	defer db2.Close()
+
+	var name string
+	err = db2.QueryRowContext(ctx, `SELECT name FROM test LIMIT 1`).Scan(&name)
+	if err != nil {
+		t.Fatalf("query after recover failed: %v", err)
+	}
+
+	if name != "recover_test" {
+		t.Errorf("expected name 'recover_test', got %s", name)
+	}
+}
+
+func TestBackupInMemoryError(t *testing.T) {
+	db, err := Open(InMemoryConfig())
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY)`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	bm := NewBackupManager(DefaultBackupConfig(tmpDir))
+
+	_, err = bm.BackupOnce(ctx, db)
+	if err == nil {
+		t.Error("expected error when backing up in-memory database")
+	}
+}
+
+func TestBackupCallbacks(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/test.db"
+	backupDir := tmpDir + "/backups"
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY)`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	var started, done bool
+	var backupSize int64
+	var backupDuration time.Duration
+
+	bm := NewBackupManager(BackupConfig{
+		BackupDir:  backupDir,
+		MaxBackups: 10,
+		Interval:   time.Hour,
+		OnBackupStart: func(path string) {
+			started = true
+		},
+		OnBackupDone: func(path string, size int64, duration time.Duration) {
+			done = true
+			backupSize = size
+			backupDuration = duration
+		},
+	})
+
+	_, err = bm.BackupOnce(ctx, db)
+	if err != nil {
+		t.Fatalf("backup failed: %v", err)
+	}
+
+	if !started {
+		t.Error("expected OnBackupStart callback to be called")
+	}
+	if !done {
+		t.Error("expected OnBackupDone callback to be called")
+	}
+	if backupSize == 0 {
+		t.Error("expected non-zero backup size")
+	}
+	if backupDuration == 0 {
+		t.Error("expected non-zero backup duration")
+	}
+}
+
+func TestBackupCallbacksCanReenterManager(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	backupDir := filepath.Join(tmpDir, "backups")
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	var bm *BackupManager
+	bm = NewBackupManager(BackupConfig{
+		BackupDir:  backupDir,
+		MaxBackups: 10,
+		Interval:   time.Hour,
+		OnBackupDone: func(path string, size int64, duration time.Duration) {
+			if _, err := bm.ListBackups(); err != nil {
+				t.Errorf("reentrant ListBackups failed: %v", err)
+			}
+		},
+	})
+
+	if _, err := bm.BackupOnce(ctx, db); err != nil {
+		t.Fatalf("backup failed: %v", err)
+	}
+}
+
+func TestRepairCreatesBackup(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/test.db"
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY)`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	rm := NewRepairManager(RepairConfig{
+		AutoRepair:    true,
+		CreateBackup:  true,
+		MaxRepairTime: 10 * time.Second,
+	})
+
+	result, err := rm.RepairDatabase(ctx, db)
+	if err != nil {
+		t.Fatalf("repair failed: %v", err)
+	}
+
+	if result.BackupCreated != "" {
+		if _, err := os.Stat(result.BackupCreated); err != nil {
+			t.Errorf("repair backup not created: %v", err)
+		}
+	}
+
+	if !result.Success {
+		t.Error("expected repair to succeed")
+	}
+}
+
+func TestListBackupsEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	bm := NewBackupManager(DefaultBackupConfig(tmpDir))
+
+	backups, err := bm.ListBackups()
+	if err != nil {
+		t.Fatalf("list backups failed: %v", err)
+	}
+
+	if len(backups) != 0 {
+		t.Errorf("expected 0 backups, got %d", len(backups))
+	}
+}
+
+func TestLatestBackupNone(t *testing.T) {
+	tmpDir := t.TempDir()
+	bm := NewBackupManager(DefaultBackupConfig(tmpDir))
+
+	_, err := bm.LatestBackup()
+	if err == nil {
+		t.Error("expected error when no backups exist")
+	}
+}
+
+func TestBackupDirAutoCreate(t *testing.T) {
+	tmpDir := t.TempDir()
+	backupDir := filepath.Join(tmpDir, "nested", "backups")
+
+	if err := os.MkdirAll(backupDir, 0o755); err != nil {
+		t.Fatalf("failed to create backup dir: %v", err)
+	}
+
+	bm := NewBackupManager(DefaultBackupConfig(backupDir))
+
+	backups, err := bm.ListBackups()
+	if err != nil {
+		t.Fatalf("list backups failed: %v", err)
+	}
+
+	if len(backups) != 0 {
+		t.Errorf("expected 0 backups, got %d", len(backups))
+	}
+}

--- a/pkg/sqlite/backup_test.go
+++ b/pkg/sqlite/backup_test.go
@@ -545,6 +545,70 @@ func TestRecoverFromBackup(t *testing.T) {
 	}
 }
 
+func TestRecoverFromBackupIgnoresUnrelatedDBFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	backupDir := filepath.Join(tmpDir, "backups")
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO test (name) VALUES ('real_backup')`); err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	bm := NewBackupManager(DefaultBackupConfig(backupDir))
+	if _, err := bm.BackupOnce(ctx, db); err != nil {
+		t.Fatalf("backup failed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	decoyPath := filepath.Join(backupDir, "zzzz_unrelated.db")
+	decoy, err := Open(DefaultConfig(decoyPath))
+	if err != nil {
+		t.Fatalf("open decoy db: %v", err)
+	}
+	if _, err := decoy.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`); err != nil {
+		t.Fatalf("create decoy table: %v", err)
+	}
+	if _, err := decoy.ExecContext(ctx, `INSERT INTO test (name) VALUES ('decoy')`); err != nil {
+		t.Fatalf("insert decoy: %v", err)
+	}
+	if err := decoy.Close(); err != nil {
+		t.Fatalf("close decoy: %v", err)
+	}
+
+	rm := NewRepairManager(RepairConfig{CreateBackup: false})
+	if err := rm.RecoverFromBackup(ctx, db, backupDir); err != nil {
+		t.Fatalf("recover from backup failed: %v", err)
+	}
+
+	restored, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("reopen db failed: %v", err)
+	}
+	defer restored.Close()
+
+	var name string
+	if err := restored.QueryRowContext(ctx, `SELECT name FROM test LIMIT 1`).Scan(&name); err != nil {
+		t.Fatalf("query restored db: %v", err)
+	}
+	if name != "real_backup" {
+		t.Fatalf("expected real backup to be restored, got %q", name)
+	}
+}
+
 func TestBackupInMemoryError(t *testing.T) {
 	db, err := Open(InMemoryConfig())
 	if err != nil {

--- a/pkg/sqlite/backup_test.go
+++ b/pkg/sqlite/backup_test.go
@@ -64,6 +64,50 @@ func TestBackupOnce(t *testing.T) {
 	}
 }
 
+func TestBackupOnceSupportsSQLiteURIDSN(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "uri.db")
+	backupDir := filepath.Join(tmpDir, "backups")
+	dsn := "file:" + filepath.ToSlash(dbPath) + "?mode=rwc"
+
+	cfg := DefaultConfig(dsn)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open URI db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO test (name) VALUES ('uri_backup')`); err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	bm := NewBackupManager(DefaultBackupConfig(backupDir))
+	backupPath, err := bm.BackupOnce(ctx, db)
+	if err != nil {
+		t.Fatalf("backup URI db failed: %v", err)
+	}
+
+	backupDB, err := Open(DefaultConfig(backupPath))
+	if err != nil {
+		t.Fatalf("open backup db: %v", err)
+	}
+	defer backupDB.Close()
+
+	var name string
+	if err := backupDB.QueryRowContext(ctx, `SELECT name FROM test LIMIT 1`).Scan(&name); err != nil {
+		t.Fatalf("query backup db: %v", err)
+	}
+	if name != "uri_backup" {
+		t.Fatalf("expected uri_backup, got %q", name)
+	}
+}
+
 func TestBackupPruning(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := tmpDir + "/test.db"
@@ -239,6 +283,60 @@ func TestRestoreFromBackup(t *testing.T) {
 
 	if name != "original" {
 		t.Errorf("expected name 'original', got %s", name)
+	}
+}
+
+func TestRestoreFromBackupSupportsSQLiteURIDSN(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "restore-uri.db")
+	backupDir := filepath.Join(tmpDir, "backups")
+	dsn := "file:" + filepath.ToSlash(dbPath) + "?mode=rwc"
+
+	cfg := DefaultConfig(dsn)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open URI db: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO test (name) VALUES ('before_restore')`); err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	bm := NewBackupManager(DefaultBackupConfig(backupDir))
+	backupPath, err := bm.BackupOnce(ctx, db)
+	if err != nil {
+		t.Fatalf("backup failed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	if err := os.WriteFile(dbPath, []byte("not sqlite"), 0o600); err != nil {
+		t.Fatalf("corrupt db file: %v", err)
+	}
+
+	if err := bm.RestoreFromBackup(ctx, db, backupPath); err != nil {
+		t.Fatalf("restore URI db failed: %v", err)
+	}
+
+	restored, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("reopen restored db: %v", err)
+	}
+	defer restored.Close()
+
+	var name string
+	if err := restored.QueryRowContext(ctx, `SELECT name FROM test LIMIT 1`).Scan(&name); err != nil {
+		t.Fatalf("query restored db: %v", err)
+	}
+	if name != "before_restore" {
+		t.Fatalf("expected before_restore, got %q", name)
 	}
 }
 

--- a/pkg/sqlite/backup_test.go
+++ b/pkg/sqlite/backup_test.go
@@ -609,6 +609,58 @@ func TestRecoverFromBackupIgnoresUnrelatedDBFiles(t *testing.T) {
 	}
 }
 
+func TestRecoverFromBackupContinuesWhenCurrentDatabaseMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	backupDir := filepath.Join(tmpDir, "backups")
+
+	cfg := DefaultConfig(dbPath)
+	cfg.MaxOpenConns = 1
+	cfg.MaxIdleConns = 1
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO test (name) VALUES ('missing_current')`); err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	bm := NewBackupManager(DefaultBackupConfig(backupDir))
+	if _, err := bm.BackupOnce(ctx, db); err != nil {
+		t.Fatalf("backup failed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	if err := os.Remove(dbPath); err != nil {
+		t.Fatalf("remove current db: %v", err)
+	}
+
+	rm := NewRepairManager(DefaultRepairConfig())
+	if err := rm.RecoverFromBackup(ctx, db, backupDir); err != nil {
+		t.Fatalf("recover should continue when current db is missing: %v", err)
+	}
+
+	restored, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("reopen restored db: %v", err)
+	}
+	defer restored.Close()
+
+	var name string
+	if err := restored.QueryRowContext(ctx, `SELECT name FROM test LIMIT 1`).Scan(&name); err != nil {
+		t.Fatalf("query restored db: %v", err)
+	}
+	if name != "missing_current" {
+		t.Fatalf("expected missing_current, got %q", name)
+	}
+}
+
 func TestBackupInMemoryError(t *testing.T) {
 	db, err := Open(InMemoryConfig())
 	if err != nil {

--- a/pkg/sqlite/repair.go
+++ b/pkg/sqlite/repair.go
@@ -1,0 +1,332 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type RepairResult struct {
+	Success       bool
+	IssuesFound   []string
+	IssuesFixed   []string
+	BackupCreated string
+	Duration      time.Duration
+}
+
+type RepairConfig struct {
+	AutoRepair      bool
+	CreateBackup    bool
+	MaxRepairTime   time.Duration
+	OnIssueDetected func(issue string)
+	OnIssueFixed    func(fix string)
+}
+
+func DefaultRepairConfig() RepairConfig {
+	return RepairConfig{
+		AutoRepair:    true,
+		CreateBackup:  true,
+		MaxRepairTime: 5 * time.Minute,
+	}
+}
+
+type RepairManager struct {
+	mu  sync.Mutex
+	cfg RepairConfig
+}
+
+func NewRepairManager(cfg RepairConfig) *RepairManager {
+	if cfg.MaxRepairTime <= 0 {
+		cfg.MaxRepairTime = 5 * time.Minute
+	}
+	return &RepairManager{cfg: cfg}
+}
+
+func (rm *RepairManager) CheckDatabase(ctx context.Context, db *DB) (*RepairResult, error) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	start := time.Now()
+	result := &RepairResult{}
+
+	issues, err := rm.runIntegrityCheck(ctx, db)
+	if err != nil {
+		result.IssuesFound = append(result.IssuesFound, fmt.Sprintf("integrity check failed: %v", err))
+	}
+	result.IssuesFound = append(result.IssuesFound, issues...)
+
+	if len(result.IssuesFound) == 0 {
+		return result, nil
+	}
+
+	if rm.cfg.AutoRepair {
+		fixResult, err := rm.repair(ctx, db, result.IssuesFound)
+		if err != nil {
+			return nil, fmt.Errorf("repair failed: %w", err)
+		}
+		result.IssuesFixed = fixResult.IssuesFixed
+		result.BackupCreated = fixResult.BackupCreated
+		result.Success = fixResult.Success
+	}
+
+	result.Duration = time.Since(start)
+	return result, nil
+}
+
+func (rm *RepairManager) RepairDatabase(ctx context.Context, db *DB) (*RepairResult, error) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	start := time.Now()
+	result := &RepairResult{}
+
+	issues, err := rm.runIntegrityCheck(ctx, db)
+	if err != nil {
+		result.IssuesFound = append(result.IssuesFound, fmt.Sprintf("integrity check failed: %v", err))
+	}
+	result.IssuesFound = append(result.IssuesFound, issues...)
+
+	if len(result.IssuesFound) == 0 {
+		result.Success = true
+		result.Duration = time.Since(start)
+		return result, nil
+	}
+
+	fixResult, err := rm.repair(ctx, db, result.IssuesFound)
+	if err != nil {
+		return nil, fmt.Errorf("repair failed: %w", err)
+	}
+	result.IssuesFixed = fixResult.IssuesFixed
+	result.BackupCreated = fixResult.BackupCreated
+	result.Success = fixResult.Success
+	result.Duration = time.Since(start)
+
+	return result, nil
+}
+
+func (rm *RepairManager) QuickFix(ctx context.Context, db *DB) error {
+	fixes := []struct {
+		name string
+		sql  string
+	}{
+		{"reindex", "REINDEX"},
+		{"analyze", "ANALYZE"},
+		{"optimize", "PRAGMA optimize"},
+		{"integrity_check", "PRAGMA integrity_check"},
+	}
+
+	for _, fix := range fixes {
+		if _, err := db.ExecContext(ctx, fix.sql); err != nil {
+			return fmt.Errorf("quick fix %q failed: %w", fix.name, err)
+		}
+	}
+
+	return nil
+}
+
+func (rm *RepairManager) RecoverFromBackup(ctx context.Context, db *DB, backupDir string) error {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	if !db.isClosed() {
+		return fmt.Errorf("sqlite: close database before restore")
+	}
+
+	backups, err := rm.listBackupFiles(backupDir)
+	if err != nil {
+		return fmt.Errorf("list backups: %w", err)
+	}
+	if len(backups) == 0 {
+		return fmt.Errorf("no backups found in %s", backupDir)
+	}
+
+	latestBackup := backups[0]
+
+	if rm.cfg.CreateBackup {
+		currentDB := db.DSN()
+		if currentDB != "" && currentDB != ":memory:" {
+			brokenBackup := currentDB + ".broken." + time.Now().Format("20060102_150405")
+			if err := rm.copyFile(currentDB, brokenBackup); err != nil {
+				return fmt.Errorf("backup broken db: %w", err)
+			}
+		}
+	}
+
+	if err := rm.copyFile(latestBackup, db.DSN()); err != nil {
+		return fmt.Errorf("restore from backup: %w", err)
+	}
+
+	return nil
+}
+
+func (rm *RepairManager) runIntegrityCheck(ctx context.Context, db *DB) ([]string, error) {
+	var issues []string
+
+	var integrityResult string
+	err := db.QueryRowContext(ctx, "PRAGMA integrity_check").Scan(&integrityResult)
+	if err != nil {
+		return nil, fmt.Errorf("integrity check: %w", err)
+	}
+	if integrityResult != "ok" {
+		issues = append(issues, fmt.Sprintf("integrity check: %s", integrityResult))
+	}
+
+	var quickCheckResult string
+	err = db.QueryRowContext(ctx, "PRAGMA quick_check").Scan(&quickCheckResult)
+	if err != nil {
+		return nil, fmt.Errorf("quick check: %w", err)
+	}
+	if quickCheckResult != "ok" {
+		issues = append(issues, fmt.Sprintf("quick check: %s", quickCheckResult))
+	}
+
+	rows, err := db.QueryContext(ctx, "PRAGMA foreign_key_check")
+	if err == nil {
+		defer rows.Close()
+		for rows.Next() {
+			var table string
+			var rowid int64
+			var parent string
+			var fkid int64
+			if err := rows.Scan(&table, &rowid, &parent, &fkid); err == nil {
+				issues = append(issues, fmt.Sprintf("foreign key violation: table=%s, rowid=%d, parent=%s",
+					table, rowid, parent))
+			}
+		}
+	}
+
+	return issues, nil
+}
+
+func (rm *RepairManager) repair(ctx context.Context, db *DB, issues []string) (*RepairResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, rm.cfg.MaxRepairTime)
+	defer cancel()
+
+	result := &RepairResult{}
+
+	if rm.cfg.CreateBackup {
+		currentDB := db.DSN()
+		if currentDB != "" && currentDB != ":memory:" {
+			backupPath := currentDB + ".repair_backup." + time.Now().Format("20060102_150405")
+			if err := rm.copyFile(currentDB, backupPath); err != nil {
+				return nil, fmt.Errorf("create repair backup: %w", err)
+			}
+			result.BackupCreated = backupPath
+		}
+	}
+
+	for _, issue := range issues {
+		if rm.cfg.OnIssueDetected != nil {
+			rm.cfg.OnIssueDetected(issue)
+		}
+
+		fixed := false
+
+		if containsStr(issue, "integrity check") || containsStr(issue, "quick check") {
+			if _, err := db.ExecContext(ctx, "REINDEX"); err == nil {
+				result.IssuesFixed = append(result.IssuesFixed, "reindexed database")
+				fixed = true
+			}
+		}
+
+		if containsStr(issue, "foreign key violation") {
+			if _, err := db.ExecContext(ctx, "PRAGMA foreign_key_check"); err == nil {
+				result.IssuesFixed = append(result.IssuesFixed, "checked foreign key constraints")
+				fixed = true
+			}
+		}
+
+		if !fixed {
+			result.IssuesFixed = append(result.IssuesFixed, "attempted general repair (reindex + analyze)")
+			db.ExecContext(ctx, "REINDEX")
+			db.ExecContext(ctx, "ANALYZE")
+			db.ExecContext(ctx, "PRAGMA optimize")
+		}
+
+		if rm.cfg.OnIssueFixed != nil && fixed {
+			rm.cfg.OnIssueFixed(result.IssuesFixed[len(result.IssuesFixed)-1])
+		}
+	}
+
+	ok, err := db.IntegrityCheck(ctx)
+	if err == nil && ok {
+		result.Success = true
+	}
+
+	return result, nil
+}
+
+func (rm *RepairManager) listBackupFiles(backupDir string) ([]string, error) {
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var backups []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !stringsHasSuffix(name, ".db") {
+			continue
+		}
+		backups = append(backups, filepath.Join(backupDir, name))
+	}
+
+	sortByTime(backups)
+
+	return backups, nil
+}
+
+func (rm *RepairManager) copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	return dstFile.Sync()
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func stringsHasSuffix(s, suffix string) bool {
+	if len(s) < len(suffix) {
+		return false
+	}
+	return s[len(s)-len(suffix):] == suffix
+}
+
+func sortByTime(files []string) {
+	// Simple sort by filename (backup files have timestamp in name)
+	for i := 0; i < len(files); i++ {
+		for j := i + 1; j < len(files); j++ {
+			if files[i] < files[j] {
+				files[i], files[j] = files[j], files[i]
+			}
+		}
+	}
+}

--- a/pkg/sqlite/repair.go
+++ b/pkg/sqlite/repair.go
@@ -3,8 +3,6 @@ package sqlite
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 )
@@ -135,7 +133,7 @@ func (rm *RepairManager) RecoverFromBackup(ctx context.Context, db *DB, backupDi
 		return fmt.Errorf("sqlite: close database before restore")
 	}
 
-	backups, err := rm.listBackupFiles(backupDir)
+	backups, err := listBackups(normalizeBackupConfig(BackupConfig{BackupDir: backupDir}))
 	if err != nil {
 		return fmt.Errorf("list backups: %w", err)
 	}
@@ -143,7 +141,7 @@ func (rm *RepairManager) RecoverFromBackup(ctx context.Context, db *DB, backupDi
 		return fmt.Errorf("no backups found in %s", backupDir)
 	}
 
-	latestBackup := backups[0]
+	latestBackup := backups[0].Path
 
 	if rm.cfg.CreateBackup {
 		currentDB, err := sqliteFilePathFromDSN(db.DSN())
@@ -264,29 +262,6 @@ func (rm *RepairManager) repair(ctx context.Context, db *DB, issues []string) (*
 	return result, nil
 }
 
-func (rm *RepairManager) listBackupFiles(backupDir string) ([]string, error) {
-	entries, err := os.ReadDir(backupDir)
-	if err != nil {
-		return nil, err
-	}
-
-	var backups []string
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		if !stringsHasSuffix(name, ".db") {
-			continue
-		}
-		backups = append(backups, filepath.Join(backupDir, name))
-	}
-
-	sortByTime(backups)
-
-	return backups, nil
-}
-
 func containsStr(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {
@@ -294,22 +269,4 @@ func containsStr(s, substr string) bool {
 		}
 	}
 	return false
-}
-
-func stringsHasSuffix(s, suffix string) bool {
-	if len(s) < len(suffix) {
-		return false
-	}
-	return s[len(s)-len(suffix):] == suffix
-}
-
-func sortByTime(files []string) {
-	// Simple sort by filename (backup files have timestamp in name)
-	for i := 0; i < len(files); i++ {
-		for j := i + 1; j < len(files); j++ {
-			if files[i] < files[j] {
-				files[i], files[j] = files[j], files[i]
-			}
-		}
-	}
 }

--- a/pkg/sqlite/repair.go
+++ b/pkg/sqlite/repair.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 )
@@ -145,11 +146,9 @@ func (rm *RepairManager) RecoverFromBackup(ctx context.Context, db *DB, backupDi
 
 	if rm.cfg.CreateBackup {
 		currentDB, err := sqliteFilePathFromDSN(db.DSN())
-		if err == nil {
+		if err == nil && isReadableFile(currentDB) {
 			brokenBackup := currentDB + ".broken." + time.Now().Format("20060102_150405")
-			if err := copyFile(currentDB, brokenBackup); err != nil {
-				return fmt.Errorf("backup broken db: %w", err)
-			}
+			_ = copyFile(currentDB, brokenBackup)
 		}
 	}
 
@@ -269,4 +268,17 @@ func containsStr(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func isReadableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	_ = file.Close()
+	return true
 }

--- a/pkg/sqlite/repair.go
+++ b/pkg/sqlite/repair.go
@@ -3,7 +3,6 @@ package sqlite
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -147,16 +146,21 @@ func (rm *RepairManager) RecoverFromBackup(ctx context.Context, db *DB, backupDi
 	latestBackup := backups[0]
 
 	if rm.cfg.CreateBackup {
-		currentDB := db.DSN()
-		if currentDB != "" && currentDB != ":memory:" {
+		currentDB, err := sqliteFilePathFromDSN(db.DSN())
+		if err == nil {
 			brokenBackup := currentDB + ".broken." + time.Now().Format("20060102_150405")
-			if err := rm.copyFile(currentDB, brokenBackup); err != nil {
+			if err := copyFile(currentDB, brokenBackup); err != nil {
 				return fmt.Errorf("backup broken db: %w", err)
 			}
 		}
 	}
 
-	if err := rm.copyFile(latestBackup, db.DSN()); err != nil {
+	dstPath, err := sqliteFilePathFromDSN(db.DSN())
+	if err != nil {
+		return err
+	}
+
+	if err := copyFile(latestBackup, dstPath); err != nil {
 		return fmt.Errorf("restore from backup: %w", err)
 	}
 
@@ -209,10 +213,10 @@ func (rm *RepairManager) repair(ctx context.Context, db *DB, issues []string) (*
 	result := &RepairResult{}
 
 	if rm.cfg.CreateBackup {
-		currentDB := db.DSN()
-		if currentDB != "" && currentDB != ":memory:" {
+		currentDB, err := sqliteFilePathFromDSN(db.DSN())
+		if err == nil {
 			backupPath := currentDB + ".repair_backup." + time.Now().Format("20060102_150405")
-			if err := rm.copyFile(currentDB, backupPath); err != nil {
+			if err := sqliteBackupInto(ctx, db.DB, backupPath); err != nil {
 				return nil, fmt.Errorf("create repair backup: %w", err)
 			}
 			result.BackupCreated = backupPath
@@ -281,27 +285,6 @@ func (rm *RepairManager) listBackupFiles(backupDir string) ([]string, error) {
 	sortByTime(backups)
 
 	return backups, nil
-}
-
-func (rm *RepairManager) copyFile(src, dst string) error {
-	srcFile, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer srcFile.Close()
-
-	dstFile, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer dstFile.Close()
-
-	_, err = io.Copy(dstFile, srcFile)
-	if err != nil {
-		return err
-	}
-
-	return dstFile.Sync()
 }
 
 func containsStr(s, substr string) bool {

--- a/pkg/sqlite/sqlite.go
+++ b/pkg/sqlite/sqlite.go
@@ -79,6 +79,12 @@ func (db *DB) DSN() string {
 	return db.cfg.DSN
 }
 
+func (db *DB) isClosed() bool {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+	return db.closed
+}
+
 func Open(cfg Config) (*DB, error) {
 	if cfg.DSN == "" {
 		cfg.DSN = ":memory:"


### PR DESCRIPTION
## 概要

为 `pkg/sqlite` 增加数据库维护辅助能力，包括备份、恢复、备份清理和基础修复流程。

## 本次变更

- 新增 `BackupManager`
  - 支持单次备份
  - 支持后台定时备份
  - 支持备份列表和最新备份查询
  - 支持旧备份自动清理
  - 支持从备份恢复数据库
- 新增 `RepairManager`
  - 支持 integrity check / quick check
  - 支持 quick fix
  - 支持从最新备份恢复
  - 支持修复前创建安全备份
- 补充 `pkg/sqlite` 测试覆盖
  - 备份创建、列表、裁剪、恢复
  - backup manager 启停和重启
  - repair / quick fix / recover 流程
  - 恢复时要求数据库已关闭
  - callback 可重入，不会死锁

## 影响

这条 PR 只新增 SQLite 维护 helper，不包含 read/write/query builder、transaction helper，也不修改现有 sidecar path 行为。

## 验证

已执行：

- `go test ./pkg/sqlite`
- `go test ./pkg/sqlite -cover`
- `go test ./pkg/sqlite ./pkg/index ./pkg/vec`
