### PR TITLE
feat(workflow): add trigger manager

### DIFF
--- a/pkg/capability/workflows/trigger.go
+++ b/pkg/capability/workflows/trigger.go
@@ -1,0 +1,660 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// TriggerType defines the source that can start a workflow graph.
+type TriggerType string
+
+const (
+	TriggerCron    TriggerType = "cron"
+	TriggerWebhook TriggerType = "webhook"
+	TriggerEvent   TriggerType = "event"
+	TriggerManual  TriggerType = "manual"
+)
+
+// TriggerConfig holds the configuration for a workflow trigger.
+type TriggerConfig struct {
+	ID          string      `json:"id"`
+	GraphID     string      `json:"graph_id"`
+	Type        TriggerType `json:"type"`
+	Name        string      `json:"name"`
+	Description string      `json:"description,omitempty"`
+	Enabled     bool        `json:"enabled"`
+	CreatedAt   time.Time   `json:"created_at"`
+	UpdatedAt   time.Time   `json:"updated_at"`
+
+	CronExpr string `json:"cron_expr,omitempty"`
+	Timezone string `json:"timezone,omitempty"`
+
+	WebhookPath   string `json:"webhook_path,omitempty"`
+	WebhookSecret string `json:"webhook_secret,omitempty"`
+
+	EventSource string   `json:"event_source,omitempty"`
+	EventTypes  []string `json:"event_types,omitempty"`
+	EventFilter string   `json:"event_filter,omitempty"`
+
+	DefaultInputs map[string]any `json:"default_inputs,omitempty"`
+	MaxRuns       int            `json:"max_runs,omitempty"`
+	TimeoutSec    int            `json:"timeout_sec,omitempty"`
+}
+
+// WorkflowTriggerEvent represents an event that can trigger a workflow.
+type WorkflowTriggerEvent struct {
+	ID        string         `json:"id"`
+	Source    string         `json:"source"`
+	Type      string         `json:"type"`
+	Payload   map[string]any `json:"payload,omitempty"`
+	Timestamp time.Time      `json:"timestamp"`
+}
+
+// TriggerRun tracks a single trigger execution.
+type TriggerRun struct {
+	TriggerID   string                `json:"trigger_id"`
+	ExecutionID string                `json:"execution_id"`
+	Status      string                `json:"status"`
+	TriggeredBy string                `json:"triggered_by"`
+	Event       *WorkflowTriggerEvent `json:"event,omitempty"`
+	StartedAt   time.Time             `json:"started_at"`
+	EndedAt     *time.Time            `json:"ended_at,omitempty"`
+	Error       string                `json:"error,omitempty"`
+}
+
+// TriggerExecutor is the minimal execution surface needed by TriggerManager.
+type TriggerExecutor interface {
+	ExecuteGraph(graph *Graph, inputs map[string]any) (*ExecutionContext, error)
+}
+
+// TriggerHook can replace graph loading and executor dispatch for integrations.
+type TriggerHook func(ctx context.Context, triggerID string, inputs map[string]any) (*ExecutionContext, error)
+
+// TriggerManager manages in-memory workflow triggers and run history.
+type TriggerManager struct {
+	mu       sync.RWMutex
+	triggers map[string]TriggerConfig
+	runs     []TriggerRun
+
+	executor   TriggerExecutor
+	graphStore GraphStore
+	hookFunc   TriggerHook
+}
+
+// NewTriggerManager creates a trigger manager.
+func NewTriggerManager(executor TriggerExecutor, graphStore GraphStore) *TriggerManager {
+	return &TriggerManager{
+		triggers:   make(map[string]TriggerConfig),
+		runs:       make([]TriggerRun, 0),
+		executor:   executor,
+		graphStore: graphStore,
+	}
+}
+
+// SetHookFunc sets a custom execution hook used instead of graphStore/executor.
+func (tm *TriggerManager) SetHookFunc(fn TriggerHook) {
+	if tm == nil {
+		return
+	}
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	tm.hookFunc = fn
+}
+
+// AddTrigger adds a trigger configuration. New triggers are enabled by default.
+func (tm *TriggerManager) AddTrigger(cfg TriggerConfig) error {
+	if tm == nil {
+		return fmt.Errorf("trigger manager is nil")
+	}
+
+	cfg = normalizeTriggerConfig(cfg)
+	if cfg.ID == "" {
+		cfg.ID = generateWorkflowID("trigger")
+	}
+	if cfg.Type == "" {
+		cfg.Type = TriggerManual
+	}
+	if strings.TrimSpace(cfg.Name) == "" {
+		cfg.Name = cfg.ID
+	}
+	if cfg.CreatedAt.IsZero() {
+		cfg.CreatedAt = time.Now().UTC()
+	}
+	cfg.UpdatedAt = time.Now().UTC()
+	cfg.Enabled = true
+
+	if err := validateTriggerConfig(cfg); err != nil {
+		return err
+	}
+
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if _, exists := tm.triggers[cfg.ID]; exists {
+		return fmt.Errorf("trigger already exists: %s", cfg.ID)
+	}
+	tm.triggers[cfg.ID] = cfg
+	return nil
+}
+
+// GetTrigger returns a defensive copy of a trigger by ID.
+func (tm *TriggerManager) GetTrigger(id string) (*TriggerConfig, bool) {
+	if tm == nil {
+		return nil, false
+	}
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	cfg, ok := tm.triggers[id]
+	if !ok {
+		return nil, false
+	}
+	cloned := cloneTriggerConfig(cfg)
+	return &cloned, true
+}
+
+// ListTriggers returns trigger configurations, optionally filtered by graph ID.
+func (tm *TriggerManager) ListTriggers(graphID string) []*TriggerConfig {
+	if tm == nil {
+		return nil
+	}
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+
+	result := make([]*TriggerConfig, 0, len(tm.triggers))
+	for _, cfg := range tm.triggers {
+		if graphID != "" && cfg.GraphID != graphID {
+			continue
+		}
+		cloned := cloneTriggerConfig(cfg)
+		result = append(result, &cloned)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ID < result[j].ID
+	})
+	return result
+}
+
+// DeleteTrigger removes a trigger.
+func (tm *TriggerManager) DeleteTrigger(id string) error {
+	if tm == nil {
+		return fmt.Errorf("trigger manager is nil")
+	}
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	if _, ok := tm.triggers[id]; !ok {
+		return fmt.Errorf("trigger not found: %s", id)
+	}
+	delete(tm.triggers, id)
+	return nil
+}
+
+// EnableTrigger enables a trigger.
+func (tm *TriggerManager) EnableTrigger(id string) error {
+	return tm.setTriggerEnabled(id, true)
+}
+
+// DisableTrigger disables a trigger.
+func (tm *TriggerManager) DisableTrigger(id string) error {
+	return tm.setTriggerEnabled(id, false)
+}
+
+// FireTrigger manually fires a trigger with optional inputs.
+func (tm *TriggerManager) FireTrigger(ctx context.Context, triggerID string, inputs map[string]any) (*TriggerRun, error) {
+	return tm.fireTrigger(ctx, triggerID, inputs, "manual", nil)
+}
+
+// HandleWebhook handles an incoming webhook payload and fires matching triggers.
+func (tm *TriggerManager) HandleWebhook(ctx context.Context, path string, payload map[string]any) ([]*TriggerRun, error) {
+	return tm.HandleWebhookWithSecret(ctx, path, "", payload)
+}
+
+// HandleWebhookWithSecret handles a webhook payload and enforces configured webhook secrets.
+func (tm *TriggerManager) HandleWebhookWithSecret(
+	ctx context.Context,
+	path string,
+	secret string,
+	payload map[string]any,
+) ([]*TriggerRun, error) {
+	if tm == nil {
+		return nil, fmt.Errorf("trigger manager is nil")
+	}
+	path = strings.TrimSpace(path)
+
+	matching := tm.matchingTriggerIDs(func(cfg TriggerConfig) bool {
+		if !cfg.Enabled || cfg.Type != TriggerWebhook || cfg.WebhookPath != path {
+			return false
+		}
+		return cfg.WebhookSecret == "" || cfg.WebhookSecret == secret
+	})
+	if len(matching) == 0 {
+		return nil, fmt.Errorf("no webhook trigger found for path: %s", path)
+	}
+
+	event := &WorkflowTriggerEvent{
+		Source:    "webhook",
+		Type:      "http_request",
+		Payload:   cloneAnyMap(payload),
+		Timestamp: time.Now().UTC(),
+	}
+	return tm.fireMatching(ctx, matching, payload, "webhook", event)
+}
+
+// HandleEvent handles an incoming event and fires matching event triggers.
+func (tm *TriggerManager) HandleEvent(ctx context.Context, event *WorkflowTriggerEvent) ([]*TriggerRun, error) {
+	if tm == nil {
+		return nil, fmt.Errorf("trigger manager is nil")
+	}
+	if event == nil {
+		return nil, fmt.Errorf("workflow trigger event is nil")
+	}
+	if event.Timestamp.IsZero() {
+		event = cloneTriggerEvent(event)
+		event.Timestamp = time.Now().UTC()
+	}
+
+	matching := tm.matchingTriggerIDs(func(cfg TriggerConfig) bool {
+		if !cfg.Enabled || cfg.Type != TriggerEvent || cfg.EventSource != event.Source {
+			return false
+		}
+		if len(cfg.EventTypes) > 0 && !matchesEventType(cfg.EventTypes, event.Type) {
+			return false
+		}
+		if cfg.EventFilter != "" {
+			ok, err := EvalCondition(cfg.EventFilter, event.Payload)
+			return err == nil && ok
+		}
+		return true
+	})
+	if len(matching) == 0 {
+		return nil, fmt.Errorf("no event trigger found for source=%s type=%s", event.Source, event.Type)
+	}
+
+	inputs := cloneAnyMap(event.Payload)
+	if inputs == nil {
+		inputs = make(map[string]any)
+	}
+	inputs["_event_source"] = event.Source
+	inputs["_event_type"] = event.Type
+	inputs["_event_timestamp"] = event.Timestamp
+	return tm.fireMatching(ctx, matching, inputs, "event", event)
+}
+
+// GetRuns returns run history, optionally filtered by trigger ID.
+func (tm *TriggerManager) GetRuns(triggerID string, limit int) []*TriggerRun {
+	if tm == nil {
+		return nil
+	}
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+
+	result := make([]*TriggerRun, 0, len(tm.runs))
+	for i := len(tm.runs) - 1; i >= 0; i-- {
+		run := tm.runs[i]
+		if triggerID != "" && run.TriggerID != triggerID {
+			continue
+		}
+		cloned := cloneTriggerRun(run)
+		result = append(result, &cloned)
+		if limit > 0 && len(result) >= limit {
+			break
+		}
+	}
+	return result
+}
+
+// GetCronTriggers returns enabled cron triggers for scheduler integration.
+func (tm *TriggerManager) GetCronTriggers() []*TriggerConfig {
+	if tm == nil {
+		return nil
+	}
+	return tm.filterTriggers(func(cfg TriggerConfig) bool {
+		return cfg.Enabled && cfg.Type == TriggerCron
+	})
+}
+
+// GetWebhookTriggers returns enabled webhook triggers for HTTP registration.
+func (tm *TriggerManager) GetWebhookTriggers() []*TriggerConfig {
+	if tm == nil {
+		return nil
+	}
+	return tm.filterTriggers(func(cfg TriggerConfig) bool {
+		return cfg.Enabled && cfg.Type == TriggerWebhook
+	})
+}
+
+// Stats returns trigger manager statistics.
+func (tm *TriggerManager) Stats() map[string]any {
+	if tm == nil {
+		return map[string]any{
+			"total_triggers": 0,
+			"by_type":        map[string]int{},
+			"by_status":      map[string]int{},
+			"total_runs":     0,
+		}
+	}
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+
+	byType := make(map[string]int)
+	byStatus := make(map[string]int)
+	for _, cfg := range tm.triggers {
+		byType[string(cfg.Type)]++
+		if cfg.Enabled {
+			byStatus["enabled"]++
+		} else {
+			byStatus["disabled"]++
+		}
+	}
+
+	return map[string]any{
+		"total_triggers": len(tm.triggers),
+		"by_type":        byType,
+		"by_status":      byStatus,
+		"total_runs":     len(tm.runs),
+	}
+}
+
+func (tm *TriggerManager) setTriggerEnabled(id string, enabled bool) error {
+	if tm == nil {
+		return fmt.Errorf("trigger manager is nil")
+	}
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	cfg, ok := tm.triggers[id]
+	if !ok {
+		return fmt.Errorf("trigger not found: %s", id)
+	}
+	cfg.Enabled = enabled
+	cfg.UpdatedAt = time.Now().UTC()
+	tm.triggers[id] = cfg
+	return nil
+}
+
+func (tm *TriggerManager) fireTrigger(
+	ctx context.Context,
+	triggerID string,
+	inputs map[string]any,
+	triggeredBy string,
+	event *WorkflowTriggerEvent,
+) (*TriggerRun, error) {
+	if tm == nil {
+		return nil, fmt.Errorf("trigger manager is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	cfg, hook, err := tm.triggerForRun(triggerID)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := cloneAnyMap(cfg.DefaultInputs)
+	if merged == nil {
+		merged = make(map[string]any)
+	}
+	for k, v := range inputs {
+		merged[k] = cloneAny(v)
+	}
+
+	runCtx := ctx
+	var cancel context.CancelFunc
+	if cfg.TimeoutSec > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, time.Duration(cfg.TimeoutSec)*time.Second)
+		defer cancel()
+	}
+
+	startedAt := time.Now().UTC()
+	execCtx, execErr := tm.executeTrigger(runCtx, cfg, hook, merged)
+	run := buildTriggerRun(triggerID, triggeredBy, event, startedAt, execCtx, execErr)
+	tm.appendRun(run)
+	return cloneTriggerRunPtr(run), execErr
+}
+
+func (tm *TriggerManager) triggerForRun(triggerID string) (TriggerConfig, TriggerHook, error) {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	cfg, ok := tm.triggers[triggerID]
+	if !ok {
+		return TriggerConfig{}, nil, fmt.Errorf("trigger not found: %s", triggerID)
+	}
+	if !cfg.Enabled {
+		return TriggerConfig{}, nil, fmt.Errorf("trigger is disabled: %s", triggerID)
+	}
+	if cfg.MaxRuns > 0 && tm.runCountLocked(triggerID) >= cfg.MaxRuns {
+		return TriggerConfig{}, nil, fmt.Errorf("trigger max_runs reached: %s", triggerID)
+	}
+	return cloneTriggerConfig(cfg), tm.hookFunc, nil
+}
+
+func (tm *TriggerManager) executeTrigger(
+	ctx context.Context,
+	cfg TriggerConfig,
+	hook TriggerHook,
+	inputs map[string]any,
+) (*ExecutionContext, error) {
+	if hook != nil {
+		execCtx, err := hook(ctx, cfg.ID, cloneAnyMap(inputs))
+		if err == nil && execCtx == nil {
+			err = fmt.Errorf("workflow trigger hook returned nil execution")
+		}
+		return execCtx, err
+	}
+	if tm.graphStore == nil {
+		return nil, fmt.Errorf("workflow graph store is nil")
+	}
+	if tm.executor == nil {
+		return nil, fmt.Errorf("workflow trigger executor is nil")
+	}
+
+	graph, err := tm.graphStore.LoadGraph(cfg.GraphID)
+	if err != nil {
+		return nil, fmt.Errorf("load graph %q: %w", cfg.GraphID, err)
+	}
+	if graph == nil {
+		return nil, fmt.Errorf("load graph %q: graph is nil", cfg.GraphID)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return tm.executor.ExecuteGraph(graph, cloneAnyMap(inputs))
+}
+
+func (tm *TriggerManager) runCountLocked(triggerID string) int {
+	count := 0
+	for _, run := range tm.runs {
+		if run.TriggerID == triggerID {
+			count++
+		}
+	}
+	return count
+}
+
+func (tm *TriggerManager) appendRun(run TriggerRun) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	tm.runs = append(tm.runs, cloneTriggerRun(run))
+}
+
+func (tm *TriggerManager) fireMatching(
+	ctx context.Context,
+	triggerIDs []string,
+	inputs map[string]any,
+	triggeredBy string,
+	event *WorkflowTriggerEvent,
+) ([]*TriggerRun, error) {
+	runs := make([]*TriggerRun, 0, len(triggerIDs))
+	var errs []error
+	for _, id := range triggerIDs {
+		run, err := tm.fireTrigger(ctx, id, inputs, triggeredBy, event)
+		if run != nil {
+			runs = append(runs, run)
+		}
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return runs, errors.Join(errs...)
+}
+
+func (tm *TriggerManager) matchingTriggerIDs(match func(TriggerConfig) bool) []string {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+
+	ids := make([]string, 0)
+	for _, cfg := range tm.triggers {
+		if match(cfg) {
+			ids = append(ids, cfg.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (tm *TriggerManager) filterTriggers(match func(TriggerConfig) bool) []*TriggerConfig {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+
+	result := make([]*TriggerConfig, 0)
+	for _, cfg := range tm.triggers {
+		if !match(cfg) {
+			continue
+		}
+		cloned := cloneTriggerConfig(cfg)
+		result = append(result, &cloned)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ID < result[j].ID
+	})
+	return result
+}
+
+func validateTriggerConfig(cfg TriggerConfig) error {
+	if strings.TrimSpace(cfg.ID) == "" {
+		return fmt.Errorf("trigger id is required")
+	}
+	if strings.TrimSpace(cfg.GraphID) == "" {
+		return fmt.Errorf("graph_id is required")
+	}
+	switch cfg.Type {
+	case TriggerManual:
+	case TriggerCron:
+		if strings.TrimSpace(cfg.CronExpr) == "" {
+			return fmt.Errorf("cron_expr is required for cron triggers")
+		}
+	case TriggerWebhook:
+		if strings.TrimSpace(cfg.WebhookPath) == "" {
+			return fmt.Errorf("webhook_path is required for webhook triggers")
+		}
+	case TriggerEvent:
+		if strings.TrimSpace(cfg.EventSource) == "" {
+			return fmt.Errorf("event_source is required for event triggers")
+		}
+	default:
+		return fmt.Errorf("unsupported trigger type: %s", cfg.Type)
+	}
+	return nil
+}
+
+func matchesEventType(allowed []string, eventType string) bool {
+	for _, candidate := range allowed {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "*" || candidate == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+func buildTriggerRun(
+	triggerID string,
+	triggeredBy string,
+	event *WorkflowTriggerEvent,
+	startedAt time.Time,
+	execCtx *ExecutionContext,
+	execErr error,
+) TriggerRun {
+	run := TriggerRun{
+		TriggerID:   triggerID,
+		TriggeredBy: triggeredBy,
+		Event:       cloneTriggerEvent(event),
+		StartedAt:   startedAt,
+	}
+	if execCtx != nil {
+		run.ExecutionID = execCtx.ExecutionID
+		run.Status = string(execCtx.Status)
+		run.StartedAt = execCtx.StartTime
+		run.EndedAt = execCtx.EndTime
+	}
+	if run.Status == "" {
+		run.Status = string(ExecutionFailed)
+	}
+	if execErr != nil {
+		run.Status = string(ExecutionFailed)
+		run.Error = execErr.Error()
+		now := time.Now().UTC()
+		run.EndedAt = &now
+	}
+	return run
+}
+
+func cloneTriggerConfig(cfg TriggerConfig) TriggerConfig {
+	cfg.EventTypes = append([]string(nil), cfg.EventTypes...)
+	cfg.DefaultInputs = cloneAnyMap(cfg.DefaultInputs)
+	return cfg
+}
+
+func normalizeTriggerConfig(cfg TriggerConfig) TriggerConfig {
+	cfg = cloneTriggerConfig(cfg)
+	cfg.ID = strings.TrimSpace(cfg.ID)
+	cfg.GraphID = strings.TrimSpace(cfg.GraphID)
+	cfg.Type = TriggerType(strings.TrimSpace(string(cfg.Type)))
+	cfg.Name = strings.TrimSpace(cfg.Name)
+	cfg.CronExpr = strings.TrimSpace(cfg.CronExpr)
+	cfg.Timezone = strings.TrimSpace(cfg.Timezone)
+	cfg.WebhookPath = strings.TrimSpace(cfg.WebhookPath)
+	cfg.WebhookSecret = strings.TrimSpace(cfg.WebhookSecret)
+	cfg.EventSource = strings.TrimSpace(cfg.EventSource)
+	cfg.EventFilter = strings.TrimSpace(cfg.EventFilter)
+	eventTypes := make([]string, 0, len(cfg.EventTypes))
+	for _, eventType := range cfg.EventTypes {
+		eventType = strings.TrimSpace(eventType)
+		if eventType != "" {
+			eventTypes = append(eventTypes, eventType)
+		}
+	}
+	cfg.EventTypes = eventTypes
+	return cfg
+}
+
+func cloneTriggerEvent(event *WorkflowTriggerEvent) *WorkflowTriggerEvent {
+	if event == nil {
+		return nil
+	}
+	cloned := *event
+	cloned.Payload = cloneAnyMap(event.Payload)
+	return &cloned
+}
+
+func cloneTriggerRun(run TriggerRun) TriggerRun {
+	run.Event = cloneTriggerEvent(run.Event)
+	if run.EndedAt != nil {
+		endedAt := *run.EndedAt
+		run.EndedAt = &endedAt
+	}
+	return run
+}
+
+func cloneTriggerRunPtr(run TriggerRun) *TriggerRun {
+	cloned := cloneTriggerRun(run)
+	return &cloned
+}

--- a/pkg/capability/workflows/trigger.go
+++ b/pkg/capability/workflows/trigger.go
@@ -80,6 +80,7 @@ type TriggerManager struct {
 	mu       sync.RWMutex
 	triggers map[string]TriggerConfig
 	runs     []TriggerRun
+	inFlight map[string]int
 
 	executor   TriggerExecutor
 	graphStore GraphStore
@@ -91,6 +92,7 @@ func NewTriggerManager(executor TriggerExecutor, graphStore GraphStore) *Trigger
 	return &TriggerManager{
 		triggers:   make(map[string]TriggerConfig),
 		runs:       make([]TriggerRun, 0),
+		inFlight:   make(map[string]int),
 		executor:   executor,
 		graphStore: graphStore,
 	}
@@ -393,10 +395,16 @@ func (tm *TriggerManager) fireTrigger(
 		return nil, err
 	}
 
-	cfg, hook, err := tm.triggerForRun(triggerID)
+	cfg, hook, err := tm.reserveTriggerRun(triggerID)
 	if err != nil {
 		return nil, err
 	}
+	reserved := true
+	defer func() {
+		if reserved {
+			tm.releaseTriggerReservation(triggerID)
+		}
+	}()
 
 	merged := cloneAnyMap(cfg.DefaultInputs)
 	if merged == nil {
@@ -416,13 +424,14 @@ func (tm *TriggerManager) fireTrigger(
 	startedAt := time.Now().UTC()
 	execCtx, execErr := tm.executeTrigger(runCtx, cfg, hook, merged)
 	run := buildTriggerRun(triggerID, triggeredBy, event, startedAt, execCtx, execErr)
-	tm.appendRun(run)
+	tm.appendRunAndRelease(run)
+	reserved = false
 	return cloneTriggerRunPtr(run), execErr
 }
 
-func (tm *TriggerManager) triggerForRun(triggerID string) (TriggerConfig, TriggerHook, error) {
-	tm.mu.RLock()
-	defer tm.mu.RUnlock()
+func (tm *TriggerManager) reserveTriggerRun(triggerID string) (TriggerConfig, TriggerHook, error) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
 	cfg, ok := tm.triggers[triggerID]
 	if !ok {
 		return TriggerConfig{}, nil, fmt.Errorf("trigger not found: %s", triggerID)
@@ -430,9 +439,13 @@ func (tm *TriggerManager) triggerForRun(triggerID string) (TriggerConfig, Trigge
 	if !cfg.Enabled {
 		return TriggerConfig{}, nil, fmt.Errorf("trigger is disabled: %s", triggerID)
 	}
-	if cfg.MaxRuns > 0 && tm.runCountLocked(triggerID) >= cfg.MaxRuns {
+	if cfg.MaxRuns > 0 && tm.runCountLocked(triggerID)+tm.inFlightCountLocked(triggerID) >= cfg.MaxRuns {
 		return TriggerConfig{}, nil, fmt.Errorf("trigger max_runs reached: %s", triggerID)
 	}
+	if tm.inFlight == nil {
+		tm.inFlight = make(map[string]int)
+	}
+	tm.inFlight[triggerID]++
 	return cloneTriggerConfig(cfg), tm.hookFunc, nil
 }
 
@@ -479,10 +492,35 @@ func (tm *TriggerManager) runCountLocked(triggerID string) int {
 	return count
 }
 
-func (tm *TriggerManager) appendRun(run TriggerRun) {
+func (tm *TriggerManager) inFlightCountLocked(triggerID string) int {
+	if tm.inFlight == nil {
+		return 0
+	}
+	return tm.inFlight[triggerID]
+}
+
+func (tm *TriggerManager) appendRunAndRelease(run TriggerRun) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 	tm.runs = append(tm.runs, cloneTriggerRun(run))
+	tm.releaseTriggerReservationLocked(run.TriggerID)
+}
+
+func (tm *TriggerManager) releaseTriggerReservation(triggerID string) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	tm.releaseTriggerReservationLocked(triggerID)
+}
+
+func (tm *TriggerManager) releaseTriggerReservationLocked(triggerID string) {
+	if tm.inFlight == nil || tm.inFlight[triggerID] == 0 {
+		return
+	}
+	if tm.inFlight[triggerID] == 1 {
+		delete(tm.inFlight, triggerID)
+		return
+	}
+	tm.inFlight[triggerID]--
 }
 
 func (tm *TriggerManager) fireMatching(

--- a/pkg/capability/workflows/trigger.go
+++ b/pkg/capability/workflows/trigger.go
@@ -260,19 +260,10 @@ func (tm *TriggerManager) HandleEvent(ctx context.Context, event *WorkflowTrigge
 		event.Timestamp = time.Now().UTC()
 	}
 
-	matching := tm.matchingTriggerIDs(func(cfg TriggerConfig) bool {
-		if !cfg.Enabled || cfg.Type != TriggerEvent || cfg.EventSource != event.Source {
-			return false
-		}
-		if len(cfg.EventTypes) > 0 && !matchesEventType(cfg.EventTypes, event.Type) {
-			return false
-		}
-		if cfg.EventFilter != "" {
-			ok, err := EvalCondition(cfg.EventFilter, event.Payload)
-			return err == nil && ok
-		}
-		return true
-	})
+	matching, err := tm.matchingEventTriggerIDs(event)
+	if err != nil {
+		return nil, err
+	}
 	if len(matching) == 0 {
 		return nil, fmt.Errorf("no event trigger found for source=%s type=%s", event.Source, event.Type)
 	}
@@ -557,6 +548,48 @@ func (tm *TriggerManager) matchingTriggerIDs(match func(TriggerConfig) bool) []s
 	}
 	sort.Strings(ids)
 	return ids
+}
+
+func (tm *TriggerManager) matchingEventTriggerIDs(event *WorkflowTriggerEvent) ([]string, error) {
+	tm.mu.RLock()
+	configs := make([]TriggerConfig, 0, len(tm.triggers))
+	for _, cfg := range tm.triggers {
+		configs = append(configs, cloneTriggerConfig(cfg))
+	}
+	tm.mu.RUnlock()
+
+	ids := make([]string, 0)
+	var errs []error
+	for _, cfg := range configs {
+		matched, err := eventTriggerMatches(cfg, event)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if matched {
+			ids = append(ids, cfg.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids, errors.Join(errs...)
+}
+
+func eventTriggerMatches(cfg TriggerConfig, event *WorkflowTriggerEvent) (bool, error) {
+	if !cfg.Enabled || cfg.Type != TriggerEvent || cfg.EventSource != event.Source {
+		return false, nil
+	}
+	if len(cfg.EventTypes) > 0 && !matchesEventType(cfg.EventTypes, event.Type) {
+		return false, nil
+	}
+	if cfg.EventFilter == "" {
+		return true, nil
+	}
+
+	ok, err := EvalCondition(cfg.EventFilter, event.Payload)
+	if err != nil {
+		return false, fmt.Errorf("event_filter for trigger %q: %w", cfg.ID, err)
+	}
+	return ok, nil
 }
 
 func (tm *TriggerManager) filterTriggers(match func(TriggerConfig) bool) []*TriggerConfig {

--- a/pkg/capability/workflows/trigger.go
+++ b/pkg/capability/workflows/trigger.go
@@ -144,7 +144,7 @@ func (tm *TriggerManager) AddTrigger(cfg TriggerConfig) error {
 	return nil
 }
 
-// GetTrigger returns a defensive copy of a trigger by ID.
+// GetTrigger returns a defensive public copy of a trigger by ID.
 func (tm *TriggerManager) GetTrigger(id string) (*TriggerConfig, bool) {
 	if tm == nil {
 		return nil, false
@@ -155,11 +155,11 @@ func (tm *TriggerManager) GetTrigger(id string) (*TriggerConfig, bool) {
 	if !ok {
 		return nil, false
 	}
-	cloned := cloneTriggerConfig(cfg)
+	cloned := clonePublicTriggerConfig(cfg)
 	return &cloned, true
 }
 
-// ListTriggers returns trigger configurations, optionally filtered by graph ID.
+// ListTriggers returns public trigger configurations, optionally filtered by graph ID.
 func (tm *TriggerManager) ListTriggers(graphID string) []*TriggerConfig {
 	if tm == nil {
 		return nil
@@ -172,7 +172,7 @@ func (tm *TriggerManager) ListTriggers(graphID string) []*TriggerConfig {
 		if graphID != "" && cfg.GraphID != graphID {
 			continue
 		}
-		cloned := cloneTriggerConfig(cfg)
+		cloned := clonePublicTriggerConfig(cfg)
 		result = append(result, &cloned)
 	}
 	sort.Slice(result, func(i, j int) bool {
@@ -310,7 +310,7 @@ func (tm *TriggerManager) GetRuns(triggerID string, limit int) []*TriggerRun {
 	return result
 }
 
-// GetCronTriggers returns enabled cron triggers for scheduler integration.
+// GetCronTriggers returns enabled public cron triggers for scheduler integration.
 func (tm *TriggerManager) GetCronTriggers() []*TriggerConfig {
 	if tm == nil {
 		return nil
@@ -320,7 +320,7 @@ func (tm *TriggerManager) GetCronTriggers() []*TriggerConfig {
 	})
 }
 
-// GetWebhookTriggers returns enabled webhook triggers for HTTP registration.
+// GetWebhookTriggers returns enabled public webhook triggers for HTTP registration.
 func (tm *TriggerManager) GetWebhookTriggers() []*TriggerConfig {
 	if tm == nil {
 		return nil
@@ -568,7 +568,7 @@ func (tm *TriggerManager) filterTriggers(match func(TriggerConfig) bool) []*Trig
 		if !match(cfg) {
 			continue
 		}
-		cloned := cloneTriggerConfig(cfg)
+		cloned := clonePublicTriggerConfig(cfg)
 		result = append(result, &cloned)
 	}
 	sort.Slice(result, func(i, j int) bool {
@@ -656,6 +656,12 @@ func buildTriggerRun(
 func cloneTriggerConfig(cfg TriggerConfig) TriggerConfig {
 	cfg.EventTypes = append([]string(nil), cfg.EventTypes...)
 	cfg.DefaultInputs = cloneAnyMap(cfg.DefaultInputs)
+	return cfg
+}
+
+func clonePublicTriggerConfig(cfg TriggerConfig) TriggerConfig {
+	cfg = cloneTriggerConfig(cfg)
+	cfg.WebhookSecret = ""
 	return cfg
 }
 

--- a/pkg/capability/workflows/trigger.go
+++ b/pkg/capability/workflows/trigger.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"sort"
@@ -231,7 +232,7 @@ func (tm *TriggerManager) HandleWebhookWithSecret(
 		if !cfg.Enabled || cfg.Type != TriggerWebhook || cfg.WebhookPath != path {
 			return false
 		}
-		return cfg.WebhookSecret == "" || cfg.WebhookSecret == secret
+		return webhookSecretMatches(cfg.WebhookSecret, secret)
 	})
 	if len(matching) == 0 {
 		return nil, fmt.Errorf("no webhook trigger found for path: %s", path)
@@ -611,6 +612,13 @@ func matchesEventType(allowed []string, eventType string) bool {
 		}
 	}
 	return false
+}
+
+func webhookSecretMatches(expected string, provided string) bool {
+	if expected == "" {
+		return true
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(provided)) == 1
 }
 
 func buildTriggerRun(

--- a/pkg/capability/workflows/trigger_test.go
+++ b/pkg/capability/workflows/trigger_test.go
@@ -1,0 +1,644 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeGraphStore struct {
+	graphs map[string]*Graph
+	loads  []string
+	err    error
+}
+
+func (s *fakeGraphStore) SaveGraph(graph *Graph) error {
+	if s.graphs == nil {
+		s.graphs = make(map[string]*Graph)
+	}
+	s.graphs[graph.ID] = graph
+	return nil
+}
+
+func (s *fakeGraphStore) LoadGraph(graphID string) (*Graph, error) {
+	s.loads = append(s.loads, graphID)
+	if s.err != nil {
+		return nil, s.err
+	}
+	graph, ok := s.graphs[graphID]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return graph, nil
+}
+
+func (s *fakeGraphStore) DeleteGraph(graphID string) error {
+	delete(s.graphs, graphID)
+	return nil
+}
+
+func (s *fakeGraphStore) ListGraphs() ([]*Graph, error) {
+	graphs := make([]*Graph, 0, len(s.graphs))
+	for _, graph := range s.graphs {
+		graphs = append(graphs, graph)
+	}
+	return graphs, nil
+}
+
+type fakeTriggerExecutor struct {
+	inputs map[string]any
+	graph  *Graph
+	err    error
+}
+
+func (e *fakeTriggerExecutor) ExecuteGraph(graph *Graph, inputs map[string]any) (*ExecutionContext, error) {
+	e.graph = graph
+	e.inputs = cloneAnyMap(inputs)
+	if e.err != nil {
+		return nil, e.err
+	}
+	exec := NewExecutionContext(graph.ID, inputs)
+	exec.MarkExecutionCompleted(map[string]any{"ok": true})
+	return exec, nil
+}
+
+func TestAddGetListTriggersUseDefensiveCopies(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	defaults := map[string]any{"nested": map[string]any{"value": "before"}}
+
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:            "manual-1",
+		GraphID:       "graph-1",
+		Type:          TriggerManual,
+		Name:          "Manual",
+		DefaultInputs: defaults,
+	}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	defaults["nested"].(map[string]any)["value"] = "after"
+
+	cfg, ok := tm.GetTrigger("manual-1")
+	if !ok {
+		t.Fatal("expected trigger to exist")
+	}
+	if !cfg.Enabled {
+		t.Fatal("expected trigger to be enabled by default")
+	}
+	if got := cfg.DefaultInputs["nested"].(map[string]any)["value"]; got != "before" {
+		t.Fatalf("expected default inputs to be cloned, got %v", got)
+	}
+
+	cfg.DefaultInputs["nested"].(map[string]any)["value"] = "mutated"
+	cfg, _ = tm.GetTrigger("manual-1")
+	if got := cfg.DefaultInputs["nested"].(map[string]any)["value"]; got != "before" {
+		t.Fatalf("GetTrigger leaked mutable state, got %v", got)
+	}
+
+	listed := tm.ListTriggers("graph-1")
+	if len(listed) != 1 {
+		t.Fatalf("expected one listed trigger, got %d", len(listed))
+	}
+	listed[0].DefaultInputs["nested"].(map[string]any)["value"] = "list-mutated"
+	cfg, _ = tm.GetTrigger("manual-1")
+	if got := cfg.DefaultInputs["nested"].(map[string]any)["value"]; got != "before" {
+		t.Fatalf("ListTriggers leaked mutable state, got %v", got)
+	}
+}
+
+func TestAddTriggerValidatesTypeSpecificFields(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+
+	tests := []struct {
+		name string
+		cfg  TriggerConfig
+		want string
+	}{
+		{
+			name: "missing graph",
+			cfg:  TriggerConfig{ID: "bad", Type: TriggerManual},
+			want: "graph_id is required",
+		},
+		{
+			name: "cron expression",
+			cfg:  TriggerConfig{ID: "bad", GraphID: "graph-1", Type: TriggerCron},
+			want: "cron_expr is required",
+		},
+		{
+			name: "webhook path",
+			cfg:  TriggerConfig{ID: "bad", GraphID: "graph-1", Type: TriggerWebhook},
+			want: "webhook_path is required",
+		},
+		{
+			name: "event source",
+			cfg:  TriggerConfig{ID: "bad", GraphID: "graph-1", Type: TriggerEvent},
+			want: "event_source is required",
+		},
+		{
+			name: "unknown type",
+			cfg:  TriggerConfig{ID: "bad", GraphID: "graph-1", Type: "unknown"},
+			want: "unsupported trigger type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tm.AddTrigger(tt.cfg)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnableDisableAndDeleteTrigger(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{ID: "manual-1", GraphID: "graph-1"}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+
+	if err := tm.DisableTrigger("manual-1"); err != nil {
+		t.Fatalf("DisableTrigger: %v", err)
+	}
+	cfg, _ := tm.GetTrigger("manual-1")
+	if cfg.Enabled {
+		t.Fatal("expected disabled trigger")
+	}
+
+	if err := tm.EnableTrigger("manual-1"); err != nil {
+		t.Fatalf("EnableTrigger: %v", err)
+	}
+	cfg, _ = tm.GetTrigger("manual-1")
+	if !cfg.Enabled {
+		t.Fatal("expected enabled trigger")
+	}
+
+	if err := tm.DeleteTrigger("manual-1"); err != nil {
+		t.Fatalf("DeleteTrigger: %v", err)
+	}
+	if _, ok := tm.GetTrigger("manual-1"); ok {
+		t.Fatal("expected trigger to be deleted")
+	}
+}
+
+func TestFireTriggerUsesHookAndRecordsRun(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:            "manual-1",
+		GraphID:       "graph-1",
+		DefaultInputs: map[string]any{"mode": "default", "keep": true},
+	}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+
+	tm.SetHookFunc(func(ctx context.Context, triggerID string, inputs map[string]any) (*ExecutionContext, error) {
+		if triggerID != "manual-1" {
+			t.Fatalf("triggerID = %q, want manual-1", triggerID)
+		}
+		if inputs["mode"] != "override" || inputs["keep"] != true {
+			t.Fatalf("merged inputs = %#v", inputs)
+		}
+		exec := NewExecutionContext("graph-1", inputs)
+		exec.MarkExecutionCompleted(map[string]any{"done": true})
+		return exec, nil
+	})
+
+	run, err := tm.FireTrigger(context.Background(), "manual-1", map[string]any{"mode": "override"})
+	if err != nil {
+		t.Fatalf("FireTrigger: %v", err)
+	}
+	if run.TriggerID != "manual-1" || run.TriggeredBy != "manual" {
+		t.Fatalf("unexpected run metadata: %#v", run)
+	}
+	if run.Status != string(ExecutionCompleted) {
+		t.Fatalf("status = %q, want completed", run.Status)
+	}
+
+	runs := tm.GetRuns("", 1)
+	if len(runs) != 1 || runs[0].ExecutionID != run.ExecutionID {
+		t.Fatalf("expected recorded run, got %#v", runs)
+	}
+}
+
+func TestFireTriggerUsesGraphStoreAndExecutor(t *testing.T) {
+	graph := NewGraph("executor", "")
+	graph.ID = "graph-1"
+	graph.AddActionNode("run", "", "plugin", "action", nil)
+	store := &fakeGraphStore{graphs: map[string]*Graph{"graph-1": graph}}
+	executor := &fakeTriggerExecutor{}
+	tm := NewTriggerManager(executor, store)
+
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:            "manual-1",
+		GraphID:       "graph-1",
+		DefaultInputs: map[string]any{"base": "yes"},
+	}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+
+	run, err := tm.FireTrigger(context.Background(), "manual-1", map[string]any{"request": "go"})
+	if err != nil {
+		t.Fatalf("FireTrigger: %v", err)
+	}
+	if run.Status != string(ExecutionCompleted) {
+		t.Fatalf("status = %q, want completed", run.Status)
+	}
+	if len(store.loads) != 1 || store.loads[0] != "graph-1" {
+		t.Fatalf("store loads = %v", store.loads)
+	}
+	if executor.graph == nil || executor.graph.ID != "graph-1" {
+		t.Fatalf("executor graph = %#v", executor.graph)
+	}
+	if executor.inputs["base"] != "yes" || executor.inputs["request"] != "go" {
+		t.Fatalf("executor inputs = %#v", executor.inputs)
+	}
+}
+
+func TestFireTriggerRecordsFailureRun(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{ID: "manual-1", GraphID: "graph-1"}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	tm.SetHookFunc(func(context.Context, string, map[string]any) (*ExecutionContext, error) {
+		return nil, errors.New("boom")
+	})
+
+	run, err := tm.FireTrigger(context.Background(), "manual-1", nil)
+	if err == nil {
+		t.Fatal("expected hook error")
+	}
+	if run == nil {
+		t.Fatal("expected failed run to be returned")
+	}
+	if run.Status != string(ExecutionFailed) || run.Error != "boom" || run.EndedAt == nil {
+		t.Fatalf("unexpected failed run: %#v", run)
+	}
+
+	runs := tm.GetRuns("manual-1", 1)
+	if len(runs) != 1 || runs[0].Error != "boom" {
+		t.Fatalf("expected failure in run history, got %#v", runs)
+	}
+}
+
+func TestFireTriggerRejectsDisabledOrMissingExecutionBackend(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{ID: "manual-1", GraphID: "graph-1"}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	if err := tm.DisableTrigger("manual-1"); err != nil {
+		t.Fatalf("DisableTrigger: %v", err)
+	}
+
+	if _, err := tm.FireTrigger(context.Background(), "manual-1", nil); err == nil {
+		t.Fatal("expected disabled trigger error")
+	}
+
+	if err := tm.EnableTrigger("manual-1"); err != nil {
+		t.Fatalf("EnableTrigger: %v", err)
+	}
+	run, err := tm.FireTrigger(context.Background(), "manual-1", nil)
+	if err == nil || !strings.Contains(err.Error(), "graph store is nil") {
+		t.Fatalf("expected missing graph store error, got run=%#v err=%v", run, err)
+	}
+	if run == nil || run.Status != string(ExecutionFailed) {
+		t.Fatalf("expected failed run for missing backend, got %#v", run)
+	}
+}
+
+func TestHandleWebhookFiresMatchingTriggers(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:            "webhook-1",
+		GraphID:       "graph-1",
+		Type:          TriggerWebhook,
+		WebhookPath:   "/hooks/deploy",
+		DefaultInputs: map[string]any{"source": "default"},
+	}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	tm.SetHookFunc(func(ctx context.Context, triggerID string, inputs map[string]any) (*ExecutionContext, error) {
+		if inputs["source"] != "payload" {
+			t.Fatalf("payload should override defaults, got %#v", inputs)
+		}
+		exec := NewExecutionContext("graph-1", inputs)
+		exec.MarkExecutionCompleted(nil)
+		return exec, nil
+	})
+
+	payload := map[string]any{"source": "payload"}
+	runs, err := tm.HandleWebhook(context.Background(), "/hooks/deploy", payload)
+	if err != nil {
+		t.Fatalf("HandleWebhook: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected one run, got %d", len(runs))
+	}
+	if runs[0].TriggeredBy != "webhook" || runs[0].Event == nil || runs[0].Event.Source != "webhook" {
+		t.Fatalf("unexpected webhook run: %#v", runs[0])
+	}
+	payload["source"] = "mutated"
+	if runs[0].Event.Payload["source"] != "payload" {
+		t.Fatalf("webhook event payload was not cloned: %#v", runs[0].Event.Payload)
+	}
+}
+
+func TestHandleWebhookEnforcesConfiguredSecret(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:            "webhook-1",
+		GraphID:       "graph-1",
+		Type:          TriggerWebhook,
+		WebhookPath:   "/hooks/private",
+		WebhookSecret: "secret-token",
+	}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	tm.SetHookFunc(func(context.Context, string, map[string]any) (*ExecutionContext, error) {
+		exec := NewExecutionContext("graph-1", nil)
+		exec.MarkExecutionCompleted(nil)
+		return exec, nil
+	})
+
+	if _, err := tm.HandleWebhook(context.Background(), "/hooks/private", nil); err == nil {
+		t.Fatal("expected secret-protected webhook to reject missing secret")
+	}
+	runs, err := tm.HandleWebhookWithSecret(context.Background(), "/hooks/private", "secret-token", nil)
+	if err != nil {
+		t.Fatalf("HandleWebhookWithSecret: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected one authenticated webhook run, got %d", len(runs))
+	}
+}
+
+func TestHandleEventFiltersByTypeAndExpression(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:          "event-1",
+		GraphID:     "graph-1",
+		Type:        TriggerEvent,
+		EventSource: "github",
+		EventTypes:  []string{"pull_request"},
+		EventFilter: "$approved == true",
+	}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	tm.SetHookFunc(func(ctx context.Context, triggerID string, inputs map[string]any) (*ExecutionContext, error) {
+		if inputs["_event_source"] != "github" || inputs["_event_type"] != "pull_request" {
+			t.Fatalf("event metadata inputs = %#v", inputs)
+		}
+		exec := NewExecutionContext("graph-1", inputs)
+		exec.MarkExecutionCompleted(nil)
+		return exec, nil
+	})
+
+	runs, err := tm.HandleEvent(context.Background(), &WorkflowTriggerEvent{
+		ID:      "evt-1",
+		Source:  "github",
+		Type:    "pull_request",
+		Payload: map[string]any{"approved": true},
+	})
+	if err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	if len(runs) != 1 || runs[0].TriggeredBy != "event" {
+		t.Fatalf("unexpected event runs: %#v", runs)
+	}
+
+	if _, err := tm.HandleEvent(context.Background(), &WorkflowTriggerEvent{
+		Source:  "github",
+		Type:    "pull_request",
+		Payload: map[string]any{"approved": false},
+	}); err == nil {
+		t.Fatal("expected no matching event trigger")
+	}
+}
+
+func TestGetRunsReturnsNewestFirstAndClones(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{ID: "manual-1", GraphID: "graph-1"}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	count := 0
+	tm.SetHookFunc(func(context.Context, string, map[string]any) (*ExecutionContext, error) {
+		count++
+		exec := NewExecutionContext("graph-1", nil)
+		exec.ExecutionID = strings.Join([]string{"exec", string(rune('0' + count))}, "-")
+		exec.MarkExecutionCompleted(nil)
+		return exec, nil
+	})
+	if _, err := tm.FireTrigger(context.Background(), "manual-1", nil); err != nil {
+		t.Fatalf("FireTrigger 1: %v", err)
+	}
+	if _, err := tm.FireTrigger(context.Background(), "manual-1", nil); err != nil {
+		t.Fatalf("FireTrigger 2: %v", err)
+	}
+
+	runs := tm.GetRuns("manual-1", 1)
+	if len(runs) != 1 || runs[0].ExecutionID != "exec-2" {
+		t.Fatalf("expected newest limited run, got %#v", runs)
+	}
+	runs[0].Status = "mutated"
+	runs = tm.GetRuns("manual-1", 1)
+	if runs[0].Status == "mutated" {
+		t.Fatal("GetRuns leaked mutable run state")
+	}
+}
+
+func TestCronWebhookHelpersAndStats(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:       "cron-1",
+		GraphID:  "graph-1",
+		Type:     TriggerCron,
+		CronExpr: "*/5 * * * *",
+	}); err != nil {
+		t.Fatalf("AddTrigger cron: %v", err)
+	}
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:          "webhook-1",
+		GraphID:     "graph-1",
+		Type:        TriggerWebhook,
+		WebhookPath: "/hook",
+	}); err != nil {
+		t.Fatalf("AddTrigger webhook: %v", err)
+	}
+	if err := tm.DisableTrigger("webhook-1"); err != nil {
+		t.Fatalf("DisableTrigger: %v", err)
+	}
+
+	cron := tm.GetCronTriggers()
+	if len(cron) != 1 || cron[0].ID != "cron-1" {
+		t.Fatalf("cron triggers = %#v", cron)
+	}
+	webhooks := tm.GetWebhookTriggers()
+	if len(webhooks) != 0 {
+		t.Fatalf("expected disabled webhook to be excluded, got %#v", webhooks)
+	}
+
+	stats := tm.Stats()
+	if stats["total_triggers"] != 2 {
+		t.Fatalf("stats total_triggers = %#v", stats["total_triggers"])
+	}
+	byType := stats["by_type"].(map[string]int)
+	if byType[string(TriggerCron)] != 1 || byType[string(TriggerWebhook)] != 1 {
+		t.Fatalf("stats by_type = %#v", byType)
+	}
+	byStatus := stats["by_status"].(map[string]int)
+	if byStatus["enabled"] != 1 || byStatus["disabled"] != 1 {
+		t.Fatalf("stats by_status = %#v", byStatus)
+	}
+}
+
+func TestFireTriggerHonorsContextCancellation(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{ID: "manual-1", GraphID: "graph-1"}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := tm.FireTrigger(ctx, "manual-1", nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}
+
+func TestFireTriggerEnforcesMaxRuns(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:      "manual-1",
+		GraphID: "graph-1",
+		MaxRuns: 1,
+	}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	tm.SetHookFunc(func(context.Context, string, map[string]any) (*ExecutionContext, error) {
+		exec := NewExecutionContext("graph-1", nil)
+		exec.MarkExecutionCompleted(nil)
+		return exec, nil
+	})
+	if _, err := tm.FireTrigger(context.Background(), "manual-1", nil); err != nil {
+		t.Fatalf("FireTrigger first: %v", err)
+	}
+	if _, err := tm.FireTrigger(context.Background(), "manual-1", nil); err == nil {
+		t.Fatal("expected max_runs error")
+	}
+}
+
+func TestFireTriggerAppliesTimeoutContext(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:         "manual-1",
+		GraphID:    "graph-1",
+		TimeoutSec: 1,
+	}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	tm.SetHookFunc(func(ctx context.Context, _ string, _ map[string]any) (*ExecutionContext, error) {
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("expected timeout deadline to be applied")
+		}
+		exec := NewExecutionContext("graph-1", nil)
+		exec.MarkExecutionCompleted(nil)
+		return exec, nil
+	})
+	if _, err := tm.FireTrigger(context.Background(), "manual-1", nil); err != nil {
+		t.Fatalf("FireTrigger: %v", err)
+	}
+}
+
+func TestFireTriggerRejectsNilHookExecution(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{ID: "manual-1", GraphID: "graph-1"}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	tm.SetHookFunc(func(context.Context, string, map[string]any) (*ExecutionContext, error) {
+		return nil, nil
+	})
+	run, err := tm.FireTrigger(nil, "manual-1", nil)
+	if err == nil || !strings.Contains(err.Error(), "nil execution") {
+		t.Fatalf("expected nil execution error, got run=%#v err=%v", run, err)
+	}
+	if run == nil || run.Status != string(ExecutionFailed) {
+		t.Fatalf("expected failed run, got %#v", run)
+	}
+}
+
+func TestNilTriggerManagerIsSafe(t *testing.T) {
+	var tm *TriggerManager
+	if err := tm.AddTrigger(TriggerConfig{}); err == nil {
+		t.Fatal("expected AddTrigger nil manager error")
+	}
+	if _, ok := tm.GetTrigger("x"); ok {
+		t.Fatal("expected no trigger from nil manager")
+	}
+	if got := tm.ListTriggers(""); got != nil {
+		t.Fatalf("expected nil list, got %#v", got)
+	}
+	if stats := tm.Stats(); stats["total_triggers"] != 0 {
+		t.Fatalf("unexpected nil stats: %#v", stats)
+	}
+	tm.SetHookFunc(nil)
+}
+
+func TestHandleEventRejectsNilEvent(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if _, err := tm.HandleEvent(context.Background(), nil); err == nil {
+		t.Fatal("expected nil event error")
+	}
+}
+
+func TestAddTriggerRejectsDuplicateIDs(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	cfg := TriggerConfig{ID: "manual-1", GraphID: "graph-1"}
+	if err := tm.AddTrigger(cfg); err != nil {
+		t.Fatalf("AddTrigger first: %v", err)
+	}
+	if err := tm.AddTrigger(cfg); err == nil {
+		t.Fatal("expected duplicate trigger error")
+	}
+}
+
+func TestHandleWebhookReturnsNoMatchError(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	_, err := tm.HandleWebhook(context.Background(), "/missing", nil)
+	if err == nil {
+		t.Fatal("expected no webhook match error")
+	}
+}
+
+func TestTriggerEventTimestampDefaultsWhenMissing(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:          "event-1",
+		GraphID:     "graph-1",
+		Type:        TriggerEvent,
+		EventSource: "system",
+		EventTypes:  []string{"*"},
+	}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	tm.SetHookFunc(func(context.Context, string, map[string]any) (*ExecutionContext, error) {
+		exec := NewExecutionContext("graph-1", nil)
+		exec.MarkExecutionCompleted(nil)
+		return exec, nil
+	})
+
+	runs, err := tm.HandleEvent(context.Background(), &WorkflowTriggerEvent{
+		Source: "system",
+		Type:   "tick",
+	})
+	if err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	if len(runs) != 1 || runs[0].Event.Timestamp.IsZero() {
+		t.Fatalf("expected default event timestamp, got %#v", runs)
+	}
+	if time.Since(runs[0].Event.Timestamp) > time.Minute {
+		t.Fatalf("default timestamp too old: %s", runs[0].Event.Timestamp)
+	}
+}

--- a/pkg/capability/workflows/trigger_test.go
+++ b/pkg/capability/workflows/trigger_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -526,6 +527,69 @@ func TestFireTriggerEnforcesMaxRuns(t *testing.T) {
 	}
 	if _, err := tm.FireTrigger(context.Background(), "manual-1", nil); err == nil {
 		t.Fatal("expected max_runs error")
+	}
+}
+
+func TestFireTriggerMaxRunsCountsInFlightRuns(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:      "manual-1",
+		GraphID: "graph-1",
+		MaxRuns: 1,
+	}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var enteredOnce sync.Once
+	tm.SetHookFunc(func(ctx context.Context, _ string, _ map[string]any) (*ExecutionContext, error) {
+		enteredOnce.Do(func() { close(entered) })
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		exec := NewExecutionContext("graph-1", nil)
+		exec.MarkExecutionCompleted(nil)
+		return exec, nil
+	})
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := tm.FireTrigger(context.Background(), "manual-1", nil)
+		firstDone <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("first trigger did not enter hook")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := tm.FireTrigger(context.Background(), "manual-1", nil)
+		secondDone <- err
+	}()
+
+	var secondErr error
+	select {
+	case secondErr = <-secondDone:
+	case <-time.After(200 * time.Millisecond):
+		secondErr = errors.New("second FireTrigger blocked instead of observing in-flight max_runs")
+	}
+
+	close(release)
+
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first FireTrigger: %v", err)
+	}
+	if secondErr != nil && strings.Contains(secondErr.Error(), "blocked") {
+		<-secondDone
+	}
+	if secondErr == nil || !strings.Contains(secondErr.Error(), "max_runs") {
+		t.Fatalf("expected in-flight max_runs rejection, got %v", secondErr)
 	}
 }
 

--- a/pkg/capability/workflows/trigger_test.go
+++ b/pkg/capability/workflows/trigger_test.go
@@ -462,6 +462,32 @@ func TestHandleEventFiltersByTypeAndExpression(t *testing.T) {
 	}
 }
 
+func TestHandleEventReturnsInvalidFilterError(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:          "event-1",
+		GraphID:     "graph-1",
+		Type:        TriggerEvent,
+		EventSource: "github",
+		EventTypes:  []string{"pull_request"},
+		EventFilter: "$approved &&",
+	}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+
+	_, err := tm.HandleEvent(context.Background(), &WorkflowTriggerEvent{
+		Source:  "github",
+		Type:    "pull_request",
+		Payload: map[string]any{"approved": true},
+	})
+	if err == nil {
+		t.Fatal("expected invalid event_filter error")
+	}
+	if !strings.Contains(err.Error(), `event_filter for trigger "event-1"`) {
+		t.Fatalf("expected trigger-specific filter error, got %v", err)
+	}
+}
+
 func TestGetRunsReturnsNewestFirstAndClones(t *testing.T) {
 	tm := NewTriggerManager(nil, nil)
 	if err := tm.AddTrigger(TriggerConfig{ID: "manual-1", GraphID: "graph-1"}); err != nil {

--- a/pkg/capability/workflows/trigger_test.go
+++ b/pkg/capability/workflows/trigger_test.go
@@ -108,6 +108,46 @@ func TestAddGetListTriggersUseDefensiveCopies(t *testing.T) {
 	}
 }
 
+func TestReadPathsRedactWebhookSecrets(t *testing.T) {
+	tm := NewTriggerManager(nil, nil)
+	if err := tm.AddTrigger(TriggerConfig{
+		ID:            "webhook-1",
+		GraphID:       "graph-1",
+		Type:          TriggerWebhook,
+		WebhookPath:   "/hooks/private",
+		WebhookSecret: "secret-token",
+	}); err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	tm.SetHookFunc(func(context.Context, string, map[string]any) (*ExecutionContext, error) {
+		exec := NewExecutionContext("graph-1", nil)
+		exec.MarkExecutionCompleted(nil)
+		return exec, nil
+	})
+
+	cfg, ok := tm.GetTrigger("webhook-1")
+	if !ok {
+		t.Fatal("expected trigger to exist")
+	}
+	if cfg.WebhookSecret != "" {
+		t.Fatalf("GetTrigger leaked webhook secret %q", cfg.WebhookSecret)
+	}
+
+	listed := tm.ListTriggers("graph-1")
+	if len(listed) != 1 || listed[0].WebhookSecret != "" {
+		t.Fatalf("ListTriggers leaked webhook secret: %#v", listed)
+	}
+
+	webhooks := tm.GetWebhookTriggers()
+	if len(webhooks) != 1 || webhooks[0].WebhookSecret != "" {
+		t.Fatalf("GetWebhookTriggers leaked webhook secret: %#v", webhooks)
+	}
+
+	if _, err := tm.HandleWebhookWithSecret(context.Background(), "/hooks/private", "secret-token", nil); err != nil {
+		t.Fatalf("redaction should not break internal secret matching: %v", err)
+	}
+}
+
 func TestAddTriggerValidatesTypeSpecificFields(t *testing.T) {
 	tm := NewTriggerManager(nil, nil)
 

--- a/pkg/capability/workflows/trigger_test.go
+++ b/pkg/capability/workflows/trigger_test.go
@@ -367,6 +367,9 @@ func TestHandleWebhookEnforcesConfiguredSecret(t *testing.T) {
 	if _, err := tm.HandleWebhook(context.Background(), "/hooks/private", nil); err == nil {
 		t.Fatal("expected secret-protected webhook to reject missing secret")
 	}
+	if _, err := tm.HandleWebhookWithSecret(context.Background(), "/hooks/private", "wrong-token", nil); err == nil {
+		t.Fatal("expected secret-protected webhook to reject wrong secret")
+	}
 	runs, err := tm.HandleWebhookWithSecret(context.Background(), "/hooks/private", "secret-token", nil)
 	if err != nil {
 		t.Fatalf("HandleWebhookWithSecret: %v", err)


### PR DESCRIPTION
## 概要

补充 workflow trigger manager，为 workflow graph 提供 manual、cron、webhook、event 等触发配置与运行记录能力。

## 本次变更

- 新增 workflow trigger 类型与配置模型
- 支持 trigger 新增、查询、列表、启用、禁用和删除
- 支持 manual trigger 执行入口
- 支持 webhook trigger 匹配与 secret 校验
- 支持 event trigger 的 source、type 和 condition filter 匹配
- 支持 trigger 默认输入合并、运行记录、统计信息和 defensive copy
- 支持 `max_runs` 与 `timeout_sec` 基础约束
- 增加对应单元测试

## 影响

这条 PR 只新增 workflow trigger manager，不接入外部命令、不执行 GitHub 自动化、不依赖未合并的 workflow file store/editor/examples PR。

## 验证

已执行：

- `go test ./pkg/capability/workflows`
- `go test ./pkg/capability/...`
- `go test ./pkg/...`
- `git diff --check`
