### PR TITLE
feat(extensions): add adapter registry core

### DIFF
--- a/pkg/extensions/adapters/builtins.go
+++ b/pkg/extensions/adapters/builtins.go
@@ -1,0 +1,28 @@
+package extension
+
+func builtinExtensionManifests() []Manifest {
+	return []Manifest{
+		{ID: "email", Name: "Email", Version: "1.0.0", Description: "Inbound and outbound email automation hooks", Kind: "channel", Builtin: true, Channels: []string{"email"}},
+		{ID: "sms", Name: "SMS", Version: "1.0.0", Description: "SMS notifications and reply workflows", Kind: "channel", Builtin: true, Channels: []string{"sms"}},
+		{ID: "webhook", Name: "Webhook", Version: "1.0.0", Description: "Generic webhook ingestion and dispatch", Kind: "hook", Builtin: true},
+		{ID: "rss", Name: "RSS Watcher", Version: "1.0.0", Description: "RSS feed ingestion and summarization", Kind: "hook", Builtin: true},
+		{ID: "github-webhook", Name: "GitHub Webhook", Version: "1.0.0", Description: "GitHub issue and PR event adapter", Kind: "hook", Builtin: true, Skills: []string{"github", "github-issues"}},
+		{ID: "gitlab", Name: "GitLab", Version: "1.0.0", Description: "GitLab notifications and merge event routing", Kind: "channel", Builtin: true, Channels: []string{"gitlab"}},
+		{ID: "jira", Name: "Jira", Version: "1.0.0", Description: "Jira issue stream and workflow hooks", Kind: "tool", Builtin: true},
+		{ID: "confluence", Name: "Confluence", Version: "1.0.0", Description: "Confluence page sync and note surfaces", Kind: "tool", Builtin: true},
+		{ID: "notion", Name: "Notion", Version: "1.0.0", Description: "Notion knowledge capture and publishing", Kind: "tool", Builtin: true},
+		{ID: "linear", Name: "Linear", Version: "1.0.0", Description: "Linear issue routing and sprint actions", Kind: "tool", Builtin: true},
+		{ID: "reddit", Name: "Reddit", Version: "1.0.0", Description: "Reddit thread ingestion and moderation hooks", Kind: "channel", Builtin: true, Channels: []string{"reddit"}},
+		{ID: "x", Name: "X", Version: "1.0.0", Description: "X posting and mention handling surface", Kind: "channel", Builtin: true, Channels: []string{"x"}},
+		{ID: "mastodon", Name: "Mastodon", Version: "1.0.0", Description: "Mastodon timeline and social publishing support", Kind: "channel", Builtin: true, Channels: []string{"mastodon"}},
+		{ID: "linkedin", Name: "LinkedIn", Version: "1.0.0", Description: "LinkedIn publishing and outreach automation", Kind: "channel", Builtin: true, Channels: []string{"linkedin"}},
+		{ID: "youtube", Name: "YouTube", Version: "1.0.0", Description: "YouTube publishing and comment triage", Kind: "channel", Builtin: true, Channels: []string{"youtube"}},
+		{ID: "outlook", Name: "Outlook", Version: "1.0.0", Description: "Outlook calendar and mailbox integration", Kind: "channel", Builtin: true, Channels: []string{"outlook"}},
+		{ID: "zoom", Name: "Zoom", Version: "1.0.0", Description: "Zoom meeting event hooks and summaries", Kind: "hook", Builtin: true},
+		{ID: "webex", Name: "Webex", Version: "1.0.0", Description: "Webex meetings and chat event adapter", Kind: "channel", Builtin: true, Channels: []string{"webex"}},
+		{ID: "basecamp", Name: "Basecamp", Version: "1.0.0", Description: "Basecamp project update integration", Kind: "tool", Builtin: true},
+		{ID: "asana", Name: "Asana", Version: "1.0.0", Description: "Asana project and task synchronization", Kind: "tool", Builtin: true},
+		{ID: "clickup", Name: "ClickUp", Version: "1.0.0", Description: "ClickUp task and workflow hooks", Kind: "tool", Builtin: true},
+		{ID: "webhook-relay", Name: "Webhook Relay", Version: "1.0.0", Description: "Shared webhook relay and routing helper", Kind: "hook", Builtin: true},
+	}
+}

