### PR TITLE
feat(extensions): add CLI adapter core

### DIFF
--- a/pkg/extensions/adapters/cli/cliadapter.go
+++ b/pkg/extensions/adapters/cli/cliadapter.go
@@ -146,25 +146,32 @@ func registerBuiltinHandler(name, desc, category string, handler ce.CommandHandl
 }
 
 func DiscoverRoot(start string) (string, bool) {
-	candidates := []string{
-		start,
-		filepath.Join(start, "CLI-Anything-0.2.0"),
-		filepath.Join(start, "CLI-Anything"),
-		"..",
-		"../..",
-		"../../..",
+	current, err := filepath.Abs(start)
+	if err != nil {
+		return "", false
 	}
 
-	for _, candidate := range candidates {
-		abs, err := filepath.Abs(candidate)
-		if err != nil {
-			continue
+	for {
+		for _, candidate := range cliRootCandidates(current) {
+			if _, err := os.Stat(filepath.Join(candidate, "registry.json")); err == nil {
+				return candidate, true
+			}
 		}
 
-		if _, err := os.Stat(filepath.Join(abs, "registry.json")); err == nil {
-			return abs, true
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
 		}
+		current = parent
 	}
 
 	return "", false
+}
+
+func cliRootCandidates(base string) []string {
+	return []string{
+		base,
+		filepath.Join(base, "CLI-Anything-0.2.0"),
+		filepath.Join(base, "CLI-Anything"),
+	}
 }

--- a/pkg/extensions/adapters/cli/cliadapter.go
+++ b/pkg/extensions/adapters/cli/cliadapter.go
@@ -1,0 +1,170 @@
+package cliadapter
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ce "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/exec"
+	cr "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/registry"
+)
+
+var defaultRegistry *cr.Registry
+var defaultExecutor *ce.Executor
+
+func Init(root string) error {
+	reg, err := cr.NewRegistry(root)
+	if err != nil {
+		return err
+	}
+
+	defaultRegistry = reg
+	defaultExecutor = ce.NewExecutor(reg)
+
+	registerBuiltInHandlers()
+
+	return nil
+}
+
+func InitFromEnv() error {
+	roots := []string{
+		os.Getenv("ANYCLAW_CLIADAPTER_ROOT"),
+		"CLI-Anything-0.2.0",
+		"../CLI-Anything-0.2.0",
+		"../../CLI-Anything-0.2.0",
+	}
+
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+
+		absRoot, err := filepath.Abs(root)
+		if err != nil {
+			continue
+		}
+
+		if _, err := os.Stat(filepath.Join(absRoot, "registry.json")); err == nil {
+			return Init(absRoot)
+		}
+	}
+
+	return nil
+}
+
+func GetRegistry() *cr.Registry {
+	return defaultRegistry
+}
+
+func GetExecutor() *ce.Executor {
+	return defaultExecutor
+}
+
+type SearchResult struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Category    string `json:"category"`
+	Description string `json:"description"`
+	Installed   bool   `json:"installed"`
+}
+
+func Search(query, category string, limit int) ([]SearchResult, error) {
+	if defaultExecutor == nil {
+		return nil, nil
+	}
+
+	entries := defaultExecutor.Search(query, category, limit)
+	results := make([]SearchResult, 0, len(entries))
+
+	for _, e := range entries {
+		results = append(results, SearchResult{
+			Name:        e.Name,
+			DisplayName: e.DisplayName,
+			Category:    e.Category,
+			Description: e.Description,
+			Installed:   e.Installed,
+		})
+
+		if limit > 0 && len(results) >= limit {
+			break
+		}
+	}
+
+	return results, nil
+}
+
+func Exec(ctx context.Context, name string, args []string) (string, error) {
+	if defaultExecutor == nil {
+		return "", nil
+	}
+
+	result := defaultExecutor.Exec(ctx, name, args)
+	if result.Error != "" {
+		return result.Output, errors.New(result.Error)
+	}
+	return result.Output, nil
+}
+
+func ListCategories() map[string]int {
+	if defaultExecutor == nil {
+		return nil
+	}
+	return defaultExecutor.Categories()
+}
+
+func registerBuiltInHandlers() {
+	if defaultExecutor == nil {
+		return
+	}
+
+	registerBuiltinHandler("echo", "Echo CLI adapter arguments", "utility", func(ctx context.Context, args []string) (string, error) {
+		return strings.Join(args, " "), nil
+	})
+
+	registerBuiltinHandler("date", "Return the current adapter date", "utility", func(ctx context.Context, args []string) (string, error) {
+		return "2026-04-03", nil
+	})
+
+	registerBuiltinHandler("pwd", "Return the current working directory", "utility", func(ctx context.Context, args []string) (string, error) {
+		dir, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return dir, nil
+	})
+
+	// Concrete CLI adapter handlers are registered by follow-up adapter packages.
+}
+
+func registerBuiltinHandler(name, desc, category string, handler ce.CommandHandler) {
+	defaultExecutor.RegisterHandler(name, handler)
+	cr.RegisterBuiltinAdapter(name, desc, category, func(args []string) (string, error) {
+		return handler(context.Background(), args)
+	})
+}
+
+func DiscoverRoot(start string) (string, bool) {
+	candidates := []string{
+		start,
+		filepath.Join(start, "CLI-Anything-0.2.0"),
+		filepath.Join(start, "CLI-Anything"),
+		"..",
+		"../..",
+		"../../..",
+	}
+
+	for _, candidate := range candidates {
+		abs, err := filepath.Abs(candidate)
+		if err != nil {
+			continue
+		}
+
+		if _, err := os.Stat(filepath.Join(abs, "registry.json")); err == nil {
+			return abs, true
+		}
+	}
+
+	return "", false
+}

