### PR TITLE
feat(cdp): add browser automation helpers

### DIFF
--- a/pkg/cdp/client.go
+++ b/pkg/cdp/client.go
@@ -1,0 +1,270 @@
+package cdp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+type Tool func(context.Context, ...chromedp.Action) error
+
+type cleanupFunc func()
+
+var runChromedp = chromedp.Run
+
+func jsStringLiteral(value string) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		// json.Marshal on a Go string should never fail; keep a safe fallback.
+		return `""`
+	}
+	return string(encoded)
+}
+
+func combineCleanup(funcs ...cleanupFunc) cleanupFunc {
+	return func() {
+		for _, fn := range funcs {
+			if fn != nil {
+				fn()
+			}
+		}
+	}
+}
+
+type BrowserTool struct {
+	ctx     context.Context
+	tooltip chromedp.Action
+}
+
+func NewBrowserTool(ctx context.Context) (*BrowserTool, error) {
+	return &BrowserTool{
+		ctx: ctx,
+	}, nil
+}
+
+func (b *BrowserTool) Navigate(url string) error {
+	return runChromedp(b.ctx,
+		chromedp.Navigate(url),
+		chromedp.WaitReady("body"),
+	)
+}
+
+func (b *BrowserTool) Screenshot() ([]byte, error) {
+	var buf []byte
+	err := runChromedp(b.ctx,
+		chromedp.FullScreenshot(&buf, 90),
+	)
+	return buf, err
+}
+
+func (b *BrowserTool) Click(selector string) error {
+	return runChromedp(b.ctx,
+		chromedp.WaitVisible(selector, chromedp.ByQuery),
+		chromedp.Click(selector, chromedp.ByQuery),
+	)
+}
+
+func (b *BrowserTool) Type(selector, text string) error {
+	return runChromedp(b.ctx,
+		chromedp.WaitVisible(selector, chromedp.ByQuery),
+		chromedp.SetValue(selector, text, chromedp.ByQuery),
+	)
+}
+
+func (b *BrowserTool) GetElementText(selector string) (string, error) {
+	var text string
+	err := runChromedp(b.ctx,
+		chromedp.Text(selector, &text, chromedp.ByQuery),
+	)
+	return text, err
+}
+
+func (b *BrowserTool) GetElementAttribute(selector, attr string) (string, error) {
+	var result string
+	err := runChromedp(b.ctx,
+		chromedp.AttributeValue(selector, attr, &result, nil, chromedp.ByQuery),
+	)
+	return result, err
+}
+
+func (b *BrowserTool) GetElementHTML(selector string) (string, error) {
+	var html string
+	err := runChromedp(b.ctx,
+		chromedp.InnerHTML(selector, &html, chromedp.ByQuery),
+	)
+	return html, err
+}
+
+func (b *BrowserTool) IsVisible(selector string) (bool, error) {
+	var visible bool
+	err := runChromedp(b.ctx,
+		chromedp.WaitVisible(selector, chromedp.ByQuery),
+	)
+	visible = (err == nil)
+	return visible, nil
+}
+
+func (b *BrowserTool) WaitForSelector(selector string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(b.ctx, timeout)
+	defer cancel()
+	return runChromedp(ctx,
+		chromedp.WaitVisible(selector, chromedp.ByQuery),
+	)
+}
+
+func (b *BrowserTool) WaitForNavigation(timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(b.ctx, timeout)
+	defer cancel()
+	return runChromedp(ctx,
+		chromedp.WaitReady("body"),
+	)
+}
+
+func (b *BrowserTool) Scroll(x, y float64) error {
+	expr := fmt.Sprintf("window.scrollTo(%v, %v)", x, y)
+	return runChromedp(b.ctx,
+		chromedp.Evaluate(expr, nil),
+	)
+}
+
+func (b *BrowserTool) ScrollToElement(selector string) error {
+	expr := fmt.Sprintf("document.querySelector(%s).scrollIntoView()", jsStringLiteral(selector))
+	return runChromedp(b.ctx,
+		chromedp.Evaluate(expr, nil),
+	)
+}
+
+func (b *BrowserTool) GetPageSource() (string, error) {
+	var source string
+	err := runChromedp(b.ctx,
+		chromedp.InnerHTML("html", &source),
+	)
+	return source, err
+}
+
+func (b *BrowserTool) GetURL() (string, error) {
+	var url string
+	err := runChromedp(b.ctx,
+		chromedp.Location(&url),
+	)
+	return url, err
+}
+
+func (b *BrowserTool) GetTitle() (string, error) {
+	var title string
+	err := runChromedp(b.ctx,
+		chromedp.Title(&title),
+	)
+	return title, err
+}
+
+func (b *BrowserTool) Close() error {
+	return nil
+}
+
+func ResolveSelectorBy(selector string, by string) string {
+	switch strings.ToLower(by) {
+	case "xpath":
+		return selector
+	case "css", "":
+		return selector
+	default:
+		return selector
+	}
+}
+
+type CDPOptions struct {
+	Headless      bool
+	WindowWidth   int
+	WindowHeight  int
+	UserAgent     string
+	Proxy         string
+	Incognito     bool
+	DisableImages bool
+	CacheDisabled bool
+}
+
+func DefaultCDPOptions() *CDPOptions {
+	return &CDPOptions{
+		Headless:     true,
+		WindowWidth:  1920,
+		WindowHeight: 1080,
+	}
+}
+
+type allocatorFlagOverride struct {
+	name  string
+	value any
+}
+
+func (o *CDPOptions) allocatorFlagOverrides() []allocatorFlagOverride {
+	var overrides []allocatorFlagOverride
+
+	if !o.Headless {
+		overrides = append(overrides,
+			allocatorFlagOverride{name: "headless", value: false},
+			allocatorFlagOverride{name: "hide-scrollbars", value: false},
+			allocatorFlagOverride{name: "mute-audio", value: false},
+		)
+	}
+
+	if o.DisableImages {
+		overrides = append(overrides, allocatorFlagOverride{name: "disable-images", value: true})
+	}
+	if o.CacheDisabled {
+		overrides = append(overrides, allocatorFlagOverride{name: "disk-cache-size", value: 0})
+	}
+
+	return overrides
+}
+
+func (o *CDPOptions) AllocatorOptions() []chromedp.ExecAllocatorOption {
+	opts := append([]chromedp.ExecAllocatorOption{}, chromedp.DefaultExecAllocatorOptions[:]...)
+
+	for _, override := range o.allocatorFlagOverrides() {
+		opts = append(opts, chromedp.Flag(override.name, override.value))
+	}
+	if o.WindowWidth > 0 && o.WindowHeight > 0 {
+		opts = append(opts, chromedp.WindowSize(o.WindowWidth, o.WindowHeight))
+	}
+	if o.UserAgent != "" {
+		opts = append(opts, chromedp.UserAgent(o.UserAgent))
+	}
+	if o.Proxy != "" {
+		opts = append(opts, chromedp.ProxyServer(o.Proxy))
+	}
+
+	return opts
+}
+
+func newAllocatorContext(parent context.Context, opts *CDPOptions) (context.Context, cleanupFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	allocCtx, allocCancel := chromedp.NewExecAllocator(parent, opts.AllocatorOptions()...)
+	rootCtx, rootCancel := chromedp.NewContext(allocCtx)
+	return rootCtx, combineCleanup(
+		func() { rootCancel() },
+		func() { allocCancel() },
+	)
+}
+
+func RunInContext(ctx context.Context, opts *CDPOptions, fn func(*BrowserTool) error) error {
+	if opts == nil {
+		opts = DefaultCDPOptions()
+	}
+
+	rootCtx, cancel := newAllocatorContext(ctx, opts)
+	defer cancel()
+
+	tool, err := NewBrowserTool(rootCtx)
+	if err != nil {
+		return err
+	}
+
+	return fn(tool)
+}

