### PR TITLE
feat(workflow): add built-in example graphs

### DIFF
--- a/pkg/capability/workflows/examples.go
+++ b/pkg/capability/workflows/examples.go
@@ -82,7 +82,8 @@ func ApprovalGateExampleGraph() *Graph {
 
 	graph.AddInputParam("request", "object", "Incoming request payload.", true, nil)
 	graph.AddInputParam("risk_threshold", "number", "Score threshold that requires approval.", false, 0.7)
-	graph.AddOutputParam("approved", "boolean", "Whether the request was approved.", "$finalize.approved")
+	graph.AddOutputParam("manual_approved", "boolean", "Whether the manual branch approved the request.", "$finalize_manual.approved")
+	graph.AddOutputParam("auto_approved", "boolean", "Whether the automatic branch approved the request.", "$finalize_auto.approved")
 
 	scoreID := addExampleAction(graph, "score_request", "Score request", "example.policy", "score", map[string]any{
 		"request": "$request",
@@ -96,16 +97,20 @@ func ApprovalGateExampleGraph() *Graph {
 		"request": "$request",
 		"reason":  "below threshold",
 	}, 520, 90)
-	finalizeID := addExampleAction(graph, "finalize", "Finalize request", "example.policy", "finalize", map[string]any{
-		"manual_result": "$manual_approval.approved",
-		"auto_result":   "$auto_approve.approved",
-	}, 780, 0)
+	finalizeManualID := addExampleAction(graph, "finalize_manual", "Finalize manual approval", "example.policy", "finalize", map[string]any{
+		"approved": "$manual_approval.approved",
+		"path":     "manual",
+	}, 780, -90)
+	finalizeAutoID := addExampleAction(graph, "finalize_auto", "Finalize auto approval", "example.policy", "finalize", map[string]any{
+		"approved": "$auto_approve.approved",
+		"path":     "auto",
+	}, 780, 90)
 
 	graph.AddEdge(scoreID, checkID, "default")
 	graph.AddEdge(checkID, approvalID, "condition_true")
 	graph.AddEdge(checkID, autoID, "condition_false")
-	graph.AddEdge(approvalID, finalizeID, "default")
-	graph.AddEdge(autoID, finalizeID, "default")
+	graph.AddEdge(approvalID, finalizeManualID, "default")
+	graph.AddEdge(autoID, finalizeAutoID, "default")
 
 	return graph
 }

--- a/pkg/capability/workflows/examples.go
+++ b/pkg/capability/workflows/examples.go
@@ -1,0 +1,190 @@
+package workflow
+
+// WorkflowExample packages an example graph with catalog metadata.
+type WorkflowExample struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Tags        []string `json:"tags,omitempty"`
+	Graph       *Graph   `json:"graph"`
+}
+
+// BuiltinWorkflowExamples returns fresh example graphs for editor demos and docs.
+//
+// The examples use the "example.*" plugin namespace to make it clear that they
+// are graph construction templates, not a claim that matching plugins exist.
+func BuiltinWorkflowExamples() []WorkflowExample {
+	graphs := []*Graph{
+		FileReviewExampleGraph(),
+		ApprovalGateExampleGraph(),
+		ParallelResearchExampleGraph(),
+	}
+
+	examples := make([]WorkflowExample, 0, len(graphs))
+	for _, graph := range graphs {
+		examples = append(examples, WorkflowExample{
+			ID:          graph.ID,
+			Name:        graph.Name,
+			Description: graph.Description,
+			Tags:        append([]string(nil), graph.Tags...),
+			Graph:       graph,
+		})
+	}
+	return examples
+}
+
+// FileReviewExampleGraph builds a simple file processing graph with a review branch.
+func FileReviewExampleGraph() *Graph {
+	graph := NewGraph("File review workflow", "Read a file, summarize it, optionally request review, and write the summary.")
+	graph.ID = "example_file_review"
+	graph.Version = "1.0.0"
+	graph.Author = "AnyClaw"
+	graph.Tags = []string{"example", "files", "review"}
+
+	graph.AddInputParam("source_file", "string", "File path to read.", true, nil)
+	graph.AddInputParam("summary_file", "string", "File path to write the summary.", true, nil)
+	graph.AddInputParam("require_review", "boolean", "Whether a human review is required.", false, true)
+	graph.AddOutputParam("summary", "string", "Generated summary text.", "$summarize_file.summary")
+	graph.AddOutputParam("written", "boolean", "Whether the summary was written.", "$write_summary.ok")
+
+	readID := addExampleAction(graph, "read_source", "Read source file", "example.files", "read", map[string]any{
+		"path": "$source_file",
+	}, 0, 0)
+	summarizeID := addExampleAction(graph, "summarize_file", "Summarize file", "example.text", "summarize", map[string]any{
+		"text": "$read_source.content",
+	}, 260, 0)
+	decisionID := addExampleCondition(graph, "review_required", "Review required?", "$require_review == true", 520, 0)
+	reviewID := addExampleAction(graph, "request_review", "Request review", "example.approvals", "request", map[string]any{
+		"title":   "Review generated summary",
+		"summary": "$summarize_file.summary",
+	}, 780, -90)
+	writeID := addExampleAction(graph, "write_summary", "Write summary", "example.files", "write", map[string]any{
+		"path":    "$summary_file",
+		"content": "$summarize_file.summary",
+	}, 780, 90)
+
+	graph.AddEdge(readID, summarizeID, "default")
+	graph.AddEdge(summarizeID, decisionID, "default")
+	graph.AddEdge(decisionID, reviewID, "condition_true")
+	graph.AddEdge(decisionID, writeID, "condition_false")
+	graph.AddEdge(reviewID, writeID, "default")
+
+	return graph
+}
+
+// ApprovalGateExampleGraph builds a graph that gates execution on a score.
+func ApprovalGateExampleGraph() *Graph {
+	graph := NewGraph("Approval gate workflow", "Score an incoming request and route high-risk items to approval.")
+	graph.ID = "example_approval_gate"
+	graph.Version = "1.0.0"
+	graph.Author = "AnyClaw"
+	graph.Tags = []string{"example", "approval", "routing"}
+
+	graph.AddInputParam("request", "object", "Incoming request payload.", true, nil)
+	graph.AddInputParam("risk_threshold", "number", "Score threshold that requires approval.", false, 0.7)
+	graph.AddOutputParam("approved", "boolean", "Whether the request was approved.", "$finalize.approved")
+
+	scoreID := addExampleAction(graph, "score_request", "Score request", "example.policy", "score", map[string]any{
+		"request": "$request",
+	}, 0, 0)
+	checkID := addExampleCondition(graph, "high_risk", "High risk?", "$score_request.score >= $risk_threshold", 260, 0)
+	approvalID := addExampleAction(graph, "manual_approval", "Manual approval", "example.approvals", "request", map[string]any{
+		"request": "$request",
+		"score":   "$score_request.score",
+	}, 520, -90)
+	autoID := addExampleAction(graph, "auto_approve", "Auto approve", "example.policy", "approve", map[string]any{
+		"request": "$request",
+		"reason":  "below threshold",
+	}, 520, 90)
+	finalizeID := addExampleAction(graph, "finalize", "Finalize request", "example.policy", "finalize", map[string]any{
+		"manual_result": "$manual_approval.approved",
+		"auto_result":   "$auto_approve.approved",
+	}, 780, 0)
+
+	graph.AddEdge(scoreID, checkID, "default")
+	graph.AddEdge(checkID, approvalID, "condition_true")
+	graph.AddEdge(checkID, autoID, "condition_false")
+	graph.AddEdge(approvalID, finalizeID, "default")
+	graph.AddEdge(autoID, finalizeID, "default")
+
+	return graph
+}
+
+// ParallelResearchExampleGraph builds a graph that fans out research tasks and joins them.
+func ParallelResearchExampleGraph() *Graph {
+	graph := NewGraph("Parallel research workflow", "Collect notes from multiple sources, combine them, and draft a brief.")
+	graph.ID = "example_parallel_research"
+	graph.Version = "1.0.0"
+	graph.Author = "AnyClaw"
+	graph.Tags = []string{"example", "research", "parallel"}
+
+	graph.AddInputParam("topic", "string", "Research topic.", true, nil)
+	graph.AddOutputParam("brief", "string", "Drafted research brief.", "$draft_brief.content")
+
+	startID := addExampleAction(graph, "normalize_topic", "Normalize topic", "example.text", "normalize", map[string]any{
+		"text": "$topic",
+	}, 0, 0)
+	fanoutID := addExampleNode(graph, Node{
+		ID:       "fanout_sources",
+		Type:     "parallel",
+		Name:     "Fan out sources",
+		Position: Position{X: 260, Y: 0},
+	})
+	docsID := addExampleAction(graph, "search_docs", "Search docs", "example.search", "docs", map[string]any{
+		"query": "$normalize_topic.text",
+	}, 520, -140)
+	webID := addExampleAction(graph, "search_web", "Search web", "example.search", "web", map[string]any{
+		"query": "$normalize_topic.text",
+	}, 520, 0)
+	notesID := addExampleAction(graph, "search_notes", "Search notes", "example.search", "notes", map[string]any{
+		"query": "$normalize_topic.text",
+	}, 520, 140)
+	joinID := addExampleNode(graph, Node{
+		ID:       "join_sources",
+		Type:     "join",
+		Name:     "Join sources",
+		Position: Position{X: 780, Y: 0},
+	})
+	draftID := addExampleAction(graph, "draft_brief", "Draft brief", "example.text", "draft", map[string]any{
+		"docs":  "$search_docs.results",
+		"web":   "$search_web.results",
+		"notes": "$search_notes.results",
+	}, 1040, 0)
+
+	graph.AddEdge(startID, fanoutID, "default")
+	graph.AddEdge(fanoutID, docsID, "branch")
+	graph.AddEdge(fanoutID, webID, "branch")
+	graph.AddEdge(fanoutID, notesID, "branch")
+	graph.AddEdge(docsID, joinID, "default")
+	graph.AddEdge(webID, joinID, "default")
+	graph.AddEdge(notesID, joinID, "default")
+	graph.AddEdge(joinID, draftID, "default")
+
+	return graph
+}
+
+func addExampleAction(graph *Graph, id, name, plugin, action string, inputs map[string]any, x, y float64) string {
+	return addExampleNode(graph, Node{
+		ID:       id,
+		Type:     "action",
+		Name:     name,
+		Plugin:   plugin,
+		Action:   action,
+		Inputs:   inputs,
+		Position: Position{X: x, Y: y},
+	})
+}
+
+func addExampleCondition(graph *Graph, id, name, condition string, x, y float64) string {
+	return addExampleNode(graph, Node{
+		ID:        id,
+		Type:      "condition",
+		Name:      name,
+		Condition: condition,
+		Position:  Position{X: x, Y: y},
+	})
+}
+
+func addExampleNode(graph *Graph, node Node) string {
+	return graph.AddNode(node)
+}

