### PR TITLE
feat(cli): add zip CLI adapter

### DIFF
--- a/pkg/extensions/adapters/cli/adapters/zip/zip.go
+++ b/pkg/extensions/adapters/cli/adapters/zip/zip.go
@@ -1,0 +1,343 @@
+package zip
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Client struct{}
+
+type Config struct{}
+
+func NewClient(cfg Config) *Client {
+	return &Client{}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "Usage: zip <command> [args]\nCommands: create, extract, list, add", nil
+	}
+
+	switch args[0] {
+	case "create", "c":
+		return c.create(ctx, args[1:])
+	case "extract", "unzip", "x":
+		return c.extract(ctx, args[1:])
+	case "list", "l":
+		return c.list(ctx, args[1:])
+	case "add", "a":
+		return c.add(ctx, args[1:])
+	default:
+		return "", fmt.Errorf("unknown command: %s", args[0])
+	}
+}
+
+func (c *Client) create(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("usage: zip create <archive> <files...>")
+	}
+
+	archive := args[0]
+	files := args[1:]
+
+	output, err := os.Create(archive)
+	if err != nil {
+		return "", err
+	}
+
+	writer := zip.NewWriter(output)
+
+	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			_ = writer.Close()
+			_ = output.Close()
+			return "", err
+		}
+		if err := c.addFile(writer, file); err != nil {
+			_ = writer.Close()
+			_ = output.Close()
+			return "", err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		_ = output.Close()
+		return "", err
+	}
+	if err := output.Close(); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Created: %s with %d files", archive, len(files)), nil
+}
+
+func (c *Client) addFile(writer *zip.Writer, path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	header, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+
+	header.Name = filepath.Base(path)
+
+	entry, err := writer.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(entry, file)
+	return err
+}
+
+func (c *Client) extract(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("usage: zip extract <archive> [destination]")
+	}
+
+	archive := args[0]
+	dest := "."
+	if len(args) > 1 {
+		dest = args[1]
+	}
+
+	reader, err := zip.OpenReader(archive)
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return "", err
+	}
+
+	count := 0
+	for _, file := range reader.File {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		path, err := safeExtractPath(dest, file.Name)
+		if err != nil {
+			return "", err
+		}
+
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(path, 0755); err != nil {
+				return "", err
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return "", err
+		}
+
+		out, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.FileInfo().Mode())
+		if err != nil {
+			return "", err
+		}
+
+		rc, err := file.Open()
+		if err != nil {
+			_ = out.Close()
+			return "", err
+		}
+
+		_, copyErr := io.Copy(out, rc)
+		closeReadErr := rc.Close()
+		closeWriteErr := out.Close()
+		if copyErr != nil {
+			return "", copyErr
+		}
+		if closeReadErr != nil {
+			return "", closeReadErr
+		}
+		if closeWriteErr != nil {
+			return "", closeWriteErr
+		}
+		count++
+	}
+
+	return fmt.Sprintf("Extracted %d files to %s", count, dest), nil
+}
+
+func (c *Client) list(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("usage: zip list <archive>")
+	}
+
+	archive := args[0]
+
+	reader, err := zip.OpenReader(archive)
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	var result []string
+	result = append(result, fmt.Sprintf("Archive: %s", archive))
+	result = append(result, fmt.Sprintf("Files: %d\n", len(reader.File)))
+
+	for _, file := range reader.File {
+		info := file.FileInfo()
+		size := info.Size()
+		if size == 0 {
+			result = append(result, fmt.Sprintf("  %s/", file.Name))
+		} else {
+			result = append(result, fmt.Sprintf("  %s (%d bytes)", file.Name, size))
+		}
+	}
+
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) add(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("usage: zip add <archive> <files...>")
+	}
+
+	archive := args[0]
+	files := args[1:]
+
+	tempFile := archive + ".tmp"
+	temp, err := os.Create(tempFile)
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tempFile)
+
+	writer := zip.NewWriter(temp)
+	zipReader, err := zip.OpenReader(archive)
+	if err == nil {
+		for _, file := range zipReader.File {
+			if err := ctx.Err(); err != nil {
+				_ = zipReader.Close()
+				_ = writer.Close()
+				_ = temp.Close()
+				return "", err
+			}
+			if err := copyZipEntry(writer, file); err != nil {
+				_ = zipReader.Close()
+				_ = writer.Close()
+				_ = temp.Close()
+				return "", err
+			}
+		}
+		if err := zipReader.Close(); err != nil {
+			_ = writer.Close()
+			_ = temp.Close()
+			return "", err
+		}
+	} else if !os.IsNotExist(err) {
+		_ = writer.Close()
+		_ = temp.Close()
+		return "", err
+	}
+
+	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			_ = writer.Close()
+			_ = temp.Close()
+			return "", err
+		}
+		if err := c.addFile(writer, file); err != nil {
+			_ = writer.Close()
+			_ = temp.Close()
+			return "", err
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		_ = temp.Close()
+		return "", err
+	}
+	if err := temp.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Rename(tempFile, archive); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Added %d files to %s", len(files), archive), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	return true
+}
+
+func ListZIP(archive string) ([]string, error) {
+	reader, err := zip.OpenReader(archive)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	files := make([]string, len(reader.File))
+	for i, file := range reader.File {
+		files[i] = file.Name
+	}
+	return files, nil
+}
+
+func safeExtractPath(dest, name string) (string, error) {
+	if filepath.IsAbs(name) {
+		return "", fmt.Errorf("unsafe zip entry path: %s", name)
+	}
+	cleanName := filepath.Clean(name)
+	if cleanName == "." || strings.HasPrefix(cleanName, ".."+string(os.PathSeparator)) || cleanName == ".." {
+		return "", fmt.Errorf("unsafe zip entry path: %s", name)
+	}
+
+	destAbs, err := filepath.Abs(dest)
+	if err != nil {
+		return "", err
+	}
+	target := filepath.Join(destAbs, cleanName)
+	targetAbs, err := filepath.Abs(target)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(destAbs, targetAbs)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("unsafe zip entry path: %s", name)
+	}
+	return targetAbs, nil
+}
+
+func copyZipEntry(writer *zip.Writer, file *zip.File) error {
+	rc, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	header, err := zip.FileInfoHeader(file.FileInfo())
+	if err != nil {
+		return err
+	}
+	header.Name = file.Name
+	header.Method = file.Method
+
+	entry, err := writer.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(entry, rc)
+	return err
+}

