### PR TITLE
feat(cli): add sqlite CLI adapter

### DIFF
--- a/pkg/extensions/adapters/cli/adapters/sqlite/sqlite.go
+++ b/pkg/extensions/adapters/cli/adapters/sqlite/sqlite.go
@@ -1,0 +1,125 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+var sqliteIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+type CommandRunner func(ctx context.Context, path string, args []string) (string, error)
+
+type Client struct {
+	sqlitePath string
+	runner     CommandRunner
+}
+
+type Config struct {
+	SQLitePath string
+	Runner     CommandRunner
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.SQLitePath
+	if path == "" {
+		path = "sqlite3"
+	}
+	runner := cfg.Runner
+	if runner == nil {
+		runner = runSQLiteCommand
+	}
+	return &Client{
+		sqlitePath: path,
+		runner:     runner,
+	}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "Usage: sqlite <db> <sql>\nCommands: tables, schema, dump", nil
+	}
+
+	dbPath := args[0]
+	if err := validateDatabasePath(dbPath); err != nil {
+		return "", err
+	}
+	switch strings.ToLower(args[1]) {
+	case "tables":
+		return c.tables(ctx, dbPath)
+	case "schema":
+		if len(args) < 3 {
+			return "", fmt.Errorf("usage: sqlite <db> schema <table>")
+		}
+		return c.schema(ctx, dbPath, args[2])
+	case "dump":
+		return c.dump(ctx, dbPath)
+	}
+
+	sqlQuery := strings.Join(args[1:], " ")
+
+	query := strings.TrimSpace(sqlQuery)
+	if strings.HasPrefix(query, ".") {
+		return "", fmt.Errorf("sqlite dot commands are disabled; use tables, schema, or dump")
+	}
+	if strings.HasPrefix(strings.ToLower(query), "select") ||
+		strings.HasPrefix(strings.ToLower(query), "pragma") {
+		return c.query(ctx, dbPath, query)
+	}
+
+	return c.execute(ctx, dbPath, query)
+}
+
+func (c *Client) query(ctx context.Context, dbPath, query string) (string, error) {
+	return c.run(ctx, []string{"-header", "-column", dbPath, query})
+}
+
+func (c *Client) execute(ctx context.Context, dbPath, query string) (string, error) {
+	return c.run(ctx, []string{dbPath, query})
+}
+
+func (c *Client) tables(ctx context.Context, dbPath string) (string, error) {
+	return c.run(ctx, []string{dbPath, ".tables"})
+}
+
+func (c *Client) schema(ctx context.Context, dbPath, table string) (string, error) {
+	if !sqliteIdentifierPattern.MatchString(table) {
+		return "", fmt.Errorf("unsafe sqlite table name: %s", table)
+	}
+	return c.run(ctx, []string{dbPath, fmt.Sprintf(".schema %s", table)})
+}
+
+func (c *Client) dump(ctx context.Context, dbPath string) (string, error) {
+	return c.run(ctx, []string{dbPath, ".dump"})
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	return c.runner(ctx, c.sqlitePath, args)
+}
+
+func runSQLiteCommand(ctx context.Context, path string, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, path, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	_, err := c.runner(ctx, c.sqlitePath, []string{"--version"})
+	return err == nil
+}
+
+func validateDatabasePath(dbPath string) error {
+	dbPath = strings.TrimSpace(dbPath)
+	if dbPath == "" {
+		return fmt.Errorf("database path is required")
+	}
+	if strings.HasPrefix(dbPath, "-") {
+		return fmt.Errorf("database path must not start with '-'")
+	}
+	return nil
+}

