### PR TITLE
feat(route): add workflow candidate routing service

### DIFF
--- a/pkg/route/workflow/service.go
+++ b/pkg/route/workflow/service.go
@@ -137,7 +137,7 @@ func (r *Router) Candidates(ctx context.Context, req CandidateRequest) ([]Candid
 		})
 	}
 
-	if len(candidates) == 0 {
+	if !hasRunnableCandidate(candidates) {
 		candidates = append(candidates, Candidate{
 			Kind:       CandidateDirect,
 			ID:         "direct-default",
@@ -255,6 +255,15 @@ func candidateFromRule(rule RouteRule, score float64) Candidate {
 		RiskLevel:        strings.TrimSpace(rule.RiskLevel),
 		Reason:           reason,
 	}
+}
+
+func hasRunnableCandidate(candidates []Candidate) bool {
+	for _, candidate := range candidates {
+		if candidate.Kind != CandidateApproval && candidate.Kind != CandidateClarify {
+			return true
+		}
+	}
+	return false
 }
 
 func detectRisk(input string) string {

--- a/pkg/route/workflow/service.go
+++ b/pkg/route/workflow/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode"
 )
 
 type CandidateKind string
@@ -212,10 +213,10 @@ func matchRule(rule RouteRule, input string) (float64, bool) {
 		return 0, false
 	}
 
-	normalizedInput := normalizeText(input)
+	inputTokens := tokenizeText(input)
 	matches := 0
 	for _, keyword := range keywords {
-		if strings.Contains(normalizedInput, keyword) {
+		if containsNormalizedPhrase(inputTokens, keyword) {
 			matches++
 		}
 	}
@@ -267,7 +268,7 @@ func hasRunnableCandidate(candidates []Candidate) bool {
 }
 
 func detectRisk(input string) string {
-	normalized := normalizeText(input)
+	inputTokens := tokenizeText(input)
 	highRiskWords := []string{
 		"delete",
 		"drop",
@@ -279,7 +280,7 @@ func detectRisk(input string) string {
 		"secret",
 	}
 	for _, word := range highRiskWords {
-		if strings.Contains(normalized, word) {
+		if containsNormalizedPhrase(inputTokens, word) {
 			return "high"
 		}
 	}
@@ -328,8 +329,34 @@ func normalizedKeywords(keywords []string) []string {
 	return normalized
 }
 
+func containsNormalizedPhrase(inputTokens []string, phrase string) bool {
+	phraseTokens := tokenizeText(phrase)
+	if len(phraseTokens) == 0 || len(inputTokens) < len(phraseTokens) {
+		return false
+	}
+	for i := 0; i <= len(inputTokens)-len(phraseTokens); i++ {
+		matched := true
+		for j, token := range phraseTokens {
+			if inputTokens[i+j] != token {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
 func normalizeText(input string) string {
-	return strings.Join(strings.Fields(strings.ToLower(input)), " ")
+	return strings.Join(tokenizeText(input), " ")
+}
+
+func tokenizeText(input string) []string {
+	return strings.FieldsFunc(strings.ToLower(input), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
 }
 
 func clampConfidence(score float64) float64 {

--- a/pkg/route/workflow/service.go
+++ b/pkg/route/workflow/service.go
@@ -1,0 +1,346 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type CandidateKind string
+
+const (
+	CandidateDirect     CandidateKind = "direct"
+	CandidateWorkflow   CandidateKind = "workflow"
+	CandidateSpecialist CandidateKind = "specialist"
+	CandidateToolchain  CandidateKind = "toolchain"
+	CandidateClarify    CandidateKind = "clarify"
+	CandidateApproval   CandidateKind = "approval"
+)
+
+type CandidateRequest struct {
+	ID         string
+	Input      string
+	Title      string
+	UserID     string
+	Org        string
+	Project    string
+	Workspace  string
+	SessionID  string
+	ConfigPath string
+}
+
+type Candidate struct {
+	Kind             CandidateKind
+	Path             string
+	ID               string
+	Plugin           string
+	Workflow         string
+	App              string
+	Confidence       float64
+	RequiresApproval bool
+	RiskLevel        string
+	Reason           string
+}
+
+type RouteRule struct {
+	ID               string
+	Kind             CandidateKind
+	Path             string
+	Plugin           string
+	Workflow         string
+	App              string
+	Keywords         []string
+	Confidence       float64
+	RequiresApproval bool
+	RiskLevel        string
+	Reason           string
+}
+
+type PlannerClient interface{}
+
+type LLMRouteDecision struct {
+	Provider string
+	Model    string
+	Reason   string
+}
+
+type Router struct {
+	rules   []RouteRule
+	planner PlannerClient
+}
+
+func NewRouter(rules []RouteRule, planner PlannerClient) *Router {
+	return &Router{
+		rules:   cloneRules(rules),
+		planner: planner,
+	}
+}
+
+type Service struct {
+	router *Router
+}
+
+func NewService(router *Router) *Service {
+	if router == nil {
+		router = NewRouter(nil, nil)
+	}
+	return &Service{router: router}
+}
+
+func NewServiceForRegistry(rules []RouteRule, planner PlannerClient) *Service {
+	return NewService(NewRouter(rules, planner))
+}
+
+func (s *Service) Candidates(ctx context.Context, req CandidateRequest) ([]Candidate, error) {
+	if s == nil || s.router == nil {
+		return nil, fmt.Errorf("workflow route service is nil")
+	}
+	return s.router.Candidates(ctx, req)
+}
+
+func (r *Router) Candidates(ctx context.Context, req CandidateRequest) ([]Candidate, error) {
+	if r == nil {
+		return nil, fmt.Errorf("workflow route router is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	input := strings.TrimSpace(req.Title + " " + req.Input)
+	if input == "" {
+		return []Candidate{{
+			Kind:       CandidateClarify,
+			ID:         "clarify-empty-request",
+			Confidence: 1,
+			Reason:     "request is empty; ask for the task goal before routing",
+		}}, nil
+	}
+
+	candidates := make([]Candidate, 0, len(r.rules)+2)
+	for _, rule := range r.rules {
+		score, matched := matchRule(rule, input)
+		if !matched {
+			continue
+		}
+		candidates = append(candidates, candidateFromRule(rule, score))
+	}
+
+	if risk := detectRisk(input); risk != "" {
+		candidates = append(candidates, Candidate{
+			Kind:             CandidateApproval,
+			ID:               "approval-" + risk,
+			Confidence:       1,
+			RequiresApproval: true,
+			RiskLevel:        risk,
+			Reason:           "request appears to involve a high-impact action",
+		})
+	}
+
+	if len(candidates) == 0 {
+		candidates = append(candidates, Candidate{
+			Kind:       CandidateDirect,
+			ID:         "direct-default",
+			Confidence: 0.55,
+			Reason:     "no workflow rule matched; route to the default direct handler",
+		})
+	}
+
+	sortCandidates(candidates)
+	return candidates, nil
+}
+
+func BuildGuidance(candidates []Candidate) string {
+	if len(candidates) == 0 {
+		return "No workflow route candidates were found."
+	}
+
+	var lines []string
+	lines = append(lines, "Workflow route candidates:")
+	for i, candidate := range candidates {
+		label := strings.TrimSpace(candidate.ID)
+		if label == "" {
+			label = string(candidate.Kind)
+		}
+		lines = append(lines, fmt.Sprintf("%d. %s (%s, %.2f)", i+1, label, candidate.Kind, candidate.Confidence))
+		if candidate.RequiresApproval {
+			lines = append(lines, fmt.Sprintf("   approval required: %s", candidate.RiskLevel))
+		}
+		if reason := strings.TrimSpace(candidate.Reason); reason != "" {
+			lines = append(lines, "   "+reason)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func AppendSuggestedSummary(summary string, candidates []Candidate) string {
+	guidance := BuildGuidance(candidates)
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		return guidance
+	}
+	return summary + "\n\n" + guidance
+}
+
+func DecideLLM(candidates []Candidate, model string) LLMRouteDecision {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		model = "default"
+	}
+
+	decision := LLMRouteDecision{
+		Provider: "local",
+		Model:    model,
+		Reason:   "default local routing model",
+	}
+	if len(candidates) == 0 {
+		return decision
+	}
+	if candidates[0].RequiresApproval {
+		decision.Reason = "top route candidate requires approval"
+		return decision
+	}
+	if candidates[0].Kind == CandidateWorkflow || candidates[0].Kind == CandidateToolchain {
+		decision.Reason = "top route candidate is workflow-oriented"
+	}
+	return decision
+}
+
+func matchRule(rule RouteRule, input string) (float64, bool) {
+	keywords := normalizedKeywords(rule.Keywords)
+	if len(keywords) == 0 {
+		return 0, false
+	}
+
+	normalizedInput := normalizeText(input)
+	matches := 0
+	for _, keyword := range keywords {
+		if strings.Contains(normalizedInput, keyword) {
+			matches++
+		}
+	}
+	if matches == 0 {
+		return 0, false
+	}
+
+	base := clampConfidence(rule.Confidence)
+	if base == 0 {
+		base = 0.6
+	}
+	score := base + float64(matches-1)*0.08
+	if matches == len(keywords) {
+		score += 0.08
+	}
+	return clampConfidence(score), true
+}
+
+func candidateFromRule(rule RouteRule, score float64) Candidate {
+	kind := rule.Kind
+	if kind == "" {
+		kind = CandidateWorkflow
+	}
+	reason := strings.TrimSpace(rule.Reason)
+	if reason == "" {
+		reason = "matched workflow route keywords"
+	}
+	return Candidate{
+		Kind:             kind,
+		Path:             strings.TrimSpace(rule.Path),
+		ID:               strings.TrimSpace(rule.ID),
+		Plugin:           strings.TrimSpace(rule.Plugin),
+		Workflow:         strings.TrimSpace(rule.Workflow),
+		App:              strings.TrimSpace(rule.App),
+		Confidence:       score,
+		RequiresApproval: rule.RequiresApproval,
+		RiskLevel:        strings.TrimSpace(rule.RiskLevel),
+		Reason:           reason,
+	}
+}
+
+func detectRisk(input string) string {
+	normalized := normalizeText(input)
+	highRiskWords := []string{
+		"delete",
+		"drop",
+		"wipe",
+		"remove all",
+		"production",
+		"payment",
+		"credential",
+		"secret",
+	}
+	for _, word := range highRiskWords {
+		if strings.Contains(normalized, word) {
+			return "high"
+		}
+	}
+	return ""
+}
+
+func sortCandidates(candidates []Candidate) {
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].Confidence != candidates[j].Confidence {
+			return candidates[i].Confidence > candidates[j].Confidence
+		}
+		return candidateKindRank(candidates[i].Kind) < candidateKindRank(candidates[j].Kind)
+	})
+}
+
+func candidateKindRank(kind CandidateKind) int {
+	switch kind {
+	case CandidateApproval:
+		return 0
+	case CandidateWorkflow:
+		return 1
+	case CandidateToolchain:
+		return 2
+	case CandidateSpecialist:
+		return 3
+	case CandidateDirect:
+		return 4
+	case CandidateClarify:
+		return 5
+	default:
+		return 6
+	}
+}
+
+func normalizedKeywords(keywords []string) []string {
+	normalized := make([]string, 0, len(keywords))
+	seen := make(map[string]bool, len(keywords))
+	for _, keyword := range keywords {
+		keyword = normalizeText(keyword)
+		if keyword == "" || seen[keyword] {
+			continue
+		}
+		seen[keyword] = true
+		normalized = append(normalized, keyword)
+	}
+	return normalized
+}
+
+func normalizeText(input string) string {
+	return strings.Join(strings.Fields(strings.ToLower(input)), " ")
+}
+
+func clampConfidence(score float64) float64 {
+	if score < 0 {
+		return 0
+	}
+	if score > 1 {
+		return 1
+	}
+	return score
+}
+
+func cloneRules(rules []RouteRule) []RouteRule {
+	if len(rules) == 0 {
+		return nil
+	}
+	cloned := make([]RouteRule, len(rules))
+	for i, rule := range rules {
+		rule.Keywords = append([]string(nil), rule.Keywords...)
+		cloned[i] = rule
+	}
+	return cloned
+}

--- a/pkg/route/workflow/service_test.go
+++ b/pkg/route/workflow/service_test.go
@@ -130,6 +130,26 @@ func TestCandidatesAddsApprovalForHighRiskInput(t *testing.T) {
 	}
 }
 
+func TestCandidatesAddsDirectFallbackWhenHighRiskHasNoRunnableMatch(t *testing.T) {
+	svc := NewServiceForRegistry(nil, nil)
+
+	candidates, err := svc.Candidates(context.Background(), CandidateRequest{
+		Input: "delete production secrets",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("expected approval gate and direct fallback, got %d: %#v", len(candidates), candidates)
+	}
+	if candidates[0].Kind != CandidateApproval {
+		t.Fatalf("expected approval candidate first, got %q", candidates[0].Kind)
+	}
+	if candidates[1].Kind != CandidateDirect {
+		t.Fatalf("expected direct fallback after approval, got %q", candidates[1].Kind)
+	}
+}
+
 func TestCandidatesFallsBackToDirectWhenNothingMatches(t *testing.T) {
 	svc := NewServiceForRegistry([]RouteRule{
 		{

--- a/pkg/route/workflow/service_test.go
+++ b/pkg/route/workflow/service_test.go
@@ -1,0 +1,290 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCandidatesReturnsClarifyForEmptyRequest(t *testing.T) {
+	svc := NewServiceForRegistry(nil, nil)
+
+	candidates, err := svc.Candidates(context.Background(), CandidateRequest{
+		Title: " ",
+		Input: "\n",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("expected one candidate, got %d", len(candidates))
+	}
+	if candidates[0].Kind != CandidateClarify {
+		t.Fatalf("expected clarify candidate, got %q", candidates[0].Kind)
+	}
+	if candidates[0].Confidence != 1 {
+		t.Fatalf("expected full confidence, got %v", candidates[0].Confidence)
+	}
+}
+
+func TestCandidatesMatchesKeywordRulesAndSortsByConfidence(t *testing.T) {
+	svc := NewServiceForRegistry([]RouteRule{
+		{
+			ID:         "specialist-docs",
+			Kind:       CandidateSpecialist,
+			Keywords:   []string{"docs"},
+			Confidence: 0.7,
+			Reason:     "documentation route",
+		},
+		{
+			ID:         "workflow-release",
+			Kind:       CandidateWorkflow,
+			Workflow:   "release",
+			Keywords:   []string{"release", "deploy"},
+			Confidence: 0.75,
+			Reason:     "release workflow",
+		},
+		{
+			ID:         "toolchain-ci",
+			Kind:       CandidateToolchain,
+			Path:       "tools/ci",
+			Keywords:   []string{"ci"},
+			Confidence: 0.95,
+		},
+	}, nil)
+
+	candidates, err := svc.Candidates(context.Background(), CandidateRequest{
+		Title: "Release docs",
+		Input: "please deploy the docs",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("expected two matching candidates, got %d: %#v", len(candidates), candidates)
+	}
+	if candidates[0].ID != "workflow-release" {
+		t.Fatalf("expected release workflow first, got %q", candidates[0].ID)
+	}
+	if candidates[1].ID != "specialist-docs" {
+		t.Fatalf("expected docs specialist second, got %q", candidates[1].ID)
+	}
+	if candidates[0].Workflow != "release" {
+		t.Fatalf("expected workflow metadata to be copied, got %q", candidates[0].Workflow)
+	}
+}
+
+func TestCandidatesUsesKindRankForConfidenceTies(t *testing.T) {
+	svc := NewServiceForRegistry([]RouteRule{
+		{
+			ID:         "toolchain",
+			Kind:       CandidateToolchain,
+			Keywords:   []string{"route"},
+			Confidence: 0.8,
+		},
+		{
+			ID:         "workflow",
+			Kind:       CandidateWorkflow,
+			Keywords:   []string{"route"},
+			Confidence: 0.8,
+		},
+	}, nil)
+
+	candidates, err := svc.Candidates(context.Background(), CandidateRequest{Input: "route this"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if candidates[0].Kind != CandidateWorkflow {
+		t.Fatalf("expected workflow to win confidence tie, got %q", candidates[0].Kind)
+	}
+}
+
+func TestCandidatesAddsApprovalForHighRiskInput(t *testing.T) {
+	svc := NewServiceForRegistry([]RouteRule{
+		{
+			ID:         "production-workflow",
+			Kind:       CandidateWorkflow,
+			Keywords:   []string{"production"},
+			Confidence: 0.9,
+		},
+	}, nil)
+
+	candidates, err := svc.Candidates(context.Background(), CandidateRequest{
+		Input: "delete production credentials",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("expected approval and workflow candidates, got %d", len(candidates))
+	}
+	if candidates[0].Kind != CandidateApproval {
+		t.Fatalf("expected approval candidate first, got %q", candidates[0].Kind)
+	}
+	if !candidates[0].RequiresApproval {
+		t.Fatal("expected approval requirement to be set")
+	}
+	if candidates[0].RiskLevel != "high" {
+		t.Fatalf("expected high risk level, got %q", candidates[0].RiskLevel)
+	}
+}
+
+func TestCandidatesFallsBackToDirectWhenNothingMatches(t *testing.T) {
+	svc := NewServiceForRegistry([]RouteRule{
+		{
+			ID:       "workflow-release",
+			Kind:     CandidateWorkflow,
+			Keywords: []string{"release"},
+		},
+	}, nil)
+
+	candidates, err := svc.Candidates(context.Background(), CandidateRequest{Input: "say hello"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("expected one fallback candidate, got %d", len(candidates))
+	}
+	if candidates[0].Kind != CandidateDirect {
+		t.Fatalf("expected direct fallback, got %q", candidates[0].Kind)
+	}
+}
+
+func TestCandidatesReturnsContextError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	svc := NewServiceForRegistry(nil, nil)
+	_, err := svc.Candidates(ctx, CandidateRequest{Input: "route"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}
+
+func TestCandidatesRejectsNilServiceAndRouter(t *testing.T) {
+	var svc *Service
+	if _, err := svc.Candidates(context.Background(), CandidateRequest{Input: "route"}); err == nil {
+		t.Fatal("expected nil service error")
+	}
+
+	var router *Router
+	if _, err := router.Candidates(context.Background(), CandidateRequest{Input: "route"}); err == nil {
+		t.Fatal("expected nil router error")
+	}
+}
+
+func TestBuildGuidanceIncludesApprovalAndReason(t *testing.T) {
+	guidance := BuildGuidance([]Candidate{
+		{
+			Kind:             CandidateApproval,
+			ID:               "approval-high",
+			Confidence:       1,
+			RequiresApproval: true,
+			RiskLevel:        "high",
+			Reason:           "needs human review",
+		},
+	})
+
+	for _, want := range []string{
+		"Workflow route candidates:",
+		"approval-high (approval, 1.00)",
+		"approval required: high",
+		"needs human review",
+	} {
+		if !strings.Contains(guidance, want) {
+			t.Fatalf("expected guidance to contain %q, got:\n%s", want, guidance)
+		}
+	}
+}
+
+func TestAppendSuggestedSummary(t *testing.T) {
+	candidates := []Candidate{{Kind: CandidateDirect, ID: "direct", Confidence: 0.55}}
+
+	if got := AppendSuggestedSummary("", candidates); !strings.HasPrefix(got, "Workflow route candidates:") {
+		t.Fatalf("expected guidance only for empty summary, got %q", got)
+	}
+
+	got := AppendSuggestedSummary("Existing summary", candidates)
+	if !strings.Contains(got, "Existing summary\n\nWorkflow route candidates:") {
+		t.Fatalf("expected summary and guidance, got %q", got)
+	}
+}
+
+func TestDecideLLMUsesDefaultAndExplainsTopCandidate(t *testing.T) {
+	decision := DecideLLM(nil, " ")
+	if decision.Provider != "local" {
+		t.Fatalf("expected local provider, got %q", decision.Provider)
+	}
+	if decision.Model != "default" {
+		t.Fatalf("expected default model, got %q", decision.Model)
+	}
+	if decision.Reason != "default local routing model" {
+		t.Fatalf("unexpected reason: %q", decision.Reason)
+	}
+
+	decision = DecideLLM([]Candidate{{Kind: CandidateWorkflow, Confidence: 0.9}}, "router-small")
+	if decision.Model != "router-small" {
+		t.Fatalf("expected explicit model, got %q", decision.Model)
+	}
+	if decision.Reason != "top route candidate is workflow-oriented" {
+		t.Fatalf("unexpected workflow reason: %q", decision.Reason)
+	}
+
+	decision = DecideLLM([]Candidate{{Kind: CandidateApproval, RequiresApproval: true}}, "router-small")
+	if decision.Reason != "top route candidate requires approval" {
+		t.Fatalf("unexpected approval reason: %q", decision.Reason)
+	}
+}
+
+func TestNewRouterClonesRuleKeywords(t *testing.T) {
+	rules := []RouteRule{{
+		ID:       "workflow-release",
+		Kind:     CandidateWorkflow,
+		Keywords: []string{"release"},
+	}}
+
+	router := NewRouter(rules, nil)
+	rules[0].Keywords[0] = "mutated"
+
+	candidates, err := router.Candidates(context.Background(), CandidateRequest{Input: "release"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].ID != "workflow-release" {
+		t.Fatalf("expected original release rule to match, got %#v", candidates)
+	}
+}
+
+func TestRuleDefaultsAndConfidenceClamp(t *testing.T) {
+	svc := NewServiceForRegistry([]RouteRule{
+		{
+			ID:         "default-kind",
+			Keywords:   []string{"default"},
+			Confidence: 1.5,
+		},
+		{
+			ID:         "negative-confidence",
+			Kind:       CandidateSpecialist,
+			Keywords:   []string{"negative", "missing"},
+			Confidence: -1,
+		},
+	}, nil)
+
+	candidates, err := svc.Candidates(context.Background(), CandidateRequest{Input: "default negative"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if candidates[0].Kind != CandidateWorkflow {
+		t.Fatalf("expected empty kind to default to workflow, got %q", candidates[0].Kind)
+	}
+	if candidates[0].Confidence != 1 {
+		t.Fatalf("expected clamped confidence, got %v", candidates[0].Confidence)
+	}
+	if candidates[1].Confidence != 0.6 {
+		t.Fatalf("expected zero base confidence to use default score, got %v", candidates[1].Confidence)
+	}
+	if candidates[1].Reason != "matched workflow route keywords" {
+		t.Fatalf("expected default reason, got %q", candidates[1].Reason)
+	}
+}

--- a/pkg/route/workflow/service_test.go
+++ b/pkg/route/workflow/service_test.go
@@ -100,6 +100,60 @@ func TestCandidatesUsesKindRankForConfidenceTies(t *testing.T) {
 	}
 }
 
+func TestCandidatesMatchesKeywordsWithTokenBoundaries(t *testing.T) {
+	svc := NewServiceForRegistry([]RouteRule{
+		{
+			ID:         "toolchain-ci",
+			Kind:       CandidateToolchain,
+			Keywords:   []string{"ci"},
+			Confidence: 0.9,
+		},
+	}, nil)
+
+	candidates, err := svc.Candidates(context.Background(), CandidateRequest{Input: "ask a specialist"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Kind != CandidateDirect {
+		t.Fatalf("expected specialist not to match ci keyword, got %#v", candidates)
+	}
+
+	candidates, err = svc.Candidates(context.Background(), CandidateRequest{Input: "run ci, please"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].ID != "toolchain-ci" {
+		t.Fatalf("expected standalone ci token to match, got %#v", candidates)
+	}
+}
+
+func TestCandidatesMatchesMultiTokenKeywordPhrases(t *testing.T) {
+	svc := NewServiceForRegistry([]RouteRule{
+		{
+			ID:         "triage-workflow",
+			Kind:       CandidateWorkflow,
+			Keywords:   []string{"open issue"},
+			Confidence: 0.8,
+		},
+	}, nil)
+
+	candidates, err := svc.Candidates(context.Background(), CandidateRequest{Input: "open issue quickly"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if candidates[0].ID != "triage-workflow" {
+		t.Fatalf("expected phrase keyword to match, got %#v", candidates)
+	}
+
+	candidates, err = svc.Candidates(context.Background(), CandidateRequest{Input: "open a new issue"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Kind != CandidateDirect {
+		t.Fatalf("expected non-contiguous phrase not to match, got %#v", candidates)
+	}
+}
+
 func TestCandidatesAddsApprovalForHighRiskInput(t *testing.T) {
 	svc := NewServiceForRegistry([]RouteRule{
 		{
@@ -127,6 +181,30 @@ func TestCandidatesAddsApprovalForHighRiskInput(t *testing.T) {
 	}
 	if candidates[0].RiskLevel != "high" {
 		t.Fatalf("expected high risk level, got %q", candidates[0].RiskLevel)
+	}
+}
+
+func TestCandidatesDetectsRiskWithTokenBoundaries(t *testing.T) {
+	svc := NewServiceForRegistry(nil, nil)
+
+	candidates, err := svc.Candidates(context.Background(), CandidateRequest{
+		Input: "message the secretary",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Kind != CandidateDirect {
+		t.Fatalf("expected secretary not to trigger secret risk, got %#v", candidates)
+	}
+
+	candidates, err = svc.Candidates(context.Background(), CandidateRequest{
+		Input: "remove all credentials",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(candidates) != 2 || candidates[0].Kind != CandidateApproval {
+		t.Fatalf("expected bounded risk phrase to trigger approval plus fallback, got %#v", candidates)
 	}
 }
 


### PR DESCRIPTION
## 概要

补充 workflow route candidate 服务，为后续将 ingress 路由、workflow、toolchain 和审批候选串起来提供一个轻量、可测试的路由候选层。

## 本次变更

- 新增 workflow route candidate 类型与规则模型
- 支持基于关键词匹配生成 workflow / toolchain / specialist 等候选
- 支持空请求返回 clarify 候选
- 支持高风险请求生成 approval 候选
- 支持候选按 confidence 和类型优先级排序
- 新增 route guidance 和 LLM route decision 辅助方法
- 增加对应单元测试

## 影响

这条 PR 只新增 `route/workflow` 的候选路由服务，不接入外部 LLM、不执行插件、不依赖未合并的 workflow store/editor/examples PR。

## 验证

已执行：

- `go test ./pkg/route/workflow`
- `go test ./pkg/route/...`
- `go test ./pkg/...`
- `git diff --check`