--- a/pkg/extensions/adapters/cli/cliadapter.go
+++ b/pkg/extensions/adapters/cli/cliadapter.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	ce "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/exec"
 	cr "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/registry"
@@ -124,7 +125,7 @@ func registerBuiltInHandlers() {
 	})
 
 	registerBuiltinHandler("date", "Return the current adapter date", "utility", func(ctx context.Context, args []string) (string, error) {
-		return "2026-04-03", nil
+		return time.Now().UTC().Format(time.DateOnly), nil
 	})
 
 	registerBuiltinHandler("pwd", "Return the current working directory", "utility", func(ctx context.Context, args []string) (string, error) {

--- a/pkg/extensions/adapters/cli/cliadapter_test.go
+++ b/pkg/extensions/adapters/cli/cliadapter_test.go
@@ -1,0 +1,158 @@
+package cliadapter
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInitRegistersBuiltinHandlers(t *testing.T) {
+	restoreDefaults := saveDefaults()
+	t.Cleanup(restoreDefaults)
+
+	root := writeCLIRegistry(t, `{"clis":[]}`)
+	if err := Init(root); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if GetRegistry() == nil {
+		t.Fatal("expected default registry")
+	}
+	if GetExecutor() == nil {
+		t.Fatal("expected default executor")
+	}
+
+	output, err := Exec(context.Background(), "echo", []string{"hello", "cli"})
+	if err != nil {
+		t.Fatalf("Exec echo: %v", err)
+	}
+	if output != "hello cli" {
+		t.Fatalf("echo output = %q, want hello cli", output)
+	}
+}
+
+func TestSearchAndListCategoriesAfterInit(t *testing.T) {
+	restoreDefaults := saveDefaults()
+	t.Cleanup(restoreDefaults)
+
+	root := writeCLIRegistry(t, `{"clis":[
+		{"name":"git","display_name":"Git","description":"Version control","category":"dev"}
+	]}`)
+	if err := Init(root); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	results, err := Search("git", "dev", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 || results[0].Name != "git" {
+		t.Fatalf("Search results = %+v, want git", results)
+	}
+
+	categories := ListCategories()
+	if categories["dev"] != 1 {
+		t.Fatalf("categories = %+v, want dev count 1", categories)
+	}
+}
+
+func TestInitFromEnvFindsRegistryRoot(t *testing.T) {
+	restoreDefaults := saveDefaults()
+	t.Cleanup(restoreDefaults)
+
+	root := writeCLIRegistry(t, `{"clis":[]}`)
+	t.Setenv("ANYCLAW_CLIADAPTER_ROOT", root)
+
+	if err := InitFromEnv(); err != nil {
+		t.Fatalf("InitFromEnv: %v", err)
+	}
+	if GetRegistry() == nil || GetRegistry().Root() != root {
+		t.Fatalf("registry root = %v, want %q", GetRegistry(), root)
+	}
+}
+
+func TestInitFromEnvWithoutRegistryIsNoop(t *testing.T) {
+	restoreDefaults := saveDefaults()
+	t.Cleanup(restoreDefaults)
+	defaultRegistry = nil
+	defaultExecutor = nil
+	t.Chdir(t.TempDir())
+	t.Setenv("ANYCLAW_CLIADAPTER_ROOT", "")
+
+	if err := InitFromEnv(); err != nil {
+		t.Fatalf("InitFromEnv: %v", err)
+	}
+	if GetRegistry() != nil || GetExecutor() != nil {
+		t.Fatal("expected defaults to remain nil")
+	}
+}
+
+func TestInitReturnsRegistryError(t *testing.T) {
+	restoreDefaults := saveDefaults()
+	t.Cleanup(restoreDefaults)
+
+	if err := Init(t.TempDir()); err == nil {
+		t.Fatal("expected missing registry error")
+	}
+}
+
+func TestDiscoverRoot(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "CLI-Anything")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "registry.json"), []byte(`{"clis":[]}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	found, ok := DiscoverRoot(root)
+	if !ok || found != nested {
+		t.Fatalf("DiscoverRoot = (%q, %v), want (%q, true)", found, ok, nested)
+	}
+}
+
+func TestDiscoverRootMissing(t *testing.T) {
+	if found, ok := DiscoverRoot(t.TempDir()); ok || found != "" {
+		t.Fatalf("DiscoverRoot missing = (%q, %v), want empty false", found, ok)
+	}
+}
+
+func TestUninitializedHelpersAreSafe(t *testing.T) {
+	restoreDefaults := saveDefaults()
+	t.Cleanup(restoreDefaults)
+	defaultRegistry = nil
+	defaultExecutor = nil
+
+	if GetRegistry() != nil || GetExecutor() != nil {
+		t.Fatal("expected nil defaults")
+	}
+	if results, err := Search("", "", 10); err != nil || results != nil {
+		t.Fatalf("Search without init = (%v, %v), want nil, nil", results, err)
+	}
+	if output, err := Exec(context.Background(), "echo", nil); err != nil || output != "" {
+		t.Fatalf("Exec without init = (%q, %v), want empty, nil", output, err)
+	}
+	if categories := ListCategories(); categories != nil {
+		t.Fatalf("ListCategories without init = %v, want nil", categories)
+	}
+}
+
+func writeCLIRegistry(t *testing.T, content string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "registry.json"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return root
+}
+
+func saveDefaults() func() {
+	previousRegistry := defaultRegistry
+	previousExecutor := defaultExecutor
+	return func() {
+		defaultRegistry = previousRegistry
+		defaultExecutor = previousExecutor
+	}
+}

--- a/pkg/extensions/adapters/cli/cliadapter_test.go
+++ b/pkg/extensions/adapters/cli/cliadapter_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestInitRegistersBuiltinHandlers(t *testing.T) {
@@ -29,6 +30,14 @@ func TestInitRegistersBuiltinHandlers(t *testing.T) {
 	}
 	if output != "hello cli" {
 		t.Fatalf("echo output = %q, want hello cli", output)
+	}
+
+	output, err = Exec(context.Background(), "date", nil)
+	if err != nil {
+		t.Fatalf("Exec date: %v", err)
+	}
+	if output != time.Now().UTC().Format(time.DateOnly) {
+		t.Fatalf("date output = %q, want current UTC date", output)
 	}
 }
 

--- a/pkg/extensions/adapters/cli/cliadapter_test.go
+++ b/pkg/extensions/adapters/cli/cliadapter_test.go
@@ -113,6 +113,55 @@ func TestDiscoverRoot(t *testing.T) {
 	}
 }
 
+func TestDiscoverRootWalksAncestorsFromNestedStart(t *testing.T) {
+	root := t.TempDir()
+	cliRoot := filepath.Join(root, "CLI-Anything-0.2.0")
+	start := filepath.Join(root, "workspace", "project", "nested")
+	if err := os.MkdirAll(cliRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll cli root: %v", err)
+	}
+	if err := os.MkdirAll(start, 0o755); err != nil {
+		t.Fatalf("MkdirAll start: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cliRoot, "registry.json"), []byte(`{"clis":[]}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	t.Chdir(t.TempDir())
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWD); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+
+	found, ok := DiscoverRoot(start)
+	if !ok || found != cliRoot {
+		t.Fatalf("DiscoverRoot nested = (%q, %v), want (%q, true)", found, ok, cliRoot)
+	}
+}
+
+func TestCLIRootCandidates(t *testing.T) {
+	base := filepath.Clean("/tmp/project")
+	got := cliRootCandidates(base)
+	want := []string{
+		base,
+		filepath.Join(base, "CLI-Anything-0.2.0"),
+		filepath.Join(base, "CLI-Anything"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("candidate count = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidate %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestDiscoverRootMissing(t *testing.T) {
 	if found, ok := DiscoverRoot(t.TempDir()); ok || found != "" {
 		t.Fatalf("DiscoverRoot missing = (%q, %v), want empty false", found, ok)

--- a/pkg/extensions/adapters/cli/exec/exec.go
+++ b/pkg/extensions/adapters/cli/exec/exec.go
@@ -1,0 +1,159 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	cr "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/registry"
+)
+
+type Executor struct {
+	mu       sync.RWMutex
+	reg      *cr.Registry
+	handlers map[string]CommandHandler
+}
+
+type CommandHandler func(ctx context.Context, args []string) (string, error)
+
+type ExecResult struct {
+	Name      string   `json:"name"`
+	Args      []string `json:"args"`
+	Output    string   `json:"output"`
+	Error     string   `json:"error,omitempty"`
+	ExitCode  int      `json:"exit_code"`
+	Installed bool     `json:"installed"`
+}
+
+func NewExecutor(reg *cr.Registry) *Executor {
+	return &Executor{
+		reg:      reg,
+		handlers: make(map[string]CommandHandler),
+	}
+}
+
+func (e *Executor) RegisterHandler(name string, handler CommandHandler) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.handlers[name] = handler
+}
+
+func (e *Executor) Exec(ctx context.Context, name string, args []string) *ExecResult {
+	result := &ExecResult{
+		Name: name,
+		Args: append([]string(nil), args...),
+	}
+
+	entry, ok := e.reg.Find(name)
+	if !ok {
+		result.Error = fmt.Sprintf("CLI not found: %s", name)
+		return result
+	}
+
+	e.mu.RLock()
+	if handler, exists := e.handlers[name]; exists {
+		e.mu.RUnlock()
+		output, err := handler(ctx, args)
+		result.Output = output
+		if err != nil {
+			result.Error = err.Error()
+			result.ExitCode = 1
+		} else {
+			result.ExitCode = 0
+		}
+		result.Installed = true
+		return result
+	}
+	e.mu.RUnlock()
+
+	if entry.Installed && entry.ExecutablePath != "" {
+		return e.execBinary(ctx, entry.ExecutablePath, args, result)
+	}
+
+	result.Error = fmt.Sprintf("CLI not installed: %s (install with: %s)", name, entry.InstallCmd)
+	result.Installed = false
+	return result
+}
+
+func (e *Executor) execBinary(ctx context.Context, path string, args []string, result *ExecResult) *ExecResult {
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	output, err := cmd.CombinedOutput()
+	result.Output = string(output)
+	result.Installed = true
+
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			result.ExitCode = exitErr.ExitCode()
+		} else {
+			result.ExitCode = 1
+		}
+		result.Error = err.Error()
+	} else {
+		result.ExitCode = 0
+	}
+
+	return result
+}
+
+func (e *Executor) AutoInstall(ctx context.Context, name string) *ExecResult {
+	result := &ExecResult{Name: name}
+
+	entry, ok := e.reg.Get(name)
+	if !ok {
+		result.Error = "CLI not found in registry"
+		result.ExitCode = 1
+		return result
+	}
+
+	if entry.InstallCmd == "" {
+		result.Error = "No install command available"
+		result.ExitCode = 1
+		return result
+	}
+
+	parts := strings.Fields(entry.InstallCmd)
+	if len(parts) < 2 {
+		result.Error = "Invalid install command"
+		result.ExitCode = 1
+		return result
+	}
+
+	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		result.Error = fmt.Sprintf("Install failed: %v", err)
+		result.ExitCode = 1
+		return result
+	}
+
+	result.Output = "Installation completed"
+	result.ExitCode = 0
+	result.Installed = true
+	e.reg.MarkInstalled(name, entry.EntryPoint)
+
+	return result
+}
+
+func (e *Executor) List() []*cr.EntryStatus {
+	return e.reg.List()
+}
+
+func (e *Executor) Search(query, category string, limit int) []*cr.EntryStatus {
+	return e.reg.Search(query, category, limit)
+}
+
+func (e *Executor) Categories() map[string]int {
+	return e.reg.Categories()
+}
+
+func (e *Executor) JSON() (string, error) {
+	return e.reg.JSON()
+}

--- a/pkg/extensions/adapters/cli/exec/exec.go
+++ b/pkg/extensions/adapters/cli/exec/exec.go
@@ -12,12 +12,18 @@ import (
 )
 
 type Executor struct {
-	mu       sync.RWMutex
-	reg      *cr.Registry
-	handlers map[string]CommandHandler
+	mu                sync.RWMutex
+	reg               *cr.Registry
+	handlers          map[string]CommandHandler
+	autoInstallPolicy AutoInstallPolicy
 }
 
 type CommandHandler func(ctx context.Context, args []string) (string, error)
+
+type AutoInstallPolicy struct {
+	TrustedRegistry bool
+	AllowedCommands map[string]struct{}
+}
 
 type ExecResult struct {
 	Name      string   `json:"name"`
@@ -39,6 +45,15 @@ func (e *Executor) RegisterHandler(name string, handler CommandHandler) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.handlers[name] = handler
+}
+
+func (e *Executor) SetAutoInstallPolicy(policy AutoInstallPolicy) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.autoInstallPolicy = AutoInstallPolicy{
+		TrustedRegistry: policy.TrustedRegistry,
+		AllowedCommands: cloneAllowedCommands(policy.AllowedCommands),
+	}
 }
 
 func (e *Executor) Exec(ctx context.Context, name string, args []string) *ExecResult {
@@ -123,6 +138,11 @@ func (e *Executor) AutoInstall(ctx context.Context, name string) *ExecResult {
 		result.ExitCode = 1
 		return result
 	}
+	if !e.allowAutoInstallCommand(parts[0]) {
+		result.Error = "Auto-install disabled or install command not allowed"
+		result.ExitCode = 1
+		return result
+	}
 
 	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
 	cmd.Stdout = os.Stdout
@@ -156,4 +176,28 @@ func (e *Executor) Categories() map[string]int {
 
 func (e *Executor) JSON() (string, error) {
 	return e.reg.JSON()
+}
+
+func (e *Executor) allowAutoInstallCommand(command string) bool {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if !e.autoInstallPolicy.TrustedRegistry {
+		return false
+	}
+	if len(e.autoInstallPolicy.AllowedCommands) == 0 {
+		return false
+	}
+	_, ok := e.autoInstallPolicy.AllowedCommands[command]
+	return ok
+}
+
+func cloneAllowedCommands(input map[string]struct{}) map[string]struct{} {
+	if input == nil {
+		return nil
+	}
+	output := make(map[string]struct{}, len(input))
+	for command := range input {
+		output[command] = struct{}{}
+	}
+	return output
 }

--- a/pkg/extensions/adapters/cli/exec/exec_test.go
+++ b/pkg/extensions/adapters/cli/exec/exec_test.go
@@ -1,0 +1,181 @@
+package exec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cr "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/registry"
+)
+
+func TestExecutorRunsRegisteredHandler(t *testing.T) {
+	registry := newTestRegistry(t)
+	executor := NewExecutor(registry)
+	executor.RegisterHandler("echo", func(ctx context.Context, args []string) (string, error) {
+		return strings.Join(args, " "), nil
+	})
+
+	args := []string{"hello", "world"}
+	result := executor.Exec(context.Background(), "echo", args)
+	args[0] = "mutated"
+
+	if result.Error != "" || result.ExitCode != 0 {
+		t.Fatalf("Exec result = %+v, want success", result)
+	}
+	if result.Output != "hello world" {
+		t.Fatalf("output = %q, want hello world", result.Output)
+	}
+	if result.Args[0] != "hello" {
+		t.Fatalf("result args aliased input args: %+v", result.Args)
+	}
+}
+
+func TestExecutorReportsHandlerError(t *testing.T) {
+	registry := newTestRegistry(t)
+	executor := NewExecutor(registry)
+	executor.RegisterHandler("echo", func(ctx context.Context, args []string) (string, error) {
+		return "partial", errors.New("boom")
+	})
+
+	result := executor.Exec(context.Background(), "echo", nil)
+	if result.Output != "partial" || result.Error != "boom" || result.ExitCode != 1 {
+		t.Fatalf("Exec result = %+v, want handler error", result)
+	}
+}
+
+func TestExecutorReportsMissingOrUninstalledCLI(t *testing.T) {
+	registry := newTestRegistry(t)
+	executor := NewExecutor(registry)
+
+	missing := executor.Exec(context.Background(), "missing", nil)
+	if !strings.Contains(missing.Error, "CLI not found") {
+		t.Fatalf("missing result = %+v", missing)
+	}
+
+	uninstalled := executor.Exec(context.Background(), "git", nil)
+	if !strings.Contains(uninstalled.Error, "CLI not installed") || uninstalled.Installed {
+		t.Fatalf("uninstalled result = %+v", uninstalled)
+	}
+}
+
+func TestExecutorDelegatesRegistryViews(t *testing.T) {
+	registry := newTestRegistry(t)
+	executor := NewExecutor(registry)
+
+	if got := len(executor.List()); got != 2 {
+		t.Fatalf("List count = %d, want 2", got)
+	}
+	if got := len(executor.Search("git", "", 10)); got != 1 {
+		t.Fatalf("Search count = %d, want 1", got)
+	}
+	if got := executor.Categories()["dev"]; got != 1 {
+		t.Fatalf("dev category = %d, want 1", got)
+	}
+	if data, err := executor.JSON(); err != nil || !strings.Contains(data, `"entries_count": 2`) {
+		t.Fatalf("JSON = (%q, %v), want entries_count", data, err)
+	}
+}
+
+func TestExecutorExecBinarySuccess(t *testing.T) {
+	t.Setenv("GO_WANT_HELPER_PROCESS", "success")
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("Executable: %v", err)
+	}
+
+	result := (&Executor{}).execBinary(
+		context.Background(),
+		executable,
+		[]string{"-test.run=TestHelperProcess", "--", "hello"},
+		&ExecResult{Name: "helper"},
+	)
+
+	if result.Error != "" || result.ExitCode != 0 || !result.Installed {
+		t.Fatalf("execBinary result = %+v, want success", result)
+	}
+	if !strings.Contains(result.Output, "helper output") {
+		t.Fatalf("output = %q, want helper output", result.Output)
+	}
+}
+
+func TestExecutorExecBinaryFailure(t *testing.T) {
+	t.Setenv("GO_WANT_HELPER_PROCESS", "failure")
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("Executable: %v", err)
+	}
+
+	result := (&Executor{}).execBinary(
+		context.Background(),
+		executable,
+		[]string{"-test.run=TestHelperProcess"},
+		&ExecResult{Name: "helper"},
+	)
+
+	if result.Error == "" || result.ExitCode != 7 || !result.Installed {
+		t.Fatalf("execBinary result = %+v, want exit 7 failure", result)
+	}
+}
+
+func TestExecutorAutoInstallRejectsInvalidInstallCommand(t *testing.T) {
+	registry := newTestRegistry(t)
+	executor := NewExecutor(registry)
+
+	result := executor.AutoInstall(context.Background(), "git")
+	if result.Error != "Invalid install command" || result.ExitCode != 1 {
+		t.Fatalf("AutoInstall result = %+v, want invalid install command without process execution", result)
+	}
+}
+
+func TestExecutorAutoInstallEarlyErrors(t *testing.T) {
+	registry := newTestRegistry(t)
+	executor := NewExecutor(registry)
+
+	missing := executor.AutoInstall(context.Background(), "missing")
+	if missing.Error != "CLI not found in registry" || missing.ExitCode != 1 {
+		t.Fatalf("missing install = %+v", missing)
+	}
+
+	noInstallRegistry := newRegistryWithEntries(t, []byte(`{"clis":[{"name":"no-install","display_name":"No Install"}]}`))
+	noInstall := NewExecutor(noInstallRegistry).AutoInstall(context.Background(), "no-install")
+	if noInstall.Error != "No install command available" || noInstall.ExitCode != 1 {
+		t.Fatalf("no install command = %+v", noInstall)
+	}
+}
+
+func TestHelperProcess(t *testing.T) {
+	switch os.Getenv("GO_WANT_HELPER_PROCESS") {
+	case "success":
+		fmt.Fprint(os.Stdout, "helper output")
+		os.Exit(0)
+	case "failure":
+		fmt.Fprint(os.Stderr, "helper failure")
+		os.Exit(7)
+	}
+}
+
+func newTestRegistry(t *testing.T) *cr.Registry {
+	t.Helper()
+	data := []byte(`{"clis":[
+		{"name":"echo","display_name":"Echo","category":"utility","entry_point":"echo","install_cmd":"builtin"},
+		{"name":"git","display_name":"Git","category":"dev","entry_point":"git","install_cmd":"git"}
+	]}`)
+	return newRegistryWithEntries(t, data)
+}
+
+func newRegistryWithEntries(t *testing.T, data []byte) *cr.Registry {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "registry.json"), data, 0o644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	registry, err := cr.NewRegistry(root)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	return registry
+}

