### PR TITLE
feat(workflow): add graph executor

### DIFF
--- a/pkg/capability/workflows/executor.go
+++ b/pkg/capability/workflows/executor.go
@@ -1,0 +1,578 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/anyclaw/pkg/extensions/plugin"
+)
+
+const (
+	defaultMaxLoopIterations = 1000
+	defaultMaxNodeExecutions = 10000
+)
+
+// WorkflowActionRunner executes action nodes for a workflow graph.
+//
+// The executor owns graph traversal and state transitions. Integrations own the
+// actual side effects behind action nodes by providing this runner.
+type WorkflowActionRunner interface {
+	RunAction(ctx context.Context, node Node, inputs map[string]any) (map[string]any, error)
+}
+
+// WorkflowActionRunnerFunc adapts a function into a WorkflowActionRunner.
+type WorkflowActionRunnerFunc func(ctx context.Context, node Node, inputs map[string]any) (map[string]any, error)
+
+// RunAction executes a workflow action node.
+func (fn WorkflowActionRunnerFunc) RunAction(ctx context.Context, node Node, inputs map[string]any) (map[string]any, error) {
+	return fn(ctx, node, inputs)
+}
+
+// WorkflowExecutor executes workflow graphs and records node state transitions.
+type WorkflowExecutor struct {
+	pluginRegistry    *plugin.Registry
+	graphStore        GraphStore
+	actionRunner      WorkflowActionRunner
+	maxLoopIterations int
+	maxNodeExecutions int
+}
+
+// NewWorkflowExecutor creates a workflow graph executor.
+func NewWorkflowExecutor(pluginRegistry *plugin.Registry, graphStore GraphStore) *WorkflowExecutor {
+	return &WorkflowExecutor{
+		pluginRegistry:    pluginRegistry,
+		graphStore:        graphStore,
+		maxLoopIterations: defaultMaxLoopIterations,
+		maxNodeExecutions: defaultMaxNodeExecutions,
+	}
+}
+
+// SetActionRunner sets the side-effect runner used by action nodes.
+func (e *WorkflowExecutor) SetActionRunner(runner WorkflowActionRunner) {
+	if e == nil {
+		return
+	}
+	e.actionRunner = runner
+}
+
+// PluginRegistry returns the plugin registry associated with this executor.
+func (e *WorkflowExecutor) PluginRegistry() *plugin.Registry {
+	if e == nil {
+		return nil
+	}
+	return e.pluginRegistry
+}
+
+// ExecuteGraph executes a graph with a background context.
+func (e *WorkflowExecutor) ExecuteGraph(graph *Graph, inputs map[string]any) (*ExecutionContext, error) {
+	return e.ExecuteGraphContext(context.Background(), graph, inputs)
+}
+
+// ExecuteStoredGraph loads a graph by ID from the configured store and executes it.
+func (e *WorkflowExecutor) ExecuteStoredGraph(ctx context.Context, graphID string, inputs map[string]any) (*ExecutionContext, error) {
+	if e == nil || e.graphStore == nil {
+		return nil, fmt.Errorf("workflow graph store is not configured")
+	}
+	graphID = strings.TrimSpace(graphID)
+	if graphID == "" {
+		return nil, fmt.Errorf("graph ID is required")
+	}
+	graph, err := e.graphStore.LoadGraph(graphID)
+	if err != nil {
+		return nil, fmt.Errorf("load graph %q: %w", graphID, err)
+	}
+	if graph == nil {
+		return nil, fmt.Errorf("load graph %q: graph is nil", graphID)
+	}
+	return e.ExecuteGraphContext(ctx, graph, inputs)
+}
+
+// ExecuteGraphContext executes a graph and returns the final execution context.
+func (e *WorkflowExecutor) ExecuteGraphContext(ctx context.Context, graph *Graph, inputs map[string]any) (exec *ExecutionContext, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := graph.Validate(); err != nil {
+		return nil, fmt.Errorf("graph validation failed: %w", err)
+	}
+	exec = NewExecutionContext(graph.ID, inputs)
+	for _, variable := range graph.Variables {
+		if strings.TrimSpace(variable.Name) == "" {
+			continue
+		}
+		exec.Variables[variable.Name] = cloneAny(variable.InitialValue)
+	}
+
+	run := &workflowExecutionRun{
+		executor: e,
+		graph:    graph,
+		exec:     exec,
+		active:   make(map[string]bool),
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			exec.Status = ExecutionFailed
+			exec.Error = &ExecutionError{
+				Code:    "panic",
+				Message: fmt.Sprintf("workflow executor panic: %v", recovered),
+			}
+			err = fmt.Errorf("%s", exec.Error.Message)
+		}
+	}()
+
+	for _, startNode := range graph.GetStartNodes() {
+		if err := run.executeNode(ctx, startNode.ID); err != nil {
+			if exec.Status != ExecutionFailed {
+				exec.Status = ExecutionFailed
+				exec.Error = &ExecutionError{
+					Code:    "execution_failed",
+					Message: err.Error(),
+					NodeID:  startNode.ID,
+				}
+			}
+			return exec, err
+		}
+	}
+	if exec.Status != ExecutionFailed {
+		exec.MarkExecutionCompleted(run.collectGraphOutputs())
+	}
+	return exec, nil
+}
+
+type workflowExecutionRun struct {
+	executor   *WorkflowExecutor
+	graph      *Graph
+	exec       *ExecutionContext
+	active     map[string]bool
+	executions int
+}
+
+func (r *workflowExecutionRun) executeNode(ctx context.Context, nodeID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	node, ok := r.graph.GetNodeByID(nodeID)
+	if !ok {
+		return fmt.Errorf("node not found: %s", nodeID)
+	}
+	if state, ok := r.exec.NodeStates[node.ID]; ok {
+		if state.Status == NodeCompleted || state.Status == NodeSkipped {
+			return nil
+		}
+	}
+	if node.Type == "join" && !r.joinParentsReady(node.ID) {
+		return nil
+	}
+	if r.active[node.ID] {
+		return fmt.Errorf("cycle detected while executing node: %s", node.ID)
+	}
+	r.executions++
+	if r.maxNodeExecutions() > 0 && r.executions > r.maxNodeExecutions() {
+		return fmt.Errorf("workflow exceeded %d node executions", r.maxNodeExecutions())
+	}
+
+	r.active[node.ID] = true
+	defer delete(r.active, node.ID)
+
+	inputs := r.exec.ResolveInputs(node, r.graph)
+	maxAttempts := nodeMaxAttempts(node)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		r.exec.MarkNodeStarted(node.ID, inputs)
+		nodeCtx, cancel := nodeExecutionContext(ctx, node)
+		outputs, err := r.executeNodeBody(nodeCtx, node, inputs)
+		cancel()
+		if err == nil {
+			outputs = cloneAnyMap(outputs)
+			r.applyNodeOutputMappings(node, outputs)
+			r.exec.MarkNodeCompleted(node.ID, outputs)
+			return r.executeNextNodes(ctx, node, outputs)
+		}
+
+		state := r.exec.NodeStates[node.ID]
+		if state != nil && state.Attempts < maxAttempts {
+			failedAttempts := state.Attempts
+			r.exec.MarkNodeRetrying(node.ID)
+			if err := sleepWithContext(ctx, retryDelay(node.RetryPolicy, failedAttempts)); err != nil {
+				return err
+			}
+			continue
+		}
+		return r.handleNodeError(ctx, node, err)
+	}
+}
+
+func (r *workflowExecutionRun) executeNodeBody(ctx context.Context, node *Node, inputs map[string]any) (map[string]any, error) {
+	switch node.Type {
+	case "action":
+		return r.executeActionNode(ctx, node, inputs)
+	case "condition":
+		return r.executeConditionNode(node, inputs)
+	case "loop":
+		return r.executeLoopNode(node)
+	case "parallel":
+		return r.executeParallelNode(node)
+	case "join":
+		return r.executeJoinNode(node)
+	default:
+		return nil, fmt.Errorf("unsupported node type: %s", node.Type)
+	}
+}
+
+func (r *workflowExecutionRun) executeActionNode(ctx context.Context, node *Node, inputs map[string]any) (map[string]any, error) {
+	if strings.TrimSpace(node.Plugin) == "" {
+		return nil, fmt.Errorf("plugin is required for action node: %s", node.ID)
+	}
+	if strings.TrimSpace(node.Action) == "" {
+		return nil, fmt.Errorf("action is required for action node: %s", node.ID)
+	}
+	if r.executor == nil || r.executor.actionRunner == nil {
+		return nil, fmt.Errorf("workflow action runner is not configured")
+	}
+	outputs, err := r.executor.actionRunner.RunAction(ctx, cloneNode(*node), cloneAnyMap(inputs))
+	if err != nil {
+		return nil, err
+	}
+	return cloneAnyMap(outputs), nil
+}
+
+func (r *workflowExecutionRun) executeConditionNode(node *Node, inputs map[string]any) (map[string]any, error) {
+	vars := r.evaluationVars(inputs)
+	result, err := EvalCondition(node.Condition, vars)
+	if err != nil {
+		return nil, fmt.Errorf("condition node %s: %w", node.ID, err)
+	}
+	return map[string]any{"result": result}, nil
+}
+
+func (r *workflowExecutionRun) executeLoopNode(node *Node) (map[string]any, error) {
+	value := r.resolveLoopValue(node.LoopOver)
+	items, err := loopItems(value)
+	if err != nil {
+		return nil, fmt.Errorf("loop node %s: %w", node.ID, err)
+	}
+	limit := r.maxLoopIterations()
+	if limit > 0 && len(items) > limit {
+		return nil, fmt.Errorf("loop node %s exceeds %d iterations", node.ID, limit)
+	}
+	return map[string]any{
+		"iterations": len(items),
+		"items":      cloneAny(items),
+	}, nil
+}
+
+func (r *workflowExecutionRun) executeParallelNode(node *Node) (map[string]any, error) {
+	branches := r.nextNodeIDsForTypes(node.ID, map[string]bool{
+		"branch":  true,
+		"default": true,
+		"success": true,
+		"":        true,
+	})
+	return map[string]any{
+		"branch_count": len(branches),
+		"branches":     branches,
+	}, nil
+}
+
+func (r *workflowExecutionRun) executeJoinNode(node *Node) (map[string]any, error) {
+	parents := r.graph.GetPreviousNodes(node.ID)
+	completed := 0
+	results := make(map[string]any)
+	for _, parentID := range parents {
+		state := r.exec.NodeStates[parentID]
+		if state == nil || (state.Status != NodeCompleted && state.Status != NodeSkipped) {
+			continue
+		}
+		completed++
+		results[parentID] = cloneAnyMap(state.Outputs)
+	}
+	return map[string]any{
+		"completed_count": completed,
+		"total_parents":   len(parents),
+		"results":         results,
+	}, nil
+}
+
+func (r *workflowExecutionRun) executeNextNodes(ctx context.Context, node *Node, outputs map[string]any) error {
+	nextIDs, err := r.nextNodeIDs(node, outputs)
+	if err != nil {
+		return err
+	}
+	for _, nextID := range nextIDs {
+		if err := r.executeNode(ctx, nextID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *workflowExecutionRun) nextNodeIDs(node *Node, outputs map[string]any) ([]string, error) {
+	next := make([]string, 0)
+	for _, edge := range r.graph.Edges {
+		if edge.Source != node.ID {
+			continue
+		}
+		follow, err := r.shouldFollowEdge(edge, outputs)
+		if err != nil {
+			return nil, err
+		}
+		if follow {
+			next = append(next, edge.Target)
+		}
+	}
+	return next, nil
+}
+
+func (r *workflowExecutionRun) shouldFollowEdge(edge Edge, outputs map[string]any) (bool, error) {
+	switch normalizeEdgeType(edge.Type) {
+	case "default", "success", "branch":
+		return true, nil
+	case "failure":
+		return false, nil
+	case "condition", "condition_true", "true":
+		if strings.TrimSpace(edge.Condition) != "" {
+			ok, err := EvalCondition(edge.Condition, r.evaluationVars(outputs))
+			if err != nil {
+				return false, fmt.Errorf("edge %s condition: %w", edge.ID, err)
+			}
+			return ok, nil
+		}
+		return toBool(outputs["result"]), nil
+	case "condition_false", "false":
+		if strings.TrimSpace(edge.Condition) != "" {
+			ok, err := EvalCondition(edge.Condition, r.evaluationVars(outputs))
+			if err != nil {
+				return false, fmt.Errorf("edge %s condition: %w", edge.ID, err)
+			}
+			return !ok, nil
+		}
+		return !toBool(outputs["result"]), nil
+	default:
+		return true, nil
+	}
+}
+
+func (r *workflowExecutionRun) handleNodeError(ctx context.Context, node *Node, err error) error {
+	if node.ErrorHandling != nil {
+		switch strings.TrimSpace(node.ErrorHandling.OnError) {
+		case "skip":
+			r.markNodeSkipped(node.ID, err)
+			return r.executeNextNodes(ctx, node, map[string]any{
+				"skipped": true,
+				"error":   err.Error(),
+			})
+		case "goto":
+			if target := strings.TrimSpace(node.ErrorHandling.TargetNode); target != "" {
+				r.markNodeSkipped(node.ID, err)
+				return r.executeNode(ctx, target)
+			}
+		}
+	}
+	nodeErr := &NodeError{
+		Code:      "execution_failed",
+		Message:   err.Error(),
+		Retryable: nodeMaxAttempts(node) > 1,
+	}
+	r.exec.MarkNodeFailed(node.ID, nodeErr)
+	return err
+}
+
+func (r *workflowExecutionRun) applyNodeOutputMappings(node *Node, outputs map[string]any) {
+	for outputName, variableName := range node.Outputs {
+		variableName = strings.TrimSpace(strings.TrimPrefix(variableName, "$"))
+		if variableName == "" {
+			continue
+		}
+		if value, ok := outputs[outputName]; ok {
+			r.exec.Variables[variableName] = cloneAny(value)
+		}
+	}
+}
+
+func (r *workflowExecutionRun) collectGraphOutputs() map[string]any {
+	if len(r.graph.Outputs) == 0 {
+		return cloneAnyMap(r.exec.Outputs)
+	}
+	outputs := make(map[string]any, len(r.graph.Outputs))
+	for _, param := range r.graph.Outputs {
+		name := strings.TrimSpace(param.Name)
+		if name == "" || strings.TrimSpace(param.Source) == "" {
+			continue
+		}
+		outputs[name] = cloneAny(r.exec.resolveValue(param.Source, r.graph))
+	}
+	return outputs
+}
+
+func (r *workflowExecutionRun) evaluationVars(overlays ...map[string]any) map[string]any {
+	vars := cloneAnyMap(r.exec.Inputs)
+	if vars == nil {
+		vars = make(map[string]any)
+	}
+	for key, value := range r.exec.Variables {
+		vars[key] = cloneAny(value)
+	}
+	for nodeID, state := range r.exec.NodeStates {
+		if state == nil || state.Outputs == nil {
+			continue
+		}
+		vars["_node_outputs:"+nodeID] = cloneAnyMap(state.Outputs)
+	}
+	for _, overlay := range overlays {
+		for key, value := range overlay {
+			vars[key] = cloneAny(value)
+		}
+	}
+	return vars
+}
+
+func (r *workflowExecutionRun) joinParentsReady(nodeID string) bool {
+	for _, parentID := range r.graph.GetPreviousNodes(nodeID) {
+		state := r.exec.NodeStates[parentID]
+		if state == nil || (state.Status != NodeCompleted && state.Status != NodeSkipped) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *workflowExecutionRun) nextNodeIDsForTypes(nodeID string, allowed map[string]bool) []string {
+	next := make([]string, 0)
+	for _, edge := range r.graph.Edges {
+		if edge.Source != nodeID {
+			continue
+		}
+		if allowed[normalizeEdgeType(edge.Type)] {
+			next = append(next, edge.Target)
+		}
+	}
+	return next
+}
+
+func (r *workflowExecutionRun) markNodeSkipped(nodeID string, err error) {
+	now := time.Now().UTC()
+	state, ok := r.exec.NodeStates[nodeID]
+	if !ok {
+		state = &NodeState{NodeID: nodeID}
+		r.exec.NodeStates[nodeID] = state
+	}
+	state.Status = NodeSkipped
+	state.EndTime = &now
+	state.Error = &NodeError{
+		Code:    "skipped",
+		Message: err.Error(),
+	}
+}
+
+func (r *workflowExecutionRun) resolveLoopValue(expr string) any {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return nil
+	}
+	if strings.HasPrefix(expr, "$") {
+		return r.exec.resolveValue(expr, r.graph)
+	}
+	if value, ok := r.exec.Variables[expr]; ok {
+		return value
+	}
+	if value, ok := r.exec.Inputs[expr]; ok {
+		return value
+	}
+	return expr
+}
+
+func (r *workflowExecutionRun) maxLoopIterations() int {
+	if r.executor == nil || r.executor.maxLoopIterations <= 0 {
+		return defaultMaxLoopIterations
+	}
+	return r.executor.maxLoopIterations
+}
+
+func (r *workflowExecutionRun) maxNodeExecutions() int {
+	if r.executor == nil || r.executor.maxNodeExecutions <= 0 {
+		return defaultMaxNodeExecutions
+	}
+	return r.executor.maxNodeExecutions
+}
+
+func nodeMaxAttempts(node *Node) int {
+	if node == nil || node.RetryPolicy == nil || node.RetryPolicy.MaxAttempts <= 0 {
+		return 1
+	}
+	return node.RetryPolicy.MaxAttempts
+}
+
+func nodeExecutionContext(ctx context.Context, node *Node) (context.Context, context.CancelFunc) {
+	if node == nil || node.TimeoutSec <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, time.Duration(node.TimeoutSec)*time.Second)
+}
+
+func retryDelay(policy *RetryPolicy, attempts int) time.Duration {
+	if policy == nil || policy.InitialDelay <= 0 {
+		return 0
+	}
+	delay := float64(policy.InitialDelay)
+	factor := policy.BackoffFactor
+	if factor <= 0 {
+		factor = 1
+	}
+	for i := 1; i < attempts; i++ {
+		delay *= factor
+	}
+	if policy.MaxDelay > 0 {
+		delay = math.Min(delay, float64(policy.MaxDelay))
+	}
+	return time.Duration(delay) * time.Millisecond
+}
+
+func sleepWithContext(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func loopItems(value any) ([]any, error) {
+	switch v := value.(type) {
+	case nil:
+		return []any{}, nil
+	case []any:
+		return cloneAny(v).([]any), nil
+	case []string:
+		items := make([]any, len(v))
+		for i, item := range v {
+			items[i] = item
+		}
+		return items, nil
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return []any{}, nil
+		}
+		if strings.HasPrefix(trimmed, "[") {
+			var items []any
+			if err := json.Unmarshal([]byte(trimmed), &items); err != nil {
+				return nil, fmt.Errorf("parse loop_over JSON array: %w", err)
+			}
+			return items, nil
+		}
+		return []any{v}, nil
+	default:
+		return []any{cloneAny(v)}, nil
+	}
+}

--- a/pkg/capability/workflows/executor.go
+++ b/pkg/capability/workflows/executor.go
@@ -156,6 +156,12 @@ type workflowExecutionRun struct {
 	executions int
 }
 
+type nodeExecutionResult struct {
+	outputs             map[string]any
+	traverseChildren    bool
+	nextNodeIDsOverride []string
+}
+
 func (r *workflowExecutionRun) executeNode(ctx context.Context, nodeID string) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -191,12 +197,20 @@ func (r *workflowExecutionRun) executeNode(ctx context.Context, nodeID string) e
 		}
 		r.exec.MarkNodeStarted(node.ID, inputs)
 		nodeCtx, cancel := nodeExecutionContext(ctx, node)