--- a/pkg/extensions/adapters/cli/adapters/sqlite/sqlite.go
+++ b/pkg/extensions/adapters/cli/adapters/sqlite/sqlite.go
@@ -61,7 +61,7 @@ func (c *Client) Run(ctx context.Context, args []string) (string, error) {
 	sqlQuery := strings.Join(args[1:], " ")
 
 	query := strings.TrimSpace(sqlQuery)
-	if strings.HasPrefix(query, ".") {
+	if containsSQLiteDotCommand(query) {
 		return "", fmt.Errorf("sqlite dot commands are disabled; use tables, schema, or dump")
 	}
 	if strings.HasPrefix(strings.ToLower(query), "select") ||
@@ -122,4 +122,13 @@ func validateDatabasePath(dbPath string) error {
 		return fmt.Errorf("database path must not start with '-'")
 	}
 	return nil
+}
+
+func containsSQLiteDotCommand(query string) bool {
+	for _, line := range strings.Split(strings.ReplaceAll(query, "\r\n", "\n"), "\n") {
+		if strings.HasPrefix(strings.TrimLeft(line, " \t\r"), ".") {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/extensions/adapters/cli/adapters/sqlite/sqlite_test.go
+++ b/pkg/extensions/adapters/cli/adapters/sqlite/sqlite_test.go
@@ -1,0 +1,176 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRunReturnsUsageWithoutDatabaseAndQuery(t *testing.T) {
+	output, err := NewClient(Config{}).Run(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(output, "Usage: sqlite") {
+		t.Fatalf("output = %q, want usage", output)
+	}
+}
+
+func TestRunSelectUsesHeaderColumnMode(t *testing.T) {
+	recorder := &recordingRunner{output: "id  name\n1   alice\n"}
+	client := NewClient(Config{
+		SQLitePath: "custom-sqlite",
+		Runner:     recorder.run,
+	})
+
+	output, err := client.Run(context.Background(), []string{"app.db", "select", "*", "from", "users"})
+	if err != nil {
+		t.Fatalf("Run select: %v", err)
+	}
+	if output != recorder.output {
+		t.Fatalf("output = %q, want %q", output, recorder.output)
+	}
+	if recorder.path != "custom-sqlite" {
+		t.Fatalf("path = %q, want custom-sqlite", recorder.path)
+	}
+	wantArgs := []string{"-header", "-column", "app.db", "select * from users"}
+	if !reflect.DeepEqual(recorder.args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", recorder.args, wantArgs)
+	}
+}
+
+func TestRunExecuteUsesDatabaseAndQuery(t *testing.T) {
+	recorder := &recordingRunner{output: "ok"}
+	client := NewClient(Config{Runner: recorder.run})
+
+	output, err := client.Run(context.Background(), []string{"app.db", "insert", "into", "users", "values", "(1)"})
+	if err != nil {
+		t.Fatalf("Run execute: %v", err)
+	}
+	if output != "ok" {
+		t.Fatalf("output = %q, want ok", output)
+	}
+	wantArgs := []string{"app.db", "insert into users values (1)"}
+	if !reflect.DeepEqual(recorder.args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", recorder.args, wantArgs)
+	}
+}
+
+func TestRunInspectionCommands(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "tables",
+			args: []string{"app.db", "tables"},
+			want: []string{"app.db", ".tables"},
+		},
+		{
+			name: "schema",
+			args: []string{"app.db", "schema", "users"},
+			want: []string{"app.db", ".schema users"},
+		},
+		{
+			name: "dump",
+			args: []string{"app.db", "dump"},
+			want: []string{"app.db", ".dump"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := &recordingRunner{output: tt.name}
+			output, err := NewClient(Config{Runner: recorder.run}).Run(context.Background(), tt.args)
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if output != tt.name {
+				t.Fatalf("output = %q, want %q", output, tt.name)
+			}
+			if !reflect.DeepEqual(recorder.args, tt.want) {
+				t.Fatalf("args = %#v, want %#v", recorder.args, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunSchemaRequiresTable(t *testing.T) {
+	_, err := NewClient(Config{Runner: (&recordingRunner{}).run}).Run(context.Background(), []string{"app.db", "schema"})
+	if err == nil {
+		t.Fatal("expected schema usage error")
+	}
+	if !strings.Contains(err.Error(), "usage: sqlite <db> schema <table>") {
+		t.Fatalf("error = %v, want schema usage", err)
+	}
+}
+
+func TestRunRejectsRawSQLiteDotCommands(t *testing.T) {
+	_, err := NewClient(Config{Runner: (&recordingRunner{}).run}).Run(context.Background(), []string{"app.db", ".shell", "calc"})
+	if err == nil {
+		t.Fatal("expected disabled dot command error")
+	}
+	if !strings.Contains(err.Error(), "dot commands are disabled") {
+		t.Fatalf("error = %v, want dot command disabled", err)
+	}
+}
+
+func TestRunRejectsUnsafeSchemaTableName(t *testing.T) {
+	_, err := NewClient(Config{Runner: (&recordingRunner{}).run}).Run(context.Background(), []string{"app.db", "schema", "users; .shell calc"})
+	if err == nil {
+		t.Fatal("expected unsafe table name error")
+	}
+	if !strings.Contains(err.Error(), "unsafe sqlite table name") {
+		t.Fatalf("error = %v, want unsafe table name", err)
+	}
+}
+
+func TestRunRejectsOptionLikeDatabasePath(t *testing.T) {
+	_, err := NewClient(Config{Runner: (&recordingRunner{}).run}).Run(context.Background(), []string{"-cmd", "select", "1"})
+	if err == nil {
+		t.Fatal("expected database path error")
+	}
+	if !strings.Contains(err.Error(), "must not start") {
+		t.Fatalf("error = %v, want option-like path rejection", err)
+	}
+}
+
+func TestIsInstalledUsesConfiguredRunner(t *testing.T) {
+	recorder := &recordingRunner{}
+	client := NewClient(Config{
+		SQLitePath: "sqlite-test",
+		Runner:     recorder.run,
+	})
+
+	if !client.IsInstalled(context.Background()) {
+		t.Fatal("expected installed")
+	}
+	if recorder.path != "sqlite-test" {
+		t.Fatalf("path = %q, want sqlite-test", recorder.path)
+	}
+	if !reflect.DeepEqual(recorder.args, []string{"--version"}) {
+		t.Fatalf("args = %#v, want --version", recorder.args)
+	}
+
+	client = NewClient(Config{Runner: func(context.Context, string, []string) (string, error) {
+		return "", errors.New("missing")
+	}})
+	if client.IsInstalled(context.Background()) {
+		t.Fatal("expected not installed")
+	}
+}
+
+type recordingRunner struct {
+	path   string
+	args   []string
+	output string
+}
+
+func (r *recordingRunner) run(ctx context.Context, path string, args []string) (string, error) {
+	r.path = path
+	r.args = append([]string(nil), args...)
+	return r.output, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/sqlite/sqlite_test.go
+++ b/pkg/extensions/adapters/cli/adapters/sqlite/sqlite_test.go
@@ -118,6 +118,34 @@ func TestRunRejectsRawSQLiteDotCommands(t *testing.T) {
 	}
 }
 
+func TestRunRejectsEmbeddedSQLiteDotCommands(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "newline shell",
+			query: "select 1;\n.shell touch /tmp/pwned",
+		},
+		{
+			name:  "crlf shell with spaces",
+			query: "select 1;\r\n  .system calc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewClient(Config{Runner: (&recordingRunner{}).run}).Run(context.Background(), []string{"app.db", tt.query})
+			if err == nil {
+				t.Fatal("expected disabled dot command error")
+			}
+			if !strings.Contains(err.Error(), "dot commands are disabled") {
+				t.Fatalf("error = %v, want dot command disabled", err)
+			}
+		})
+	}
+}
+
 func TestRunRejectsUnsafeSchemaTableName(t *testing.T) {
 	_, err := NewClient(Config{Runner: (&recordingRunner{}).run}).Run(context.Background(), []string{"app.db", "schema", "users; .shell calc"})
 	if err == nil {

--- a/pkg/extensions/adapters/cli/cliadapter.go
+++ b/pkg/extensions/adapters/cli/cliadapter.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	sqliteadapter "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/sqlite"
 	zipadapter "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/zip"
 	ce "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/exec"
 	cr "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/registry"
@@ -139,6 +140,10 @@ func registerBuiltInHandlers() {
 
 	registerBuiltinHandler("zip", "Create, list, extract, and update ZIP archives", "archive", func(ctx context.Context, args []string) (string, error) {
 		return zipadapter.NewClient(zipadapter.Config{}).Run(ctx, args)
+	})
+
+	registerBuiltinHandler("sqlite", "Run SQLite queries and inspection commands", "database", func(ctx context.Context, args []string) (string, error) {
+		return sqliteadapter.NewClient(sqliteadapter.Config{}).Run(ctx, args)
 	})
 }
 

--- a/pkg/extensions/adapters/cli/cliadapter_test.go
+++ b/pkg/extensions/adapters/cli/cliadapter_test.go
@@ -48,6 +48,14 @@ func TestInitRegistersBuiltinHandlers(t *testing.T) {
 	if !strings.Contains(output, "Usage: zip") {
 		t.Fatalf("zip output = %q, want usage", output)
 	}
+
+	output, err = Exec(context.Background(), "sqlite", nil)
+	if err != nil {
+		t.Fatalf("Exec sqlite: %v", err)
+	}
+	if !strings.Contains(output, "Usage: sqlite") {
+		t.Fatalf("sqlite output = %q, want usage", output)
+	}
 }
 
 func TestSearchAndListCategoriesAfterInit(t *testing.T) {


### PR DESCRIPTION
## 概要

新增 CLI adapter 的 `sqlite` 适配器，提供 SQLite 查询、执行和基础结构检查能力，作为 concrete CLI adapters 的下一批小范围落地内容。

## 本次变更

- 新增 `pkg/extensions/adapters/cli/adapters/sqlite`
  - 支持 `sqlite <db> <sql>`
  - 支持 `tables`、`schema`、`dump` inspection 命令
  - 支持自定义 `sqlite3` 可执行路径
  - 支持测试注入 runner，避免 CI 依赖本机安装 `sqlite3`
- 将 `sqlite` 注册为 CLI built-in handler
- 补充 adapter 单元测试和 CLI 注册测试

## 安全说明

- 不通过 shell 拼接执行命令，只使用 `exec.CommandContext`
- 禁止 raw SQLite dot commands，避免 `.shell` / `.system` 等路径带来本地命令执行风险
- `schema` 的 table name 使用白名单校验
- 拒绝以 `-` 开头的数据库路径，避免被 SQLite CLI 当作命令参数解析

## 验证

已执行：

- `go test ./pkg/extensions/adapters/cli/adapters/sqlite`
- `go test ./pkg/extensions/adapters/cli/...`
- `go test -cover ./pkg/extensions/adapters/cli/...`
