### PR TITLE
feat(workflow): add editor schema and node palette

### DIFF
--- a/pkg/capability/workflows/editor.go
+++ b/pkg/capability/workflows/editor.go
@@ -274,7 +274,6 @@ func nodeSchema() map[string]any {
 			"description":    stringProperty("Optional node description."),
 			"plugin":         stringProperty("Plugin name for action nodes."),
 			"action":         stringProperty("Plugin action name for action nodes."),
-			"workflow":       stringProperty("Referenced workflow ID for workflow action nodes."),
 			"inputs":         freeformObjectProperty("Node input values."),
 			"outputs":        freeformStringMapProperty("Node output name mappings."),
 			"condition":      expressionSchema(),

--- a/pkg/capability/workflows/editor.go
+++ b/pkg/capability/workflows/editor.go
@@ -226,7 +226,7 @@ func GetConditionHelpers() []ConditionHelper {
 		{
 			Name:        "is_null",
 			Signature:   "is_null(value)",
-			Description: "Checks whether a value is null or missing.",
+			Description: "Checks whether a value is explicitly null.",
 			Examples:    []string{`is_null($error)`},
 		},
 		{

--- a/pkg/capability/workflows/editor.go
+++ b/pkg/capability/workflows/editor.go
@@ -1,0 +1,445 @@
+package workflow
+
+// WorkflowEditorSchema describes the graph JSON surface exposed to visual editors.
+type WorkflowEditorSchema struct {
+	Schema      string         `json:"$schema"`
+	Title       string         `json:"title"`
+	Type        string         `json:"type"`
+	Required    []string       `json:"required,omitempty"`
+	Properties  map[string]any `json:"properties"`
+	Definitions map[string]any `json:"definitions,omitempty"`
+}
+
+// NodePalette groups node templates that a visual editor can offer to users.
+type NodePalette struct {
+	Categories []PaletteCategory `json:"categories"`
+}
+
+type PaletteCategory struct {
+	Name  string        `json:"name"`
+	Label string        `json:"label"`
+	Nodes []PaletteNode `json:"nodes"`
+}
+
+type PaletteNode struct {
+	Type        string         `json:"type"`
+	Label       string         `json:"label"`
+	Description string         `json:"description"`
+	Defaults    map[string]any `json:"defaults"`
+	Ports       NodePorts      `json:"ports"`
+}
+
+type NodePorts struct {
+	Inputs  []Port `json:"inputs,omitempty"`
+	Outputs []Port `json:"outputs,omitempty"`
+}
+
+type Port struct {
+	ID          string `json:"id"`
+	Label       string `json:"label"`
+	Type        string `json:"type"`
+	Description string `json:"description,omitempty"`
+}
+
+type ConditionHelper struct {
+	Name        string   `json:"name"`
+	Signature   string   `json:"signature"`
+	Description string   `json:"description"`
+	Examples    []string `json:"examples,omitempty"`
+}
+
+// GetWorkflowJSONSchema returns a JSON-schema-compatible description of Graph.
+func GetWorkflowJSONSchema() map[string]any {
+	return map[string]any{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"title":   "AnyClaw Workflow Graph",
+		"type":    "object",
+		"required": []string{
+			"id",
+			"name",
+			"nodes",
+		},
+		"additionalProperties": true,
+		"properties": map[string]any{
+			"id":          stringProperty("Unique workflow graph ID."),
+			"name":        stringProperty("Human-readable workflow name."),
+			"description": stringProperty("Optional workflow description."),
+			"version":     stringProperty("Optional semantic or product-specific version."),
+			"author":      stringProperty("Optional workflow author."),
+			"created_at":  dateTimeProperty("Creation timestamp."),
+			"updated_at":  dateTimeProperty("Last update timestamp."),
+			"nodes":       arrayProperty(nodeSchema(), 1, "Workflow nodes."),
+			"edges":       arrayProperty(edgeSchema(), 0, "Directed links between workflow nodes."),
+			"inputs":      arrayProperty(inputParamSchema(), 0, "Graph-level input parameters."),
+			"outputs":     arrayProperty(outputParamSchema(), 0, "Graph-level output parameters."),
+			"variables":   arrayProperty(variableSchema(), 0, "Graph-level variables."),
+			"metadata":    freeformObjectProperty("Arbitrary workflow metadata."),
+			"tags":        arrayProperty(stringProperty("Workflow tag."), 0, "Workflow tags."),
+		},
+		"definitions": map[string]any{
+			"node":       nodeSchema(),
+			"edge":       edgeSchema(),
+			"input":      inputParamSchema(),
+			"output":     outputParamSchema(),
+			"variable":   variableSchema(),
+			"retry":      retryPolicySchema(),
+			"on_error":   errorHandlingSchema(),
+			"position":   positionSchema(),
+			"expression": expressionSchema(),
+		},
+	}
+}
+
+// GetNodePalette returns editor-ready templates for supported node types.
+func GetNodePalette() NodePalette {
+	return NodePalette{
+		Categories: []PaletteCategory{
+			{
+				Name:  "control",
+				Label: "Control Flow",
+				Nodes: []PaletteNode{
+					{
+						Type:        "condition",
+						Label:       "Condition",
+						Description: "Branch execution by evaluating a condition expression.",
+						Defaults: map[string]any{
+							"type":      "condition",
+							"name":      "Condition",
+							"condition": "$input == true",
+						},
+						Ports: NodePorts{
+							Inputs: []Port{{ID: "in", Label: "In", Type: "flow"}},
+							Outputs: []Port{
+								{ID: "true", Label: "True", Type: "flow"},
+								{ID: "false", Label: "False", Type: "flow"},
+							},
+						},
+					},
+					{
+						Type:        "loop",
+						Label:       "Loop",
+						Description: "Iterate over an array value and execute downstream nodes per item.",
+						Defaults: map[string]any{
+							"type":      "loop",
+							"name":      "Loop",
+							"loop_var":  "item",
+							"loop_over": "$items",
+						},
+						Ports: NodePorts{
+							Inputs:  []Port{{ID: "in", Label: "In", Type: "flow"}},
+							Outputs: []Port{{ID: "each", Label: "Each", Type: "flow"}},
+						},
+					},
+					{
+						Type:        "parallel",
+						Label:       "Parallel",
+						Description: "Fan out execution to multiple branches.",
+						Defaults: map[string]any{
+							"type": "parallel",
+							"name": "Parallel",
+						},
+						Ports: NodePorts{
+							Inputs:  []Port{{ID: "in", Label: "In", Type: "flow"}},
+							Outputs: []Port{{ID: "branch", Label: "Branch", Type: "flow"}},
+						},
+					},
+					{
+						Type:        "join",
+						Label:       "Join",
+						Description: "Join multiple branches back into one path.",
+						Defaults: map[string]any{
+							"type": "join",
+							"name": "Join",
+						},
+						Ports: NodePorts{
+							Inputs:  []Port{{ID: "branches", Label: "Branches", Type: "flow"}},
+							Outputs: []Port{{ID: "out", Label: "Out", Type: "flow"}},
+						},
+					},
+				},
+			},
+			{
+				Name:  "actions",
+				Label: "Actions",
+				Nodes: []PaletteNode{
+					{
+						Type:        "action",
+						Label:       "Action",
+						Description: "Invoke a plugin action with resolved inputs.",
+						Defaults: map[string]any{
+							"type":   "action",
+							"name":   "Action",
+							"plugin": "plugin-name",
+							"action": "action-name",
+							"inputs": map[string]any{},
+						},
+						Ports: NodePorts{
+							Inputs:  []Port{{ID: "in", Label: "In", Type: "flow"}},
+							Outputs: []Port{{ID: "out", Label: "Out", Type: "flow"}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// GetConditionHelpers returns the condition helpers supported by EvalCondition.
+func GetConditionHelpers() []ConditionHelper {
+	return []ConditionHelper{
+		{
+			Name:        "contains",
+			Signature:   "contains(value, needle)",
+			Description: "Checks whether a string, array, or map contains a value.",
+			Examples:    []string{`contains($title, "urgent")`, `contains($tags, "todo")`},
+		},
+		{
+			Name:        "starts_with",
+			Signature:   "starts_with(value, prefix)",
+			Description: "Checks whether a string starts with a prefix.",
+			Examples:    []string{`starts_with($branch, "release/")`},
+		},
+		{
+			Name:        "ends_with",
+			Signature:   "ends_with(value, suffix)",
+			Description: "Checks whether a string ends with a suffix.",
+			Examples:    []string{`ends_with($file, ".md")`},
+		},
+		{
+			Name:        "empty",
+			Signature:   "empty(value)",
+			Description: "Checks whether a value is empty.",
+			Examples:    []string{`empty($assignee)`},
+		},
+		{
+			Name:        "not_empty",
+			Signature:   "not_empty(value)",
+			Description: "Checks whether a value is not empty.",
+			Examples:    []string{`not_empty($summary)`},
+		},
+		{
+			Name:        "length",
+			Signature:   "length(value)",
+			Description: "Returns the length of a string, array, or map.",
+			Examples:    []string{`length($items) > 0`},
+		},
+		{
+			Name:        "is_null",
+			Signature:   "is_null(value)",
+			Description: "Checks whether a value is null or missing.",
+			Examples:    []string{`is_null($error)`},
+		},
+		{
+			Name:        "is_string",
+			Signature:   "is_string(value)",
+			Description: "Checks whether a value is a string.",
+		},
+		{
+			Name:        "is_number",
+			Signature:   "is_number(value)",
+			Description: "Checks whether a value is numeric.",
+		},
+		{
+			Name:        "is_bool",
+			Signature:   "is_bool(value)",
+			Description: "Checks whether a value is boolean.",
+		},
+		{
+			Name:        "is_array",
+			Signature:   "is_array(value)",
+			Description: "Checks whether a value is an array.",
+		},
+		{
+			Name:        "is_map",
+			Signature:   "is_map(value)",
+			Description: "Checks whether a value is an object/map.",
+		},
+	}
+}
+
+func nodeSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": true,
+		"required":             []string{"id", "type", "name"},
+		"properties": map[string]any{
+			"id":             stringProperty("Unique node ID."),
+			"type":           enumStringProperty("Node type.", []string{"action", "condition", "loop", "parallel", "join"}),
+			"name":           stringProperty("Human-readable node name."),
+			"description":    stringProperty("Optional node description."),
+			"plugin":         stringProperty("Plugin name for action nodes."),
+			"action":         stringProperty("Plugin action name for action nodes."),
+			"workflow":       stringProperty("Referenced workflow ID for workflow action nodes."),
+			"inputs":         freeformObjectProperty("Node input values."),
+			"outputs":        freeformStringMapProperty("Node output name mappings."),
+			"condition":      expressionSchema(),
+			"loop_var":       stringProperty("Variable name used by loop nodes."),
+			"loop_over":      expressionSchema(),
+			"timeout_sec":    numberProperty("Node timeout in seconds."),
+			"retry_policy":   retryPolicySchema(),
+			"error_handling": errorHandlingSchema(),
+			"position":       positionSchema(),
+		},
+	}
+}
+
+func edgeSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": true,
+		"required":             []string{"id", "source", "target", "type"},
+		"properties": map[string]any{
+			"id":        stringProperty("Unique edge ID."),
+			"source":    stringProperty("Source node ID."),
+			"target":    stringProperty("Target node ID."),
+			"type":      stringProperty("Edge type, such as default, condition_true, or condition_false."),
+			"condition": expressionSchema(),
+			"label":     stringProperty("Optional edge label."),
+		},
+	}
+}
+
+func inputParamSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": true,
+		"required":             []string{"name", "type"},
+		"properties": map[string]any{
+			"name":        stringProperty("Input name."),
+			"type":        stringProperty("Input type."),
+			"description": stringProperty("Input description."),
+			"required":    booleanProperty("Whether the input is required."),
+			"default":     map[string]any{"description": "Default input value."},
+		},
+	}
+}
+
+func outputParamSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": true,
+		"required":             []string{"name", "type"},
+		"properties": map[string]any{
+			"name":        stringProperty("Output name."),
+			"type":        stringProperty("Output type."),
+			"description": stringProperty("Output description."),
+			"source":      stringProperty("Source expression or node output reference."),
+		},
+	}
+}
+
+func variableSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": true,
+		"required":             []string{"name", "type"},
+		"properties": map[string]any{
+			"name":          stringProperty("Variable name."),
+			"type":          stringProperty("Variable type."),
+			"description":   stringProperty("Variable description."),
+			"initial_value": map[string]any{"description": "Initial variable value."},
+		},
+	}
+}
+
+func retryPolicySchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"max_attempts":   numberProperty("Maximum retry attempts."),
+			"initial_delay":  numberProperty("Initial retry delay."),
+			"max_delay":      numberProperty("Maximum retry delay."),
+			"backoff_factor": numberProperty("Retry backoff multiplier."),
+		},
+	}
+}
+
+func errorHandlingSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": true,
+		"properties": map[string]any{
+			"on_error":    stringProperty("Error strategy."),
+			"target_node": stringProperty("Target node for error routing."),
+			"max_retries": numberProperty("Maximum handler retries."),
+		},
+	}
+}
+
+func positionSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"x": numberProperty("Horizontal editor position."),
+			"y": numberProperty("Vertical editor position."),
+		},
+	}
+}
+
+func expressionSchema() map[string]any {
+	return stringProperty("Workflow expression or condition.")
+}
+
+func stringProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": description,
+	}
+}
+
+func enumStringProperty(description string, values []string) map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": description,
+		"enum":        append([]string(nil), values...),
+	}
+}
+
+func dateTimeProperty(description string) map[string]any {
+	schema := stringProperty(description)
+	schema["format"] = "date-time"
+	return schema
+}
+
+func numberProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "number",
+		"description": description,
+	}
+}
+
+func booleanProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "boolean",
+		"description": description,
+	}
+}
+
+func arrayProperty(items any, minItems int, description string) map[string]any {
+	return map[string]any{
+		"type":        "array",
+		"description": description,
+		"items":       items,
+		"minItems":    minItems,
+	}
+}
+
+func freeformObjectProperty(description string) map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"description":          description,
+		"additionalProperties": true,
+	}
+}
+
+func freeformStringMapProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "object",
+		"description": description,
+		"additionalProperties": map[string]any{
+			"type": "string",
+		},
+	}
+}