-		outputs, err := r.executeNodeBody(nodeCtx, node, inputs)
+		result, err := r.executeNodeBody(nodeCtx, node, inputs)
 		cancel()
 		if err == nil {
-			outputs = cloneAnyMap(outputs)
+			outputs := cloneAnyMap(result.outputs)
 			r.applyNodeOutputMappings(node, outputs)
 			r.exec.MarkNodeCompleted(node.ID, outputs)
+			if !result.traverseChildren {
+				for _, nextID := range result.nextNodeIDsOverride {
+					if err := r.executeNode(ctx, nextID); err != nil {
+						return err
+					}
+				}
+				return nil
+			}
 			return r.executeNextNodes(ctx, node, outputs)
 		}
 		if cancelErr := ctx.Err(); cancelErr != nil {
@@ -216,20 +230,33 @@ func (r *workflowExecutionRun) executeNode(ctx context.Context, nodeID string) e
 	}
 }
 
-func (r *workflowExecutionRun) executeNodeBody(ctx context.Context, node *Node, inputs map[string]any) (map[string]any, error) {
+func (r *workflowExecutionRun) executeNodeBody(ctx context.Context, node *Node, inputs map[string]any) (nodeExecutionResult, error) {
+	result := nodeExecutionResult{traverseChildren: true}
 	switch node.Type {
 	case "action":
-		return r.executeActionNode(ctx, node, inputs)
+		outputs, err := r.executeActionNode(ctx, node, inputs)
+		result.outputs = outputs
+		return result, err
 	case "condition":
-		return r.executeConditionNode(node, inputs)
+		outputs, err := r.executeConditionNode(node, inputs)
+		result.outputs = outputs
+		return result, err
 	case "loop":
-		return r.executeLoopNode(node)
+		outputs, nextNodeIDs, err := r.executeLoopNode(ctx, node)
+		result.outputs = outputs
+		result.traverseChildren = false
+		result.nextNodeIDsOverride = nextNodeIDs
+		return result, err
 	case "parallel":
-		return r.executeParallelNode(node)
+		outputs, err := r.executeParallelNode(node)
+		result.outputs = outputs
+		return result, err
 	case "join":
-		return r.executeJoinNode(node)
+		outputs, err := r.executeJoinNode(node)
+		result.outputs = outputs
+		return result, err
 	default:
-		return nil, fmt.Errorf("unsupported node type: %s", node.Type)
+		return result, fmt.Errorf("unsupported node type: %s", node.Type)
 	}
 }
 
@@ -259,20 +286,39 @@ func (r *workflowExecutionRun) executeConditionNode(node *Node, inputs map[strin
 	return map[string]any{"result": result}, nil
 }
 
-func (r *workflowExecutionRun) executeLoopNode(node *Node) (map[string]any, error) {
+func (r *workflowExecutionRun) executeLoopNode(ctx context.Context, node *Node) (map[string]any, []string, error) {
 	value := r.resolveLoopValue(node.LoopOver)
 	items, err := loopItems(value)
 	if err != nil {
-		return nil, fmt.Errorf("loop node %s: %w", node.ID, err)
+		return nil, nil, fmt.Errorf("loop node %s: %w", node.ID, err)
 	}
 	limit := r.maxLoopIterations()
 	if limit > 0 && len(items) > limit {
-		return nil, fmt.Errorf("loop node %s exceeds %d iterations", node.ID, limit)
+		return nil, nil, fmt.Errorf("loop node %s exceeds %d iterations", node.ID, limit)
+	}
+	bodyNodeIDs, continuationNodeIDs := r.loopEdgeNodeIDs(node.ID)
+	results := make([]any, 0, len(items)*len(bodyNodeIDs))
+	restore := r.snapshotLoopVariables(node.LoopVar)
+	defer restore()
+	for i, item := range items {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		beforeStates := r.snapshotNodeStateKeys()
+		r.bindLoopVariables(node.LoopVar, item, i, len(items))
+		for _, bodyNodeID := range bodyNodeIDs {
+			if err := r.executeNode(ctx, bodyNodeID); err != nil {
+				return nil, nil, fmt.Errorf("loop node %s iteration %d: %w", node.ID, i, err)
+			}
+		}
+		results = append(results, r.collectIterationResults(i, beforeStates)...)
+		r.restoreIterationNodeStates(beforeStates)
 	}
 	return map[string]any{
 		"iterations": len(items),
 		"items":      cloneAny(items),
-	}, nil
+		"results":    results,
+	}, continuationNodeIDs, nil
 }
 
 func (r *workflowExecutionRun) executeParallelNode(node *Node) (map[string]any, error) {
@@ -461,6 +507,100 @@ func (r *workflowExecutionRun) nextNodeIDsForTypes(nodeID string, allowed map[st
 		}
 	}
 	return next
+}
+
+func (r *workflowExecutionRun) loopEdgeNodeIDs(nodeID string) ([]string, []string) {
+	body := make([]string, 0)
+	continuation := make([]string, 0)
+	for _, edge := range r.graph.Edges {
+		if edge.Source != nodeID {
+			continue
+		}
+		switch normalizeEdgeType(edge.Type) {
+		case "each", "branch":
+			body = append(body, edge.Target)
+		default:
+			continuation = append(continuation, edge.Target)
+		}
+	}
+	if len(body) == 0 {
+		return continuation, nil
+	}
+	return body, continuation
+}
+
+func (r *workflowExecutionRun) bindLoopVariables(loopVar string, item any, index int, count int) {
+	loopVar = strings.TrimSpace(loopVar)
+	if loopVar == "" {
+		return
+	}
+	r.exec.Variables[loopVar] = cloneAny(item)
+	r.exec.Variables[loopVar+"_index"] = index
+	r.exec.Variables[loopVar+"_first"] = index == 0
+	r.exec.Variables[loopVar+"_last"] = index == count-1
+	r.exec.Variables[loopVar+"_count"] = count
+}
+
+func (r *workflowExecutionRun) snapshotLoopVariables(loopVar string) func() {
+	loopVar = strings.TrimSpace(loopVar)
+	if loopVar == "" {
+		return func() {}
+	}
+	keys := []string{
+		loopVar,
+		loopVar + "_index",
+		loopVar + "_first",
+		loopVar + "_last",
+		loopVar + "_count",
+	}
+	originals := make(map[string]any, len(keys))
+	present := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		if value, ok := r.exec.Variables[key]; ok {
+			originals[key] = cloneAny(value)
+			present[key] = true
+		}
+	}
+	return func() {
+		for _, key := range keys {
+			if present[key] {
+				r.exec.Variables[key] = cloneAny(originals[key])
+				continue
+			}
+			delete(r.exec.Variables, key)
+		}
+	}
+}
+
+func (r *workflowExecutionRun) snapshotNodeStateKeys() map[string]bool {
+	keys := make(map[string]bool, len(r.exec.NodeStates))
+	for key := range r.exec.NodeStates {
+		keys[key] = true
+	}
+	return keys
+}
+
+func (r *workflowExecutionRun) collectIterationResults(iteration int, before map[string]bool) []any {
+	results := make([]any, 0)
+	for nodeID, state := range r.exec.NodeStates {
+		if before[nodeID] || state == nil || state.Outputs == nil {
+			continue
+		}
+		results = append(results, map[string]any{
+			"iteration": iteration,
+			"node_id":   nodeID,
+			"outputs":   cloneAnyMap(state.Outputs),
+		})
+	}
+	return results
+}
+
+func (r *workflowExecutionRun) restoreIterationNodeStates(before map[string]bool) {
+	for nodeID := range r.exec.NodeStates {
+		if !before[nodeID] {
+			delete(r.exec.NodeStates, nodeID)
+		}
+	}
 }
 
 func (r *workflowExecutionRun) markNodeSkipped(nodeID string, err error) {

--- a/pkg/capability/workflows/executor.go
+++ b/pkg/capability/workflows/executor.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -126,6 +127,10 @@ func (e *WorkflowExecutor) ExecuteGraphContext(ctx context.Context, graph *Graph
 
 	for _, startNode := range graph.GetStartNodes() {
 		if err := run.executeNode(ctx, startNode.ID); err != nil {
+			if isExecutionCancellation(err) {
+				markExecutionCancelled(exec, err)
+				return exec, err
+			}
 			if exec.Status != ExecutionFailed {
 				exec.Status = ExecutionFailed
 				exec.Error = &ExecutionError{
@@ -193,6 +198,9 @@ func (r *workflowExecutionRun) executeNode(ctx context.Context, nodeID string) e
 			r.applyNodeOutputMappings(node, outputs)
 			r.exec.MarkNodeCompleted(node.ID, outputs)
 			return r.executeNextNodes(ctx, node, outputs)
+		}
+		if cancelErr := ctx.Err(); cancelErr != nil {
+			return cancelErr
 		}
 
 		state := r.exec.NodeStates[node.ID]
@@ -513,6 +521,27 @@ func nodeExecutionContext(ctx context.Context, node *Node) (context.Context, con
 		return ctx, func() {}
 	}
 	return context.WithTimeout(ctx, time.Duration(node.TimeoutSec)*time.Second)
+}
+
+func isExecutionCancellation(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func markExecutionCancelled(exec *ExecutionContext, err error) {
+	if exec == nil {
+		return
+	}
+	now := time.Now().UTC()
+	exec.Status = ExecutionCancelled
+	exec.EndTime = &now
+	code := "execution_cancelled"
+	if errors.Is(err, context.DeadlineExceeded) {
+		code = "execution_deadline_exceeded"
+	}
+	exec.Error = &ExecutionError{
+		Code:    code,
+		Message: err.Error(),
+	}
 }
 
 func retryDelay(policy *RetryPolicy, attempts int) time.Duration {

--- a/pkg/capability/workflows/executor_test.go
+++ b/pkg/capability/workflows/executor_test.go
@@ -1,0 +1,335 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type workflowActionCall struct {
+	NodeID string
+	Inputs map[string]any
+}
+
+type recordingWorkflowActionRunner struct {
+	calls    []workflowActionCall
+	handlers map[string]func(map[string]any) (map[string]any, error)
+}
+
+func (r *recordingWorkflowActionRunner) RunAction(ctx context.Context, node Node, inputs map[string]any) (map[string]any, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	r.calls = append(r.calls, workflowActionCall{
+		NodeID: node.ID,
+		Inputs: cloneAnyMap(inputs),
+	})
+	if r.handlers != nil {
+		if handler := r.handlers[node.ID]; handler != nil {
+			return handler(inputs)
+		}
+	}
+	return map[string]any{"ok": true, "node_id": node.ID}, nil
+}
+
+func TestWorkflowExecutorExecutesActionsConditionsAndGraphOutputs(t *testing.T) {
+	graph := NewGraph("approval", "")
+	graph.ID = "graph-approval"
+	graph.AddInputParam("threshold", "number", "", true, nil)
+	graph.AddOutputParam("approved", "boolean", "", "$approve.approved")
+
+	scoreID := graph.AddNode(Node{
+		ID:     "score",
+		Type:   "action",
+		Name:   "Score request",
+		Plugin: "policy",
+		Action: "score",
+	})
+	checkID := graph.AddConditionNode("Check threshold", "", "$score.score >= $threshold")
+	approveID := graph.AddNode(Node{
+		ID:     "approve",
+		Type:   "action",
+		Name:   "Approve",
+		Plugin: "policy",
+		Action: "approve",
+		Inputs: map[string]any{"score": "$score.score"},
+	})
+	rejectID := graph.AddNode(Node{
+		ID:     "reject",
+		Type:   "action",
+		Name:   "Reject",
+		Plugin: "policy",
+		Action: "reject",
+	})
+	graph.AddEdge(scoreID, checkID, "default")
+	graph.AddEdge(checkID, approveID, "condition_true")
+	graph.AddEdge(checkID, rejectID, "condition_false")
+
+	runner := &recordingWorkflowActionRunner{handlers: map[string]func(map[string]any) (map[string]any, error){
+		"score": func(map[string]any) (map[string]any, error) {
+			return map[string]any{"score": 0.91}, nil
+		},
+		"approve": func(inputs map[string]any) (map[string]any, error) {
+			if inputs["score"] != 0.91 {
+				t.Fatalf("approve score input = %#v, want 0.91", inputs["score"])
+			}
+			return map[string]any{"approved": true}, nil
+		},
+		"reject": func(map[string]any) (map[string]any, error) {
+			t.Fatal("reject branch should not run")
+			return nil, nil
+		},
+	}}
+	executor := NewWorkflowExecutor(nil, nil)
+	executor.SetActionRunner(runner)
+
+	exec, err := executor.ExecuteGraph(graph, map[string]any{"threshold": 0.7})
+	if err != nil {
+		t.Fatalf("ExecuteGraph: %v", err)
+	}
+	if exec.Status != ExecutionCompleted {
+		t.Fatalf("status = %s, want completed", exec.Status)
+	}
+	if exec.Outputs["approved"] != true {
+		t.Fatalf("graph outputs = %#v, want approved=true", exec.Outputs)
+	}
+	if got := callNodeIDs(runner.calls); !reflect.DeepEqual(got, []string{"score", "approve"}) {
+		t.Fatalf("action call order = %v, want score then approve", got)
+	}
+	if exec.NodeStates[checkID].Outputs["result"] != true {
+		t.Fatalf("condition result = %#v, want true", exec.NodeStates[checkID].Outputs)
+	}
+}
+
+func TestWorkflowExecutorFailsActionNodesWithoutRunner(t *testing.T) {
+	graph := NewGraph("missing runner", "")
+	graph.AddActionNode("run", "", "policy", "score", nil)
+
+	exec, err := NewWorkflowExecutor(nil, nil).ExecuteGraph(graph, nil)
+	if err == nil {
+		t.Fatal("expected missing action runner error")
+	}
+	if exec == nil || exec.Status != ExecutionFailed {
+		t.Fatalf("execution = %#v, want failed context", exec)
+	}
+	if !strings.Contains(err.Error(), "action runner is not configured") {
+		t.Fatalf("error = %v, want action runner message", err)
+	}
+}
+
+func TestWorkflowExecutorRetriesActionNodes(t *testing.T) {
+	graph := NewGraph("retry", "")
+	graph.AddNode(Node{
+		ID:     "flaky",
+		Type:   "action",
+		Name:   "Flaky action",
+		Plugin: "policy",
+		Action: "flaky",
+		RetryPolicy: &RetryPolicy{
+			MaxAttempts: 2,
+		},
+	})
+
+	attempts := 0
+	runner := &recordingWorkflowActionRunner{handlers: map[string]func(map[string]any) (map[string]any, error){
+		"flaky": func(map[string]any) (map[string]any, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, errors.New("temporary failure")
+			}
+			return map[string]any{"ok": true}, nil
+		},
+	}}
+	executor := NewWorkflowExecutor(nil, nil)
+	executor.SetActionRunner(runner)
+
+	exec, err := executor.ExecuteGraph(graph, nil)
+	if err != nil {
+		t.Fatalf("ExecuteGraph: %v", err)
+	}
+	if exec.NodeStates["flaky"].Attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", exec.NodeStates["flaky"].Attempts)
+	}
+	if exec.NodeStates["flaky"].Status != NodeCompleted {
+		t.Fatalf("state = %#v, want completed", exec.NodeStates["flaky"])
+	}
+}
+
+func TestWorkflowExecutorAppliesNodeTimeoutToActionRunner(t *testing.T) {
+	graph := NewGraph("timeout", "")
+	graph.AddNode(Node{
+		ID:         "timed",
+		Type:       "action",
+		Name:       "Timed",
+		Plugin:     "policy",
+		Action:     "run",
+		TimeoutSec: 1,
+	})
+	executor := NewWorkflowExecutor(nil, nil)
+	executor.SetActionRunner(WorkflowActionRunnerFunc(func(ctx context.Context, node Node, inputs map[string]any) (map[string]any, error) {
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("expected action context to include node timeout deadline")
+		}
+		return map[string]any{"ok": true}, nil
+	}))
+
+	if _, err := executor.ExecuteGraph(graph, nil); err != nil {
+		t.Fatalf("ExecuteGraph: %v", err)
+	}
+}
+
+func TestWorkflowExecutorConvertsActionPanicsToFailedExecutions(t *testing.T) {
+	graph := NewGraph("panic", "")
+	graph.AddNode(Node{
+		ID:     "panic_node",
+		Type:   "action",
+		Name:   "Panic",
+		Plugin: "policy",
+		Action: "panic",
+	})
+	executor := NewWorkflowExecutor(nil, nil)
+	executor.SetActionRunner(WorkflowActionRunnerFunc(func(context.Context, Node, map[string]any) (map[string]any, error) {
+		panic("runner exploded")
+	}))
+
+	exec, err := executor.ExecuteGraph(graph, nil)
+	if err == nil {
+		t.Fatal("expected panic conversion error")
+	}
+	if exec == nil || exec.Status != ExecutionFailed {
+		t.Fatalf("execution = %#v, want failed context", exec)
+	}
+	if exec.Error == nil || !strings.Contains(exec.Error.Message, "runner exploded") {
+		t.Fatalf("execution error = %#v, want panic message", exec.Error)
+	}
+}
+
+func TestWorkflowExecutorRunsJoinAfterAllParentsComplete(t *testing.T) {
+	graph := NewGraph("join", "")
+	startID := graph.AddNode(Node{ID: "start", Type: "action", Name: "Start", Plugin: "p", Action: "start"})
+	fanoutID := graph.AddNode(Node{ID: "fanout", Type: "parallel", Name: "Fan out"})
+	leftID := graph.AddNode(Node{ID: "left", Type: "action", Name: "Left", Plugin: "p", Action: "left"})
+	rightID := graph.AddNode(Node{ID: "right", Type: "action", Name: "Right", Plugin: "p", Action: "right"})
+	joinID := graph.AddNode(Node{ID: "join", Type: "join", Name: "Join"})
+	finalID := graph.AddNode(Node{
+		ID:     "final",
+		Type:   "action",
+		Name:   "Final",
+		Plugin: "p",
+		Action: "final",
+		Inputs: map[string]any{"joined": "$join.completed_count"},
+	})
+	graph.AddEdge(startID, fanoutID, "default")
+	graph.AddEdge(fanoutID, leftID, "branch")
+	graph.AddEdge(fanoutID, rightID, "branch")
+	graph.AddEdge(leftID, joinID, "default")
+	graph.AddEdge(rightID, joinID, "default")
+	graph.AddEdge(joinID, finalID, "default")
+
+	runner := &recordingWorkflowActionRunner{handlers: map[string]func(map[string]any) (map[string]any, error){
+		"left":  func(map[string]any) (map[string]any, error) { return map[string]any{"side": "left"}, nil },
+		"right": func(map[string]any) (map[string]any, error) { return map[string]any{"side": "right"}, nil },
+		"final": func(inputs map[string]any) (map[string]any, error) {
+			if inputs["joined"] != 2 {
+				t.Fatalf("final joined input = %#v, want 2", inputs["joined"])
+			}
+			return map[string]any{"done": true}, nil
+		},
+	}}
+	executor := NewWorkflowExecutor(nil, nil)
+	executor.SetActionRunner(runner)
+
+	exec, err := executor.ExecuteGraph(graph, nil)
+	if err != nil {
+		t.Fatalf("ExecuteGraph: %v", err)
+	}
+	if exec.NodeStates[joinID].Outputs["completed_count"] != 2 {
+		t.Fatalf("join outputs = %#v, want completed_count=2", exec.NodeStates[joinID].Outputs)
+	}
+	if exec.NodeStates[finalID].Status != NodeCompleted {
+		t.Fatalf("final state = %#v, want completed", exec.NodeStates[finalID])
+	}
+}
+
+func TestWorkflowExecutorLoopResolvesInputCollection(t *testing.T) {
+	graph := NewGraph("loop", "")
+	graph.AddNode(Node{
+		ID:       "each_item",
+		Type:     "loop",
+		Name:     "Each item",
+		LoopVar:  "item",
+		LoopOver: "$items",
+	})
+
+	exec, err := NewWorkflowExecutor(nil, nil).ExecuteGraph(graph, map[string]any{
+		"items": []any{"a", "b", "c"},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteGraph: %v", err)
+	}
+	outputs := exec.NodeStates["each_item"].Outputs
+	if outputs["iterations"] != 3 {
+		t.Fatalf("loop outputs = %#v, want 3 iterations", outputs)
+	}
+	if !reflect.DeepEqual(outputs["items"], []any{"a", "b", "c"}) {
+		t.Fatalf("loop items = %#v, want original collection", outputs["items"])
+	}
+}
+
+func TestWorkflowExecutorExecutesStoredGraphByID(t *testing.T) {
+	graph := NewGraph("stored", "")
+	graph.ID = "graph-stored"
+	graph.AddNode(Node{
+		ID:     "run",
+		Type:   "action",
+		Name:   "Run",
+		Plugin: "policy",
+		Action: "run",
+		Inputs: map[string]any{"request": "$request"},
+	})
+	store := &fakeGraphStore{graphs: map[string]*Graph{graph.ID: graph}}
+	runner := &recordingWorkflowActionRunner{}
+	executor := NewWorkflowExecutor(nil, store)
+	executor.SetActionRunner(runner)
+
+	exec, err := executor.ExecuteStoredGraph(context.Background(), graph.ID, map[string]any{"request": "ok"})
+	if err != nil {
+		t.Fatalf("ExecuteStoredGraph: %v", err)
+	}
+	if exec.GraphID != graph.ID || exec.Status != ExecutionCompleted {
+		t.Fatalf("execution = %#v, want completed stored graph", exec)
+	}
+	if len(store.loads) != 1 || store.loads[0] != graph.ID {
+		t.Fatalf("store loads = %v, want %q", store.loads, graph.ID)
+	}
+	if len(runner.calls) != 1 || runner.calls[0].Inputs["request"] != "ok" {
+		t.Fatalf("runner calls = %#v, want request input", runner.calls)
+	}
+}
+
+func callNodeIDs(calls []workflowActionCall) []string {
+	ids := make([]string, 0, len(calls))
+	for _, call := range calls {
+		ids = append(ids, call.NodeID)
+	}
+	return ids
+}
+
+func TestWorkflowExecutorReturnsGraphValidationErrors(t *testing.T) {
+	graph := NewGraph("invalid", "")
+	graph.Nodes = nil
+
+	exec, err := NewWorkflowExecutor(nil, nil).ExecuteGraph(graph, nil)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if exec != nil {
+		t.Fatalf("execution = %#v, want nil for validation failure", exec)
+	}
+	if !strings.Contains(fmt.Sprint(err), "graph validation failed") {
+		t.Fatalf("error = %v, want graph validation wrapper", err)
+	}
+}

--- a/pkg/capability/workflows/executor_test.go
+++ b/pkg/capability/workflows/executor_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 type workflowActionCall struct {
@@ -178,6 +179,64 @@ func TestWorkflowExecutorAppliesNodeTimeoutToActionRunner(t *testing.T) {
 
 	if _, err := executor.ExecuteGraph(graph, nil); err != nil {
 		t.Fatalf("ExecuteGraph: %v", err)
+	}
+}
+
+func TestWorkflowExecutorMarksInterruptedContextAsCancelled(t *testing.T) {
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		cancel   context.CancelFunc
+		wantErr  error
+		wantCode string
+	}{
+		{
+			name:     "cancelled",
+			wantErr:  context.Canceled,
+			wantCode: "execution_cancelled",
+		},
+		{
+			name:     "deadline exceeded",
+			wantErr:  context.DeadlineExceeded,
+			wantCode: "execution_deadline_exceeded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			graph := NewGraph("interrupted", "")
+			graph.AddNode(Node{
+				ID:     "run",
+				Type:   "action",
+				Name:   "Run",
+				Plugin: "policy",
+				Action: "run",
+			})
+			if tt.wantErr == context.Canceled {
+				tt.ctx, tt.cancel = context.WithCancel(context.Background())
+				tt.cancel()
+			} else {
+				tt.ctx, tt.cancel = context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+				defer tt.cancel()
+			}
+
+			executor := NewWorkflowExecutor(nil, nil)
+			executor.SetActionRunner(&recordingWorkflowActionRunner{})
+
+			exec, err := executor.ExecuteGraphContext(tt.ctx, graph, nil)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+			if exec == nil || exec.Status != ExecutionCancelled {
+				t.Fatalf("execution = %#v, want cancelled status", exec)
+			}
+			if exec.Error == nil || exec.Error.Code != tt.wantCode {
+				t.Fatalf("execution error = %#v, want %s", exec.Error, tt.wantCode)
+			}
+			if exec.EndTime == nil {
+				t.Fatal("cancelled execution should record end time")
+			}
+		})
 	}
 }
 

--- a/pkg/capability/workflows/executor_test.go
+++ b/pkg/capability/workflows/executor_test.go
@@ -315,15 +315,32 @@ func TestWorkflowExecutorRunsJoinAfterAllParentsComplete(t *testing.T) {
 
 func TestWorkflowExecutorLoopResolvesInputCollection(t *testing.T) {
 	graph := NewGraph("loop", "")
-	graph.AddNode(Node{
+	loopID := graph.AddNode(Node{
 		ID:       "each_item",
 		Type:     "loop",
 		Name:     "Each item",
 		LoopVar:  "item",
 		LoopOver: "$items",
 	})
+	collectID := graph.AddNode(Node{
+		ID:     "collect",
+		Type:   "action",
+		Name:   "Collect item",
+		Plugin: "policy",
+		Action: "collect",
+		Inputs: map[string]any{
+			"item":  "$item",
+			"index": "$item_index",
+			"count": "$item_count",
+		},
+	})
+	graph.AddEdge(loopID, collectID, "default")
 
-	exec, err := NewWorkflowExecutor(nil, nil).ExecuteGraph(graph, map[string]any{
+	runner := &recordingWorkflowActionRunner{}
+	executor := NewWorkflowExecutor(nil, nil)
+	executor.SetActionRunner(runner)
+
+	exec, err := executor.ExecuteGraph(graph, map[string]any{
 		"items": []any{"a", "b", "c"},
 	})
 	if err != nil {
@@ -335,6 +352,79 @@ func TestWorkflowExecutorLoopResolvesInputCollection(t *testing.T) {
 	}
 	if !reflect.DeepEqual(outputs["items"], []any{"a", "b", "c"}) {
 		t.Fatalf("loop items = %#v, want original collection", outputs["items"])
+	}
+	if got := callNodeIDs(runner.calls); !reflect.DeepEqual(got, []string{"collect", "collect", "collect"}) {
+		t.Fatalf("loop body calls = %v, want collect once per item", got)
+	}
+	for i, want := range []any{"a", "b", "c"} {
+		if runner.calls[i].Inputs["item"] != want {
+			t.Fatalf("call %d item = %#v, want %#v", i, runner.calls[i].Inputs["item"], want)
+		}
+		if runner.calls[i].Inputs["index"] != i {
+			t.Fatalf("call %d index = %#v, want %d", i, runner.calls[i].Inputs["index"], i)
+		}
+		if runner.calls[i].Inputs["count"] != 3 {
+			t.Fatalf("call %d count = %#v, want 3", i, runner.calls[i].Inputs["count"])
+		}
+	}
+	if exec.Variables["item"] != nil || exec.Variables["item_index"] != nil {
+		t.Fatalf("loop variables leaked after execution: %#v", exec.Variables)
+	}
+}
+
+func TestWorkflowExecutorContinuesAfterLoopJoin(t *testing.T) {
+	graph := NewGraph("loop join", "")
+	loopID := graph.AddNode(Node{
+		ID:       "loop",
+		Type:     "loop",
+		Name:     "Loop",
+		LoopVar:  "item",
+		LoopOver: "$items",
+	})
+	bodyID := graph.AddNode(Node{
+		ID:     "body",
+		Type:   "action",
+		Name:   "Body",
+		Plugin: "policy",
+		Action: "body",
+		Inputs: map[string]any{"item": "$item"},
+	})
+	joinID := graph.AddNode(Node{
+		ID:   "join",
+		Type: "join",
+		Name: "Join",
+	})
+	finalID := graph.AddNode(Node{
+		ID:     "final",
+		Type:   "action",
+		Name:   "Final",
+		Plugin: "policy",
+		Action: "final",
+		Inputs: map[string]any{"iterations": "$loop.iterations"},
+	})
+	graph.AddEdge(loopID, bodyID, "each")
+	graph.AddEdge(loopID, joinID, "default")
+	graph.AddEdge(joinID, finalID, "default")
+
+	runner := &recordingWorkflowActionRunner{}
+	executor := NewWorkflowExecutor(nil, nil)
+	executor.SetActionRunner(runner)
+
+	exec, err := executor.ExecuteGraph(graph, map[string]any{"items": []any{"x", "y"}})
+	if err != nil {
+		t.Fatalf("ExecuteGraph: %v", err)
+	}
+	if got := callNodeIDs(runner.calls); !reflect.DeepEqual(got, []string{"body", "body", "final"}) {
+		t.Fatalf("calls = %v, want loop body twice then final", got)
+	}
+	if runner.calls[2].Inputs["iterations"] != 2 {
+		t.Fatalf("final iterations input = %#v, want 2", runner.calls[2].Inputs["iterations"])
+	}
+	if exec.NodeStates[bodyID] != nil {
+		t.Fatalf("loop body state should not be retained as final singleton state: %#v", exec.NodeStates[bodyID])
+	}
+	if exec.NodeStates[joinID].Status != NodeCompleted {
+		t.Fatalf("join state = %#v, want completed", exec.NodeStates[joinID])
 	}
 }
 


### PR DESCRIPTION
## 概要

补充 workflow graph executor，让现有 workflow graph、condition evaluator、store、trigger 等能力具备可执行的核心链路。

## 本次变更

- 新增 `WorkflowExecutor`
  - 支持直接执行 graph
  - 支持从 `GraphStore` 按 graph ID 加载并执行
  - 支持 `ExecutionContext`、节点状态、执行结果和 graph outputs 汇总
- 新增可注入的 `WorkflowActionRunner`
  - action 节点由集成方提供 runner 执行
  - executor 本身不默认执行外部命令或插件 side effect
- 支持基础节点执行流
  - action
  - condition
  - loop collection resolution
  - parallel/fanout routing
  - join 等待父节点完成
- 支持执行安全与可靠性细节
  - graph validation error 包装
  - node timeout context
  - retry policy
  - panic 转 failed execution
  - context cancellation
  - cycle / execution budget 防护

## 验证

已执行：

- `go test ./pkg/capability/workflows`
- `go test -cover ./pkg/capability/workflows`
- `go vet ./pkg/capability/workflows`
- `go test ./pkg/capability/...`
- `go test ./pkg/...`
- `go test ./...`
- `git diff --check`

## 说明

这条 PR 只补 workflow graph executor 核心，不接真实外部命令执行，也没有使用 GitHub API、force push 或历史重写操作。
