### PR TITLE
feat(cli): add ollama CLI adapter

### DIFF
--- a/pkg/extensions/adapters/cli/adapters/ollama/ollama.go
+++ b/pkg/extensions/adapters/cli/adapters/ollama/ollama.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	defaultBaseURL = "http://localhost:11434"
-	defaultModel   = "llama2"
+	defaultModel   = "llama3.2"
 )
 
 type Client struct {

--- a/pkg/extensions/adapters/cli/adapters/ollama/ollama.go
+++ b/pkg/extensions/adapters/cli/adapters/ollama/ollama.go
@@ -1,0 +1,291 @@
+package ollama
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultBaseURL = "http://localhost:11434"
+	defaultModel   = "llama2"
+)
+
+type Client struct {
+	baseURL    *url.URL
+	httpClient *http.Client
+	model      string
+}
+
+type Config struct {
+	BaseURL     string
+	Model       string
+	HTTPClient  *http.Client
+	AllowRemote bool
+}
+
+type Model struct {
+	Name       string `json:"name"`
+	Size       int64  `json:"size"`
+	ModifiedAt string `json:"modified_at"`
+	Digest     string `json:"digest"`
+}
+
+type generateRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+	Stream bool   `json:"stream"`
+}
+
+type generateResponse struct {
+	Response string `json:"response"`
+}
+
+type chatRequest struct {
+	Model    string    `json:"model"`
+	Messages []Message `json:"messages"`
+	Stream   bool      `json:"stream"`
+}
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatResponse struct {
+	Message Message `json:"message"`
+}
+
+type listResponse struct {
+	Models []Model `json:"models"`
+}
+
+func NewClient(cfg Config) (*Client, error) {
+	rawBaseURL := strings.TrimSpace(cfg.BaseURL)
+	if rawBaseURL == "" {
+		rawBaseURL = defaultBaseURL
+	}
+	parsed, err := validateBaseURL(rawBaseURL, cfg.AllowRemote)
+	if err != nil {
+		return nil, err
+	}
+
+	model := strings.TrimSpace(cfg.Model)
+	if model == "" {
+		model = defaultModel
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	return &Client{
+		baseURL:    parsed,
+		httpClient: httpClient,
+		model:      model,
+	}, nil
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.listModelsText(ctx)
+	}
+
+	switch args[0] {
+	case "list", "models":
+		return c.listModelsText(ctx)
+	case "generate", "run":
+		if len(args) < 2 {
+			return "", fmt.Errorf("usage: ollama run <prompt>")
+		}
+		return c.Generate(ctx, strings.Join(args[1:], " "))
+	case "chat":
+		if len(args) < 2 {
+			return "", fmt.Errorf("usage: ollama chat <message>")
+		}
+		return c.Chat(ctx, []Message{{Role: "user", Content: strings.Join(args[1:], " ")}})
+	case "show":
+		model := c.model
+		if len(args) > 1 {
+			model = args[1]
+		}
+		return c.Show(ctx, model)
+	case "status":
+		if c.IsRunning(ctx) {
+			return "Ollama is running", nil
+		}
+		return "Ollama is not reachable", nil
+	default:
+		return c.Generate(ctx, strings.Join(args, " "))
+	}
+}
+
+func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return "", fmt.Errorf("prompt is required")
+	}
+
+	body, err := json.Marshal(generateRequest{
+		Model:  c.model,
+		Prompt: prompt,
+		Stream: false,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var result generateResponse
+	if err := c.doJSON(ctx, http.MethodPost, "/api/generate", bytes.NewReader(body), &result); err != nil {
+		return "", err
+	}
+	return result.Response, nil
+}
+
+func (c *Client) Chat(ctx context.Context, messages []Message) (string, error) {
+	if len(messages) == 0 {
+		return "", fmt.Errorf("at least one message is required")
+	}
+
+	body, err := json.Marshal(chatRequest{
+		Model:    c.model,
+		Messages: messages,
+		Stream:   false,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var result chatResponse
+	if err := c.doJSON(ctx, http.MethodPost, "/api/chat", bytes.NewReader(body), &result); err != nil {
+		return "", err
+	}
+	return result.Message.Content, nil
+}
+
+func (c *Client) ListModels(ctx context.Context) ([]Model, error) {
+	var result listResponse
+	if err := c.doJSON(ctx, http.MethodGet, "/api/tags", nil, &result); err != nil {
+		return nil, err
+	}
+	return append([]Model(nil), result.Models...), nil
+}
+
+func (c *Client) Show(ctx context.Context, model string) (string, error) {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return "", fmt.Errorf("model is required")
+	}
+
+	body, err := json.Marshal(map[string]string{"name": model})
+	if err != nil {
+		return "", err
+	}
+
+	var result map[string]any
+	if err := c.doJSON(ctx, http.MethodPost, "/api/show", bytes.NewReader(body), &result); err != nil {
+		return "", err
+	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (c *Client) IsRunning(ctx context.Context) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint("/api/tags"), nil)
+	if err != nil {
+		return false
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode < http.StatusMultipleChoices
+}
+
+func (c *Client) listModelsText(ctx context.Context) (string, error) {
+	models, err := c.ListModels(ctx)
+	if err != nil {
+		return "", err
+	}
+	if len(models) == 0 {
+		return "No Ollama models found", nil
+	}
+	lines := make([]string, 0, len(models))
+	for _, model := range models {
+		lines = append(lines, model.Name)
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+func (c *Client) doJSON(ctx context.Context, method, path string, body io.Reader, out any) error {
+	req, err := http.NewRequestWithContext(ctx, method, c.endpoint(path), body)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("ollama request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("ollama returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("decode ollama response: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) endpoint(path string) string {
+	resolved := *c.baseURL
+	resolved.Path = strings.TrimRight(c.baseURL.Path, "/") + "/" + strings.TrimLeft(path, "/")
+	resolved.RawQuery = ""
+	resolved.Fragment = ""
+	return resolved.String()
+}
+
+func validateBaseURL(raw string, allowRemote bool) (*url.URL, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ollama base URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("ollama base URL must use http or https")
+	}
+	if parsed.Hostname() == "" {
+		return nil, fmt.Errorf("ollama base URL must include a host")
+	}
+	if !allowRemote && !isLoopbackHost(parsed.Hostname()) {
+		return nil, fmt.Errorf("ollama base URL must be loopback unless AllowRemote is set")
+	}
+	return parsed, nil
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/pkg/extensions/adapters/cli/adapters/ollama/ollama.go
+++ b/pkg/extensions/adapters/cli/adapters/ollama/ollama.go
@@ -96,7 +96,7 @@ func NewClient(cfg Config) (*Client, error) {
 
 func (c *Client) Run(ctx context.Context, args []string) (string, error) {
 	if len(args) == 0 {
-		return c.listModelsText(ctx)
+		return "Usage: ollama <command> [args]\nCommands: list, models, run, generate, chat, show, status", nil
 	}
 
 	switch args[0] {

--- a/pkg/extensions/adapters/cli/adapters/ollama/ollama_test.go
+++ b/pkg/extensions/adapters/cli/adapters/ollama/ollama_test.go
@@ -17,7 +17,7 @@ func TestRunListsModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run list: %v", err)
 	}
-	if output != "llama2\ncodellama" {
+	if output != "llama3.2\ncodellama" {
 		t.Fatalf("output = %q, want model list", output)
 	}
 }
@@ -52,11 +52,11 @@ func TestShowReturnsFormattedJSON(t *testing.T) {
 	server := newOllamaTestServer(t)
 	client := newTestClient(t, server)
 
-	output, err := client.Run(context.Background(), []string{"show", "llama2"})
+	output, err := client.Run(context.Background(), []string{"show", "llama3.2"})
 	if err != nil {
 		t.Fatalf("Run show: %v", err)
 	}
-	if !strings.Contains(output, `"name": "llama2"`) {
+	if !strings.Contains(output, `"name": "llama3.2"`) {
 		t.Fatalf("output = %q, want model json", output)
 	}
 }
@@ -139,7 +139,7 @@ func newOllamaTestServer(t *testing.T) *httptest.Server {
 		switch r.URL.Path {
 		case "/api/tags":
 			writeJSON(t, w, listResponse{Models: []Model{
-				{Name: "llama2"},
+				{Name: "llama3.2"},
 				{Name: "codellama"},
 			}})
 		case "/api/generate":
@@ -165,10 +165,10 @@ func newOllamaTestServer(t *testing.T) *httptest.Server {
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				t.Fatalf("decode show request: %v", err)
 			}
-			if req["name"] != "llama2" {
-				t.Fatalf("show request = %+v, want llama2", req)
+			if req["name"] != "llama3.2" {
+				t.Fatalf("show request = %+v, want llama3.2", req)
 			}
-			writeJSON(t, w, map[string]any{"name": "llama2", "family": "llama"})
+			writeJSON(t, w, map[string]any{"name": "llama3.2", "family": "llama"})
 		default:
 			http.NotFound(w, r)
 		}

--- a/pkg/extensions/adapters/cli/adapters/ollama/ollama_test.go
+++ b/pkg/extensions/adapters/cli/adapters/ollama/ollama_test.go
@@ -1,0 +1,185 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRunListsModels(t *testing.T) {
+	server := newOllamaTestServer(t)
+	client := newTestClient(t, server)
+
+	output, err := client.Run(context.Background(), []string{"list"})
+	if err != nil {
+		t.Fatalf("Run list: %v", err)
+	}
+	if output != "llama2\ncodellama" {
+		t.Fatalf("output = %q, want model list", output)
+	}
+}
+
+func TestGenerateSendsPromptAndReturnsResponse(t *testing.T) {
+	server := newOllamaTestServer(t)
+	client := newTestClient(t, server)
+
+	output, err := client.Run(context.Background(), []string{"run", "hello", "ollama"})
+	if err != nil {
+		t.Fatalf("Run generate: %v", err)
+	}
+	if output != "generated response" {
+		t.Fatalf("output = %q, want generated response", output)
+	}
+}
+
+func TestChatSendsMessageAndReturnsAssistantContent(t *testing.T) {
+	server := newOllamaTestServer(t)
+	client := newTestClient(t, server)
+
+	output, err := client.Run(context.Background(), []string{"chat", "hello"})
+	if err != nil {
+		t.Fatalf("Run chat: %v", err)
+	}
+	if output != "chat response" {
+		t.Fatalf("output = %q, want chat response", output)
+	}
+}
+
+func TestShowReturnsFormattedJSON(t *testing.T) {
+	server := newOllamaTestServer(t)
+	client := newTestClient(t, server)
+
+	output, err := client.Run(context.Background(), []string{"show", "llama2"})
+	if err != nil {
+		t.Fatalf("Run show: %v", err)
+	}
+	if !strings.Contains(output, `"name": "llama2"`) {
+		t.Fatalf("output = %q, want model json", output)
+	}
+}
+
+func TestStatusReportsReachability(t *testing.T) {
+	server := newOllamaTestServer(t)
+	client := newTestClient(t, server)
+
+	output, err := client.Run(context.Background(), []string{"status"})
+	if err != nil {
+		t.Fatalf("Run status: %v", err)
+	}
+	if output != "Ollama is running" {
+		t.Fatalf("output = %q, want running", output)
+	}
+}
+
+func TestNewClientRejectsRemoteBaseURLByDefault(t *testing.T) {
+	_, err := NewClient(Config{BaseURL: "http://example.com:11434"})
+	if err == nil {
+		t.Fatal("expected remote URL rejection")
+	}
+	if !strings.Contains(err.Error(), "loopback") {
+		t.Fatalf("error = %v, want loopback rejection", err)
+	}
+}
+
+func TestNewClientAllowsRemoteWhenExplicit(t *testing.T) {
+	client, err := NewClient(Config{BaseURL: "http://example.com:11434", AllowRemote: true})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if client.endpoint("/api/tags") != "http://example.com:11434/api/tags" {
+		t.Fatalf("endpoint = %q, want remote endpoint", client.endpoint("/api/tags"))
+	}
+}
+
+func TestEndpointPreservesBasePathAndDropsQuery(t *testing.T) {
+	client, err := NewClient(Config{BaseURL: "http://127.0.0.1:11434/ollama?token=secret#frag"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if got := client.endpoint("/api/tags"); got != "http://127.0.0.1:11434/ollama/api/tags" {
+		t.Fatalf("endpoint = %q, want base path without query", got)
+	}
+}
+
+func TestRunReturnsHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusBadGateway)
+	}))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server)
+
+	_, err := client.Run(context.Background(), []string{"list"})
+	if err == nil {
+		t.Fatal("expected HTTP error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 502") {
+		t.Fatalf("error = %v, want HTTP status", err)
+	}
+}
+
+func newTestClient(t *testing.T, server *httptest.Server) *Client {
+	t.Helper()
+	client, err := NewClient(Config{
+		BaseURL:    server.URL,
+		HTTPClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client
+}
+
+func newOllamaTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/tags":
+			writeJSON(t, w, listResponse{Models: []Model{
+				{Name: "llama2"},
+				{Name: "codellama"},
+			}})
+		case "/api/generate":
+			var req generateRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode generate request: %v", err)
+			}
+			if req.Prompt != "hello ollama" || req.Model != defaultModel || req.Stream {
+				t.Fatalf("generate request = %+v, want prompt/model/no stream", req)
+			}
+			writeJSON(t, w, generateResponse{Response: "generated response"})
+		case "/api/chat":
+			var req chatRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode chat request: %v", err)
+			}
+			if len(req.Messages) != 1 || req.Messages[0].Content != "hello" || req.Messages[0].Role != "user" {
+				t.Fatalf("chat request = %+v, want user hello", req)
+			}
+			writeJSON(t, w, chatResponse{Message: Message{Role: "assistant", Content: "chat response"}})
+		case "/api/show":
+			var req map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode show request: %v", err)
+			}
+			if req["name"] != "llama2" {
+				t.Fatalf("show request = %+v, want llama2", req)
+			}
+			writeJSON(t, w, map[string]any{"name": "llama2", "family": "llama"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/ollama/ollama_test.go
+++ b/pkg/extensions/adapters/cli/adapters/ollama/ollama_test.go
@@ -6,8 +6,30 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
+
+func TestRunWithoutArgsReturnsUsageWithoutNetwork(t *testing.T) {
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server)
+
+	output, err := client.Run(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Run without args: %v", err)
+	}
+	if !strings.Contains(output, "Usage: ollama") {
+		t.Fatalf("output = %q, want usage", output)
+	}
+	if got := atomic.LoadInt32(&requests); got != 0 {
+		t.Fatalf("requests = %d, want no network I/O", got)
+	}
+}
 
 func TestRunListsModels(t *testing.T) {
 	server := newOllamaTestServer(t)

--- a/pkg/extensions/adapters/cli/cliadapter.go
+++ b/pkg/extensions/adapters/cli/cliadapter.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	ollamaadapter "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/ollama"
 	sqliteadapter "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/sqlite"
 	zipadapter "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/adapters/zip"
 	ce "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/exec"
@@ -144,6 +145,14 @@ func registerBuiltInHandlers() {
 
 	registerBuiltinHandler("sqlite", "Run SQLite queries and inspection commands", "database", func(ctx context.Context, args []string) (string, error) {
 		return sqliteadapter.NewClient(sqliteadapter.Config{}).Run(ctx, args)
+	})
+
+	registerBuiltinHandler("ollama", "Interact with a local Ollama server", "ai", func(ctx context.Context, args []string) (string, error) {
+		client, err := ollamaadapter.NewClient(ollamaadapter.Config{})
+		if err != nil {
+			return "", err
+		}
+		return client.Run(ctx, args)
 	})
 }
 

--- a/pkg/extensions/adapters/cli/cliadapter_test.go
+++ b/pkg/extensions/adapters/cli/cliadapter_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	cr "github.com/1024XEngineer/anyclaw/pkg/extensions/adapters/cli/registry"
 )
 
 func TestInitRegistersBuiltinHandlers(t *testing.T) {
@@ -55,6 +57,14 @@ func TestInitRegistersBuiltinHandlers(t *testing.T) {
 	}
 	if !strings.Contains(output, "Usage: sqlite") {
 		t.Fatalf("sqlite output = %q, want usage", output)
+	}
+
+	adapter, ok := cr.GetBuiltinAdapter("ollama")
+	if !ok {
+		t.Fatal("expected ollama builtin adapter")
+	}
+	if adapter.Category != "ai" {
+		t.Fatalf("ollama category = %q, want ai", adapter.Category)
 	}
 }
 


### PR DESCRIPTION
## 概要

新增 CLI adapter 的 `ollama` 适配器，用于连接本机 Ollama 服务并执行模型列表、生成、聊天、模型详情和状态检查等操作。

## 本次变更

- 新增 `pkg/extensions/adapters/cli/adapters/ollama`
- 支持 `list` / `models`
- 支持 `run` / `generate`
- 支持 `chat`
- 支持 `show`
- 支持 `status`
- 将 `ollama` 注册为 CLI built-in handler
- 补充 adapter 单元测试和 CLI 注册测试

## 安全说明

- 默认只允许访问 localhost / loopback Ollama 服务
- 远程 Ollama URL 必须通过 `AllowRemote` 显式开启
- 测试使用本地 `httptest`，不会访问真实网络或真实 Ollama 服务
- 不执行 shell、不调用外部命令

## 验证

已执行：

- `go test ./pkg/extensions/adapters/cli/adapters/ollama`
- `go test ./pkg/extensions/adapters/cli/...`
- `go test -cover ./pkg/extensions/adapters/cli/...`