--- a/pkg/capability/workflows/editor.go
+++ b/pkg/capability/workflows/editor.go
@@ -262,6 +262,11 @@ func nodeSchema() map[string]any {
 		"type":                 "object",
 		"additionalProperties": true,
 		"required":             []string{"id", "type", "name"},
+		"allOf": []map[string]any{
+			nodeTypeRequiredSchema("action", []string{"plugin", "action"}),
+			nodeTypeRequiredSchema("condition", []string{"condition"}),
+			nodeTypeRequiredSchema("loop", []string{"loop_var", "loop_over"}),
+		},
 		"properties": map[string]any{
 			"id":             stringProperty("Unique node ID."),
 			"type":           enumStringProperty("Node type.", []string{"action", "condition", "loop", "parallel", "join"}),
@@ -279,6 +284,22 @@ func nodeSchema() map[string]any {
 			"retry_policy":   retryPolicySchema(),
 			"error_handling": errorHandlingSchema(),
 			"position":       positionSchema(),
+		},
+	}
+}
+
+func nodeTypeRequiredSchema(nodeType string, required []string) map[string]any {
+	return map[string]any{
+		"if": map[string]any{
+			"properties": map[string]any{
+				"type": map[string]any{
+					"const": nodeType,
+				},
+			},
+			"required": []string{"type"},
+		},
+		"then": map[string]any{
+			"required": append([]string(nil), required...),
 		},
 	}
 }