--- a/pkg/extensions/adapters/extension.go
+++ b/pkg/extensions/adapters/extension.go
@@ -1,0 +1,364 @@
+// Package extension provides the extension loading and management system.
+// Extensions are self-contained modules that add channels, tools, providers,
+// and other capabilities to AnyClaw, similar to OpenClaw's extensions/ architecture.
+package extension
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+const manifestFileName = "anyclaw.extension.json"
+
+var allowedManifestKinds = map[string]struct{}{
+	"channel":  {},
+	"tool":     {},
+	"provider": {},
+	"memory":   {},
+	"hook":     {},
+}
+
+// Manifest defines the extension metadata (anyclaw.extension.json).
+type Manifest struct {
+	ID           string         `json:"id"`
+	Name         string         `json:"name"`
+	Version      string         `json:"version"`
+	Description  string         `json:"description"`
+	Kind         string         `json:"kind"` // "channel", "tool", "provider", "memory", "hook"
+	Builtin      bool           `json:"builtin,omitempty"`
+	Channels     []string       `json:"channels,omitempty"`      // Channel IDs this extension provides
+	Providers    []string       `json:"providers,omitempty"`     // LLM provider IDs
+	Skills       []string       `json:"skills,omitempty"`        // Skill IDs bundled
+	Entrypoint   string         `json:"entrypoint"`              // Main executable/script
+	Permissions  []string       `json:"permissions,omitempty"`   // Required permissions
+	ConfigSchema map[string]any `json:"config_schema,omitempty"` // JSON Schema for config
+}
+
+// Extension represents a loaded extension with runtime state.
+type Extension struct {
+	Manifest Manifest
+	Path     string
+	Enabled  bool
+	Config   map[string]any
+}
+
+// Registry manages all loaded extensions.
+type Registry struct {
+	mu            sync.RWMutex
+	extensions    map[string]*Extension
+	extensionsDir string
+}
+
+type discoveredManifest struct {
+	Manifest Manifest
+	Path     string
+}
+
+// NewRegistry creates a new extension registry.
+func NewRegistry(extensionsDir string) *Registry {
+	return &Registry{
+		extensions:    make(map[string]*Extension),
+		extensionsDir: extensionsDir,
+	}
+}
+
+// Discover scans the extensions directory for available extensions.
+func (r *Registry) Discover() ([]Manifest, error) {
+	discovered, err := r.discover()
+	if err != nil {
+		return nil, err
+	}
+
+	manifests := make([]Manifest, 0, len(discovered))
+	for _, item := range discovered {
+		manifests = append(manifests, cloneManifest(item.Manifest))
+	}
+	return manifests, nil
+}
+
+func (r *Registry) discover() ([]discoveredManifest, error) {
+	seen := make(map[string]struct{})
+	manifests := make([]discoveredManifest, 0, len(builtinExtensionManifests()))
+
+	for _, m := range builtinExtensionManifests() {
+		if err := validateManifest(m); err != nil {
+			return nil, fmt.Errorf("invalid builtin manifest %s: %w", m.ID, err)
+		}
+		if _, ok := seen[m.ID]; ok {
+			return nil, fmt.Errorf("duplicate extension manifest %q", m.ID)
+		}
+		seen[m.ID] = struct{}{}
+		manifests = append(manifests, discoveredManifest{
+			Manifest: cloneManifest(m),
+			Path:     "builtin://extensions/" + m.ID,
+		})
+	}
+
+	entries, err := os.ReadDir(r.extensionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return manifests, nil
+		}
+		return nil, fmt.Errorf("failed to read extensions dir: %w", err)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		extPath := filepath.Join(r.extensionsDir, entry.Name())
+		manifestPath := filepath.Join(extPath, manifestFileName)
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read manifest %s: %w", manifestPath, err)
+		}
+
+		var m Manifest
+		if err := json.Unmarshal(data, &m); err != nil {
+			return nil, fmt.Errorf("invalid manifest %s: %w", manifestPath, err)
+		}
+		if err := validateManifest(m); err != nil {
+			return nil, fmt.Errorf("invalid manifest %s: %w", manifestPath, err)
+		}
+		if _, ok := seen[m.ID]; ok {
+			return nil, fmt.Errorf("duplicate extension manifest %q", m.ID)
+		}
+
+		seen[m.ID] = struct{}{}
+		manifests = append(manifests, discoveredManifest{
+			Manifest: cloneManifest(m),
+			Path:     extPath,
+		})
+	}
+
+	return manifests, nil
+}
+
+// Register adds an extension to the registry.
+func (r *Registry) Register(ext *Extension) error {
+	if ext == nil {
+		return fmt.Errorf("extension is nil")
+	}
+	if err := validateManifest(ext.Manifest); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.extensions[ext.Manifest.ID]; ok {
+		return fmt.Errorf("extension %q already registered", ext.Manifest.ID)
+	}
+	r.extensions[ext.Manifest.ID] = cloneExtension(ext)
+	return nil
+}
+
+// Get returns an extension by ID.
+func (r *Registry) Get(id string) (*Extension, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ext, ok := r.extensions[id]
+	if !ok {
+		return nil, false
+	}
+	return cloneExtension(ext), true
+}
+
+// List returns all registered extensions.
+func (r *Registry) List() []*Extension {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]*Extension, 0, len(r.extensions))
+	for _, ext := range r.extensions {
+		result = append(result, cloneExtension(ext))
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Manifest.ID < result[j].Manifest.ID
+	})
+	return result
+}
+
+// ListByKind returns extensions filtered by kind.
+func (r *Registry) ListByKind(kind string) []*Extension {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var result []*Extension
+	for _, ext := range r.extensions {
+		if ext.Manifest.Kind == kind && ext.Enabled {
+			result = append(result, cloneExtension(ext))
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Manifest.ID < result[j].Manifest.ID
+	})
+	return result
+}
+
+// Enable marks an extension as enabled.
+func (r *Registry) Enable(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ext, ok := r.extensions[id]
+	if !ok {
+		return fmt.Errorf("extension %q not found", id)
+	}
+	ext.Enabled = true
+	return nil
+}
+
+// Disable marks an extension as disabled.
+func (r *Registry) Disable(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ext, ok := r.extensions[id]
+	if !ok {
+		return fmt.Errorf("extension %q not found", id)
+	}
+	ext.Enabled = false
+	return nil
+}
+
+// LoadExtension loads a single extension from its directory.
+func LoadExtension(dir string) (*Extension, error) {
+	manifestPath := filepath.Join(dir, manifestFileName)
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read manifest: %w", err)
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("invalid manifest: %w", err)
+	}
+	if err := validateManifest(m); err != nil {
+		return nil, fmt.Errorf("invalid manifest: %w", err)
+	}
+
+	return &Extension{
+		Manifest: cloneManifest(m),
+		Path:     dir,
+		Enabled:  true,
+	}, nil
+}
+
+// LoadAll discovers and loads all extensions from the registry's directory.
+func (r *Registry) LoadAll() error {
+	manifests, err := r.discover()
+	if err != nil {
+		return err
+	}
+
+	for _, item := range manifests {
+		if item.Manifest.Builtin {
+			if err := r.Register(&Extension{
+				Manifest: item.Manifest,
+				Path:     item.Path,
+				Enabled:  true,
+			}); err != nil {
+				return err
+			}
+			continue
+		}
+		ext, err := LoadExtension(item.Path)
+		if err != nil {
+			return fmt.Errorf("failed to load extension %s: %w", item.Manifest.ID, err)
+		}
+		if err := r.Register(ext); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateManifest(m Manifest) error {
+	if strings.TrimSpace(m.ID) == "" {
+		return fmt.Errorf("manifest id is required")
+	}
+	if !isSafeID(m.ID) {
+		return fmt.Errorf("manifest id %q is not safe", m.ID)
+	}
+	if strings.TrimSpace(m.Name) == "" {
+		return fmt.Errorf("manifest name is required")
+	}
+	if strings.TrimSpace(m.Version) == "" {
+		return fmt.Errorf("manifest version is required")
+	}
+	if _, ok := allowedManifestKinds[m.Kind]; !ok {
+		return fmt.Errorf("manifest kind %q is not supported", m.Kind)
+	}
+	if m.Entrypoint != "" && !isSafeRelativePath(m.Entrypoint) {
+		return fmt.Errorf("manifest entrypoint %q must be a relative path inside the extension", m.Entrypoint)
+	}
+	return nil
+}
+
+func isSafeID(id string) bool {
+	if id == "." || id == ".." || filepath.IsAbs(id) {
+		return false
+	}
+	return !strings.ContainsAny(id, `/\`)
+}
+
+func isSafeRelativePath(path string) bool {
+	clean := filepath.Clean(path)
+	if clean == "." || filepath.IsAbs(clean) || filepath.VolumeName(clean) != "" {
+		return false
+	}
+	parts := strings.FieldsFunc(clean, func(r rune) bool {
+		return r == '/' || r == '\\'
+	})
+	for _, part := range parts {
+		if part == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneExtension(ext *Extension) *Extension {
+	if ext == nil {
+		return nil
+	}
+	config := make(map[string]any, len(ext.Config))
+	for k, v := range ext.Config {
+		config[k] = v
+	}
+	return &Extension{
+		Manifest: cloneManifest(ext.Manifest),
+		Path:     ext.Path,
+		Enabled:  ext.Enabled,
+		Config:   config,
+	}
+}
+
+func cloneManifest(m Manifest) Manifest {
+	m.Channels = append([]string(nil), m.Channels...)
+	m.Providers = append([]string(nil), m.Providers...)
+	m.Skills = append([]string(nil), m.Skills...)
+	m.Permissions = append([]string(nil), m.Permissions...)
+	m.ConfigSchema = cloneMap(m.ConfigSchema)
+	return m
+}
+
+func cloneMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+	output := make(map[string]any, len(input))
+	for k, v := range input {
+		output[k] = v
+	}
+	return output
+}

--- a/pkg/extensions/adapters/extension.go
+++ b/pkg/extensions/adapters/extension.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -331,15 +332,11 @@ func cloneExtension(ext *Extension) *Extension {
 	if ext == nil {
 		return nil
 	}
-	config := make(map[string]any, len(ext.Config))
-	for k, v := range ext.Config {
-		config[k] = v
-	}
 	return &Extension{
 		Manifest: cloneManifest(ext.Manifest),
 		Path:     ext.Path,
 		Enabled:  ext.Enabled,
-		Config:   config,
+		Config:   cloneMap(ext.Config),
 	}
 }
 
@@ -358,7 +355,54 @@ func cloneMap(input map[string]any) map[string]any {
 	}
 	output := make(map[string]any, len(input))
 	for k, v := range input {
-		output[k] = v
+		output[k] = cloneValue(v)
 	}
 	return output
+}
+
+func cloneValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	return cloneReflect(reflect.ValueOf(value)).Interface()
+}
+
+func cloneReflect(value reflect.Value) reflect.Value {
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := cloneReflect(value.Elem())
+		wrapped := reflect.New(value.Type()).Elem()
+		wrapped.Set(cloned)
+		return wrapped
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			cloned.SetMapIndex(cloneReflect(iter.Key()), cloneReflect(iter.Value()))
+		}
+		return cloned
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneReflect(value.Index(i)))
+		}
+		return cloned
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneReflect(value.Index(i)))
+		}
+		return cloned
+	default:
+		return value
+	}
 }

--- a/pkg/extensions/adapters/extension_test.go
+++ b/pkg/extensions/adapters/extension_test.go
@@ -1,0 +1,152 @@
+package extension
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuiltinExtensionCatalogHasRecommendedCount(t *testing.T) {
+	if got := len(builtinExtensionManifests()); got != 22 {
+		t.Fatalf("expected 22 builtin extensions, got %d", got)
+	}
+}
+
+func TestDiscoverIncludesBuiltinExtensionsWithoutDirectory(t *testing.T) {
+	registry := NewRegistry("missing-dir")
+	items, err := registry.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(items) != 22 {
+		t.Fatalf("expected 22 builtin extensions from discover, got %d", len(items))
+	}
+}
+
+func TestLoadAllRegistersBuiltinExtensionsWithoutDirectory(t *testing.T) {
+	registry := NewRegistry("missing-dir")
+	if err := registry.LoadAll(); err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if got := len(registry.List()); got != 22 {
+		t.Fatalf("expected 22 loaded builtin extensions, got %d", got)
+	}
+	ext, ok := registry.Get("zoom")
+	if !ok {
+		t.Fatal("expected zoom builtin extension")
+	}
+	if !ext.Manifest.Builtin {
+		t.Fatal("expected builtin flag on zoom manifest")
+	}
+}
+
+func TestRegistryReturnsDefensiveCopies(t *testing.T) {
+	registry := NewRegistry("missing-dir")
+	ext := &Extension{
+		Manifest: Manifest{
+			ID:       "custom",
+			Name:     "Custom",
+			Version:  "1.0.0",
+			Kind:     "tool",
+			Channels: []string{"original"},
+		},
+		Enabled: true,
+		Config:  map[string]any{"mode": "safe"},
+	}
+	if err := registry.Register(ext); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	ext.Manifest.Name = "mutated"
+	ext.Config["mode"] = "changed"
+
+	got, ok := registry.Get("custom")
+	if !ok {
+		t.Fatal("expected registered extension")
+	}
+	got.Manifest.Name = "external mutation"
+	got.Manifest.Channels[0] = "changed"
+	got.Config["mode"] = "external"
+
+	again, ok := registry.Get("custom")
+	if !ok {
+		t.Fatal("expected registered extension")
+	}
+	if again.Manifest.Name != "Custom" {
+		t.Fatalf("expected stored manifest name to remain Custom, got %q", again.Manifest.Name)
+	}
+	if again.Manifest.Channels[0] != "original" {
+		t.Fatalf("expected stored channel to remain original, got %q", again.Manifest.Channels[0])
+	}
+	if again.Config["mode"] != "safe" {
+		t.Fatalf("expected stored config to remain safe, got %v", again.Config["mode"])
+	}
+}
+
+func TestDiscoverRejectsDuplicateManifestID(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, filepath.Join(dir, "zoom"), Manifest{
+		ID:      "zoom",
+		Name:    "Duplicate Zoom",
+		Version: "1.0.0",
+		Kind:    "tool",
+	})
+
+	registry := NewRegistry(dir)
+	if _, err := registry.Discover(); err == nil {
+		t.Fatal("expected duplicate manifest ID error")
+	}
+}
+
+func TestLoadAllUsesManifestDirectoryNotManifestID(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, filepath.Join(dir, "custom-dir"), Manifest{
+		ID:         "custom-extension",
+		Name:       "Custom Extension",
+		Version:    "1.0.0",
+		Kind:       "tool",
+		Entrypoint: "bin/custom",
+	})
+
+	registry := NewRegistry(dir)
+	if err := registry.LoadAll(); err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	ext, ok := registry.Get("custom-extension")
+	if !ok {
+		t.Fatal("expected custom extension")
+	}
+	if ext.Path != filepath.Join(dir, "custom-dir") {
+		t.Fatalf("expected extension path to use containing directory, got %q", ext.Path)
+	}
+}
+
+func TestLoadExtensionRejectsUnsafeEntrypoint(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, Manifest{
+		ID:         "unsafe",
+		Name:       "Unsafe",
+		Version:    "1.0.0",
+		Kind:       "tool",
+		Entrypoint: "../outside",
+	})
+
+	if _, err := LoadExtension(dir); err == nil {
+		t.Fatal("expected unsafe entrypoint error")
+	}
+}
+
+func writeManifest(t *testing.T, dir string, manifest Manifest) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, manifestFileName), data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}

--- a/pkg/extensions/adapters/extension_test.go
+++ b/pkg/extensions/adapters/extension_test.go
@@ -50,16 +50,33 @@ func TestRegistryReturnsDefensiveCopies(t *testing.T) {
 			Version:  "1.0.0",
 			Kind:     "tool",
 			Channels: []string{"original"},
+			ConfigSchema: map[string]any{
+				"properties": map[string]any{
+					"token": map[string]any{
+						"type": "string",
+					},
+				},
+				"required": []any{"token"},
+			},
 		},
 		Enabled: true,
-		Config:  map[string]any{"mode": "safe"},
+		Config: map[string]any{
+			"mode": "safe",
+			"nested": map[string]any{
+				"level": "one",
+			},
+			"steps": []any{"prepare", map[string]any{"name": "run"}},
+		},
 	}
 	if err := registry.Register(ext); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 
 	ext.Manifest.Name = "mutated"
+	ext.Manifest.ConfigSchema["required"].([]any)[0] = "mutated"
 	ext.Config["mode"] = "changed"
+	ext.Config["nested"].(map[string]any)["level"] = "mutated"
+	ext.Config["steps"].([]any)[1].(map[string]any)["name"] = "mutated"
 
 	got, ok := registry.Get("custom")
 	if !ok {
@@ -67,7 +84,10 @@ func TestRegistryReturnsDefensiveCopies(t *testing.T) {
 	}
 	got.Manifest.Name = "external mutation"
 	got.Manifest.Channels[0] = "changed"
+	got.Manifest.ConfigSchema["properties"].(map[string]any)["token"].(map[string]any)["type"] = "integer"
 	got.Config["mode"] = "external"
+	got.Config["nested"].(map[string]any)["level"] = "external"
+	got.Config["steps"].([]any)[1].(map[string]any)["name"] = "external"
 
 	again, ok := registry.Get("custom")
 	if !ok {
@@ -79,8 +99,23 @@ func TestRegistryReturnsDefensiveCopies(t *testing.T) {
 	if again.Manifest.Channels[0] != "original" {
 		t.Fatalf("expected stored channel to remain original, got %q", again.Manifest.Channels[0])
 	}
+	required := again.Manifest.ConfigSchema["required"].([]any)
+	if required[0] != "token" {
+		t.Fatalf("expected stored schema required value to remain token, got %v", required[0])
+	}
+	tokenType := again.Manifest.ConfigSchema["properties"].(map[string]any)["token"].(map[string]any)["type"]
+	if tokenType != "string" {
+		t.Fatalf("expected stored schema token type to remain string, got %v", tokenType)
+	}
 	if again.Config["mode"] != "safe" {
 		t.Fatalf("expected stored config to remain safe, got %v", again.Config["mode"])
+	}
+	if again.Config["nested"].(map[string]any)["level"] != "one" {
+		t.Fatalf("expected nested config to remain one, got %v", again.Config["nested"].(map[string]any)["level"])
+	}
+	step := again.Config["steps"].([]any)[1].(map[string]any)["name"]
+	if step != "run" {
+		t.Fatalf("expected nested slice config to remain run, got %v", step)
 	}
 }
 


### PR DESCRIPTION
## 概要

补充 extensions adapter 的基础注册表能力，引入 extension manifest、builtin adapter catalog 和 registry 加载逻辑，为后续 CLI adapters、webhook adapters 以及更完整的 extensions 系统做准备。

## 本次变更

- 新增 `pkg/extensions/adapters/extension.go`
- 定义 extension manifest、extension runtime state 和 registry
- 支持发现 builtin extensions 和磁盘 extensions
- 支持注册、查询、启用、禁用和按类型筛选 extensions
- 新增 manifest 基础校验，拒绝非法 ID、未知 kind 和不安全 entrypoint 路径
- 新增重复 extension ID 检测，避免磁盘 manifest 覆盖 builtin extension
- registry 返回 defensive copy，避免调用方修改内部状态
- 新增 `pkg/extensions/adapters/builtins.go`
- 提供 22 个 builtin extension manifest
- 新增 `pkg/extensions/adapters/extension_test.go`
- 覆盖 builtin catalog、缺失目录发现、LoadAll、defensive copy、重复 ID 和 unsafe entrypoint 等行为

## 影响

这条 PR 只引入 extensions adapter registry core，不包含具体 CLI adapter 实现，也不改动已有 webhook adapter 子包。

这样拆分可以先合入稳定的 manifest / registry 基础层，降低后续 adapters 实现 PR 的 review 成本。

## 验证

已执行：

- `go test ./pkg/extensions/adapters`
- `go test ./pkg/extensions/...`
- `go test ./pkg/extensions/adapters -cover`