--- a/pkg/extensions/adapters/cli/adapters/zip/zip.go
+++ b/pkg/extensions/adapters/cli/adapters/zip/zip.go
@@ -76,6 +76,11 @@ func (c *Client) create(ctx context.Context, args []string) (string, error) {
 }
 
 func (c *Client) addFile(writer *zip.Writer, path string) error {
+	entryName, err := archiveEntryName(path)
+	if err != nil {
+		return err
+	}
+
 	file, err := os.Open(path)
 	if err != nil {
 		return err
@@ -92,7 +97,7 @@ func (c *Client) addFile(writer *zip.Writer, path string) error {
 		return err
 	}
 
-	header.Name = filepath.Base(path)
+	header.Name = entryName
 
 	entry, err := writer.CreateHeader(header)
 	if err != nil {
@@ -290,6 +295,49 @@ func ListZIP(archive string) ([]string, error) {
 		files[i] = file.Name
 	}
 	return files, nil
+}
+
+func archiveEntryName(path string) (string, error) {
+	cleanPath := filepath.Clean(path)
+	if cleanPath == "." || cleanPath == "" {
+		return "", fmt.Errorf("unsafe archive entry path: %s", path)
+	}
+	if filepath.IsAbs(cleanPath) || filepath.VolumeName(cleanPath) != "" {
+		cleanPath = archiveNameForAbsolutePath(cleanPath)
+	}
+	if cleanPath == "" {
+		return "", fmt.Errorf("unsafe archive entry path: %s", path)
+	}
+
+	entryName := filepath.ToSlash(cleanPath)
+	for _, part := range strings.Split(entryName, "/") {
+		if part == "" || part == "." || part == ".." {
+			return "", fmt.Errorf("unsafe archive entry path: %s", path)
+		}
+	}
+	return entryName, nil
+}
+
+func archiveNameForAbsolutePath(path string) string {
+	workingDir, err := os.Getwd()
+	if err == nil {
+		if rel, err := filepath.Rel(workingDir, path); err == nil && isSafeRelativeArchivePath(rel) {
+			return rel
+		}
+	}
+	return filepath.Base(path)
+}
+
+func isSafeRelativeArchivePath(path string) bool {
+	if path == "." || path == "" || filepath.IsAbs(path) || filepath.VolumeName(path) != "" {
+		return false
+	}
+	for _, part := range strings.Split(filepath.ToSlash(filepath.Clean(path)), "/") {
+		if part == "" || part == "." || part == ".." {
+			return false
+		}
+	}
+	return true
 }
 
 func safeExtractPath(dest, name string) (string, error) {

--- a/pkg/extensions/adapters/cli/adapters/zip/zip.go
+++ b/pkg/extensions/adapters/cli/adapters/zip/zip.go
@@ -293,7 +293,7 @@ func ListZIP(archive string) ([]string, error) {
 }
 
 func safeExtractPath(dest, name string) (string, error) {
-	if filepath.IsAbs(name) {
+	if filepath.IsAbs(name) || filepath.VolumeName(name) != "" {
 		return "", fmt.Errorf("unsafe zip entry path: %s", name)
 	}
 	cleanName := filepath.Clean(name)
@@ -317,7 +317,50 @@ func safeExtractPath(dest, name string) (string, error) {
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
 		return "", fmt.Errorf("unsafe zip entry path: %s", name)
 	}
+	if err := rejectSymlinkPath(destAbs, targetAbs, name); err != nil {
+		return "", err
+	}
 	return targetAbs, nil
+}
+
+func rejectSymlinkPath(destAbs, targetAbs, name string) error {
+	destAbs = filepath.Clean(destAbs)
+	targetAbs = filepath.Clean(targetAbs)
+
+	if info, err := os.Lstat(destAbs); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("unsafe zip entry path: %s", name)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	rel, err := filepath.Rel(destAbs, targetAbs)
+	if err != nil {
+		return err
+	}
+	if rel == "." {
+		return nil
+	}
+
+	current := destAbs
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("unsafe zip entry path: %s", name)
+		}
+	}
+	return nil
 }
 
 func copyZipEntry(writer *zip.Writer, file *zip.File) error {

--- a/pkg/extensions/adapters/cli/adapters/zip/zip_test.go
+++ b/pkg/extensions/adapters/cli/adapters/zip/zip_test.go
@@ -53,6 +53,78 @@ func TestRunCreateListAndExtract(t *testing.T) {
 	}
 }
 
+func TestRunCreatePreservesDirectoryStructure(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.MkdirAll(filepath.Join("dir1"), 0o755); err != nil {
+		t.Fatalf("MkdirAll dir1: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join("dir2"), 0o755); err != nil {
+		t.Fatalf("MkdirAll dir2: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("dir1", "a.txt"), []byte("one"), 0o644); err != nil {
+		t.Fatalf("WriteFile dir1: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("dir2", "a.txt"), []byte("two"), 0o644); err != nil {
+		t.Fatalf("WriteFile dir2: %v", err)
+	}
+
+	client := NewClient(Config{})
+	firstPath, err := filepath.Abs(filepath.Join("dir1", "a.txt"))
+	if err != nil {
+		t.Fatalf("Abs first: %v", err)
+	}
+	secondPath, err := filepath.Abs(filepath.Join("dir2", "a.txt"))
+	if err != nil {
+		t.Fatalf("Abs second: %v", err)
+	}
+	if _, err := client.Run(context.Background(), []string{"create", "bundle.zip", firstPath, secondPath}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	files, err := ListZIP("bundle.zip")
+	if err != nil {
+		t.Fatalf("ListZIP: %v", err)
+	}
+	if strings.Join(files, ",") != "dir1/a.txt,dir2/a.txt" {
+		t.Fatalf("files = %v, want preserved relative directories", files)
+	}
+
+	dest := filepath.Join(dir, "out")
+	if _, err := client.Run(context.Background(), []string{"extract", "bundle.zip", dest}); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	first, err := os.ReadFile(filepath.Join(dest, "dir1", "a.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile dir1: %v", err)
+	}
+	second, err := os.ReadFile(filepath.Join(dest, "dir2", "a.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile dir2: %v", err)
+	}
+	if string(first) != "one" || string(second) != "two" {
+		t.Fatalf("contents = %q/%q, want one/two", first, second)
+	}
+}
+
+func TestRunCreateRejectsUnsafeArchiveEntryName(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "secret.txt")
+	archive := filepath.Join(dir, "bundle.zip")
+	if err := os.WriteFile(source, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Chdir(filepath.Join(dir))
+
+	_, err := NewClient(Config{}).Run(context.Background(), []string{"create", archive, filepath.Join("..", "secret.txt")})
+	if err == nil {
+		t.Fatal("expected unsafe archive entry error")
+	}
+	if !strings.Contains(err.Error(), "unsafe archive entry path") {
+		t.Fatalf("error = %v, want unsafe archive entry", err)
+	}
+}
+
 func TestExtractRejectsZipSlipPath(t *testing.T) {
 	dir := t.TempDir()
 	archive := filepath.Join(dir, "malicious.zip")

--- a/pkg/extensions/adapters/cli/adapters/zip/zip_test.go
+++ b/pkg/extensions/adapters/cli/adapters/zip/zip_test.go
@@ -1,0 +1,131 @@
+package zip
+
+import (
+	stdzip "archive/zip"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunCreateListAndExtract(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "alpha.txt")
+	archive := filepath.Join(dir, "bundle.zip")
+	dest := filepath.Join(dir, "out")
+	if err := os.WriteFile(source, []byte("hello zip"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	client := NewClient(Config{})
+	if output, err := client.Run(context.Background(), []string{"create", archive, source}); err != nil {
+		t.Fatalf("create: %v", err)
+	} else if !strings.Contains(output, "Created:") {
+		t.Fatalf("create output = %q, want Created", output)
+	}
+
+	files, err := ListZIP(archive)
+	if err != nil {
+		t.Fatalf("ListZIP: %v", err)
+	}
+	if len(files) != 1 || files[0] != "alpha.txt" {
+		t.Fatalf("files = %v, want alpha.txt", files)
+	}
+
+	output, err := client.Run(context.Background(), []string{"list", archive})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(output, "alpha.txt") {
+		t.Fatalf("list output = %q, want alpha.txt", output)
+	}
+
+	if _, err := client.Run(context.Background(), []string{"extract", archive, dest}); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dest, "alpha.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile extracted: %v", err)
+	}
+	if string(data) != "hello zip" {
+		t.Fatalf("extracted content = %q, want hello zip", data)
+	}
+}
+
+func TestExtractRejectsZipSlipPath(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "malicious.zip")
+	dest := filepath.Join(dir, "out")
+	if err := writeTestArchive(archive, map[string]string{
+		"../evil.txt": "owned",
+	}); err != nil {
+		t.Fatalf("writeTestArchive: %v", err)
+	}
+
+	_, err := NewClient(Config{}).Run(context.Background(), []string{"extract", archive, dest})
+	if err == nil {
+		t.Fatal("expected unsafe path error")
+	}
+	if !strings.Contains(err.Error(), "unsafe zip entry path") {
+		t.Fatalf("error = %v, want unsafe path", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "evil.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("evil file stat = %v, want not exist", statErr)
+	}
+}
+
+func TestRunAddCreatesAndUpdatesArchive(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.txt")
+	second := filepath.Join(dir, "second.txt")
+	archive := filepath.Join(dir, "bundle.zip")
+	if err := os.WriteFile(first, []byte("one"), 0o644); err != nil {
+		t.Fatalf("WriteFile first: %v", err)
+	}
+	if err := os.WriteFile(second, []byte("two"), 0o644); err != nil {
+		t.Fatalf("WriteFile second: %v", err)
+	}
+
+	client := NewClient(Config{})
+	if _, err := client.Run(context.Background(), []string{"add", archive, first}); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	if _, err := client.Run(context.Background(), []string{"add", archive, second}); err != nil {
+		t.Fatalf("second add: %v", err)
+	}
+
+	files, err := ListZIP(archive)
+	if err != nil {
+		t.Fatalf("ListZIP: %v", err)
+	}
+	if strings.Join(files, ",") != "first.txt,second.txt" {
+		t.Fatalf("files = %v, want first.txt and second.txt", files)
+	}
+}
+
+func writeTestArchive(path string, entries map[string]string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	writer := stdzip.NewWriter(file)
+	for name, content := range entries {
+		entry, err := writer.Create(name)
+		if err != nil {
+			_ = writer.Close()
+			_ = file.Close()
+			return err
+		}
+		if _, err := entry.Write([]byte(content)); err != nil {
+			_ = writer.Close()
+			_ = file.Close()
+			return err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}

--- a/pkg/extensions/adapters/cli/adapters/zip/zip_test.go
+++ b/pkg/extensions/adapters/cli/adapters/zip/zip_test.go
@@ -75,6 +75,38 @@ func TestExtractRejectsZipSlipPath(t *testing.T) {
 	}
 }
 
+func TestExtractRejectsSymlinkParent(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "symlink.zip")
+	dest := filepath.Join(dir, "out")
+	outside := filepath.Join(dir, "outside")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatalf("MkdirAll dest: %v", err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("MkdirAll outside: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dest, "link")); err != nil {
+		t.Skipf("symlink unavailable on this platform: %v", err)
+	}
+	if err := writeTestArchive(archive, map[string]string{
+		"link/pwn.txt": "owned",
+	}); err != nil {
+		t.Fatalf("writeTestArchive: %v", err)
+	}
+
+	_, err := NewClient(Config{}).Run(context.Background(), []string{"extract", archive, dest})
+	if err == nil {
+		t.Fatal("expected symlink parent error")
+	}
+	if !strings.Contains(err.Error(), "unsafe zip entry path") {
+		t.Fatalf("error = %v, want unsafe path", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "pwn.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("outside file stat = %v, want not exist", statErr)
+	}
+}
+
 func TestRunAddCreatesAndUpdatesArchive(t *testing.T) {
 	dir := t.TempDir()
 	first := filepath.Join(dir, "first.txt")

--- a/pkg/extensions/adapters/cli/cliadapter.go
+++ b/pkg/extensions/adapters/cli/cliadapter.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	zipadapter "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/zip"
 	ce "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/exec"
 	cr "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/registry"
 )
@@ -136,7 +137,9 @@ func registerBuiltInHandlers() {
 		return dir, nil
 	})
 
-	// Concrete CLI adapter handlers are registered by follow-up adapter packages.
+	registerBuiltinHandler("zip", "Create, list, extract, and update ZIP archives", "archive", func(ctx context.Context, args []string) (string, error) {
+		return zipadapter.NewClient(zipadapter.Config{}).Run(ctx, args)
+	})
 }
 
 func registerBuiltinHandler(name, desc, category string, handler ce.CommandHandler) {

--- a/pkg/extensions/adapters/cli/cliadapter_test.go
+++ b/pkg/extensions/adapters/cli/cliadapter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -38,6 +39,14 @@ func TestInitRegistersBuiltinHandlers(t *testing.T) {
 	}
 	if output != time.Now().UTC().Format(time.DateOnly) {
 		t.Fatalf("date output = %q, want current UTC date", output)
+	}
+
+	output, err = Exec(context.Background(), "zip", nil)
+	if err != nil {
+		t.Fatalf("Exec zip: %v", err)
+	}
+	if !strings.Contains(output, "Usage: zip") {
+		t.Fatalf("zip output = %q, want usage", output)
 	}
 }
 


### PR DESCRIPTION
## 概要

新增 CLI adapter 的 `zip` 适配器，先引入一个不依赖外部命令、不访问网络的纯 Go adapter，作为 concrete CLI adapters 的第一批落地内容。

## 本次变更

- 新增 `pkg/extensions/adapters/cli/adapters/zip`
- 支持 `create`、`list`、`extract`、`add` 等 ZIP 操作
- 将 `zip` 注册为 CLI built-in handler
- 补充 ZIP 创建、列表、解压、追加和安全解压测试

## 安全说明

- 该 adapter 不执行 shell、不调用外部 CLI、不发起网络请求
- 解压时会拒绝 `../`、绝对路径等 ZIP Slip 路径穿越输入
- ZIP 写入、复制、关闭、重命名等错误会返回给调用方，不再静默忽略

## 验证

已执行：

- `go test ./pkg/extensions/adapters/cli/...`
- `go test -cover ./pkg/extensions/adapters/cli/...`