--- a/pkg/extensions/adapters/cli/exec/exec_test.go
+++ b/pkg/extensions/adapters/cli/exec/exec_test.go
@@ -121,13 +121,89 @@ func TestExecutorExecBinaryFailure(t *testing.T) {
 	}
 }
 
-func TestExecutorAutoInstallRejectsInvalidInstallCommand(t *testing.T) {
+func TestExecutorAutoInstallRejectsInvalidInstallCommandBeforePolicy(t *testing.T) {
 	registry := newTestRegistry(t)
 	executor := NewExecutor(registry)
 
 	result := executor.AutoInstall(context.Background(), "git")
 	if result.Error != "Invalid install command" || result.ExitCode != 1 {
 		t.Fatalf("AutoInstall result = %+v, want invalid install command without process execution", result)
+	}
+}
+
+func TestExecutorAutoInstallIsDisabledByDefault(t *testing.T) {
+	registry := newRegistryWithEntries(t, []byte(`{"clis":[
+		{"name":"tool","display_name":"Tool","entry_point":"tool","install_cmd":"go version"}
+	]}`))
+	executor := NewExecutor(registry)
+
+	result := executor.AutoInstall(context.Background(), "tool")
+	if result.Error != "Auto-install disabled or install command not allowed" || result.ExitCode != 1 {
+		t.Fatalf("AutoInstall result = %+v, want disabled", result)
+	}
+}
+
+func TestExecutorAutoInstallRequiresTrustedRegistryAndAllowedCommand(t *testing.T) {
+	registry := newRegistryWithEntries(t, []byte(`{"clis":[
+		{"name":"tool","display_name":"Tool","entry_point":"tool","install_cmd":"go version"}
+	]}`))
+	executor := NewExecutor(registry)
+
+	executor.SetAutoInstallPolicy(AutoInstallPolicy{
+		TrustedRegistry: false,
+		AllowedCommands: map[string]struct{}{
+			"go": {},
+		},
+	})
+	if result := executor.AutoInstall(context.Background(), "tool"); result.Error != "Auto-install disabled or install command not allowed" {
+		t.Fatalf("AutoInstall without trust = %+v, want disabled", result)
+	}
+
+	executor.SetAutoInstallPolicy(AutoInstallPolicy{
+		TrustedRegistry: true,
+		AllowedCommands: map[string]struct{}{
+			"npm": {},
+		},
+	})
+	if result := executor.AutoInstall(context.Background(), "tool"); result.Error != "Auto-install disabled or install command not allowed" {
+		t.Fatalf("AutoInstall without command allowlist = %+v, want disabled", result)
+	}
+}
+
+func TestExecutorAutoInstallAllowedCommand(t *testing.T) {
+	registry := newRegistryWithEntries(t, []byte(`{"clis":[
+		{"name":"tool","display_name":"Tool","entry_point":"tool","install_cmd":"go version"}
+	]}`))
+	executor := NewExecutor(registry)
+	executor.SetAutoInstallPolicy(AutoInstallPolicy{
+		TrustedRegistry: true,
+		AllowedCommands: map[string]struct{}{
+			"go": {},
+		},
+	})
+
+	result := executor.AutoInstall(context.Background(), "tool")
+	if result.Error != "" || result.ExitCode != 0 || !result.Installed {
+		t.Fatalf("AutoInstall result = %+v, want success", result)
+	}
+
+	installed, _ := registry.Get("tool")
+	if !installed.Installed || installed.ExecutablePath != "tool" {
+		t.Fatalf("installed entry = %+v, want installed tool", installed)
+	}
+}
+
+func TestExecutorAutoInstallPolicyIsCopied(t *testing.T) {
+	executor := NewExecutor(newTestRegistry(t))
+	allowed := map[string]struct{}{"go": {}}
+	executor.SetAutoInstallPolicy(AutoInstallPolicy{
+		TrustedRegistry: true,
+		AllowedCommands: allowed,
+	})
+	delete(allowed, "go")
+
+	if !executor.allowAutoInstallCommand("go") {
+		t.Fatal("expected policy to retain copied command")
 	}
 }
 

--- a/pkg/extensions/adapters/cli/registry/registry.go
+++ b/pkg/extensions/adapters/cli/registry/registry.go
@@ -1,0 +1,304 @@
+package cliadapter
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+type Entry struct {
+	Name           string `json:"name"`
+	DisplayName    string `json:"display_name"`
+	Version        string `json:"version"`
+	Description    string `json:"description"`
+	Requires       string `json:"requires"`
+	Homepage       string `json:"homepage"`
+	InstallCmd     string `json:"install_cmd"`
+	EntryPoint     string `json:"entry_point"`
+	SkillMD        string `json:"skill_md"`
+	Category       string `json:"category"`
+	Contributor    string `json:"contributor"`
+	ContributorURL string `json:"contributor_url"`
+}
+
+type EntryStatus struct {
+	Entry
+	Installed      bool   `json:"installed"`
+	ExecutablePath string `json:"executable_path,omitempty"`
+}
+
+type Registry struct {
+	mu         sync.RWMutex
+	root       string
+	entries    map[string]*EntryStatus
+	categories map[string]int
+}
+
+func NewRegistry(root string) (*Registry, error) {
+	r := &Registry{
+		root:       root,
+		entries:    make(map[string]*EntryStatus),
+		categories: make(map[string]int),
+	}
+
+	if err := r.load(); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (r *Registry) load() error {
+	data, err := os.ReadFile(filepath.Join(r.root, "registry.json"))
+	if err != nil {
+		return err
+	}
+
+	var file struct {
+		Meta struct {
+			Repo        string `json:"repo"`
+			Description string `json:"description"`
+			Updated     string `json:"updated"`
+		} `json:"meta"`
+		CLIs []Entry `json:"clis"`
+	}
+
+	if err := json.Unmarshal(data, &file); err != nil {
+		return err
+	}
+
+	for _, e := range file.CLIs {
+		entry := e
+		entry.Name = strings.TrimSpace(entry.Name)
+		if entry.Name == "" {
+			return fmt.Errorf("registry entry name is required")
+		}
+		key := strings.ToLower(entry.Name)
+		if _, exists := r.entries[key]; exists {
+			return fmt.Errorf("duplicate registry entry %q", entry.Name)
+		}
+		r.entries[key] = &EntryStatus{
+			Entry:     entry,
+			Installed: false,
+		}
+		r.categories[entry.Category]++
+	}
+
+	return nil
+}
+
+func (r *Registry) Get(name string) (*EntryStatus, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, ok := r.entries[strings.ToLower(strings.TrimSpace(name))]
+	if !ok {
+		return nil, false
+	}
+	return cloneEntryStatus(entry), true
+}
+
+func (r *Registry) List() []*EntryStatus {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]*EntryStatus, 0, len(r.entries))
+	for _, e := range r.entries {
+		result = append(result, cloneEntryStatus(e))
+	}
+	sortEntryStatuses(result)
+	return result
+}
+
+func (r *Registry) Search(query string, category string, limit int) []*EntryStatus {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	entries := make([]*EntryStatus, 0, len(r.entries))
+	for _, e := range r.entries {
+		entries = append(entries, e)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name < entries[j].Name
+	})
+
+	var results []*EntryStatus
+	query = strings.ToLower(query)
+	category = strings.ToLower(category)
+
+	for _, e := range entries {
+		if category != "" && strings.ToLower(e.Category) != category {
+			continue
+		}
+
+		if query == "" {
+			results = append(results, cloneEntryStatus(e))
+		} else if strings.Contains(strings.ToLower(e.Name), query) ||
+			strings.Contains(strings.ToLower(e.DisplayName), query) ||
+			strings.Contains(strings.ToLower(e.Description), query) {
+			results = append(results, cloneEntryStatus(e))
+		}
+
+		if limit > 0 && len(results) >= limit {
+			break
+		}
+	}
+
+	return results
+}
+
+func (r *Registry) Categories() map[string]int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make(map[string]int)
+	for k, v := range r.categories {
+		result[k] = v
+	}
+	return result
+}
+
+func (r *Registry) Root() string {
+	return r.root
+}
+
+func (r *Registry) EntriesCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.entries)
+}
+
+type builtinAdapter struct {
+	Name        string
+	Description string
+	Category    string
+	Handler     func(args []string) (string, error)
+}
+
+var builtinAdapters = map[string]*builtinAdapter{}
+var builtinAdaptersMu sync.RWMutex
+
+func RegisterBuiltinAdapter(name, desc, category string, handler func(args []string) (string, error)) {
+	builtinAdaptersMu.Lock()
+	defer builtinAdaptersMu.Unlock()
+	builtinAdapters[strings.ToLower(strings.TrimSpace(name))] = &builtinAdapter{
+		Name:        name,
+		Description: desc,
+		Category:    category,
+		Handler:     handler,
+	}
+}
+
+func GetBuiltinAdapter(name string) (*builtinAdapter, bool) {
+	builtinAdaptersMu.RLock()
+	defer builtinAdaptersMu.RUnlock()
+	a, ok := builtinAdapters[strings.ToLower(strings.TrimSpace(name))]
+	if !ok {
+		return nil, false
+	}
+	return cloneBuiltinAdapter(a), true
+}
+
+func ListBuiltinAdapters() []*builtinAdapter {
+	builtinAdaptersMu.RLock()
+	defer builtinAdaptersMu.RUnlock()
+	result := make([]*builtinAdapter, 0, len(builtinAdapters))
+	for _, a := range builtinAdapters {
+		result = append(result, cloneBuiltinAdapter(a))
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+func (r *Registry) Find(name string) (*EntryStatus, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	name = strings.ToLower(strings.TrimSpace(name))
+
+	if entry, ok := r.entries[name]; ok {
+		return cloneEntryStatus(entry), true
+	}
+
+	for _, e := range r.entries {
+		if strings.ToLower(e.EntryPoint) == name ||
+			strings.ToLower(e.DisplayName) == name {
+			return cloneEntryStatus(e), true
+		}
+	}
+
+	builtinAdaptersMu.RLock()
+	adapter, ok := builtinAdapters[name]
+	builtinAdaptersMu.RUnlock()
+	if ok {
+		return &EntryStatus{
+			Entry: Entry{
+				Name:        adapter.Name,
+				DisplayName: adapter.Name,
+				Description: adapter.Description,
+				Category:    adapter.Category,
+			},
+			Installed: true,
+		}, true
+	}
+
+	return nil, false
+}
+
+func (r *Registry) MarkInstalled(name string, path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if e, ok := r.entries[strings.ToLower(strings.TrimSpace(name))]; ok {
+		e.Installed = true
+		e.ExecutablePath = path
+	}
+}
+
+func (r *Registry) JSON() (string, error) {
+	builtinAdaptersMu.RLock()
+	builtinCount := len(builtinAdapters)
+	builtinAdaptersMu.RUnlock()
+
+	data := map[string]any{
+		"root":          r.root,
+		"entries_count": r.EntriesCount(),
+		"categories":    r.Categories(),
+		"entries":       r.List(),
+		"builtin_count": builtinCount,
+	}
+
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}
+
+func cloneEntryStatus(entry *EntryStatus) *EntryStatus {
+	if entry == nil {
+		return nil
+	}
+	cloned := *entry
+	return &cloned
+}
+
+func cloneBuiltinAdapter(adapter *builtinAdapter) *builtinAdapter {
+	if adapter == nil {
+		return nil
+	}
+	cloned := *adapter
+	return &cloned
+}
+
+func sortEntryStatuses(entries []*EntryStatus) {
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name < entries[j].Name
+	})
+}