--- a/pkg/capability/workflows/editor.go
+++ b/pkg/capability/workflows/editor.go
@@ -280,7 +280,7 @@ func nodeSchema() map[string]any {
 			"condition":      expressionSchema(),
 			"loop_var":       stringProperty("Variable name used by loop nodes."),
 			"loop_over":      expressionSchema(),
-			"timeout_sec":    numberProperty("Node timeout in seconds."),
+			"timeout_sec":    integerProperty("Node timeout in seconds."),
 			"retry_policy":   retryPolicySchema(),
 			"error_handling": errorHandlingSchema(),
 			"position":       positionSchema(),
@@ -368,9 +368,9 @@ func retryPolicySchema() map[string]any {
 		"type":                 "object",
 		"additionalProperties": false,
 		"properties": map[string]any{
-			"max_attempts":   numberProperty("Maximum retry attempts."),
-			"initial_delay":  numberProperty("Initial retry delay."),
-			"max_delay":      numberProperty("Maximum retry delay."),
+			"max_attempts":   integerProperty("Maximum retry attempts."),
+			"initial_delay":  integerProperty("Initial retry delay."),
+			"max_delay":      integerProperty("Maximum retry delay."),
 			"backoff_factor": numberProperty("Retry backoff multiplier."),
 		},
 	}
@@ -383,7 +383,7 @@ func errorHandlingSchema() map[string]any {
 		"properties": map[string]any{
 			"on_error":    stringProperty("Error strategy."),
 			"target_node": stringProperty("Target node for error routing."),
-			"max_retries": numberProperty("Maximum handler retries."),
+			"max_retries": integerProperty("Maximum handler retries."),
 		},
 	}
 }