--- a/pkg/cdp/client.go
+++ b/pkg/cdp/client.go
@@ -101,11 +101,31 @@ func (b *BrowserTool) GetElementHTML(selector string) (string, error) {
 
 func (b *BrowserTool) IsVisible(selector string) (bool, error) {
 	var visible bool
-	err := runChromedp(b.ctx,
-		chromedp.WaitVisible(selector, chromedp.ByQuery),
-	)
-	visible = (err == nil)
+	if err := runChromedp(b.ctx,
+		chromedp.Evaluate(visibleCheckExpression(selector), &visible),
+	); err != nil {
+		return false, err
+	}
 	return visible, nil
+}
+
+func visibleCheckExpression(selector string) string {
+	return fmt.Sprintf(
+		`(() => {
+	const element = document.querySelector(%s);
+	if (!element) {
+		return false;
+	}
+	const style = window.getComputedStyle(element);
+	const rect = element.getBoundingClientRect();
+	return style.display !== "none" &&
+		style.visibility !== "hidden" &&
+		style.opacity !== "0" &&
+		rect.width > 0 &&
+		rect.height > 0;
+})()`,
+		jsStringLiteral(selector),
+	)
 }
 
 func (b *BrowserTool) WaitForSelector(selector string, timeout time.Duration) error {

--- a/pkg/cdp/client_test.go
+++ b/pkg/cdp/client_test.go
@@ -1,0 +1,436 @@
+package cdp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/chromedp"
+)
+
+func stubRun(t *testing.T, fn func(context.Context, ...chromedp.Action) error) {
+	t.Helper()
+	original := runChromedp
+	runChromedp = fn
+	t.Cleanup(func() {
+		runChromedp = original
+	})
+}
+
+func TestAllocatorFlagOverridesHeadlessFalse(t *testing.T) {
+	overrides := (&CDPOptions{Headless: false}).allocatorFlagOverrides()
+	got := map[string]any{}
+	for _, override := range overrides {
+		got[override.name] = override.value
+	}
+
+	want := map[string]any{
+		"headless":        false,
+		"hide-scrollbars": false,
+		"mute-audio":      false,
+	}
+
+	for key, value := range want {
+		if got[key] != value {
+			t.Fatalf("override %q = %v, want %v", key, got[key], value)
+		}
+	}
+}
+
+func TestAllocatorFlagOverridesHeadlessTrue(t *testing.T) {
+	overrides := (&CDPOptions{
+		Headless:      true,
+		DisableImages: true,
+		CacheDisabled: true,
+	}).allocatorFlagOverrides()
+
+	got := map[string]any{}
+	for _, override := range overrides {
+		got[override.name] = override.value
+	}
+
+	if _, exists := got["headless"]; exists {
+		t.Fatal("unexpected headless override when Headless is true")
+	}
+	if got["disable-images"] != true {
+		t.Fatalf("disable-images override = %v, want true", got["disable-images"])
+	}
+	if got["disk-cache-size"] != 0 {
+		t.Fatalf("disk-cache-size override = %v, want 0", got["disk-cache-size"])
+	}
+}
+
+func TestCombineCleanupRunsAllFuncs(t *testing.T) {
+	var calls []string
+	cleanup := combineCleanup(
+		func() { calls = append(calls, "root") },
+		nil,
+		func() { calls = append(calls, "alloc") },
+	)
+
+	cleanup()
+
+	if len(calls) != 2 || calls[0] != "root" || calls[1] != "alloc" {
+		t.Fatalf("cleanup calls = %v, want [root alloc]", calls)
+	}
+}
+
+func TestNewAllocatorContextReturnsCancelableContext(t *testing.T) {
+	parent, parentCancel := context.WithCancel(context.Background())
+	ctx, cleanup := newAllocatorContext(parent, &CDPOptions{Headless: false})
+	if ctx == nil {
+		t.Fatal("expected non-nil context")
+	}
+	if cleanup == nil {
+		t.Fatal("expected non-nil cleanup")
+	}
+
+	cleanup()
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("expected cleanup to cancel returned context")
+	}
+
+	if err := ctx.Err(); err == nil || err != context.Canceled {
+		t.Fatalf("context error = %v, want %v", err, context.Canceled)
+	}
+
+	ctx, cleanup = newAllocatorContext(parent, &CDPOptions{Headless: false})
+	parentCancel()
+	defer cleanup()
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("expected parent cancellation to cancel returned context")
+	}
+}
+
+func TestExtraHTTPHeadersSeparatesUserAgent(t *testing.T) {
+	eb := &EnhancedBrowser{
+		headers: map[string]string{
+			"Authorization": "Bearer test-token",
+			"X-Trace-ID":    "trace-123",
+			"User-Agent":    "from-header",
+		},
+		userAgent: "custom-agent",
+	}
+
+	gotHeaders, gotUserAgent := eb.extraHTTPHeaders()
+	wantHeaders := network.Headers{
+		"Authorization": "Bearer test-token",
+		"X-Trace-ID":    "trace-123",
+	}
+
+	if gotUserAgent != "custom-agent" {
+		t.Fatalf("user agent = %q, want %q", gotUserAgent, "custom-agent")
+	}
+	if len(gotHeaders) != len(wantHeaders) {
+		t.Fatalf("header count = %d, want %d", len(gotHeaders), len(wantHeaders))
+	}
+	for key, value := range wantHeaders {
+		if gotHeaders[key] != value {
+			t.Fatalf("header %q = %v, want %v", key, gotHeaders[key], value)
+		}
+	}
+	if _, exists := gotHeaders["User-Agent"]; exists {
+		t.Fatal("unexpected User-Agent header in extra HTTP headers")
+	}
+}
+
+func TestJSStringLiteralRoundTrip(t *testing.T) {
+	input := "key'with\"quotes\\and\nnewline"
+	encoded := jsStringLiteral(input)
+
+	var decoded string
+	if err := json.Unmarshal([]byte(encoded), &decoded); err != nil {
+		t.Fatalf("encoded literal %q did not decode: %v", encoded, err)
+	}
+	if decoded != input {
+		t.Fatalf("decoded literal = %q, want %q", decoded, input)
+	}
+}
+
+func TestBrowserToolMethodsUseRunner(t *testing.T) {
+	var calls int
+	var lastCtx context.Context
+	var lastActions int
+	stubRun(t, func(ctx context.Context, actions ...chromedp.Action) error {
+		calls++
+		lastCtx = ctx
+		lastActions = len(actions)
+		return nil
+	})
+
+	tool, err := NewBrowserTool(context.Background())
+	if err != nil {
+		t.Fatalf("NewBrowserTool error = %v", err)
+	}
+
+	if err := tool.Navigate("https://example.com"); err != nil {
+		t.Fatalf("Navigate error = %v", err)
+	}
+	if calls == 0 || lastCtx == nil || lastActions != 2 {
+		t.Fatalf("Navigate runner calls=%d ctx=%v actions=%d", calls, lastCtx, lastActions)
+	}
+
+	if _, err := tool.Screenshot(); err != nil {
+		t.Fatalf("Screenshot error = %v", err)
+	}
+	if err := tool.Click("#submit"); err != nil {
+		t.Fatalf("Click error = %v", err)
+	}
+	if err := tool.Type("#name", "anyclaw"); err != nil {
+		t.Fatalf("Type error = %v", err)
+	}
+	if _, err := tool.GetElementText("#title"); err != nil {
+		t.Fatalf("GetElementText error = %v", err)
+	}
+	if _, err := tool.GetElementAttribute("#title", "data-id"); err != nil {
+		t.Fatalf("GetElementAttribute error = %v", err)
+	}
+	if _, err := tool.GetElementHTML("#title"); err != nil {
+		t.Fatalf("GetElementHTML error = %v", err)
+	}
+	if err := tool.Scroll(10, 20); err != nil {
+		t.Fatalf("Scroll error = %v", err)
+	}
+	if err := tool.ScrollToElement(`#weird'"slash\selector`); err != nil {
+		t.Fatalf("ScrollToElement error = %v", err)
+	}
+	if _, err := tool.GetPageSource(); err != nil {
+		t.Fatalf("GetPageSource error = %v", err)
+	}
+	if _, err := tool.GetURL(); err != nil {
+		t.Fatalf("GetURL error = %v", err)
+	}
+	if _, err := tool.GetTitle(); err != nil {
+		t.Fatalf("GetTitle error = %v", err)
+	}
+	if err := tool.Close(); err != nil {
+		t.Fatalf("Close error = %v", err)
+	}
+}
+
+func TestBrowserToolVisibilityAndWaitHelpers(t *testing.T) {
+	tool := &BrowserTool{ctx: context.Background()}
+
+	stubRun(t, func(ctx context.Context, actions ...chromedp.Action) error {
+		return nil
+	})
+	visible, err := tool.IsVisible("#ok")
+	if err != nil || !visible {
+		t.Fatalf("IsVisible success = (%v, %v), want (true, nil)", visible, err)
+	}
+	if err := tool.WaitForSelector("#ok", time.Second); err != nil {
+		t.Fatalf("WaitForSelector error = %v", err)
+	}
+	if err := tool.WaitForNavigation(time.Second); err != nil {
+		t.Fatalf("WaitForNavigation error = %v", err)
+	}
+
+	stubRun(t, func(ctx context.Context, actions ...chromedp.Action) error {
+		return errors.New("boom")
+	})
+	visible, err = tool.IsVisible("#missing")
+	if err != nil || visible {
+		t.Fatalf("IsVisible failure = (%v, %v), want (false, nil)", visible, err)
+	}
+}
+
+func TestSelectorHelpers(t *testing.T) {
+	if got := ResolveSelectorBy("//div", "xpath"); got != "//div" {
+		t.Fatalf("ResolveSelectorBy xpath = %q", got)
+	}
+	if got := ResolveSelectorBy(".card", "css"); got != ".card" {
+		t.Fatalf("ResolveSelectorBy css = %q", got)
+	}
+	if got := ResolveSelectorBy("#id", "unknown"); got != "#id" {
+		t.Fatalf("ResolveSelectorBy default = %q", got)
+	}
+
+	tests := []struct {
+		input string
+		want  string
+		kind  string
+	}{
+		{"//button", "//button", "xpath"},
+		{"#submit", "#submit", "id"},
+		{".primary", ".primary", "class"},
+		{"name=value", `[name="value"]`, "css"},
+		{"button", "button", "css"},
+	}
+
+	for _, tc := range tests {
+		if got := ResolveCDPSelector(tc.input); got != tc.want {
+			t.Fatalf("ResolveCDPSelector(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+		parsedSelector, parsedKind := ParseSelector(tc.want)
+		if parsedSelector != tc.want || parsedKind != tc.kind {
+			t.Fatalf("ParseSelector(%q) = (%q, %q), want (%q, %q)", tc.want, parsedSelector, parsedKind, tc.want, tc.kind)
+		}
+	}
+}
+
+func TestCDPOptionsHelpers(t *testing.T) {
+	opts := DefaultCDPOptions()
+	if !opts.Headless || opts.WindowWidth != 1920 || opts.WindowHeight != 1080 {
+		t.Fatalf("DefaultCDPOptions = %+v", opts)
+	}
+
+	allocOpts := (&CDPOptions{
+		Headless:      false,
+		WindowWidth:   1280,
+		WindowHeight:  720,
+		UserAgent:     "ua",
+		Proxy:         "http://proxy",
+		DisableImages: true,
+		CacheDisabled: true,
+	}).AllocatorOptions()
+
+	if len(allocOpts) == 0 {
+		t.Fatal("expected allocator options")
+	}
+}
+
+func TestRunInContextInvokesCallback(t *testing.T) {
+	called := false
+	if err := RunInContext(context.Background(), &CDPOptions{Headless: false}, func(tool *BrowserTool) error {
+		called = true
+		if tool == nil {
+			t.Fatal("expected tool")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("RunInContext error = %v", err)
+	}
+	if !called {
+		t.Fatal("expected callback to run")
+	}
+}
+
+func TestEnhancedBrowserHelpersAndMethods(t *testing.T) {
+	var calls int
+	var actionCounts []int
+	stubRun(t, func(ctx context.Context, actions ...chromedp.Action) error {
+		calls++
+		actionCounts = append(actionCounts, len(actions))
+		return nil
+	})
+
+	eb, err := NewEnhancedBrowser(&CDPOptions{Headless: false})
+	if err != nil {
+		t.Fatalf("NewEnhancedBrowser error = %v", err)
+	}
+
+	eb.SetHeader("Authorization", "Bearer abc")
+	eb.SetUserAgent("custom-agent")
+	if err := eb.Navigate("https://example.com"); err != nil {
+		t.Fatalf("Navigate error = %v", err)
+	}
+	if err := eb.NavigateWithHeaders("https://example.com"); err != nil {
+		t.Fatalf("NavigateWithHeaders error = %v", err)
+	}
+	if _, err := eb.GetLocalStorage(`k'"\`); err != nil {
+		t.Fatalf("GetLocalStorage error = %v", err)
+	}
+	if err := eb.SetLocalStorage(`k'"\`, `v'"\`); err != nil {
+		t.Fatalf("SetLocalStorage error = %v", err)
+	}
+	if err := eb.RemoveLocalStorage(`k'"\`); err != nil {
+		t.Fatalf("RemoveLocalStorage error = %v", err)
+	}
+	if err := eb.ClearLocalStorage(); err != nil {
+		t.Fatalf("ClearLocalStorage error = %v", err)
+	}
+	if _, err := eb.GetSessionStorage(`k'"\`); err != nil {
+		t.Fatalf("GetSessionStorage error = %v", err)
+	}
+	if err := eb.SetSessionStorage(`k'"\`, `v'"\`); err != nil {
+		t.Fatalf("SetSessionStorage error = %v", err)
+	}
+	if err := eb.ClearSessionStorage(); err != nil {
+		t.Fatalf("ClearSessionStorage error = %v", err)
+	}
+	eb.ClearHeaders()
+	if eb.headers != nil {
+		t.Fatal("expected headers to be cleared")
+	}
+	if err := eb.Close(); err != nil {
+		t.Fatalf("Close error = %v", err)
+	}
+	if calls < 9 {
+		t.Fatalf("expected multiple runner calls, got %d", calls)
+	}
+	if len(actionCounts) < 2 || actionCounts[0] != 2 || actionCounts[1] < 4 {
+		t.Fatalf("unexpected action counts: %v", actionCounts)
+	}
+}
+
+func TestEnhancedBrowserGetAllLocalStorageErrorPaths(t *testing.T) {
+	eb := &EnhancedBrowser{ctx: context.Background()}
+
+	stubRun(t, func(ctx context.Context, actions ...chromedp.Action) error {
+		return errors.New("run failed")
+	})
+	if _, err := eb.GetAllLocalStorage(); err == nil {
+		t.Fatal("expected runner error")
+	}
+
+	stubRun(t, func(ctx context.Context, actions ...chromedp.Action) error {
+		return nil
+	})
+	if _, err := eb.GetAllLocalStorage(); err == nil {
+		t.Fatal("expected json decode error")
+	}
+}
+
+func TestElementFinderAndFormHandlerMethods(t *testing.T) {
+	var calls int
+	stubRun(t, func(ctx context.Context, actions ...chromedp.Action) error {
+		calls++
+		return nil
+	})
+
+	finder := NewElementFinder(context.Background())
+	if finder == nil {
+		t.Fatal("expected finder")
+	}
+	if _, err := finder.FindByText(`quote'"\text`); err != nil {
+		t.Fatalf("FindByText error = %v", err)
+	}
+	if got, err := finder.FindByAttribute("data-id", "42"); err != nil || got != `[data-id="42"]` {
+		t.Fatalf("FindByAttribute = (%q, %v)", got, err)
+	}
+	if _, err := finder.FindByXPath(`//div[@data-x='"quoted"']`); err == nil {
+		t.Fatal("expected FindByXPath to report not found without a real DOM result")
+	}
+	if _, err := finder.Count(`div[data-id="42"]`); err != nil {
+		t.Fatalf("Count error = %v", err)
+	}
+
+	form := NewFormHandler(context.Background())
+	if form == nil {
+		t.Fatal("expected form handler")
+	}
+	if err := form.Fill("#profile", map[string]string{"name": "AnyClaw", "title": "Builder"}); err != nil {
+		t.Fatalf("Fill error = %v", err)
+	}
+	if err := form.Submit("#profile"); err != nil {
+		t.Fatalf("Submit error = %v", err)
+	}
+	if err := form.Reset("#profile"); err != nil {
+		t.Fatalf("Reset error = %v", err)
+	}
+	if _, err := form.GetValues("#profile", []string{"name", "title"}); err != nil {
+		t.Fatalf("GetValues error = %v", err)
+	}
+	if calls < 8 {
+		t.Fatalf("expected runner calls, got %d", calls)
+	}
+}

--- a/pkg/cdp/client_test.go
+++ b/pkg/cdp/client_test.go
@@ -142,6 +142,15 @@ func TestExtraHTTPHeadersSeparatesUserAgent(t *testing.T) {
 	if _, exists := gotHeaders["User-Agent"]; exists {
 		t.Fatal("unexpected User-Agent header in extra HTTP headers")
 	}
+
+	eb.ClearHeaders()
+	gotHeaders, gotUserAgent = eb.extraHTTPHeaders()
+	if gotHeaders != nil {
+		t.Fatalf("headers after ClearHeaders = %v, want nil", gotHeaders)
+	}
+	if gotUserAgent != "" {
+		t.Fatalf("user agent after ClearHeaders = %q, want empty", gotUserAgent)
+	}
 }
 
 func TestJSStringLiteralRoundTrip(t *testing.T) {
@@ -374,6 +383,9 @@ func TestEnhancedBrowserHelpersAndMethods(t *testing.T) {
 	eb.ClearHeaders()
 	if eb.headers != nil {
 		t.Fatal("expected headers to be cleared")
+	}
+	if eb.userAgent != "" {
+		t.Fatal("expected user agent to be cleared")
 	}
 	if err := eb.Close(); err != nil {
 		t.Fatalf("Close error = %v", err)

--- a/pkg/cdp/client_test.go
+++ b/pkg/cdp/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -224,8 +225,11 @@ func TestBrowserToolVisibilityAndWaitHelpers(t *testing.T) {
 		return nil
 	})
 	visible, err := tool.IsVisible("#ok")
-	if err != nil || !visible {
-		t.Fatalf("IsVisible success = (%v, %v), want (true, nil)", visible, err)
+	if err != nil {
+		t.Fatalf("IsVisible error = %v", err)
+	}
+	if visible {
+		t.Fatal("stubbed runner should not mutate visibility result")
 	}
 	if err := tool.WaitForSelector("#ok", time.Second); err != nil {
 		t.Fatalf("WaitForSelector error = %v", err)
@@ -234,12 +238,22 @@ func TestBrowserToolVisibilityAndWaitHelpers(t *testing.T) {
 		t.Fatalf("WaitForNavigation error = %v", err)
 	}
 
+	runnerErr := errors.New("boom")
 	stubRun(t, func(ctx context.Context, actions ...chromedp.Action) error {
-		return errors.New("boom")
+		return runnerErr
 	})
 	visible, err = tool.IsVisible("#missing")
-	if err != nil || visible {
-		t.Fatalf("IsVisible failure = (%v, %v), want (false, nil)", visible, err)
+	if !errors.Is(err, runnerErr) || visible {
+		t.Fatalf("IsVisible failure = (%v, %v), want (false, %v)", visible, err, runnerErr)
+	}
+}
+
+func TestVisibleCheckExpressionEscapesSelector(t *testing.T) {
+	selector := `#id'"\with-newline
+`
+	expr := visibleCheckExpression(selector)
+	if !strings.Contains(expr, "document.querySelector("+jsStringLiteral(selector)+")") {
+		t.Fatalf("visible expression did not include escaped selector: %s", expr)
 	}
 }
 

--- a/pkg/cdp/client_test.go
+++ b/pkg/cdp/client_test.go
@@ -460,3 +460,34 @@ func TestElementFinderAndFormHandlerMethods(t *testing.T) {
 		t.Fatalf("expected runner calls, got %d", calls)
 	}
 }
+
+func TestFormFieldSelectorEscapesFieldName(t *testing.T) {
+	field := "user'name\\id\"line\n"
+	got := formFieldSelector("#profile", field)
+	want := "#profile [name=\"user'name\\\\id\\\"line\\a \"]"
+	if got != want {
+		t.Fatalf("form field selector = %q, want %q", got, want)
+	}
+}
+
+func TestCSSStringLiteralEscapesSpecialCharacters(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "simple", value: "field", want: `"field"`},
+		{name: "quote and slash", value: `quote"slash\`, want: `"quote\"slash\\"`},
+		{name: "nul", value: string([]byte{0}), want: `"\fffd "`},
+		{name: "line separators", value: "a\r\f", want: `"a\d \c "`},
+		{name: "control chars", value: string([]rune{'x', 0x1f, 0x7f}), want: `"x\1f \7f "`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cssStringLiteral(tc.value); got != tc.want {
+				t.Fatalf("cssStringLiteral(%q) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/cdp/enhanced.go
+++ b/pkg/cdp/enhanced.go
@@ -1,0 +1,314 @@
+package cdp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/chromedp/cdproto/emulation"
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/chromedp"
+)
+
+type EnhancedBrowser struct {
+	ctx     context.Context
+	cleanup cleanupFunc
+
+	headers   map[string]string
+	userAgent string
+}
+
+func NewEnhancedBrowser(opts *CDPOptions) (*EnhancedBrowser, error) {
+	if opts == nil {
+		opts = DefaultCDPOptions()
+	}
+
+	rootCtx, cleanup := newAllocatorContext(context.Background(), opts)
+
+	eb := &EnhancedBrowser{
+		ctx:     rootCtx,
+		cleanup: cleanup,
+	}
+
+	return eb, nil
+}
+
+func (eb *EnhancedBrowser) Navigate(url string) error {
+	return runChromedp(eb.ctx,
+		chromedp.Navigate(url),
+		chromedp.WaitReady("body"),
+	)
+}
+
+func (eb *EnhancedBrowser) NavigateWithHeaders(url string) error {
+	actions := []chromedp.Action{
+		network.Enable(),
+	}
+
+	headers, userAgent := eb.extraHTTPHeaders()
+	if len(headers) > 0 {
+		actions = append(actions, network.SetExtraHTTPHeaders(headers))
+	}
+	if userAgent != "" {
+		actions = append(actions, emulation.SetUserAgentOverride(userAgent))
+	}
+
+	actions = append(actions,
+		chromedp.Navigate(url),
+		chromedp.WaitReady("body"),
+	)
+
+	return runChromedp(eb.ctx, actions...)
+}
+
+func (eb *EnhancedBrowser) SetHeader(key, value string) {
+	if eb.headers == nil {
+		eb.headers = make(map[string]string)
+	}
+	eb.headers[key] = value
+}
+
+func (eb *EnhancedBrowser) SetUserAgent(ua string) {
+	eb.userAgent = ua
+	eb.SetHeader("User-Agent", ua)
+}
+
+func (eb *EnhancedBrowser) ClearHeaders() {
+	eb.headers = nil
+}
+
+func (eb *EnhancedBrowser) extraHTTPHeaders() (network.Headers, string) {
+	if len(eb.headers) == 0 {
+		return nil, eb.userAgent
+	}
+
+	headers := make(network.Headers, len(eb.headers))
+	for key, value := range eb.headers {
+		if strings.EqualFold(key, "User-Agent") {
+			continue
+		}
+		headers[key] = value
+	}
+
+	return headers, eb.userAgent
+}
+
+func (eb *EnhancedBrowser) GetLocalStorage(key string) (string, error) {
+	var result string
+	err := runChromedp(eb.ctx,
+		chromedp.Evaluate(fmt.Sprintf("localStorage.getItem(%s)", jsStringLiteral(key)), &result),
+	)
+	return result, err
+}
+
+func (eb *EnhancedBrowser) SetLocalStorage(key, value string) error {
+	return runChromedp(eb.ctx,
+		chromedp.Evaluate(
+			fmt.Sprintf("localStorage.setItem(%s, %s)", jsStringLiteral(key), jsStringLiteral(value)),
+			nil,
+		),
+	)
+}
+
+func (eb *EnhancedBrowser) RemoveLocalStorage(key string) error {
+	return runChromedp(eb.ctx,
+		chromedp.Evaluate(fmt.Sprintf("localStorage.removeItem(%s)", jsStringLiteral(key)), nil),
+	)
+}
+
+func (eb *EnhancedBrowser) ClearLocalStorage() error {
+	return runChromedp(eb.ctx,
+		chromedp.Evaluate("localStorage.clear()", nil),
+	)
+}
+
+func (eb *EnhancedBrowser) GetAllLocalStorage() (map[string]string, error) {
+	var result string
+	err := runChromedp(eb.ctx,
+		chromedp.Evaluate("JSON.stringify(localStorage)", &result),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var storage map[string]string
+	if err := json.Unmarshal([]byte(result), &storage); err != nil {
+		return nil, err
+	}
+	return storage, nil
+}
+
+func (eb *EnhancedBrowser) GetSessionStorage(key string) (string, error) {
+	var result string
+	err := runChromedp(eb.ctx,
+		chromedp.Evaluate(fmt.Sprintf("sessionStorage.getItem(%s)", jsStringLiteral(key)), &result),
+	)
+	return result, err
+}
+
+func (eb *EnhancedBrowser) SetSessionStorage(key, value string) error {
+	return runChromedp(eb.ctx,
+		chromedp.Evaluate(
+			fmt.Sprintf("sessionStorage.setItem(%s, %s)", jsStringLiteral(key), jsStringLiteral(value)),
+			nil,
+		),
+	)
+}
+
+func (eb *EnhancedBrowser) ClearSessionStorage() error {
+	return runChromedp(eb.ctx,
+		chromedp.Evaluate("sessionStorage.clear()", nil),
+	)
+}
+
+func (eb *EnhancedBrowser) Close() error {
+	if eb.cleanup != nil {
+		eb.cleanup()
+	}
+	return nil
+}
+
+type ElementFinder struct {
+	ctx context.Context
+}
+
+func NewElementFinder(ctx context.Context) *ElementFinder {
+	return &ElementFinder{ctx: ctx}
+}
+
+func (ef *ElementFinder) FindByText(text string) (string, error) {
+	var selector string
+	err := runChromedp(ef.ctx,
+		chromedp.Evaluate(
+			fmt.Sprintf(
+				`Array.from(document.querySelectorAll("*")).find(el => el.textContent.includes(%s))?.tagName`,
+				jsStringLiteral(text),
+			),
+			&selector,
+		),
+	)
+	return selector, err
+}
+
+func (ef *ElementFinder) FindByAttribute(attr, value string) (string, error) {
+	return fmt.Sprintf("[%s=\"%s\"]", attr, value), nil
+}
+
+func (ef *ElementFinder) FindByXPath(xpath string) (string, error) {
+	var result bool
+	err := runChromedp(ef.ctx,
+		chromedp.Evaluate(
+			fmt.Sprintf(
+				`document.evaluate(%s, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue !== null`,
+				jsStringLiteral(xpath),
+			),
+			&result,
+		),
+	)
+	if err != nil || !result {
+		return "", fmt.Errorf("xpath not found")
+	}
+	return xpath, nil
+}
+
+func (ef *ElementFinder) Count(selector string) (int, error) {
+	var count int
+	err := runChromedp(ef.ctx,
+		chromedp.Evaluate(
+			fmt.Sprintf(`document.querySelectorAll(%s).length`, jsStringLiteral(selector)),
+			&count,
+		),
+	)
+	return count, err
+}
+
+type FormHandler struct {
+	ctx context.Context
+}
+
+func NewFormHandler(ctx context.Context) *FormHandler {
+	return &FormHandler{ctx: ctx}
+}
+
+func (fh *FormHandler) Fill(selector string, values map[string]string) error {
+	for field, value := range values {
+		fieldSelector := fmt.Sprintf("%s [name='%s']", selector, field)
+		if err := runChromedp(fh.ctx,
+			chromedp.SetValue(fieldSelector, value, chromedp.ByQuery),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (fh *FormHandler) Submit(selector string) error {
+	return runChromedp(fh.ctx,
+		chromedp.Submit(selector, chromedp.ByQuery),
+	)
+}
+
+func (fh *FormHandler) Reset(selector string) error {
+	return runChromedp(fh.ctx,
+		chromedp.Reset(selector, chromedp.ByQuery),
+	)
+}
+
+func (fh *FormHandler) GetValues(selector string, fields []string) (map[string]string, error) {
+	result := make(map[string]string)
+
+	for _, field := range fields {
+		fieldSelector := fmt.Sprintf("%s [name='%s']", selector, field)
+		var value string
+		if err := runChromedp(fh.ctx,
+			chromedp.Value(fieldSelector, &value, chromedp.ByQuery),
+		); err != nil {
+			return nil, err
+		}
+		result[field] = value
+	}
+
+	return result, nil
+}
+
+func ResolveCDPSelector(selector string) string {
+	selector = strings.TrimSpace(selector)
+
+	if strings.HasPrefix(selector, "//") {
+		return selector
+	}
+
+	if strings.HasPrefix(selector, "#") {
+		return selector
+	}
+
+	if strings.HasPrefix(selector, ".") {
+		return selector
+	}
+
+	if strings.Contains(selector, "=") {
+		parts := strings.SplitN(selector, "=", 2)
+		return fmt.Sprintf("[%s=\"%s\"]", parts[0], parts[1])
+	}
+
+	return selector
+}
+
+func ParseSelector(selector string) (string, string) {
+	selector = strings.TrimSpace(selector)
+
+	if strings.HasPrefix(selector, "//") {
+		return selector, "xpath"
+	}
+
+	if strings.HasPrefix(selector, "#") {
+		return selector, "id"
+	}
+
+	if strings.HasPrefix(selector, ".") {
+		return selector, "class"
+	}
+
+	return selector, "css"
+}

--- a/pkg/cdp/enhanced.go
+++ b/pkg/cdp/enhanced.go
@@ -234,7 +234,7 @@ func NewFormHandler(ctx context.Context) *FormHandler {
 
 func (fh *FormHandler) Fill(selector string, values map[string]string) error {
 	for field, value := range values {
-		fieldSelector := fmt.Sprintf("%s [name='%s']", selector, field)
+		fieldSelector := formFieldSelector(selector, field)
 		if err := runChromedp(fh.ctx,
 			chromedp.SetValue(fieldSelector, value, chromedp.ByQuery),
 		); err != nil {
@@ -260,7 +260,7 @@ func (fh *FormHandler) GetValues(selector string, fields []string) (map[string]s
 	result := make(map[string]string)
 
 	for _, field := range fields {
-		fieldSelector := fmt.Sprintf("%s [name='%s']", selector, field)
+		fieldSelector := formFieldSelector(selector, field)
 		var value string
 		if err := runChromedp(fh.ctx,
 			chromedp.Value(fieldSelector, &value, chromedp.ByQuery),
@@ -271,6 +271,39 @@ func (fh *FormHandler) GetValues(selector string, fields []string) (map[string]s
 	}
 
 	return result, nil
+}
+
+func formFieldSelector(formSelector, fieldName string) string {
+	return fmt.Sprintf("%s [name=%s]", formSelector, cssStringLiteral(fieldName))
+}
+
+func cssStringLiteral(value string) string {
+	var sb strings.Builder
+	sb.WriteByte('"')
+	for _, r := range value {
+		switch r {
+		case 0:
+			sb.WriteString(`\fffd `)
+		case '\\':
+			sb.WriteString(`\\`)
+		case '"':
+			sb.WriteString(`\"`)
+		case '\n':
+			sb.WriteString(`\a `)
+		case '\r':
+			sb.WriteString(`\d `)
+		case '\f':
+			sb.WriteString(`\c `)
+		default:
+			if r < 0x20 || r == 0x7f {
+				sb.WriteString(fmt.Sprintf(`\%x `, r))
+				continue
+			}
+			sb.WriteRune(r)
+		}
+	}
+	sb.WriteByte('"')
+	return sb.String()
 }
 
 func ResolveCDPSelector(selector string) string {

--- a/pkg/cdp/enhanced.go
+++ b/pkg/cdp/enhanced.go
@@ -76,6 +76,7 @@ func (eb *EnhancedBrowser) SetUserAgent(ua string) {
 
 func (eb *EnhancedBrowser) ClearHeaders() {
 	eb.headers = nil
+	eb.userAgent = ""
 }
 
 func (eb *EnhancedBrowser) extraHTTPHeaders() (network.Headers, string) {


### PR DESCRIPTION
## 概要

新增 CDP 浏览器自动化基础能力，提供页面导航、截图、元素操作、存储访问、表单处理和 enhanced browser helper，为后续浏览器工具集成提供基础模块。

## 本次变更

- 新增 `pkg/cdp/client.go`
  - 提供 `BrowserTool` 基础浏览器操作
  - 支持导航、截图、点击、输入、读取文本/属性/HTML、等待、滚动和页面信息读取
  - 提供 CDP allocator options 和 `RunInContext` helper
- 新增 `pkg/cdp/enhanced.go`
  - 提供 enhanced browser helper
  - 支持自定义请求 headers / user agent
  - 支持 localStorage / sessionStorage helper
  - 支持元素查找、表单填写、提交和重置
- 新增 `pkg/cdp/client_test.go`
  - 覆盖 allocator options、cleanup、headers、JS 字符串转义、browser helper、selector helper、storage helper 和 form helper

## 安全与稳定性

- `Headless: false` 会显式覆盖 chromedp 默认 headless flag
- allocator 和 browser context 会一起清理，避免 Chrome 进程泄漏
- `RunInContext` 会继承调用方 `context.Context`
- JS 表达式中的动态字符串使用 JSON string literal 转义，避免引号和反斜杠破坏脚本

## 验证

已执行：

- `go test ./pkg/cdp`
- `go test ./pkg/cdp -cover`