--- a/pkg/extensions/adapters/cli/registry/registry_test.go
+++ b/pkg/extensions/adapters/cli/registry/registry_test.go
@@ -1,0 +1,134 @@
+package cliadapter
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegistryLoadsSearchesAndReturnsCopies(t *testing.T) {
+	root := writeRegistry(t, []Entry{
+		{Name: "git", DisplayName: "Git", Description: "Version control", Category: "dev", EntryPoint: "git"},
+		{Name: "docker", DisplayName: "Docker", Description: "Container runtime", Category: "ops", EntryPoint: "docker"},
+	})
+
+	registry, err := NewRegistry(root)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	if got := registry.EntriesCount(); got != 2 {
+		t.Fatalf("EntriesCount = %d, want 2", got)
+	}
+	if got := registry.Categories()["dev"]; got != 1 {
+		t.Fatalf("dev category count = %d, want 1", got)
+	}
+
+	entry, ok := registry.Get("GIT")
+	if !ok {
+		t.Fatal("expected case-insensitive get")
+	}
+	entry.Name = "mutated"
+	entry.Installed = true
+
+	again, ok := registry.Get("git")
+	if !ok {
+		t.Fatal("expected git entry")
+	}
+	if again.Name != "git" || again.Installed {
+		t.Fatalf("registry entry was mutated through returned copy: %+v", again)
+	}
+
+	list := registry.List()
+	if len(list) != 2 || list[0].Name != "docker" || list[1].Name != "git" {
+		t.Fatalf("List order = %+v, want docker then git", list)
+	}
+
+	search := registry.Search("", "", 1)
+	if len(search) != 1 || search[0].Name != "docker" {
+		t.Fatalf("Search limit result = %+v, want docker", search)
+	}
+
+	found, ok := registry.Find("Docker")
+	if !ok || found.Name != "docker" {
+		t.Fatalf("Find by display name = (%+v, %v), want docker", found, ok)
+	}
+
+	registry.MarkInstalled("git", "/usr/bin/git")
+	installed, _ := registry.Get("git")
+	if !installed.Installed || installed.ExecutablePath != "/usr/bin/git" {
+		t.Fatalf("installed git = %+v", installed)
+	}
+}
+
+func TestRegistryRejectsDuplicateNames(t *testing.T) {
+	root := writeRegistry(t, []Entry{
+		{Name: "git", DisplayName: "Git", Category: "dev"},
+		{Name: "GIT", DisplayName: "Git Duplicate", Category: "dev"},
+	})
+
+	if _, err := NewRegistry(root); err == nil {
+		t.Fatal("expected duplicate registry entry error")
+	}
+}
+
+func TestBuiltinAdaptersReturnCopies(t *testing.T) {
+	resetBuiltinAdapters(t)
+	RegisterBuiltinAdapter("echo", "Echo", "utility", func(args []string) (string, error) {
+		return "", nil
+	})
+
+	adapter, ok := GetBuiltinAdapter("ECHO")
+	if !ok {
+		t.Fatal("expected builtin adapter")
+	}
+	adapter.Name = "mutated"
+
+	again, ok := GetBuiltinAdapter("echo")
+	if !ok {
+		t.Fatal("expected builtin adapter")
+	}
+	if again.Name != "echo" {
+		t.Fatalf("builtin adapter mutated through returned copy: %+v", again)
+	}
+
+	list := ListBuiltinAdapters()
+	if len(list) != 1 || list[0].Name != "echo" {
+		t.Fatalf("builtin adapter list = %+v", list)
+	}
+}
+
+func writeRegistry(t *testing.T, entries []Entry) string {
+	t.Helper()
+	root := t.TempDir()
+	data, err := json.Marshal(map[string]any{
+		"meta": map[string]any{
+			"repo":        "test",
+			"description": "test registry",
+			"updated":     "2026-04-27",
+		},
+		"clis": entries,
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "registry.json"), data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return root
+}
+
+func resetBuiltinAdapters(t *testing.T) {
+	t.Helper()
+	builtinAdaptersMu.Lock()
+	previous := builtinAdapters
+	builtinAdapters = map[string]*builtinAdapter{}
+	builtinAdaptersMu.Unlock()
+
+	t.Cleanup(func() {
+		builtinAdaptersMu.Lock()
+		builtinAdapters = previous
+		builtinAdaptersMu.Unlock()
+	})
+}


### PR DESCRIPTION
## 概要

新增 extensions CLI adapter 的核心基础设施，为后续分批接入具体 CLI adapters 做准备。

## 本次变更

- 新增 CLI adapter 顶层入口
  - 支持初始化 registry / executor
  - 支持从环境变量或常见目录发现 CLI registry
  - 支持搜索、执行和分类查询
  - 注册轻量 builtin handlers：`echo`、`date`、`pwd`
- 新增 CLI executor
  - 支持注册 command handler
  - 支持执行 registry 中的 CLI entry
  - 支持未安装、缺失、handler error 和 binary exit code 的结果封装
- 新增 CLI registry
  - 支持加载 `registry.json`
  - 支持 entry 查询、搜索、分类统计、安装状态标记和 JSON 输出
  - 返回 defensive copy，避免调用方修改内部状态
  - 搜索和列表结果按名称稳定排序
  - 拒绝重复 registry entry
- 新增单元测试
  - 覆盖 init / env discovery / root discovery
  - 覆盖 executor handler、binary execution、error paths
  - 覆盖 registry load/search/copy/dedup/builtin adapter 行为

## 影响

这条 PR 只引入 CLI adapter core，不包含具体应用 adapter 实现。

具体 adapters 会在后续 PR 中分批加入，避免一次性提交过大的文件集。

## 验证

已执行：

- `go test ./pkg/extensions/adapters/cli/...`
- `go test ./pkg/extensions/adapters/cli/... -cover`
- `go test ./pkg/extensions/...`