@@ -427,6 +427,13 @@ func dateTimeProperty(description string) map[string]any {
 func numberProperty(description string) map[string]any {
 	return map[string]any{
 		"type":        "number",
+		"description": description,
+	}
+}
+
+func integerProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "integer",
 		"description": description,
 	}
 }

--- a/pkg/capability/workflows/editor_test.go
+++ b/pkg/capability/workflows/editor_test.go
@@ -26,6 +26,9 @@ func TestGetWorkflowJSONSchemaShape(t *testing.T) {
 	}
 
 	nodeProps := nodes["items"].(map[string]any)["properties"].(map[string]any)
+	if _, ok := nodeProps["workflow"]; ok {
+		t.Fatal("node schema should not expose workflow until sub-workflow execution is supported")
+	}
 	nodeType := nodeProps["type"].(map[string]any)
 	enum := nodeType["enum"].([]string)
 	for _, want := range []string{"action", "condition", "loop", "parallel", "join"} {

--- a/pkg/capability/workflows/editor_test.go
+++ b/pkg/capability/workflows/editor_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -112,6 +113,9 @@ func TestConditionHelpersCoverEvaluatorSurface(t *testing.T) {
 	for _, helper := range helpers {
 		if helper.Name == "" || helper.Signature == "" || helper.Description == "" {
 			t.Fatalf("helper = %+v, want name/signature/description", helper)
+		}
+		if helper.Name == "is_null" && strings.Contains(helper.Description, "missing") {
+			t.Fatalf("is_null description = %q, should not claim missing variables are null", helper.Description)
 		}
 		names[helper.Name] = true
 	}

--- a/pkg/capability/workflows/editor_test.go
+++ b/pkg/capability/workflows/editor_test.go
@@ -33,6 +33,17 @@ func TestGetWorkflowJSONSchemaShape(t *testing.T) {
 			t.Fatalf("node enum = %v, missing %q", enum, want)
 		}
 	}
+	assertSchemaType(t, nodeProps["timeout_sec"], "integer")
+	assertSchemaType(t, nodeProps["position"].(map[string]any)["properties"].(map[string]any)["x"], "number")
+
+	retryProps := nodeProps["retry_policy"].(map[string]any)["properties"].(map[string]any)
+	assertSchemaType(t, retryProps["max_attempts"], "integer")
+	assertSchemaType(t, retryProps["initial_delay"], "integer")
+	assertSchemaType(t, retryProps["max_delay"], "integer")
+	assertSchemaType(t, retryProps["backoff_factor"], "number")
+
+	errorProps := nodeProps["error_handling"].(map[string]any)["properties"].(map[string]any)
+	assertSchemaType(t, errorProps["max_retries"], "integer")
 
 	allOf := nodes["items"].(map[string]any)["allOf"].([]map[string]any)
 	assertNodeTypeRequired(t, allOf, "action", []string{"plugin", "action"})
@@ -176,4 +187,15 @@ func assertNodeTypeRequired(t *testing.T, rules []map[string]any, nodeType strin
 		return
 	}
 	t.Fatalf("missing conditional required rule for %q", nodeType)
+}
+
+func assertSchemaType(t *testing.T, schema any, want string) {
+	t.Helper()
+	got, ok := schema.(map[string]any)["type"].(string)
+	if !ok {
+		t.Fatalf("schema = %#v, missing string type", schema)
+	}
+	if got != want {
+		t.Fatalf("schema type = %q, want %q", got, want)
+	}
 }

