### PR TITLE
feat(workflow): add file-backed graph store

### DIFF
--- a/pkg/capability/workflows/store.go
+++ b/pkg/capability/workflows/store.go
@@ -397,6 +397,9 @@ func (cm *CheckpointManager) Recover(executionID string) (*ExecutionContext, err
 	}
 	exec.Status = ExecutionRunning
 	exec.Error = nil
+	if err := cm.store.SaveExecution(exec); err != nil {
+		return nil, fmt.Errorf("persist recovered execution: %w", err)
+	}
 	return exec, nil
 }
 

--- a/pkg/capability/workflows/store.go
+++ b/pkg/capability/workflows/store.go
@@ -293,9 +293,6 @@ func (s *FileExecutionStore) List(graphID string) ([]*ExecutionContext, error) {
 		return nil, fmt.Errorf("execution store is nil")
 	}
 
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	entries, err := os.ReadDir(s.baseDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/capability/workflows/store.go
+++ b/pkg/capability/workflows/store.go
@@ -1,0 +1,463 @@
+package workflow
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// FileGraphStore persists workflow graphs and execution checkpoints on disk.
+type FileGraphStore struct {
+	baseDir   string
+	graphsDir string
+	mu        sync.RWMutex
+	index     map[string]graphIndexEntry
+	execStore *FileExecutionStore
+}
+
+type graphIndexEntry struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Version   string    `json:"version,omitempty"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Path      string    `json:"path"`
+}
+
+// FileExecutionStore persists execution contexts for checkpoint/recovery.
+type FileExecutionStore struct {
+	baseDir string
+	mu      sync.RWMutex
+}
+
+// NewFileGraphStore creates a filesystem-backed workflow graph store.
+func NewFileGraphStore(baseDir string) (*FileGraphStore, error) {
+	if strings.TrimSpace(baseDir) == "" {
+		baseDir = filepath.Join(".anyclaw", "workflows")
+	}
+
+	graphsDir := filepath.Join(baseDir, "graphs")
+	execDir := filepath.Join(baseDir, "executions")
+	for _, dir := range []string{graphsDir, execDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("create workflow store directory %s: %w", dir, err)
+		}
+	}
+
+	store := &FileGraphStore{
+		baseDir:   baseDir,
+		graphsDir: graphsDir,
+		index:     make(map[string]graphIndexEntry),
+		execStore: &FileExecutionStore{baseDir: execDir},
+	}
+	if err := store.loadIndex(); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *FileGraphStore) loadIndex() error {
+	entries, err := os.ReadDir(s.graphsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read workflow graph directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(s.graphsDir, entry.Name())
+		graph, err := loadGraphFile(path)
+		if err != nil || graph.ID == "" {
+			continue
+		}
+		if _, err := safeStoreID(graph.ID); err != nil {
+			continue
+		}
+		s.index[graph.ID] = graphIndexEntry{
+			ID:        graph.ID,
+			Name:      graph.Name,
+			Version:   graph.Version,
+			UpdatedAt: graph.UpdatedAt,
+			Path:      path,
+		}
+	}
+	return nil
+}
+
+// SaveGraph writes a graph snapshot to disk and updates the in-memory index.
+func (s *FileGraphStore) SaveGraph(graph *Graph) error {
+	if s == nil {
+		return fmt.Errorf("graph store is nil")
+	}
+	if graph == nil {
+		return fmt.Errorf("graph is nil")
+	}
+
+	path, err := s.graphPath(graph.ID)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	graph.UpdatedAt = time.Now().UTC()
+	if err := writeJSONFile(path, graph); err != nil {
+		return fmt.Errorf("write graph %s: %w", graph.ID, err)
+	}
+
+	s.index[graph.ID] = graphIndexEntry{
+		ID:        graph.ID,
+		Name:      graph.Name,
+		Version:   graph.Version,
+		UpdatedAt: graph.UpdatedAt,
+		Path:      path,
+	}
+	return nil
+}
+
+// LoadGraph reads a graph by ID.
+func (s *FileGraphStore) LoadGraph(graphID string) (*Graph, error) {
+	if s == nil {
+		return nil, fmt.Errorf("graph store is nil")
+	}
+	if _, err := safeStoreID(graphID); err != nil {
+		return nil, err
+	}
+
+	s.mu.RLock()
+	entry, ok := s.index[graphID]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("graph not found: %s", graphID)
+	}
+
+	graph, err := loadGraphFile(entry.Path)
+	if err != nil {
+		return nil, fmt.Errorf("load graph %s: %w", graphID, err)
+	}
+	return graph, nil
+}
+
+// DeleteGraph removes a graph from disk and the index.
+func (s *FileGraphStore) DeleteGraph(graphID string) error {
+	if s == nil {
+		return fmt.Errorf("graph store is nil")
+	}
+	if _, err := safeStoreID(graphID); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.index[graphID]
+	if !ok {
+		return fmt.Errorf("graph not found: %s", graphID)
+	}
+	if err := os.Remove(entry.Path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("delete graph %s: %w", graphID, err)
+	}
+	delete(s.index, graphID)
+	return nil
+}
+
+// ListGraphs returns graphs sorted by most recent update first.
+func (s *FileGraphStore) ListGraphs() ([]*Graph, error) {
+	if s == nil {
+		return nil, fmt.Errorf("graph store is nil")
+	}
+
+	s.mu.RLock()
+	entries := make([]graphIndexEntry, 0, len(s.index))
+	for _, entry := range s.index {
+		entries = append(entries, entry)
+	}
+	s.mu.RUnlock()
+
+	graphs := make([]*Graph, 0, len(entries))
+	for _, entry := range entries {
+		graph, err := loadGraphFile(entry.Path)
+		if err != nil {
+			continue
+		}
+		graphs = append(graphs, graph)
+	}
+	sort.Slice(graphs, func(i, j int) bool {
+		return graphs[i].UpdatedAt.After(graphs[j].UpdatedAt)
+	})
+	return graphs, nil
+}
+
+// SaveExecution persists an execution context.
+func (s *FileGraphStore) SaveExecution(exec *ExecutionContext) error {
+	if s == nil {
+		return fmt.Errorf("graph store is nil")
+	}
+	return s.execStore.Save(exec)
+}
+
+// LoadExecution reads an execution context by ID.
+func (s *FileGraphStore) LoadExecution(executionID string) (*ExecutionContext, error) {
+	if s == nil {
+		return nil, fmt.Errorf("graph store is nil")
+	}
+	return s.execStore.Load(executionID)
+}
+
+// ListExecutions returns persisted executions, optionally filtered by graph ID.
+func (s *FileGraphStore) ListExecutions(graphID string) ([]*ExecutionContext, error) {
+	if s == nil {
+		return nil, fmt.Errorf("graph store is nil")
+	}
+	return s.execStore.List(graphID)
+}
+
+// DeleteExecution removes a persisted execution.
+func (s *FileGraphStore) DeleteExecution(executionID string) error {
+	if s == nil {
+		return fmt.Errorf("graph store is nil")
+	}
+	return s.execStore.Delete(executionID)
+}
+
+func (s *FileGraphStore) graphPath(graphID string) (string, error) {
+	filename, err := safeStoreID(graphID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(s.graphsDir, filename+".json"), nil
+}
+
+// Save writes an execution context to disk.
+func (s *FileExecutionStore) Save(exec *ExecutionContext) error {
+	if s == nil {
+		return fmt.Errorf("execution store is nil")
+	}
+	if exec == nil {
+		return fmt.Errorf("execution context is nil")
+	}
+	path, err := s.executionPath(exec.ExecutionID)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := writeJSONFile(path, exec); err != nil {
+		return fmt.Errorf("write execution %s: %w", exec.ExecutionID, err)
+	}
+	return nil
+}
+
+// Load reads an execution context by ID.
+func (s *FileExecutionStore) Load(executionID string) (*ExecutionContext, error) {
+	if s == nil {
+		return nil, fmt.Errorf("execution store is nil")
+	}
+	path, err := s.executionPath(executionID)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("execution not found: %s", executionID)
+		}
+		return nil, fmt.Errorf("read execution %s: %w", executionID, err)
+	}
+
+	var exec ExecutionContext
+	if err := json.Unmarshal(data, &exec); err != nil {
+		return nil, fmt.Errorf("decode execution %s: %w", executionID, err)
+	}
+	return &exec, nil
+}
+
+// List returns executions sorted by start time descending.
+func (s *FileExecutionStore) List(graphID string) ([]*ExecutionContext, error) {
+	if s == nil {
+		return nil, fmt.Errorf("execution store is nil")
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entries, err := os.ReadDir(s.baseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read execution directory: %w", err)
+	}
+
+	executions := make([]*ExecutionContext, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(s.baseDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		var exec ExecutionContext
+		if err := json.Unmarshal(data, &exec); err != nil {
+			continue
+		}
+		if graphID != "" && exec.GraphID != graphID {
+			continue
+		}
+		executions = append(executions, &exec)
+	}
+
+	sort.Slice(executions, func(i, j int) bool {
+		return executions[i].StartTime.After(executions[j].StartTime)
+	})
+	return executions, nil
+}
+
+// Delete removes an execution context from disk.
+func (s *FileExecutionStore) Delete(executionID string) error {
+	if s == nil {
+		return fmt.Errorf("execution store is nil")
+	}
+	path, err := s.executionPath(executionID)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("delete execution %s: %w", executionID, err)
+	}
+	return nil
+}
+
+func (s *FileExecutionStore) executionPath(executionID string) (string, error) {
+	filename, err := safeStoreID(executionID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(s.baseDir, filename+".json"), nil
+}
+
+// CheckpointManager handles workflow checkpoint and recovery persistence.
+type CheckpointManager struct {
+	store *FileGraphStore
+}
+
+// NewCheckpointManager creates a checkpoint manager for a graph store.
+func NewCheckpointManager(store *FileGraphStore) *CheckpointManager {
+	return &CheckpointManager{store: store}
+}
+
+// Checkpoint saves the current execution state with checkpoint evidence.
+func (cm *CheckpointManager) Checkpoint(exec *ExecutionContext, checkpointType string) error {
+	if cm == nil || cm.store == nil {
+		return fmt.Errorf("checkpoint manager has no store")
+	}
+	if exec == nil {
+		return fmt.Errorf("execution context is nil")
+	}
+	exec.AddEvidence("checkpoint", fmt.Sprintf("checkpoint: %s", checkpointType), map[string]any{
+		"type":         checkpointType,
+		"current_node": exec.CurrentNode,
+		"status":       string(exec.Status),
+		"node_count":   len(exec.NodeStates),
+	})
+	return cm.store.SaveExecution(exec)
+}
+
+// Recover loads a checkpoint and moves non-terminal executions back to running.
+func (cm *CheckpointManager) Recover(executionID string) (*ExecutionContext, error) {
+	if cm == nil || cm.store == nil {
+		return nil, fmt.Errorf("checkpoint manager has no store")
+	}
+	exec, err := cm.store.LoadExecution(executionID)
+	if err != nil {
+		return nil, err
+	}
+	if exec.Status == ExecutionCompleted || exec.Status == ExecutionCancelled {
+		return nil, fmt.Errorf("cannot recover from terminal state: %s", exec.Status)
+	}
+	exec.Status = ExecutionRunning
+	exec.Error = nil
+	return exec, nil
+}
+
+// ListCheckpoints returns all persisted checkpoints for a graph.
+func (cm *CheckpointManager) ListCheckpoints(graphID string) ([]*ExecutionContext, error) {
+	if cm == nil || cm.store == nil {
+		return nil, fmt.Errorf("checkpoint manager has no store")
+	}
+	return cm.store.ListExecutions(graphID)
+}
+
+func safeStoreID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("store ID is required")
+	}
+	if id == "." || id == ".." || filepath.IsAbs(id) || strings.ContainsAny(id, `/\`) {
+		return "", fmt.Errorf("invalid store ID: %q", id)
+	}
+	if filepath.Clean(id) != id || filepath.Base(id) != id {
+		return "", fmt.Errorf("invalid store ID: %q", id)
+	}
+	for _, r := range id {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' || r == '.' {
+			continue
+		}
+		return "", fmt.Errorf("invalid store ID: %q", id)
+	}
+	return id, nil
+}
+
+func loadGraphFile(path string) (*Graph, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var graph Graph
+	if err := json.Unmarshal(data, &graph); err != nil {
+		return nil, err
+	}
+	return &graph, nil
+}
+
+func writeJSONFile(path string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		if removeErr := os.Remove(path); removeErr != nil && !os.IsNotExist(removeErr) {
+			_ = os.Remove(tmp)
+			return err
+		}
+		if renameErr := os.Rename(tmp, path); renameErr != nil {
+			_ = os.Remove(tmp)
+			return renameErr
+		}
+	}
+	return nil
+}

--- a/pkg/capability/workflows/store.go
+++ b/pkg/capability/workflows/store.go
@@ -75,11 +75,11 @@ func (s *FileGraphStore) loadIndex() error {
 		}
 		path := filepath.Join(s.graphsDir, entry.Name())
 		graph, err := loadGraphFile(path)
-		if err != nil || graph.ID == "" {
-			continue
+		if err != nil {
+			return fmt.Errorf("load workflow graph %s: %w", entry.Name(), err)
 		}
 		if _, err := safeStoreID(graph.ID); err != nil {
-			continue
+			return fmt.Errorf("load workflow graph %s: %w", entry.Name(), err)
 		}
 		s.index[graph.ID] = graphIndexEntry{
 			ID:        graph.ID,

--- a/pkg/capability/workflows/store_test.go
+++ b/pkg/capability/workflows/store_test.go
@@ -149,6 +149,13 @@ func TestCheckpointManagerRecover(t *testing.T) {
 	if len(recovered.Evidence) != 1 || recovered.Evidence[0].Type != "checkpoint" {
 		t.Fatalf("evidence = %+v, want checkpoint evidence", recovered.Evidence)
 	}
+	persisted, err := store.LoadExecution("exec_checkpoint")
+	if err != nil {
+		t.Fatalf("LoadExecution after Recover: %v", err)
+	}
+	if persisted.Status != ExecutionRunning || persisted.Error != nil {
+		t.Fatalf("persisted recovered execution = %+v, want running without error", persisted)
+	}
 
 	recovered.Status = ExecutionCompleted
 	if err := store.SaveExecution(recovered); err != nil {

--- a/pkg/capability/workflows/store_test.go
+++ b/pkg/capability/workflows/store_test.go
@@ -1,0 +1,168 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFileGraphStoreSaveLoadListDelete(t *testing.T) {
+	store, err := NewFileGraphStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileGraphStore: %v", err)
+	}
+
+	first := testStoreGraph("graph_one", "first")
+	if err := store.SaveGraph(first); err != nil {
+		t.Fatalf("SaveGraph first: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	second := testStoreGraph("graph_two", "second")
+	if err := store.SaveGraph(second); err != nil {
+		t.Fatalf("SaveGraph second: %v", err)
+	}
+
+	loaded, err := store.LoadGraph("graph_one")
+	if err != nil {
+		t.Fatalf("LoadGraph: %v", err)
+	}
+	if loaded.ID != first.ID || loaded.Name != first.Name {
+		t.Fatalf("loaded graph = %+v, want %+v", loaded, first)
+	}
+
+	graphs, err := store.ListGraphs()
+	if err != nil {
+		t.Fatalf("ListGraphs: %v", err)
+	}
+	if len(graphs) != 2 {
+		t.Fatalf("graphs = %d, want 2", len(graphs))
+	}
+	if graphs[0].ID != "graph_two" {
+		t.Fatalf("first graph = %q, want most recently saved graph_two", graphs[0].ID)
+	}
+
+	reopened, err := NewFileGraphStore(store.baseDir)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	if _, err := reopened.LoadGraph("graph_two"); err != nil {
+		t.Fatalf("LoadGraph after reopen: %v", err)
+	}
+
+	if err := store.DeleteGraph("graph_one"); err != nil {
+		t.Fatalf("DeleteGraph: %v", err)
+	}
+	if _, err := store.LoadGraph("graph_one"); err == nil {
+		t.Fatal("expected deleted graph to be missing")
+	}
+}
+
+func TestFileGraphStoreRejectsEscapingIDs(t *testing.T) {
+	parent := t.TempDir()
+	base := filepath.Join(parent, "store")
+	store, err := NewFileGraphStore(base)
+	if err != nil {
+		t.Fatalf("NewFileGraphStore: %v", err)
+	}
+
+	graph := testStoreGraph("../escape", "escape")
+	if err := store.SaveGraph(graph); err == nil {
+		t.Fatal("expected graph ID traversal rejection")
+	}
+	if _, err := os.Stat(filepath.Join(parent, "escape.json")); !os.IsNotExist(err) {
+		t.Fatalf("escape file stat err = %v, want not exist", err)
+	}
+
+	exec := NewExecutionContext("graph_one", nil)
+	exec.ExecutionID = "..\\escape"
+	if err := store.SaveExecution(exec); err == nil {
+		t.Fatal("expected execution ID traversal rejection")
+	}
+}
+
+func TestFileExecutionStoreSaveLoadListDelete(t *testing.T) {
+	store, err := NewFileGraphStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileGraphStore: %v", err)
+	}
+
+	first := NewExecutionContext("graph_one", map[string]any{"name": "first"})
+	first.ExecutionID = "exec_one"
+	second := NewExecutionContext("graph_two", map[string]any{"name": "second"})
+	second.ExecutionID = "exec_two"
+
+	if err := store.SaveExecution(first); err != nil {
+		t.Fatalf("SaveExecution first: %v", err)
+	}
+	if err := store.SaveExecution(second); err != nil {
+		t.Fatalf("SaveExecution second: %v", err)
+	}
+
+	loaded, err := store.LoadExecution("exec_one")
+	if err != nil {
+		t.Fatalf("LoadExecution: %v", err)
+	}
+	if loaded.GraphID != "graph_one" || loaded.Inputs["name"] != "first" {
+		t.Fatalf("loaded execution = %+v, want first execution", loaded)
+	}
+
+	filtered, err := store.ListExecutions("graph_two")
+	if err != nil {
+		t.Fatalf("ListExecutions: %v", err)
+	}
+	if len(filtered) != 1 || filtered[0].ExecutionID != "exec_two" {
+		t.Fatalf("filtered executions = %+v, want exec_two only", filtered)
+	}
+
+	if err := store.DeleteExecution("exec_one"); err != nil {
+		t.Fatalf("DeleteExecution: %v", err)
+	}
+	if _, err := store.LoadExecution("exec_one"); err == nil {
+		t.Fatal("expected deleted execution to be missing")
+	}
+}
+
+func TestCheckpointManagerRecover(t *testing.T) {
+	store, err := NewFileGraphStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileGraphStore: %v", err)
+	}
+	manager := NewCheckpointManager(store)
+
+	exec := NewExecutionContext("graph_one", nil)
+	exec.ExecutionID = "exec_checkpoint"
+	exec.Status = ExecutionFailed
+	exec.Error = &ExecutionError{Code: "boom", Message: "failed"}
+	if err := manager.Checkpoint(exec, "node_failed"); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+
+	recovered, err := manager.Recover("exec_checkpoint")
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if recovered.Status != ExecutionRunning || recovered.Error != nil {
+		t.Fatalf("recovered = %+v, want running without error", recovered)
+	}
+	if len(recovered.Evidence) != 1 || recovered.Evidence[0].Type != "checkpoint" {
+		t.Fatalf("evidence = %+v, want checkpoint evidence", recovered.Evidence)
+	}
+
+	recovered.Status = ExecutionCompleted
+	if err := store.SaveExecution(recovered); err != nil {
+		t.Fatalf("SaveExecution completed: %v", err)
+	}
+	_, err = manager.Recover("exec_checkpoint")
+	if err == nil || !strings.Contains(err.Error(), "terminal state") {
+		t.Fatalf("Recover completed err = %v, want terminal state error", err)
+	}
+}
+
+func testStoreGraph(id, name string) *Graph {
+	graph := NewGraph(name, "test graph")
+	graph.ID = id
+	graph.AddActionNode("run", "execute", "plugin", "action", map[string]any{"ok": true})
+	return graph
+}

--- a/pkg/capability/workflows/store_test.go
+++ b/pkg/capability/workflows/store_test.go
@@ -59,6 +59,55 @@ func TestFileGraphStoreSaveLoadListDelete(t *testing.T) {
 	}
 }
 
+func TestFileGraphStoreLoadIndexReportsInvalidGraphFiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		content  string
+		want     string
+	}{
+		{
+			name:     "malformed JSON",
+			filename: "broken.json",
+			content:  "{",
+			want:     "broken.json",
+		},
+		{
+			name:     "missing ID",
+			filename: "missing-id.json",
+			content:  `{"name":"missing id"}`,
+			want:     "store ID is required",
+		},
+		{
+			name:     "unsafe ID",
+			filename: "unsafe-id.json",
+			content:  `{"id":"../escape","name":"unsafe id"}`,
+			want:     "invalid store ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := t.TempDir()
+			graphsDir := filepath.Join(base, "graphs")
+			if err := os.MkdirAll(graphsDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll graphs: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(graphsDir, tt.filename), []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("WriteFile graph: %v", err)
+			}
+
+			_, err := NewFileGraphStore(base)
+			if err == nil {
+				t.Fatal("expected invalid graph file to fail store initialization")
+			}
+			if !strings.Contains(err.Error(), tt.filename) || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want filename %q and %q", err, tt.filename, tt.want)
+			}
+		})
+	}
+}
+
 func TestFileGraphStoreRejectsEscapingIDs(t *testing.T) {
 	parent := t.TempDir()
 	base := filepath.Join(parent, "store")

--- a/pkg/capability/workflows/store_test.go
+++ b/pkg/capability/workflows/store_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -170,6 +171,39 @@ func TestFileExecutionStoreSaveLoadListDelete(t *testing.T) {
 	}
 	if _, err := store.LoadExecution("exec_one"); err == nil {
 		t.Fatal("expected deleted execution to be missing")
+	}
+}
+
+func TestFileExecutionStoreListDoesNotDependOnStoreLock(t *testing.T) {
+	store, err := NewFileGraphStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileGraphStore: %v", err)
+	}
+	exec := NewExecutionContext("graph_one", nil)
+	exec.ExecutionID = "exec_one"
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	store.execStore.mu.Lock()
+	defer store.execStore.mu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		executions, err := store.ListExecutions("graph_one")
+		if err == nil && len(executions) != 1 {
+			err = fmt.Errorf("executions = %d, want 1", len(executions))
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ListExecutions: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ListExecutions blocked on execution store lock")
 	}
 }
 


### PR DESCRIPTION
## 概要

补充 workflow graph 的文件型持久化能力，为后续 workflow editor、trigger 和执行恢复能力提供基础存储层。

## 本次变更

- 新增文件型 `GraphStore`
- 支持保存、加载、删除和列出 workflow graph
- 新增 execution context 的文件型 checkpoint 存储
- 新增 `CheckpointManager`，支持 checkpoint 保存和非终态 execution 恢复
- 增加 store ID 校验，避免 graph/execution ID 造成路径逃逸
- 增加对应单元测试

## 影响

这条 PR 只引入 workflow 存储层，不包含 workflow editor、trigger manager、route workflow service 或实际执行入口。

## 验证

已执行：

- `go test ./pkg/capability/workflows`
- `go test ./pkg/capability/...`