--- a/pkg/capability/workflows/examples_test.go
+++ b/pkg/capability/workflows/examples_test.go
@@ -104,6 +104,16 @@ func TestWorkflowExamplesUseExamplePluginNamespace(t *testing.T) {
 	}
 }
 
+func TestApprovalGateExampleDoesNotMergeExclusiveOutputs(t *testing.T) {
+	graph := ApprovalGateExampleGraph()
+	for _, node := range graph.Nodes {
+		refs := collectSimpleRefs(node.Inputs)
+		if containsRef(refs, "$manual_approval.approved") && containsRef(refs, "$auto_approve.approved") {
+			t.Fatalf("node %q reads both exclusive approval branch outputs: %v", node.ID, refs)
+		}
+	}
+}
+
 var simpleNodeReferencePattern = regexp.MustCompile(`^\$[A-Za-z0-9_-]+\.[A-Za-z0-9_.-]+$`)
 
 func collectSimpleRefs(value any) []string {
@@ -126,4 +136,13 @@ func collectSimpleRefs(value any) []string {
 		return refs
 	}
 	return nil
+}
+
+func containsRef(refs []string, want string) bool {
+	for _, ref := range refs {
+		if ref == want {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/capability/workflows/examples_test.go
+++ b/pkg/capability/workflows/examples_test.go
@@ -1,0 +1,129 @@
+package workflow
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestBuiltinWorkflowExamplesValidateAndRoundTrip(t *testing.T) {
+	examples := BuiltinWorkflowExamples()
+	if len(examples) != 3 {
+		t.Fatalf("examples = %d, want 3", len(examples))
+	}
+
+	seen := make(map[string]bool, len(examples))
+	for _, example := range examples {
+		if example.ID == "" || example.Name == "" || example.Description == "" {
+			t.Fatalf("example metadata incomplete: %+v", example)
+		}
+		if example.Graph == nil {
+			t.Fatalf("example %q has nil graph", example.ID)
+		}
+		if example.ID != example.Graph.ID {
+			t.Fatalf("example ID = %q, graph ID = %q", example.ID, example.Graph.ID)
+		}
+		if seen[example.ID] {
+			t.Fatalf("duplicate example ID %q", example.ID)
+		}
+		seen[example.ID] = true
+
+		if err := example.Graph.Validate(); err != nil {
+			t.Fatalf("example %q Validate: %v", example.ID, err)
+		}
+		data, err := example.Graph.ToJSON()
+		if err != nil {
+			t.Fatalf("example %q ToJSON: %v", example.ID, err)
+		}
+		if !json.Valid(data) {
+			t.Fatalf("example %q produced invalid JSON: %s", example.ID, string(data))
+		}
+		loaded, err := FromJSON(data)
+		if err != nil {
+			t.Fatalf("example %q FromJSON: %v", example.ID, err)
+		}
+		if err := loaded.Validate(); err != nil {
+			t.Fatalf("example %q round-trip Validate: %v", example.ID, err)
+		}
+	}
+}
+
+func TestBuiltinWorkflowExamplesReturnFreshGraphs(t *testing.T) {
+	first := BuiltinWorkflowExamples()
+	first[0].Name = "mutated metadata"
+	first[0].Tags[0] = "mutated tag"
+	first[0].Graph.Name = "mutated graph"
+	first[0].Graph.Tags[0] = "mutated graph tag"
+
+	second := BuiltinWorkflowExamples()
+	if second[0].Name == "mutated metadata" || second[0].Graph.Name == "mutated graph" {
+		t.Fatal("BuiltinWorkflowExamples leaked mutable graph state across calls")
+	}
+	if second[0].Tags[0] == "mutated tag" || second[0].Graph.Tags[0] == "mutated graph tag" {
+		t.Fatal("BuiltinWorkflowExamples leaked mutable tag state across calls")
+	}
+}
+
+func TestWorkflowExampleReferencesPointAtKnownNodes(t *testing.T) {
+	for _, example := range BuiltinWorkflowExamples() {
+		nodeIDs := make(map[string]bool, len(example.Graph.Nodes))
+		for _, node := range example.Graph.Nodes {
+			nodeIDs[node.ID] = true
+		}
+
+		for _, node := range example.Graph.Nodes {
+			for _, ref := range collectSimpleRefs(node.Inputs) {
+				nodeID := strings.TrimPrefix(strings.SplitN(ref, ".", 2)[0], "$")
+				if !nodeIDs[nodeID] {
+					t.Fatalf("example %q node %q references unknown node %q in %q", example.ID, node.ID, nodeID, ref)
+				}
+			}
+		}
+		for _, output := range example.Graph.Outputs {
+			for _, ref := range collectSimpleRefs(output.Source) {
+				nodeID := strings.TrimPrefix(strings.SplitN(ref, ".", 2)[0], "$")
+				if !nodeIDs[nodeID] {
+					t.Fatalf("example %q output %q references unknown node %q in %q", example.ID, output.Name, nodeID, ref)
+				}
+			}
+		}
+	}
+}
+
+func TestWorkflowExamplesUseExamplePluginNamespace(t *testing.T) {
+	for _, example := range BuiltinWorkflowExamples() {
+		for _, node := range example.Graph.Nodes {
+			if node.Type != "action" {
+				continue
+			}
+			if !strings.HasPrefix(node.Plugin, "example.") {
+				t.Fatalf("example %q action node %q plugin = %q, want example.* namespace", example.ID, node.ID, node.Plugin)
+			}
+		}
+	}
+}
+
+var simpleNodeReferencePattern = regexp.MustCompile(`^\$[A-Za-z0-9_-]+\.[A-Za-z0-9_.-]+$`)
+
+func collectSimpleRefs(value any) []string {
+	switch v := value.(type) {
+	case string:
+		if simpleNodeReferencePattern.MatchString(v) {
+			return []string{v}
+		}
+	case map[string]any:
+		var refs []string
+		for _, nested := range v {
+			refs = append(refs, collectSimpleRefs(nested)...)
+		}
+		return refs
+	case []any:
+		var refs []string
+		for _, nested := range v {
+			refs = append(refs, collectSimpleRefs(nested)...)
+		}
+		return refs
+	}
+	return nil
+}


### PR DESCRIPTION
## 概要

补充 workflow 内置示例 graph，为后续 editor、docs 和示例展示提供可验证的 graph 模板。

## 本次变更

- 新增 `BuiltinWorkflowExamples`
- 新增 3 个示例 graph：
  - file review workflow
  - approval gate workflow
  - parallel research workflow
- 示例使用稳定 node ID，确保 `$node.output` 引用可追踪
- 示例统一使用 `example.*` plugin namespace，避免暗示真实插件已实现
- 增加验证、JSON round-trip、引用校验和 fresh graph 测试

## 影响

这条 PR 只新增 workflow 示例，不包含实际 executor、trigger、editor UI 或插件实现。

## 验证

已执行：

- `go test ./pkg/capability/workflows`
- `go test ./pkg/capability/...`
- `git diff --check`