--- a/pkg/capability/workflows/editor_test.go
+++ b/pkg/capability/workflows/editor_test.go
@@ -1,0 +1,153 @@
+package workflow
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGetWorkflowJSONSchemaShape(t *testing.T) {
+	schema := GetWorkflowJSONSchema()
+	if schema["title"] != "AnyClaw Workflow Graph" {
+		t.Fatalf("schema title = %v, want workflow title", schema["title"])
+	}
+	if _, err := json.Marshal(schema); err != nil {
+		t.Fatalf("schema should marshal as JSON: %v", err)
+	}
+
+	required := schema["required"].([]string)
+	if !containsString(required, "id") || !containsString(required, "name") || !containsString(required, "nodes") {
+		t.Fatalf("required = %v, want id/name/nodes", required)
+	}
+
+	props := schema["properties"].(map[string]any)
+	nodes := props["nodes"].(map[string]any)
+	if nodes["minItems"] != 1 {
+		t.Fatalf("nodes minItems = %v, want 1", nodes["minItems"])
+	}
+
+	nodeProps := nodes["items"].(map[string]any)["properties"].(map[string]any)
+	nodeType := nodeProps["type"].(map[string]any)
+	enum := nodeType["enum"].([]string)
+	for _, want := range []string{"action", "condition", "loop", "parallel", "join"} {
+		if !containsString(enum, want) {
+			t.Fatalf("node enum = %v, missing %q", enum, want)
+		}
+	}
+}
+
+func TestNodePaletteTemplatesMatchSupportedNodeTypes(t *testing.T) {
+	palette := GetNodePalette()
+	if len(palette.Categories) == 0 {
+		t.Fatal("expected node palette categories")
+	}
+
+	seen := map[string]bool{}
+	for _, category := range palette.Categories {
+		if category.Name == "" || category.Label == "" {
+			t.Fatalf("category = %+v, want name and label", category)
+		}
+		for _, paletteNode := range category.Nodes {
+			seen[paletteNode.Type] = true
+			graph := NewGraph("palette "+paletteNode.Type, "")
+			graph.AddNode(nodeFromPalette(paletteNode))
+			if err := graph.Validate(); err != nil {
+				t.Fatalf("palette node %q should validate: %v", paletteNode.Type, err)
+			}
+			if len(paletteNode.Ports.Inputs) == 0 && paletteNode.Type != "join" {
+				t.Fatalf("palette node %q should expose input ports", paletteNode.Type)
+			}
+			if len(paletteNode.Ports.Outputs) == 0 {
+				t.Fatalf("palette node %q should expose output ports", paletteNode.Type)
+			}
+		}
+	}
+
+	for _, want := range []string{"action", "condition", "loop", "parallel", "join"} {
+		if !seen[want] {
+			t.Fatalf("palette missing node type %q", want)
+		}
+	}
+}
+
+func TestEditorMetadataReturnsFreshValues(t *testing.T) {
+	palette := GetNodePalette()
+	palette.Categories[0].Nodes[0].Defaults["name"] = "mutated"
+	nextPalette := GetNodePalette()
+	if nextPalette.Categories[0].Nodes[0].Defaults["name"] == "mutated" {
+		t.Fatal("GetNodePalette leaked mutable defaults across calls")
+	}
+
+	schema := GetWorkflowJSONSchema()
+	props := schema["properties"].(map[string]any)
+	props["name"] = "mutated"
+	nextSchema := GetWorkflowJSONSchema()
+	nextProps := nextSchema["properties"].(map[string]any)
+	if nextProps["name"] == "mutated" {
+		t.Fatal("GetWorkflowJSONSchema leaked mutable properties across calls")
+	}
+}
+
+func TestConditionHelpersCoverEvaluatorSurface(t *testing.T) {
+	helpers := GetConditionHelpers()
+	names := make(map[string]bool, len(helpers))
+	for _, helper := range helpers {
+		if helper.Name == "" || helper.Signature == "" || helper.Description == "" {
+			t.Fatalf("helper = %+v, want name/signature/description", helper)
+		}
+		names[helper.Name] = true
+	}
+
+	for _, want := range []string{
+		"contains",
+		"starts_with",
+		"ends_with",
+		"empty",
+		"not_empty",
+		"length",
+		"is_null",
+		"is_string",
+		"is_number",
+		"is_bool",
+		"is_array",
+		"is_map",
+	} {
+		if !names[want] {
+			t.Fatalf("condition helpers missing %q", want)
+		}
+	}
+}
+
+func nodeFromPalette(paletteNode PaletteNode) Node {
+	defaults := paletteNode.Defaults
+	node := Node{
+		ID:          "node_" + paletteNode.Type,
+		Type:        stringDefault(defaults["type"], paletteNode.Type),
+		Name:        stringDefault(defaults["name"], paletteNode.Label),
+		Description: paletteNode.Description,
+		Plugin:      stringDefault(defaults["plugin"], ""),
+		Action:      stringDefault(defaults["action"], ""),
+		Condition:   stringDefault(defaults["condition"], ""),
+		LoopVar:     stringDefault(defaults["loop_var"], ""),
+		LoopOver:    stringDefault(defaults["loop_over"], ""),
+	}
+	if inputs, ok := defaults["inputs"].(map[string]any); ok {
+		node.Inputs = inputs
+	}
+	return node
+}
+
+func stringDefault(value any, fallback string) string {
+	if text, ok := value.(string); ok && text != "" {
+		return text
+	}
+	return fallback
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/capability/workflows/editor_test.go
+++ b/pkg/capability/workflows/editor_test.go
@@ -33,6 +33,11 @@ func TestGetWorkflowJSONSchemaShape(t *testing.T) {
 			t.Fatalf("node enum = %v, missing %q", enum, want)
 		}
 	}
