### PR TITLE
test(gateway): cover status approval and typing helpers

### DIFF
--- a/pkg/gateway/gateway_status_test.go
+++ b/pkg/gateway/gateway_status_test.go
@@ -1,0 +1,42 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/state"
+)
+
+func TestTypingSessionActiveIgnoresStaleSessions(t *testing.T) {
+	now := time.Date(2026, 4, 12, 2, 0, 0, 0, time.UTC)
+
+	if typingSessionActive(nil, now, typingSessionStaleAfter) {
+		t.Fatal("nil session should not be active")
+	}
+
+	stale := &state.Session{
+		Typing:       true,
+		LastActiveAt: now.Add(-typingSessionStaleAfter - time.Second),
+		UpdatedAt:    now.Add(-typingSessionStaleAfter - time.Second),
+	}
+	if typingSessionActive(stale, now, typingSessionStaleAfter) {
+		t.Fatal("stale typing session should not be treated as active")
+	}
+
+	fresh := &state.Session{
+		Typing:       true,
+		LastActiveAt: now.Add(-5 * time.Second),
+		UpdatedAt:    now.Add(-5 * time.Second),
+	}
+	if !typingSessionActive(fresh, now, typingSessionStaleAfter) {
+		t.Fatal("fresh typing session should be treated as active")
+	}
+
+	fallback := &state.Session{
+		Typing:    true,
+		UpdatedAt: now.Add(-3 * time.Second),
+	}
+	if !typingSessionActive(fallback, now, typingSessionStaleAfter) {
+		t.Fatal("updated_at should be used when last_active_at is missing")
+	}
+}

--- a/pkg/gateway/transport/status_test.go
+++ b/pkg/gateway/transport/status_test.go
@@ -1,0 +1,27 @@
+package transport
+
+import (
+	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/state"
+)
+
+func TestSummarizeApprovalsIgnoresOrphanedSessionApprovals(t *testing.T) {
+	summary := summarizeApprovals([]*state.Approval{
+		{ID: "approval-live", SessionID: "sess-live", Status: "pending"},
+		{ID: "approval-orphan", SessionID: "sess-missing", Status: "pending"},
+		{ID: "approval-rejected", SessionID: "sess-live", Status: "rejected"},
+	}, []*state.Session{
+		{ID: "sess-live"},
+	}, nil)
+
+	if summary.Pending != 1 {
+		t.Fatalf("expected 1 pending actionable approval, got %#v", summary)
+	}
+	if summary.Denied != 1 {
+		t.Fatalf("expected rejected approval to count as denied, got %#v", summary)
+	}
+	if summary.Total != 2 {
+		t.Fatalf("expected orphaned approval to be excluded from totals, got %#v", summary)
+	}
+}


### PR DESCRIPTION
## 概要

补充 gateway status 相关测试覆盖，聚焦状态汇总中容易回归的 approval 统计和 typing session 活跃判断逻辑。

## 本次变更

- 新增 `pkg/gateway/gateway_status_test.go`
  - 覆盖 typing session 活跃判断
  - 校验 stale session 不会被误判为活跃
  - 校验缺少 `LastActiveAt` 时会回退使用 `UpdatedAt`
- 新增 `pkg/gateway/transport/status_test.go`
  - 覆盖 approval status 汇总逻辑
  - 校验孤立 session approval 不计入 actionable totals
  - 校验 rejected approval 会计入 denied

## 影响

这条 PR 只新增测试，不改动生产代码。

## 验证

已执行：

- `go test ./pkg/gateway/transport`
- `go test ./pkg/gateway`
- `go test ./pkg/gateway/...`