+
+	allOf := nodes["items"].(map[string]any)["allOf"].([]map[string]any)
+	assertNodeTypeRequired(t, allOf, "action", []string{"plugin", "action"})
+	assertNodeTypeRequired(t, allOf, "condition", []string{"condition"})
+	assertNodeTypeRequired(t, allOf, "loop", []string{"loop_var", "loop_over"})
 }
 
 func TestNodePaletteTemplatesMatchSupportedNodeTypes(t *testing.T) {
@@ -150,4 +155,25 @@ func containsString(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func assertNodeTypeRequired(t *testing.T, rules []map[string]any, nodeType string, required []string) {
+	t.Helper()
+	for _, rule := range rules {
+		ifSchema := rule["if"].(map[string]any)
+		props := ifSchema["properties"].(map[string]any)
+		typeSchema := props["type"].(map[string]any)
+		if typeSchema["const"] != nodeType {
+			continue
+		}
+		thenSchema := rule["then"].(map[string]any)
+		got := thenSchema["required"].([]string)
+		for _, want := range required {
+			if !containsString(got, want) {
+				t.Fatalf("%s required = %v, missing %q", nodeType, got, want)
+			}
+		}
+		return
+	}
+	t.Fatalf("missing conditional required rule for %q", nodeType)
 }


### PR DESCRIPTION
## 概要

补充 workflow visual editor 所需的基础元数据，包括 workflow JSON schema、节点面板 palette 和 condition helper 说明，为后续 workflow editor / trigger 配置 UI 做准备。

## 本次变更

- 新增 workflow JSON schema 描述
- 新增 action、condition、loop、parallel、join 节点 palette
- 新增 condition helper metadata
- 覆盖 schema 可序列化、palette 模板可校验、helper 覆盖面等测试

## 影响

这条 PR 只补充 editor metadata，不包含文件存储、trigger manager、route workflow service 或实际执行入口。

## 验证

已执行：

- `go test ./pkg/capability/workflows`
- `go test ./pkg/capability/...`
- `git diff --check`
