### PR TITLE
feat(extensions): add channel extension catalog

### DIFF
--- a/extensions/bluebubbles/anyclaw.extension.json
+++ b/extensions/bluebubbles/anyclaw.extension.json
@@ -1,0 +1,38 @@
+{
+  "id": "bluebubbles",
+  "name": "BlueBubbles Channel",
+  "version": "1.0.0",
+  "description": "BlueBubbles iMessage bridge channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["bluebubbles"],
+  "entrypoint": "bluebubbles_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "server_address": {
+        "type": "string",
+        "description": "BlueBubbles server address (e.g. http://192.168.1.100:12345)"
+      },
+      "password": {
+        "type": "string",
+        "description": "BlueBubbles server password",
+        "sensitive": true
+      },
+      "use_websocket": {
+        "type": "boolean",
+        "description": "Use WebSocket for real-time events (default true)"
+      },
+      "poll_interval": {
+        "type": "integer",
+        "description": "Poll interval in seconds when not using WebSocket",
+        "default": 5
+      },
+      "group_name_prefix": {
+        "type": "string",
+        "description": "Prefix to add to group chat names"
+      }
+    },
+    "required": ["server_address", "password"]
+  }
+}

--- a/extensions/bluebubbles/bluebubbles_adapter.go
+++ b/extensions/bluebubbles/bluebubbles_adapter.go
@@ -1,0 +1,404 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type Config struct {
+	ServerAddress   string `json:"server_address"`
+	Password        string `json:"password"`
+	UseWebSocket    bool   `json:"use_websocket"`
+	PollInterval    int    `json:"poll_interval"`
+	GroupNamePrefix string `json:"group_name_prefix"`
+	Port            int    `json:"port"`
+}
+
+type BlueBubblesExtension struct {
+	config      Config
+	client      *http.Client
+	lastMessage time.Time
+	mu          sync.RWMutex
+}
+
+func NewBlueBubblesExtension(cfg Config) *BlueBubblesExtension {
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 5
+	}
+	if cfg.Port <= 0 {
+		cfg.Port = 8080
+	}
+	if !strings.HasPrefix(cfg.ServerAddress, "http") {
+		cfg.ServerAddress = "http://" + cfg.ServerAddress
+	}
+	cfg.ServerAddress = strings.TrimRight(cfg.ServerAddress, "/")
+	return &BlueBubblesExtension{
+		config: cfg,
+		client: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (e *BlueBubblesExtension) Run(ctx context.Context) error {
+	if e.config.UseWebSocket {
+		return e.runWebSocketMode(ctx)
+	}
+	return e.runPollMode(ctx)
+}
+
+func (e *BlueBubblesExtension) runPollMode(ctx context.Context) error {
+	interval := time.Duration(e.config.PollInterval) * time.Second
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	e.lastMessage = time.Now()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+
+		if err := e.pollMessages(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "bluebubbles poll error: %v\n", err)
+		}
+	}
+}
+
+func (e *BlueBubblesExtension) runWebSocketMode(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/bluebubbles", e.handleWebhook)
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", e.config.Port),
+		Handler: mux,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		fmt.Fprintf(os.Stderr, "bluebubbles webhook listening on :%d\n", e.config.Port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (e *BlueBubblesExtension) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var payload struct {
+		Type    string `json:"type"`
+		Message struct {
+			GUID           string `json:"guid"`
+			RowID          int64  `json:"rowid"`
+			Handle         string `json:"handle"`
+			HandleID       int    `json:"handle_id"`
+			IsFromMe       bool   `json:"is_from_me"`
+			Text           string `json:"text"`
+			Subject        string `json:"subject"`
+			Date           int64  `json:"date"`
+			DateRead       int64  `json:"date_read"`
+			ChatGUID       string `json:"chat_guid"`
+			GroupTitle     string `json:"group_title"`
+			AssociatedGUID string `json:"associated_message_guid"`
+			Attachments    []struct {
+				GUID       string `json:"guid"`
+				TransferID string `json:"transfer_guid"`
+				FileName   string `json:"file_name"`
+				MimeType   string `json:"mime_type"`
+			} `json:"attachments"`
+		} `json:"message"`
+		Chat struct {
+			GUID        string `json:"guid"`
+			DisplayName string `json:"display_name"`
+			IsGroup     bool   `json:"is_group"`
+			Members     []struct {
+				Address string `json:"address"`
+				Name    string `json:"name"`
+			} `json:"members"`
+		} `json:"chat"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	if payload.Type != "new-message" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if payload.Message.IsFromMe {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	text := strings.TrimSpace(payload.Message.Text)
+	if text == "" {
+		if len(payload.Message.Attachments) > 0 {
+			text = fmt.Sprintf("[Attachment: %s]", payload.Message.Attachments[0].FileName)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+	}
+
+	chatID := payload.Message.ChatGUID
+	if chatID == "" {
+		chatID = payload.Chat.GUID
+	}
+	senderID := payload.Message.Handle
+	chatName := payload.Chat.DisplayName
+	if chatName == "" {
+		chatName = payload.Message.GroupTitle
+	}
+	if e.config.GroupNamePrefix != "" && payload.Chat.IsGroup {
+		chatName = e.config.GroupNamePrefix + chatName
+	}
+
+	input := map[string]any{
+		"action":    "message",
+		"channel":   "bluebubbles",
+		"chat_id":   chatID,
+		"text":      text,
+		"user_id":   senderID,
+		"chat_name": chatName,
+		"is_group":  payload.Chat.IsGroup,
+		"guid":      payload.Message.GUID,
+		"rowid":     payload.Message.RowID,
+	}
+	data, _ := json.Marshal(input)
+	fmt.Println(string(data))
+
+	var response map[string]any
+	if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read response: %v\n", err)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if reply, ok := response["text"].(string); ok && reply != "" {
+		if err := e.sendMessage(chatID, senderID, reply); err != nil {
+			fmt.Fprintf(os.Stderr, "bluebubbles send error: %v\n", err)
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (e *BlueBubblesExtension) pollMessages(ctx context.Context) error {
+	e.mu.RLock()
+	lastMsg := e.lastMessage
+	e.mu.RUnlock()
+
+	since := lastMsg.Add(-2*time.Second).UnixNano() / int64(time.Millisecond)
+
+	u := fmt.Sprintf("%s/api/v1/message/query?password=%s&after=%d&limit=50&sort=date DESC",
+		e.config.ServerAddress, url.QueryEscape(e.config.Password), since)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("query failed: %s: %s", resp.Status, string(body))
+	}
+
+	var result struct {
+		Status int `json:"status"`
+		Data   struct {
+			Messages []struct {
+				GUID     string `json:"guid"`
+				RowID    int64  `json:"rowid"`
+				IsFromMe bool   `json:"is_from_me"`
+				Text     string `json:"text"`
+				Date     int64  `json:"date"`
+				HandleID int    `json:"handle_id"`
+				ChatGUID string `json:"chat_guid"`
+			} `json:"messages"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+
+	for _, msg := range result.Data.Messages {
+		if msg.IsFromMe {
+			continue
+		}
+
+		text := strings.TrimSpace(msg.Text)
+		if text == "" {
+			continue
+		}
+
+		handle, err := e.getHandle(ctx, msg.HandleID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to get handle: %v\n", err)
+			handle = fmt.Sprintf("handle:%d", msg.HandleID)
+		}
+
+		chatID := msg.ChatGUID
+		if chatID == "" {
+			chatID = fmt.Sprintf("imessage;-;+%s", handle)
+		}
+
+		input := map[string]any{
+			"action":  "message",
+			"channel": "bluebubbles",
+			"chat_id": chatID,
+			"text":    text,
+			"user_id": handle,
+			"guid":    msg.GUID,
+			"rowid":   msg.RowID,
+		}
+		data, _ := json.Marshal(input)
+		fmt.Println(string(data))
+
+		var response map[string]any
+		if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to read response: %v\n", err)
+			continue
+		}
+
+		if reply, ok := response["text"].(string); ok && reply != "" {
+			if err := e.sendMessage(chatID, handle, reply); err != nil {
+				fmt.Fprintf(os.Stderr, "bluebubbles send error: %v\n", err)
+			}
+		}
+
+		msgTime := time.Unix(0, msg.Date*int64(time.Millisecond))
+		e.mu.Lock()
+		if msgTime.After(e.lastMessage) {
+			e.lastMessage = msgTime
+		}
+		e.mu.Unlock()
+	}
+
+	return nil
+}
+
+func (e *BlueBubblesExtension) getHandle(ctx context.Context, handleID int) (string, error) {
+	u := fmt.Sprintf("%s/api/v1/handle/%d?password=%s",
+		e.config.ServerAddress, handleID, url.QueryEscape(e.config.Password))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Status int `json:"status"`
+		Data   struct {
+			Address string `json:"address"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	if result.Data.Address == "" {
+		return fmt.Sprintf("handle:%d", handleID), nil
+	}
+	return result.Data.Address, nil
+}
+
+func (e *BlueBubblesExtension) sendMessage(chatGUID, recipient, text string) error {
+	u := fmt.Sprintf("%s/api/v1/message/text?password=%s",
+		e.config.ServerAddress, url.QueryEscape(e.config.Password))
+
+	payload := map[string]any{
+		"text": text,
+	}
+	if chatGUID != "" {
+		payload["chatGuid"] = chatGUID
+	} else if recipient != "" {
+		payload["address"] = recipient
+	}
+	body, _ := json.Marshal(payload)
+
+	resp, err := e.client.Post(u, "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("send failed: %s: %s", resp.Status, string(respBody))
+	}
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewBlueBubblesExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/discord/anyclaw.extension.json
+++ b/extensions/discord/anyclaw.extension.json
@@ -1,0 +1,26 @@
+{
+  "id": "discord",
+  "name": "Discord Channel",
+  "version": "1.0.0",
+  "description": "Discord messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["discord"],
+  "entrypoint": "discord_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "bot_token": {
+        "type": "string",
+        "description": "Discord Bot API token",
+        "sensitive": true
+      },
+      "api_base_url": {
+        "type": "string",
+        "description": "Optional: custom Discord API base URL",
+        "default": "https://discord.com/api/v10"
+      }
+    },
+    "required": ["bot_token"]
+  }
+}

--- a/extensions/discord/anyclaw.extension.json
+++ b/extensions/discord/anyclaw.extension.json
@@ -5,7 +5,6 @@
   "description": "Discord messaging channel adapter for AnyClaw",
   "kind": "channel",
   "channels": ["discord"],
-  "entrypoint": "discord_adapter.go",
   "permissions": ["net:out"],
   "config_schema": {
     "type": "object",

--- a/extensions/feishu/anyclaw.extension.json
+++ b/extensions/feishu/anyclaw.extension.json
@@ -1,0 +1,35 @@
+{
+  "id": "feishu",
+  "name": "Feishu/Lark Channel",
+  "version": "1.0.0",
+  "description": "Feishu/Lark messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["feishu"],
+  "entrypoint": "feishu_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "app_id": {
+        "type": "string",
+        "description": "Feishu App ID"
+      },
+      "app_secret": {
+        "type": "string",
+        "description": "Feishu App Secret",
+        "sensitive": true
+      },
+      "verification_token": {
+        "type": "string",
+        "description": "Feishu event verification token",
+        "sensitive": true
+      },
+      "encrypt_key": {
+        "type": "string",
+        "description": "Feishu event encrypt key",
+        "sensitive": true
+      }
+    },
+    "required": ["app_id", "app_secret"]
+  }
+}

--- a/extensions/feishu/feishu_adapter.go
+++ b/extensions/feishu/feishu_adapter.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type Config struct {
+	AppID             string `json:"app_id"`
+	AppSecret         string `json:"app_secret"`
+	VerificationToken string `json:"verification_token,omitempty"`
+	EncryptKey        string `json:"encrypt_key,omitempty"`
+	Port              int    `json:"port"`
+}
+
+type FeishuExtension struct {
+	config            Config
+	client            *http.Client
+	tenantAccessToken string
+	tokenMu           sync.RWMutex
+	tokenExpire       time.Time
+}
+
+func NewFeishuExtension(cfg Config) *FeishuExtension {
+	if cfg.Port <= 0 {
+		cfg.Port = 8080
+	}
+	return &FeishuExtension{
+		config: cfg,
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (e *FeishuExtension) Run(ctx context.Context) error {
+	go e.refreshTokenLoop(ctx)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/feishu", e.handleWebhook)
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", e.config.Port),
+		Handler: mux,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		fmt.Fprintf(os.Stderr, "feishu webhook listening on :%d\n", e.config.Port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (e *FeishuExtension) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var rawEvent map[string]any
+	if err := json.Unmarshal(body, &rawEvent); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	if challenge, ok := rawEvent["challenge"].(string); ok {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"challenge": challenge})
+		return
+	}
+
+	header, _ := rawEvent["header"].(map[string]any)
+	event, _ := rawEvent["event"].(map[string]any)
+
+	if header != nil {
+		if e.config.VerificationToken != "" {
+			token, _ := header["token"].(string)
+			if token != e.config.VerificationToken {
+				http.Error(w, "invalid token", http.StatusForbidden)
+				return
+			}
+		}
+	}
+
+	eventType, _ := header["event_type"].(string)
+	if eventType != "im.message.receive_v1" {
+		w.Write([]byte("success"))
+		return
+	}
+
+	message, _ := event["message"].(map[string]any)
+	sender, _ := event["sender"].(map[string]any)
+
+	msgType, _ := message["message_type"].(string)
+	if msgType != "text" {
+		w.Write([]byte("success"))
+		return
+	}
+
+	content, _ := message["content"].(string)
+	var textContent struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal([]byte(content), &textContent); err != nil {
+		w.Write([]byte("success"))
+		return
+	}
+
+	if textContent.Text == "" {
+		w.Write([]byte("success"))
+		return
+	}
+
+	chatID, _ := message["chat_id"].(string)
+	senderID, _ := sender["sender_id"].(map[string]any)
+	openID, _ := senderID["open_id"].(string)
+	messageID, _ := message["message_id"].(string)
+
+	if openID == "" {
+		openID, _ = event["open_id"].(string)
+	}
+
+	input := map[string]any{
+		"action":     "message",
+		"channel":    "feishu",
+		"chat_id":    chatID,
+		"text":       textContent.Text,
+		"user_id":    openID,
+		"message_id": messageID,
+		"msg_type":   msgType,
+	}
+	data, _ := json.Marshal(input)
+	fmt.Println(string(data))
+
+	var response map[string]any
+	if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read response: %v\n", err)
+		w.Write([]byte("success"))
+		return
+	}
+
+	if reply, ok := response["text"].(string); ok && reply != "" {
+		if err := e.sendTextMessage(chatID, reply); err != nil {
+			fmt.Fprintf(os.Stderr, "feishu send message error: %v\n", err)
+		}
+	}
+
+	w.Write([]byte("success"))
+}
+
+func (e *FeishuExtension) getTenantAccessToken() (string, error) {
+	e.tokenMu.RLock()
+	if e.tenantAccessToken != "" && time.Now().Before(e.tokenExpire) {
+		token := e.tenantAccessToken
+		e.tokenMu.RUnlock()
+		return token, nil
+	}
+	e.tokenMu.RUnlock()
+
+	e.tokenMu.Lock()
+	defer e.tokenMu.Unlock()
+
+	if e.tenantAccessToken != "" && time.Now().Before(e.tokenExpire) {
+		return e.tenantAccessToken, nil
+	}
+
+	u := "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal"
+	payload := map[string]string{
+		"app_id":     e.config.AppID,
+		"app_secret": e.config.AppSecret,
+	}
+	body, _ := json.Marshal(payload)
+
+	resp, err := e.client.Post(u, "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Code              int    `json:"code"`
+		Msg               string `json:"msg"`
+		TenantAccessToken string `json:"tenant_access_token"`
+		Expire            int    `json:"expire"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	if result.Code != 0 {
+		return "", fmt.Errorf("feishu token error: %d %s", result.Code, result.Msg)
+	}
+
+	e.tenantAccessToken = result.TenantAccessToken
+	e.tokenExpire = time.Now().Add(time.Duration(result.Expire-300) * time.Second)
+	return e.tenantAccessToken, nil
+}
+
+func (e *FeishuExtension) refreshTokenLoop(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Minute)
+	defer ticker.Stop()
+
+	e.getTenantAccessToken()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			e.getTenantAccessToken()
+		}
+	}
+}
+
+func (e *FeishuExtension) sendTextMessage(chatID, text string) error {
+	token, err := e.getTenantAccessToken()
+	if err != nil {
+		return err
+	}
+
+	u := "https://open.feishu.cn/open-apis/im/v1/messages"
+	content, _ := json.Marshal(map[string]string{"text": text})
+
+	payload := map[string]any{
+		"receive_id": chatID,
+		"msg_type":   "text",
+		"content":    string(content),
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s?receive_id_type=chat_id", u), strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+
+	if result.Code != 0 {
+		return fmt.Errorf("feishu send error: %d %s", result.Code, result.Msg)
+	}
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewFeishuExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/googlechat/anyclaw.extension.json
+++ b/extensions/googlechat/anyclaw.extension.json
@@ -1,0 +1,28 @@
+{
+  "id": "googlechat",
+  "name": "Google Chat Channel",
+  "version": "1.0.0",
+  "description": "Google Chat messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["googlechat"],
+  "entrypoint": "googlechat_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "project_id": {
+        "type": "string",
+        "description": "Google Cloud Project ID"
+      },
+      "service_account_key": {
+        "type": "string",
+        "description": "Path to service account JSON key file"
+      },
+      "webhook_url": {
+        "type": "string",
+        "description": "Google Chat webhook URL for outbound messages"
+      }
+    },
+    "required": ["project_id"]
+  }
+}

--- a/extensions/googlechat/anyclaw.extension.json
+++ b/extensions/googlechat/anyclaw.extension.json
@@ -10,19 +10,11 @@
   "config_schema": {
     "type": "object",
     "properties": {
-      "project_id": {
-        "type": "string",
-        "description": "Google Cloud Project ID"
-      },
-      "service_account_key": {
-        "type": "string",
-        "description": "Path to service account JSON key file"
-      },
       "webhook_url": {
         "type": "string",
-        "description": "Google Chat webhook URL for outbound messages"
+        "description": "Google Chat incoming webhook URL for outbound replies"
       }
     },
-    "required": ["project_id"]
+    "required": ["webhook_url"]
   }
 }

--- a/extensions/googlechat/googlechat_adapter.go
+++ b/extensions/googlechat/googlechat_adapter.go
@@ -1,0 +1,342 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type Config struct {
+	ProjectID         string `json:"project_id"`
+	ServiceAccountKey string `json:"service_account_key,omitempty"`
+	WebhookURL        string `json:"webhook_url,omitempty"`
+	Port              int    `json:"port"`
+}
+
+type GoogleChatExtension struct {
+	config Config
+	client *http.Client
+}
+
+func NewGoogleChatExtension(cfg Config) *GoogleChatExtension {
+	if cfg.Port <= 0 {
+		cfg.Port = 8080
+	}
+	return &GoogleChatExtension{
+		config: cfg,
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (e *GoogleChatExtension) Run(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/googlechat", e.handleWebhook)
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", e.config.Port),
+		Handler: mux,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		fmt.Fprintf(os.Stderr, "google chat webhook listening on :%d\n", e.config.Port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (e *GoogleChatExtension) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var payload struct {
+		Type      string `json:"type"`
+		EventTime string `json:"eventTime"`
+		Action    struct {
+			ActionMethodName string `json:"actionMethodName"`
+			Parameters       []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"parameters"`
+		} `json:"action"`
+		Message struct {
+			Name   string `json:"name"`
+			Sender struct {
+				Name        string `json:"name"`
+				DisplayName string `json:"displayName"`
+				Type        string `json:"type"`
+				Domain      struct {
+					Name string `json:"name"`
+				} `json:"domain"`
+			} `json:"sender"`
+			Space struct {
+				Name        string `json:"name"`
+				Type        string `json:"type"`
+				DisplayName string `json:"displayName"`
+				SpaceType   string `json:"spaceType"`
+			} `json:"space"`
+			Thread struct {
+				Name string `json:"name"`
+			} `json:"thread"`
+			ArgumentText string `json:"argumentText"`
+			Annotations  []struct {
+				Type        string `json:"type"`
+				UserMention struct {
+					User struct {
+						DisplayName string `json:"displayName"`
+					} `json:"user"`
+					Type string `json:"type"`
+				} `json:"userMention"`
+			} `json:"annotations"`
+			Text             string `json:"text"`
+			FallbackText     string `json:"fallbackText"`
+			CreateTime       string `json:"createTime"`
+			LastUpdateTime   string `json:"lastUpdateTime"`
+			LastActiveThread struct {
+				Name string `json:"name"`
+			} `json:"lastActiveThread"`
+		} `json:"message"`
+		Space struct {
+			Name        string `json:"name"`
+			Type        string `json:"type"`
+			DisplayName string `json:"displayName"`
+		} `json:"space"`
+		User struct {
+			Name        string `json:"name"`
+			DisplayName string `json:"displayName"`
+		} `json:"user"`
+		ConfigCompleteRequested bool `json:"configCompleteRequested"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	if payload.Type == "MESSAGE" {
+		e.handleMessage(w, &payload)
+		return
+	}
+
+	if payload.Type == "ADDED_TO_SPACE" {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"text": fmt.Sprintf("Thank you for adding me to %s!", payload.Space.DisplayName),
+		})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (e *GoogleChatExtension) handleMessage(w http.ResponseWriter, payload *struct {
+	Type      string `json:"type"`
+	EventTime string `json:"eventTime"`
+	Action    struct {
+		ActionMethodName string `json:"actionMethodName"`
+		Parameters       []struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		} `json:"parameters"`
+	} `json:"action"`
+	Message struct {
+		Name   string `json:"name"`
+		Sender struct {
+			Name        string `json:"name"`
+			DisplayName string `json:"displayName"`
+			Type        string `json:"type"`
+			Domain      struct {
+				Name string `json:"name"`
+			} `json:"domain"`
+		} `json:"sender"`
+		Space struct {
+			Name        string `json:"name"`
+			Type        string `json:"type"`
+			DisplayName string `json:"displayName"`
+			SpaceType   string `json:"spaceType"`
+		} `json:"space"`
+		Thread struct {
+			Name string `json:"name"`
+		} `json:"thread"`
+		ArgumentText string `json:"argumentText"`
+		Annotations  []struct {
+			Type        string `json:"type"`
+			UserMention struct {
+				User struct {
+					DisplayName string `json:"displayName"`
+				} `json:"user"`
+				Type string `json:"type"`
+			} `json:"userMention"`
+		} `json:"annotations"`
+		Text             string `json:"text"`
+		FallbackText     string `json:"fallbackText"`
+		CreateTime       string `json:"createTime"`
+		LastUpdateTime   string `json:"lastUpdateTime"`
+		LastActiveThread struct {
+			Name string `json:"name"`
+		} `json:"lastActiveThread"`
+	} `json:"message"`
+	Space struct {
+		Name        string `json:"name"`
+		Type        string `json:"type"`
+		DisplayName string `json:"displayName"`
+	} `json:"space"`
+	User struct {
+		Name        string `json:"name"`
+		DisplayName string `json:"displayName"`
+	} `json:"user"`
+	ConfigCompleteRequested bool `json:"configCompleteRequested"`
+}) {
+	text := strings.TrimSpace(payload.Message.Text)
+	if text == "" {
+		text = strings.TrimSpace(payload.Message.ArgumentText)
+	}
+	if text == "" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	senderID := payload.Message.Sender.Name
+	senderName := payload.Message.Sender.DisplayName
+	if senderName == "" {
+		senderName = payload.User.DisplayName
+	}
+	spaceID := payload.Message.Space.Name
+	if spaceID == "" {
+		spaceID = payload.Space.Name
+	}
+	threadName := payload.Message.Thread.Name
+
+	input := map[string]any{
+		"action":     "message",
+		"channel":    "googlechat",
+		"chat_id":    spaceID,
+		"text":       text,
+		"user_id":    senderID,
+		"username":   senderName,
+		"thread":     threadName,
+		"space_type": payload.Message.Space.SpaceType,
+	}
+	data, _ := json.Marshal(input)
+	fmt.Println(string(data))
+
+	var response map[string]any
+	if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read response: %v\n", err)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if reply, ok := response["text"].(string); ok && reply != "" {
+		if err := e.sendReply(payload.Message.Name, reply); err != nil {
+			fmt.Fprintf(os.Stderr, "google chat send message error: %v\n", err)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"text": ""})
+}
+
+func (e *GoogleChatExtension) sendReply(messageName, text string) error {
+	if e.config.WebhookURL != "" {
+		return e.sendViaWebhook(text)
+	}
+
+	u := fmt.Sprintf("https://chat.googleapis.com/v1/%s/replies", messageName)
+	payload := map[string]any{
+		"text": text,
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequest(http.MethodPost, u, strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("google chat reply error: %s: %s", resp.Status, string(respBody))
+	}
+	return nil
+}
+
+func (e *GoogleChatExtension) sendViaWebhook(text string) error {
+	payload := map[string]any{
+		"text": text,
+	}
+	body, _ := json.Marshal(payload)
+
+	resp, err := e.client.Post(e.config.WebhookURL, "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("google chat webhook error: %s: %s", resp.Status, string(respBody))
+	}
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewGoogleChatExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/googlechat/googlechat_adapter.go
+++ b/extensions/googlechat/googlechat_adapter.go
@@ -14,10 +14,8 @@ import (
 )
 
 type Config struct {
-	ProjectID         string `json:"project_id"`
-	ServiceAccountKey string `json:"service_account_key,omitempty"`
-	WebhookURL        string `json:"webhook_url,omitempty"`
-	Port              int    `json:"port"`
+	WebhookURL string `json:"webhook_url"`
+	Port       int    `json:"port"`
 }
 
 type GoogleChatExtension struct {
@@ -263,33 +261,10 @@ func (e *GoogleChatExtension) handleMessage(w http.ResponseWriter, payload *stru
 }
 
 func (e *GoogleChatExtension) sendReply(messageName, text string) error {
-	if e.config.WebhookURL != "" {
-		return e.sendViaWebhook(text)
+	if strings.TrimSpace(e.config.WebhookURL) == "" {
+		return fmt.Errorf("google chat webhook_url is required for outbound replies to %s", messageName)
 	}
-
-	u := fmt.Sprintf("https://chat.googleapis.com/v1/%s/replies", messageName)
-	payload := map[string]any{
-		"text": text,
-	}
-	body, _ := json.Marshal(payload)
-
-	req, err := http.NewRequest(http.MethodPost, u, strings.NewReader(string(body)))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := e.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 300 {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("google chat reply error: %s: %s", resp.Status, string(respBody))
-	}
-	return nil
+	return e.sendViaWebhook(text)
 }
 
 func (e *GoogleChatExtension) sendViaWebhook(text string) error {

--- a/extensions/imessage/anyclaw.extension.json
+++ b/extensions/imessage/anyclaw.extension.json
@@ -1,0 +1,40 @@
+{
+  "id": "imessage",
+  "name": "iMessage Channel",
+  "version": "1.0.0",
+  "description": "iMessage channel adapter for AnyClaw (macOS only)",
+  "kind": "channel",
+  "channels": ["imessage"],
+  "entrypoint": "imessage_adapter.go",
+  "permissions": ["net:out", "exec"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "mode": {
+        "type": "string",
+        "description": "Connection mode: 'bridge' (BlueBubbles/local server) or 'database' (poll chat.db)",
+        "default": "bridge"
+      },
+      "bridge_url": {
+        "type": "string",
+        "description": "Bridge server URL (e.g. http://localhost:12345)",
+        "default": "http://localhost:12345"
+      },
+      "bridge_password": {
+        "type": "string",
+        "description": "Bridge server password",
+        "sensitive": true
+      },
+      "chat_db_path": {
+        "type": "string",
+        "description": "Path to Messages chat.db (for database mode)"
+      },
+      "poll_interval": {
+        "type": "integer",
+        "description": "Poll interval in seconds",
+        "default": 5
+      }
+    },
+    "required": ["mode"]
+  }
+}

--- a/extensions/imessage/imessage_adapter.go
+++ b/extensions/imessage/imessage_adapter.go
@@ -1,0 +1,390 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type Config struct {
+	Mode           string `json:"mode"`
+	BridgeURL      string `json:"bridge_url,omitempty"`
+	BridgePassword string `json:"bridge_password,omitempty"`
+	ChatDBPath     string `json:"chat_db_path,omitempty"`
+	PollInterval   int    `json:"poll_interval"`
+	Port           int    `json:"port"`
+}
+
+type IMessageExtension struct {
+	config    Config
+	client    *http.Client
+	lastRowID int64
+	mu        sync.Mutex
+}
+
+func NewIMessageExtension(cfg Config) *IMessageExtension {
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 5
+	}
+	if cfg.Port <= 0 {
+		cfg.Port = 8080
+	}
+	if cfg.BridgeURL == "" {
+		cfg.BridgeURL = "http://localhost:12345"
+	}
+	return &IMessageExtension{
+		config: cfg,
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (e *IMessageExtension) Run(ctx context.Context) error {
+	switch e.config.Mode {
+	case "bridge":
+		return e.runBridgeMode(ctx)
+	case "database":
+		return e.runDatabaseMode(ctx)
+	default:
+		return fmt.Errorf("unknown mode: %s (use 'bridge' or 'database')", e.config.Mode)
+	}
+}
+
+func (e *IMessageExtension) runBridgeMode(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/imessage", e.handleBridgeWebhook)
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", e.config.Port),
+		Handler: mux,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		fmt.Fprintf(os.Stderr, "imessage bridge webhook listening on :%d\n", e.config.Port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (e *IMessageExtension) handleBridgeWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var payload struct {
+		Type    string `json:"type"`
+		Message struct {
+			GUID                  string `json:"guid"`
+			RowID                 int64  `json:"rowid"`
+			Handle                string `json:"handle"`
+			HandleID              int    `json:"handle_id"`
+			IsFromMe              bool   `json:"is_from_me"`
+			Text                  string `json:"text"`
+			Subject               string `json:"subject"`
+			Date                  int64  `json:"date"`
+			DateRead              int64  `json:"date_read"`
+			ChatGUID              string `json:"chat_guid"`
+			GroupTitle            string `json:"group_title"`
+			AssociatedMessageGUID string `json:"associated_message_guid"`
+			ExpressiveSend        struct {
+				Type string `json:"type"`
+			} `json:"expressive_send"`
+		} `json:"message"`
+		Chat struct {
+			GUID        string `json:"guid"`
+			DisplayName string `json:"display_name"`
+			IsGroup     bool   `json:"is_group"`
+			Members     []struct {
+				Address string `json:"address"`
+			} `json:"members"`
+		} `json:"chat"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	if payload.Type != "new-message" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if payload.Message.IsFromMe {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	text := strings.TrimSpace(payload.Message.Text)
+	if text == "" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	chatID := payload.Message.ChatGUID
+	if chatID == "" {
+		chatID = payload.Chat.GUID
+	}
+	senderID := payload.Message.Handle
+	chatName := payload.Chat.DisplayName
+	if chatName == "" {
+		chatName = payload.Message.GroupTitle
+	}
+
+	input := map[string]any{
+		"action":    "message",
+		"channel":   "imessage",
+		"chat_id":   chatID,
+		"text":      text,
+		"user_id":   senderID,
+		"chat_name": chatName,
+		"is_group":  payload.Chat.IsGroup,
+		"guid":      payload.Message.GUID,
+	}
+	data, _ := json.Marshal(input)
+	fmt.Println(string(data))
+
+	var response map[string]any
+	if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read response: %v\n", err)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if reply, ok := response["text"].(string); ok && reply != "" {
+		if err := e.sendBridgeMessage(chatID, senderID, reply); err != nil {
+			fmt.Fprintf(os.Stderr, "imessage send error: %v\n", err)
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (e *IMessageExtension) sendBridgeMessage(chatGUID, recipient, text string) error {
+	u := fmt.Sprintf("%s/api/v1/message", strings.TrimRight(e.config.BridgeURL, "/"))
+
+	payload := map[string]any{
+		"method": "text",
+		"text":   text,
+	}
+	if chatGUID != "" {
+		payload["chatGuid"] = chatGUID
+	} else if recipient != "" {
+		payload["address"] = recipient
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequest(http.MethodPost, u, strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if e.config.BridgePassword != "" {
+		req.Header.Set("Authorization", "Bearer "+e.config.BridgePassword)
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge send error: %s: %s", resp.Status, string(respBody))
+	}
+	return nil
+}
+
+func (e *IMessageExtension) runDatabaseMode(ctx context.Context) error {
+	if e.config.ChatDBPath == "" {
+		e.config.ChatDBPath = os.Getenv("HOME") + "/Library/Messages/chat.db"
+	}
+
+	interval := time.Duration(e.config.PollInterval) * time.Second
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	e.lastRowID = e.getLastRowID()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+
+		if err := e.pollDatabase(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "imessage poll error: %v\n", err)
+		}
+	}
+}
+
+func (e *IMessageExtension) getLastRowID() int64 {
+	cmd := exec.Command("sqlite3", e.config.ChatDBPath, "SELECT MAX(rowid) FROM message;")
+	out, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	var rowID int64
+	fmt.Sscanf(strings.TrimSpace(string(out)), "%d", &rowID)
+	return rowID
+}
+
+func (e *IMessageExtension) pollDatabase(ctx context.Context) error {
+	e.mu.Lock()
+	lastRowID := e.lastRowID
+	e.mu.Unlock()
+
+	query := fmt.Sprintf(
+		"SELECT m.rowid, m.guid, m.text, m.is_from_me, m.date, h.id, c.guid as chat_guid, c.display_name "+
+			"FROM message m "+
+			"LEFT JOIN handle h ON m.handle_id = h.ROWID "+
+			"LEFT JOIN chat_message_join cmj ON m.ROWID = cmj.message_id "+
+			"LEFT JOIN chat c ON cmj.chat_id = c.ROWID "+
+			"WHERE m.rowid > %d AND m.is_from_me = 0 AND m.text IS NOT NULL AND m.text != '' "+
+			"ORDER BY m.rowid ASC;",
+		lastRowID,
+	)
+
+	cmd := exec.CommandContext(ctx, "sqlite3", "-json", e.config.ChatDBPath, query)
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("sqlite3 query failed: %w", err)
+	}
+
+	var messages []struct {
+		RowID    int64  `json:"rowid"`
+		GUID     string `json:"guid"`
+		Text     string `json:"text"`
+		IsFromMe int    `json:"is_from_me"`
+		Date     int64  `json:"date"`
+		ID       string `json:"id"`
+		ChatGUID string `json:"chat_guid"`
+		ChatName string `json:"display_name"`
+	}
+	if err := json.Unmarshal(out, &messages); err != nil {
+		return fmt.Errorf("failed to parse messages: %w", err)
+	}
+
+	for _, msg := range messages {
+		text := strings.TrimSpace(msg.Text)
+		if text == "" {
+			continue
+		}
+
+		chatID := msg.ChatGUID
+		if chatID == "" {
+			chatID = "imessage;-;" + msg.ID
+		}
+		senderID := msg.ID
+
+		input := map[string]any{
+			"action":    "message",
+			"channel":   "imessage",
+			"chat_id":   chatID,
+			"text":      text,
+			"user_id":   senderID,
+			"chat_name": msg.ChatName,
+			"guid":      msg.GUID,
+		}
+		data, _ := json.Marshal(input)
+		fmt.Println(string(data))
+
+		var response map[string]any
+		if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to read response: %v\n", err)
+			continue
+		}
+
+		if reply, ok := response["text"].(string); ok && reply != "" {
+			if err := e.sendDatabaseMessage(senderID, reply); err != nil {
+				fmt.Fprintf(os.Stderr, "imessage send error: %v\n", err)
+			}
+		}
+
+		e.mu.Lock()
+		if msg.RowID > e.lastRowID {
+			e.lastRowID = msg.RowID
+		}
+		e.mu.Unlock()
+	}
+
+	return nil
+}
+
+func (e *IMessageExtension) sendDatabaseMessage(recipient, text string) error {
+	escapedText := strings.ReplaceAll(text, "'", "'\"'\"'")
+	escapedRecipient := strings.ReplaceAll(recipient, "'", "'\"'\"'")
+
+	script := fmt.Sprintf(`
+		tell application "Messages"
+			set targetService to 1st service whose service type = iMessage
+			set targetBuddy to buddy "%s" of targetService
+			send "%s" to targetBuddy
+		end tell
+	`, escapedRecipient, escapedText)
+
+	cmd := exec.Command("osascript", "-e", script)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("osascript failed: %w: %s", err, string(output))
+	}
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewIMessageExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/irc/anyclaw.extension.json
+++ b/extensions/irc/anyclaw.extension.json
@@ -1,0 +1,40 @@
+{
+  "id": "irc",
+  "name": "IRC Channel",
+  "version": "1.0.0",
+  "description": "IRC messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["irc"],
+  "entrypoint": "irc_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "server": {
+        "type": "string",
+        "description": "IRC server address",
+        "default": "irc.libera.chat"
+      },
+      "port": {
+        "type": "integer",
+        "description": "IRC server port",
+        "default": 6667
+      },
+      "nick": {
+        "type": "string",
+        "description": "IRC nickname"
+      },
+      "channels": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Channels to join"
+      },
+      "use_tls": {
+        "type": "boolean",
+        "description": "Use TLS connection",
+        "default": false
+      }
+    },
+    "required": ["nick", "channels"]
+  }
+}

--- a/extensions/irc/anyclaw.extension.json
+++ b/extensions/irc/anyclaw.extension.json
@@ -5,7 +5,6 @@
   "description": "IRC messaging channel adapter for AnyClaw",
   "kind": "channel",
   "channels": ["irc"],
-  "entrypoint": "irc_adapter.go",
   "permissions": ["net:out"],
   "config_schema": {
     "type": "object",

--- a/extensions/line/anyclaw.extension.json
+++ b/extensions/line/anyclaw.extension.json
@@ -1,0 +1,26 @@
+{
+  "id": "line",
+  "name": "LINE Channel",
+  "version": "1.0.0",
+  "description": "LINE messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["line"],
+  "entrypoint": "line_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "channel_access_token": {
+        "type": "string",
+        "description": "LINE Channel Access Token",
+        "sensitive": true
+      },
+      "channel_secret": {
+        "type": "string",
+        "description": "LINE Channel Secret",
+        "sensitive": true
+      }
+    },
+    "required": ["channel_access_token", "channel_secret"]
+  }
+}

--- a/extensions/line/line_adapter.go
+++ b/extensions/line/line_adapter.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type Config struct {
+	ChannelAccessToken string `json:"channel_access_token"`
+	ChannelSecret      string `json:"channel_secret"`
+	Port               int    `json:"port"`
+}
+
+type LINEExtension struct {
+	config Config
+	client *http.Client
+}
+
+func NewLINEExtension(cfg Config) *LINEExtension {
+	if cfg.Port <= 0 {
+		cfg.Port = 8080
+	}
+	return &LINEExtension{
+		config: cfg,
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (e *LINEExtension) Run(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/line", e.handleWebhook)
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", e.config.Port),
+		Handler: mux,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		fmt.Fprintf(os.Stderr, "line webhook listening on :%d\n", e.config.Port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (e *LINEExtension) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	if !e.verifySignature(body, r.Header.Get("X-Line-Signature")) {
+		http.Error(w, "invalid signature", http.StatusForbidden)
+		return
+	}
+
+	var payload struct {
+		Events []struct {
+			Type       string `json:"type"`
+			ReplyToken string `json:"replyToken"`
+			Source     struct {
+				Type    string `json:"type"`
+				UserID  string `json:"userId"`
+				GroupID string `json:"groupId"`
+				RoomID  string `json:"roomId"`
+			} `json:"source"`
+			Message struct {
+				Type string `json:"type"`
+				ID   string `json:"id"`
+				Text string `json:"text"`
+			} `json:"message"`
+			Timestamp int64 `json:"timestamp"`
+		} `json:"events"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	for _, event := range payload.Events {
+		if event.Type != "message" {
+			continue
+		}
+		if event.Message.Type != "text" || event.Message.Text == "" {
+			continue
+		}
+
+		senderID := event.Source.UserID
+		chatID := event.Source.UserID
+		if event.Source.GroupID != "" {
+			chatID = event.Source.GroupID
+		} else if event.Source.RoomID != "" {
+			chatID = event.Source.RoomID
+		}
+
+		input := map[string]any{
+			"action":      "message",
+			"channel":     "line",
+			"chat_id":     chatID,
+			"text":        event.Message.Text,
+			"user_id":     senderID,
+			"reply_token": event.ReplyToken,
+			"msg_type":    event.Message.Type,
+		}
+		data, _ := json.Marshal(input)
+		fmt.Println(string(data))
+
+		var response map[string]any
+		if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to read response: %v\n", err)
+			continue
+		}
+
+		if reply, ok := response["text"].(string); ok && reply != "" {
+			if err := e.replyTextMessage(event.ReplyToken, reply); err != nil {
+				fmt.Fprintf(os.Stderr, "line send message error: %v\n", err)
+			}
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("success"))
+}
+
+func (e *LINEExtension) verifySignature(body []byte, signature string) bool {
+	if e.config.ChannelSecret == "" {
+		return true
+	}
+	mac := hmac.New(sha256.New, []byte(e.config.ChannelSecret))
+	mac.Write(body)
+	computed := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(computed), []byte(signature))
+}
+
+func (e *LINEExtension) replyTextMessage(replyToken, text string) error {
+	u := "https://api.line.me/v2/bot/message/reply"
+	payload := map[string]any{
+		"replyToken": replyToken,
+		"messages": []map[string]any{
+			{"type": "text", "text": text},
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequest(http.MethodPost, u, strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+e.config.ChannelAccessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("line reply error: %s: %s", resp.Status, string(respBody))
+	}
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewLINEExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/matrix/anyclaw.extension.json
+++ b/extensions/matrix/anyclaw.extension.json
@@ -1,0 +1,35 @@
+{
+  "id": "matrix",
+  "name": "Matrix Channel",
+  "version": "1.0.0",
+  "description": "Matrix messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["matrix"],
+  "entrypoint": "matrix_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "homeserver": {
+        "type": "string",
+        "description": "Matrix homeserver URL",
+        "default": "https://matrix.org"
+      },
+      "access_token": {
+        "type": "string",
+        "description": "Matrix access token",
+        "sensitive": true
+      },
+      "user_id": {
+        "type": "string",
+        "description": "Matrix user ID (e.g. @user:matrix.org)"
+      },
+      "rooms": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Room IDs to monitor"
+      }
+    },
+    "required": ["homeserver", "access_token"]
+  }
+}

--- a/extensions/matrix/matrix_adapter.go
+++ b/extensions/matrix/matrix_adapter.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	Homeserver  string   `json:"homeserver"`
+	AccessToken string   `json:"access_token"`
+	UserID      string   `json:"user_id,omitempty"`
+	Rooms       []string `json:"rooms,omitempty"`
+	PollEvery   int      `json:"poll_every"`
+}
+
+type MatrixExtension struct {
+	config    Config
+	client    *http.Client
+	syncToken string
+	baseURL   string
+}
+
+func NewMatrixExtension(cfg Config) *MatrixExtension {
+	hs := strings.TrimRight(cfg.Homeserver, "/")
+	return &MatrixExtension{
+		config:  cfg,
+		client:  &http.Client{Timeout: 30 * time.Second},
+		baseURL: hs,
+	}
+}
+
+func (e *MatrixExtension) Run(ctx context.Context) error {
+	interval := time.Duration(e.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := e.pollOnce(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "matrix sync error: %v\n", err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (e *MatrixExtension) pollOnce(ctx context.Context) error {
+	syncURL := fmt.Sprintf("%s/_matrix/client/v3/sync?timeout=0", e.baseURL)
+	if e.syncToken != "" {
+		syncURL += fmt.Sprintf("&since=%s", e.syncToken)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, syncURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+e.config.AccessToken)
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("sync failed: %s: %s", resp.Status, string(body))
+	}
+
+	var syncResp struct {
+		NextBatch string `json:"next_batch"`
+		Rooms     struct {
+			Join map[string]struct {
+				Timeline struct {
+					Events []struct {
+						Type    string `json:"type"`
+						Sender  string `json:"sender"`
+						Content struct {
+							Body    string `json:"body"`
+							MsgType string `json:"msgtype"`
+						} `json:"content"`
+					} `json:"events"`
+				} `json:"timeline"`
+			} `json:"join"`
+		} `json:"rooms"`
+	}
+	if err := json.Unmarshal(body, &syncResp); err != nil {
+		return err
+	}
+
+	e.syncToken = syncResp.NextBatch
+
+	for roomID, room := range syncResp.Rooms.Join {
+		if len(e.config.Rooms) > 0 && !e.isRoomAllowed(roomID) {
+			continue
+		}
+
+		for _, event := range room.Timeline.Events {
+			if event.Type != "m.room.message" {
+				continue
+			}
+			if event.Content.MsgType != "m.text" {
+				continue
+			}
+			if e.config.UserID != "" && event.Sender == e.config.UserID {
+				continue
+			}
+
+			input := map[string]any{
+				"action":  "message",
+				"channel": "matrix",
+				"chat_id": roomID,
+				"text":    event.Content.Body,
+				"user_id": event.Sender,
+			}
+			data, _ := json.Marshal(input)
+			fmt.Println(string(data))
+
+			var response map[string]any
+			if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+				return fmt.Errorf("failed to read response: %w", err)
+			}
+
+			if reply, ok := response["text"].(string); ok && reply != "" {
+				if err := e.sendMessage(ctx, roomID, reply); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (e *MatrixExtension) isRoomAllowed(roomID string) bool {
+	for _, room := range e.config.Rooms {
+		if room == roomID {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *MatrixExtension) sendMessage(ctx context.Context, roomID, text string) error {
+	txnID := fmt.Sprintf("anyclaw.%d", time.Now().UnixNano())
+	url := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/send/m.room.message/%s", e.baseURL, roomID, txnID)
+
+	payload := map[string]any{
+		"msgtype": "m.text",
+		"body":    text,
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+e.config.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("send message failed: %s: %s", resp.Status, string(respBody))
+	}
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewMatrixExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/mattermost/anyclaw.extension.json
+++ b/extensions/mattermost/anyclaw.extension.json
@@ -1,0 +1,34 @@
+{
+  "id": "mattermost",
+  "name": "Mattermost Channel",
+  "version": "1.0.0",
+  "description": "Mattermost messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["mattermost"],
+  "entrypoint": "mattermost_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "server_url": {
+        "type": "string",
+        "description": "Mattermost server URL (e.g. https://mattermost.example.com)"
+      },
+      "bot_token": {
+        "type": "string",
+        "description": "Mattermost bot access token",
+        "sensitive": true
+      },
+      "team_id": {
+        "type": "string",
+        "description": "Mattermost team ID"
+      },
+      "poll_interval": {
+        "type": "integer",
+        "description": "Poll interval in seconds",
+        "default": 5
+      }
+    },
+    "required": ["server_url", "bot_token"]
+  }
+}

--- a/extensions/mattermost/mattermost_adapter.go
+++ b/extensions/mattermost/mattermost_adapter.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	ServerURL    string `json:"server_url"`
+	BotToken     string `json:"bot_token"`
+	TeamID       string `json:"team_id,omitempty"`
+	PollInterval int    `json:"poll_interval"`
+}
+
+type MattermostExtension struct {
+	config     Config
+	client     *http.Client
+	baseURL    string
+	lastPostID map[string]string
+}
+
+func NewMattermostExtension(cfg Config) *MattermostExtension {
+	serverURL := strings.TrimRight(cfg.ServerURL, "/")
+	return &MattermostExtension{
+		config:     cfg,
+		client:     &http.Client{Timeout: 30 * time.Second},
+		baseURL:    serverURL,
+		lastPostID: make(map[string]string),
+	}
+}
+
+func (e *MattermostExtension) Run(ctx context.Context) error {
+	interval := time.Duration(e.config.PollInterval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+
+	if err := e.initChannels(ctx); err != nil {
+		return fmt.Errorf("failed to initialize channels: %w", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := e.pollOnce(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "mattermost poll error: %v\n", err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (e *MattermostExtension) initChannels(ctx context.Context) error {
+	if e.config.TeamID == "" {
+		return nil
+	}
+
+	channels, err := e.listChannels(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, ch := range channels {
+		e.lastPostID[ch.ID] = ""
+	}
+
+	return nil
+}
+
+func (e *MattermostExtension) listChannels(ctx context.Context) ([]Channel, error) {
+	url := fmt.Sprintf("%s/api/v4/users/me/teams/%s/channels", e.baseURL, e.config.TeamID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+e.config.BotToken)
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("list channels failed: %s: %s", resp.Status, string(body))
+	}
+
+	var channels []Channel
+	if err := json.Unmarshal(body, &channels); err != nil {
+		return nil, err
+	}
+
+	return channels, nil
+}
+
+type Channel struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Type        string `json:"type"`
+	TeamID      string `json:"team_id"`
+}
+
+type Post struct {
+	ID        string `json:"id"`
+	ChannelID string `json:"channel_id"`
+	UserID    string `json:"user_id"`
+	Message   string `json:"message"`
+	CreateAt  int64  `json:"create_at"`
+}
+
+type PostsResponse struct {
+	Order      []string         `json:"order"`
+	Posts      map[string]*Post `json:"posts"`
+	NextPostID string           `json:"next_post_id"`
+	PrevPostID string           `json:"prev_post_id"`
+}
+
+func (e *MattermostExtension) pollOnce(ctx context.Context) error {
+	channels, err := e.listChannels(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, ch := range channels {
+		if ch.Type != "O" && ch.Type != "P" && ch.Type != "D" {
+			continue
+		}
+
+		posts, err := e.fetchPosts(ctx, ch.ID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to fetch posts for channel %s: %v\n", ch.ID, err)
+			continue
+		}
+
+		for _, postID := range posts.Order {
+			post, ok := posts.Posts[postID]
+			if !ok {
+				continue
+			}
+
+			if post.Message == "" {
+				continue
+			}
+
+			if e.lastPostID[ch.ID] != "" && post.ID == e.lastPostID[ch.ID] {
+				break
+			}
+
+			if e.lastPostID[ch.ID] != "" {
+				input := map[string]any{
+					"action":   "message",
+					"channel":  "mattermost",
+					"chat_id":  ch.ID,
+					"text":     post.Message,
+					"user_id":  post.UserID,
+					"username": "",
+				}
+				data, _ := json.Marshal(input)
+				fmt.Println(string(data))
+
+				var response map[string]any
+				if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+					return fmt.Errorf("failed to read response: %w", err)
+				}
+
+				if reply, ok := response["text"].(string); ok && reply != "" {
+					if err := e.sendMessage(ctx, ch.ID, reply); err != nil {
+						return err
+					}
+				}
+			}
+
+			if e.lastPostID[ch.ID] == "" || isNewerPost(post.ID, e.lastPostID[ch.ID], posts.Order) {
+				e.lastPostID[ch.ID] = post.ID
+			}
+		}
+	}
+
+	return nil
+}
+
+func isNewerPost(postID, lastID string, order []string) bool {
+	lastIdx := -1
+	postIdx := -1
+	for i, id := range order {
+		if id == lastID {
+			lastIdx = i
+		}
+		if id == postID {
+			postIdx = i
+		}
+	}
+	if postIdx == -1 {
+		return false
+	}
+	if lastIdx == -1 {
+		return true
+	}
+	return postIdx < lastIdx
+}
+
+func (e *MattermostExtension) fetchPosts(ctx context.Context, channelID string) (*PostsResponse, error) {
+	url := fmt.Sprintf("%s/api/v4/channels/%s/posts", e.baseURL, channelID)
+	if lastID, ok := e.lastPostID[channelID]; ok && lastID != "" {
+		url += fmt.Sprintf("?after=%s", lastID)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+e.config.BotToken)
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch posts failed: %s: %s", resp.Status, string(body))
+	}
+
+	var postsResp PostsResponse
+	if err := json.Unmarshal(body, &postsResp); err != nil {
+		return nil, err
+	}
+
+	return &postsResp, nil
+}
+
+func (e *MattermostExtension) sendMessage(ctx context.Context, channelID, text string) error {
+	url := fmt.Sprintf("%s/api/v4/posts", e.baseURL)
+
+	payload := map[string]string{
+		"channel_id": channelID,
+		"message":    text,
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+e.config.BotToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("send message failed: %s: %s", resp.Status, string(respBody))
+	}
+
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewMattermostExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/msteams/anyclaw.extension.json
+++ b/extensions/msteams/anyclaw.extension.json
@@ -1,0 +1,33 @@
+{
+  "id": "msteams",
+  "name": "Microsoft Teams Channel",
+  "version": "1.0.0",
+  "description": "Microsoft Teams messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["msteams"],
+  "entrypoint": "msteams_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "app_id": {
+        "type": "string",
+        "description": "Azure AD App (client) ID"
+      },
+      "app_secret": {
+        "type": "string",
+        "description": "Azure AD App Secret",
+        "sensitive": true
+      },
+      "tenant_id": {
+        "type": "string",
+        "description": "Azure AD Tenant ID"
+      },
+      "webhook_url": {
+        "type": "string",
+        "description": "Teams incoming webhook URL for outbound messages"
+      }
+    },
+    "required": ["app_id", "app_secret", "tenant_id"]
+  }
+}

--- a/extensions/msteams/msteams_adapter.go
+++ b/extensions/msteams/msteams_adapter.go
@@ -1,0 +1,411 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type Config struct {
+	AppID      string `json:"app_id"`
+	AppSecret  string `json:"app_secret"`
+	TenantID   string `json:"tenant_id"`
+	WebhookURL string `json:"webhook_url,omitempty"`
+	Port       int    `json:"port"`
+}
+
+type MSTeamsExtension struct {
+	config      Config
+	client      *http.Client
+	accessToken string
+	tokenMu     sync.RWMutex
+	tokenExpire time.Time
+}
+
+func NewMSTeamsExtension(cfg Config) *MSTeamsExtension {
+	if cfg.Port <= 0 {
+		cfg.Port = 8080
+	}
+	return &MSTeamsExtension{
+		config: cfg,
+		client: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (e *MSTeamsExtension) Run(ctx context.Context) error {
+	go e.refreshTokenLoop(ctx)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/msteams", e.handleWebhook)
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", e.config.Port),
+		Handler: mux,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		fmt.Fprintf(os.Stderr, "msteams webhook listening on :%d\n", e.config.Port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (e *MSTeamsExtension) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var payload struct {
+		Type           string `json:"type"`
+		ID             string `json:"id"`
+		Timestamp      string `json:"timestamp"`
+		LocalTimestamp string `json:"localTimestamp"`
+		ServiceURL     string `json:"serviceUrl"`
+		ChannelID      string `json:"channelId"`
+		From           struct {
+			ID       string `json:"id"`
+			Name     string `json:"name"`
+			AadID    string `json:"aadObjectId"`
+			TenantID string `json:"tenantId"`
+		} `json:"from"`
+		Conversation struct {
+			IsGroup          bool   `json:"isGroup"`
+			ConversationType string `json:"conversationType"`
+			ID               string `json:"id"`
+			TenantID         string `json:"tenantId"`
+			Name             string `json:"name"`
+		} `json:"conversation"`
+		Recipient struct {
+			ID    string `json:"id"`
+			Name  string `json:"name"`
+			AadID string `json:"aadObjectId"`
+		} `json:"recipient"`
+		Text       string `json:"text"`
+		TextFormat string `json:"textFormat"`
+		Locale     string `json:"locale"`
+		ReplyToID  string `json:"replyToId"`
+		Entities   []struct {
+			Type      string `json:"type"`
+			Mentioned struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"mentioned"`
+			Text string `json:"text"`
+		} `json:"entities"`
+		ChannelData struct {
+			TeamsChannelID   string `json:"teamsChannelId"`
+			TeamsTeamID      string `json:"teamsTeamId"`
+			TeamsChannelData struct {
+				Channel struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"channel"`
+				Team struct {
+					ID string `json:"id"`
+				} `json:"team"`
+				Tenant struct {
+					ID string `json:"id"`
+				} `json:"tenant"`
+			} `json:"teamsChannelData"`
+		} `json:"channelData"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	if payload.Type == "message" && payload.Text != "" {
+		e.handleMessage(w, &payload)
+		return
+	}
+
+	if payload.Type == "conversationUpdate" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (e *MSTeamsExtension) handleMessage(w http.ResponseWriter, payload *struct {
+	Type           string `json:"type"`
+	ID             string `json:"id"`
+	Timestamp      string `json:"timestamp"`
+	LocalTimestamp string `json:"localTimestamp"`
+	ServiceURL     string `json:"serviceUrl"`
+	ChannelID      string `json:"channelId"`
+	From           struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		AadID    string `json:"aadObjectId"`
+		TenantID string `json:"tenantId"`
+	} `json:"from"`
+	Conversation struct {
+		IsGroup          bool   `json:"isGroup"`
+		ConversationType string `json:"conversationType"`
+		ID               string `json:"id"`
+		TenantID         string `json:"tenantId"`
+		Name             string `json:"name"`
+	} `json:"conversation"`
+	Recipient struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		AadID string `json:"aadObjectId"`
+	} `json:"recipient"`
+	Text       string `json:"text"`
+	TextFormat string `json:"textFormat"`
+	Locale     string `json:"locale"`
+	ReplyToID  string `json:"replyToId"`
+	Entities   []struct {
+		Type      string `json:"type"`
+		Mentioned struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"mentioned"`
+		Text string `json:"text"`
+	} `json:"entities"`
+	ChannelData struct {
+		TeamsChannelID   string `json:"teamsChannelId"`
+		TeamsTeamID      string `json:"teamsTeamId"`
+		TeamsChannelData struct {
+			Channel struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"channel"`
+			Team struct {
+				ID string `json:"id"`
+			} `json:"team"`
+			Tenant struct {
+				ID string `json:"id"`
+			} `json:"tenant"`
+		} `json:"teamsChannelData"`
+	} `json:"channelData"`
+}) {
+	text := strings.TrimSpace(payload.Text)
+	if text == "" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	senderID := payload.From.ID
+	senderName := payload.From.Name
+	conversationID := payload.Conversation.ID
+	serviceURL := payload.ServiceURL
+	isGroup := payload.Conversation.IsGroup
+
+	input := map[string]any{
+		"action":      "message",
+		"channel":     "msteams",
+		"chat_id":     conversationID,
+		"text":        text,
+		"user_id":     senderID,
+		"username":    senderName,
+		"service_url": serviceURL,
+		"reply_to_id": payload.ReplyToID,
+		"activity_id": payload.ID,
+		"is_group":    isGroup,
+		"conv_type":   payload.Conversation.ConversationType,
+	}
+	data, _ := json.Marshal(input)
+	fmt.Println(string(data))
+
+	var response map[string]any
+	if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read response: %v\n", err)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if reply, ok := response["text"].(string); ok && reply != "" {
+		if err := e.sendReply(serviceURL, conversationID, payload.ID, reply); err != nil {
+			fmt.Fprintf(os.Stderr, "msteams send message error: %v\n", err)
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (e *MSTeamsExtension) getAccessToken() (string, error) {
+	e.tokenMu.RLock()
+	if e.accessToken != "" && time.Now().Before(e.tokenExpire) {
+		token := e.accessToken
+		e.tokenMu.RUnlock()
+		return token, nil
+	}
+	e.tokenMu.RUnlock()
+
+	e.tokenMu.Lock()
+	defer e.tokenMu.Unlock()
+
+	if e.accessToken != "" && time.Now().Before(e.tokenExpire) {
+		return e.accessToken, nil
+	}
+
+	tokenURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", e.config.TenantID)
+	formData := url.Values{}
+	formData.Set("grant_type", "client_credentials")
+	formData.Set("client_id", e.config.AppID)
+	formData.Set("client_secret", e.config.AppSecret)
+	formData.Set("scope", "https://api.botframework.com/.default")
+
+	resp, err := e.client.PostForm(tokenURL, formData)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return "", err
+	}
+
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("msteams token error: no access_token in response")
+	}
+
+	e.accessToken = tokenResp.AccessToken
+	if tokenResp.ExpiresIn > 0 {
+		e.tokenExpire = time.Now().Add(time.Duration(tokenResp.ExpiresIn-300) * time.Second)
+	} else {
+		e.tokenExpire = time.Now().Add(30 * time.Minute)
+	}
+	return e.accessToken, nil
+}
+
+func (e *MSTeamsExtension) refreshTokenLoop(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Minute)
+	defer ticker.Stop()
+
+	e.getAccessToken()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			e.getAccessToken()
+		}
+	}
+}
+
+func (e *MSTeamsExtension) sendReply(serviceURL, conversationID, replyToID, text string) error {
+	if e.config.WebhookURL != "" {
+		return e.sendViaWebhook(text)
+	}
+
+	if serviceURL == "" {
+		return fmt.Errorf("no service_url available to send reply")
+	}
+
+	u := fmt.Sprintf("%s/v3/conversations/%s/activities/%s", strings.TrimRight(serviceURL, "/"), conversationID, replyToID)
+	payload := map[string]any{
+		"type": "message",
+		"text": text,
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequest(http.MethodPost, u, strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+
+	token, err := e.getAccessToken()
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("msteams reply error: %s: %s", resp.Status, string(respBody))
+	}
+	return nil
+}
+
+func (e *MSTeamsExtension) sendViaWebhook(text string) error {
+	payload := map[string]any{
+		"text": text,
+	}
+	body, _ := json.Marshal(payload)
+
+	resp, err := e.client.Post(e.config.WebhookURL, "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("msteams webhook error: %s: %s", resp.Status, string(respBody))
+	}
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewMSTeamsExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/nextcloud-talk/anyclaw.extension.json
+++ b/extensions/nextcloud-talk/anyclaw.extension.json
@@ -1,0 +1,34 @@
+{
+  "id": "nextcloud-talk",
+  "name": "Nextcloud Talk Channel",
+  "version": "1.0.0",
+  "description": "Nextcloud Talk messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["nextcloud-talk"],
+  "entrypoint": "nextcloud_talk_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "server_url": {
+        "type": "string",
+        "description": "Nextcloud server URL (e.g. https://cloud.example.com)"
+      },
+      "username": {
+        "type": "string",
+        "description": "Nextcloud username"
+      },
+      "app_password": {
+        "type": "string",
+        "description": "Nextcloud app password",
+        "sensitive": true
+      },
+      "poll_interval": {
+        "type": "integer",
+        "description": "Poll interval in seconds",
+        "default": 10
+      }
+    },
+    "required": ["server_url", "username", "app_password"]
+  }
+}

--- a/extensions/nextcloud-talk/nextcloud_talk_adapter.go
+++ b/extensions/nextcloud-talk/nextcloud_talk_adapter.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	ServerURL    string `json:"server_url"`
+	Username     string `json:"username"`
+	AppPassword  string `json:"app_password"`
+	PollInterval int    `json:"poll_interval"`
+}
+
+type NextcloudTalkExtension struct {
+	config     Config
+	client     *http.Client
+	baseURL    string
+	authHeader string
+	lastMsgID  map[string]int
+}
+
+func NewNextcloudTalkExtension(cfg Config) *NextcloudTalkExtension {
+	server := strings.TrimRight(cfg.ServerURL, "/")
+	creds := base64.StdEncoding.EncodeToString([]byte(cfg.Username + ":" + cfg.AppPassword))
+	return &NextcloudTalkExtension{
+		config:     cfg,
+		client:     &http.Client{Timeout: 30 * time.Second},
+		baseURL:    server,
+		authHeader: "Basic " + creds,
+		lastMsgID:  make(map[string]int),
+	}
+}
+
+func (e *NextcloudTalkExtension) Run(ctx context.Context) error {
+	interval := time.Duration(e.config.PollInterval) * time.Second
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := e.pollOnce(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "nextcloud-talk poll error: %v\n", err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (e *NextcloudTalkExtension) pollOnce(ctx context.Context) error {
+	conversations, err := e.getConversations(ctx)
+	if err != nil {
+		return fmt.Errorf("get conversations: %w", err)
+	}
+
+	for _, conv := range conversations {
+		token := conv.Token
+		if token == "" {
+			continue
+		}
+
+		messages, err := e.getMessages(ctx, token)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "nextcloud-talk get messages error for %s: %v\n", token, err)
+			continue
+		}
+
+		for _, msg := range messages {
+			if msg.ActorID == e.config.Username {
+				continue
+			}
+			if msg.MessageType != "" && msg.MessageType != "comment" {
+				continue
+			}
+			if msg.SystemMessage != "" {
+				continue
+			}
+
+			lastID, seen := e.lastMsgID[token]
+			if seen && msg.ID <= lastID {
+				continue
+			}
+
+			e.lastMsgID[token] = msg.ID
+
+			input := map[string]any{
+				"action":     "message",
+				"channel":    "nextcloud-talk",
+				"chat_id":    token,
+				"text":       e.parseMessage(msg.Message),
+				"user_id":    msg.ActorID,
+				"actor_name": msg.ActorDisplayName,
+				"message_id": msg.ID,
+			}
+			data, _ := json.Marshal(input)
+			fmt.Println(string(data))
+
+			var response map[string]any
+			if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+				return fmt.Errorf("failed to read response: %w", err)
+			}
+
+			if reply, ok := response["text"].(string); ok && reply != "" {
+				if err := e.sendMessage(ctx, token, reply); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (e *NextcloudTalkExtension) getConversations(ctx context.Context) ([]Conversation, error) {
+	url := fmt.Sprintf("%s/ocs/v2.php/apps/spreed/api/v4/room", e.baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", e.authHeader)
+	req.Header.Set("OCS-APIRequest", "true")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("get conversations failed: %s: %s", resp.Status, string(body))
+	}
+
+	var ocsResp struct {
+		OCS struct {
+			Data []Conversation `json:"data"`
+		} `json:"ocs"`
+	}
+	if err := json.Unmarshal(body, &ocsResp); err != nil {
+		return nil, err
+	}
+
+	return ocsResp.OCS.Data, nil
+}
+
+func (e *NextcloudTalkExtension) getMessages(ctx context.Context, token string) ([]Message, error) {
+	url := fmt.Sprintf("%s/ocs/v2.php/apps/spreed/api/v4/chat/%s", e.baseURL, token)
+	if lastID, ok := e.lastMsgID[token]; ok {
+		url += fmt.Sprintf("?lastKnownMessageId=%d", lastID)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", e.authHeader)
+	req.Header.Set("OCS-APIRequest", "true")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("get messages failed: %s: %s", resp.Status, string(body))
+	}
+
+	var ocsResp struct {
+		OCS struct {
+			Data []Message `json:"data"`
+		} `json:"ocs"`
+	}
+	if err := json.Unmarshal(body, &ocsResp); err != nil {
+		return nil, err
+	}
+
+	return ocsResp.OCS.Data, nil
+}
+
+func (e *NextcloudTalkExtension) sendMessage(ctx context.Context, token, text string) error {
+	url := fmt.Sprintf("%s/ocs/v2.php/apps/spreed/api/v1/chat/%s", e.baseURL, token)
+
+	payload := map[string]string{
+		"message": text,
+	}
+	bodyBytes, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", e.authHeader)
+	req.Header.Set("OCS-APIRequest", "true")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("send message failed: %s: %s", resp.Status, string(respBody))
+	}
+
+	return nil
+}
+
+func (e *NextcloudTalkExtension) parseMessage(raw string) string {
+	var parsed struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err == nil && parsed.Message != "" {
+		return parsed.Message
+	}
+	return raw
+}
+
+type Conversation struct {
+	Token       string `json:"token"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	LastMessage struct {
+		ID   int    `json:"id"`
+		Type string `json:"type"`
+	} `json:"lastMessage"`
+	UnreadMessages int `json:"unreadMessages"`
+}
+
+type Message struct {
+	ID               int    `json:"id"`
+	MessageType      string `json:"messageType"`
+	SystemMessage    string `json:"systemMessage"`
+	Message          string `json:"message"`
+	ActorID          string `json:"actorId"`
+	ActorDisplayName string `json:"actorDisplayName"`
+	Timestamp        int    `json:"timestamp"`
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewNextcloudTalkExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/nostr/anyclaw.extension.json
+++ b/extensions/nostr/anyclaw.extension.json
@@ -1,0 +1,31 @@
+{
+  "id": "nostr",
+  "name": "Nostr Channel",
+  "version": "1.0.0",
+  "description": "Nostr decentralized messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["nostr"],
+  "entrypoint": "nostr_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "relay_url": {
+        "type": "string",
+        "description": "Nostr relay URL (e.g. wss://relay.damus.io)",
+        "default": "wss://relay.damus.io"
+      },
+      "private_key": {
+        "type": "string",
+        "description": "Nostr private key (hex)",
+        "sensitive": true
+      },
+      "poll_interval": {
+        "type": "integer",
+        "description": "Poll interval in seconds",
+        "default": 10
+      }
+    },
+    "required": ["relay_url", "private_key"]
+  }
+}

--- a/extensions/nostr/nostr_adapter.go
+++ b/extensions/nostr/nostr_adapter.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	RelayURL     string `json:"relay_url"`
+	PrivateKey   string `json:"private_key"`
+	PollInterval int    `json:"poll_interval"`
+}
+
+type NostrExtension struct {
+	config  Config
+	client  *http.Client
+	pubkey  string
+	seenIDs map[string]bool
+	baseURL string
+}
+
+func NewNostrExtension(cfg Config) *NostrExtension {
+	relayURL := strings.TrimRight(cfg.RelayURL, "/")
+	pubkey := derivePubkey(cfg.PrivateKey)
+	return &NostrExtension{
+		config:  cfg,
+		client:  &http.Client{Timeout: 30 * time.Second},
+		pubkey:  pubkey,
+		seenIDs: make(map[string]bool),
+		baseURL: relayURL,
+	}
+}
+
+func derivePubkey(privateKey string) string {
+	return privateKey + "_pub"
+}
+
+func (e *NostrExtension) Run(ctx context.Context) error {
+	interval := time.Duration(e.config.PollInterval) * time.Second
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	fmt.Fprintf(os.Stderr, "nostr adapter started, pubkey=%s, relay=%s\n", e.pubkey, e.baseURL)
+
+	for {
+		if err := e.pollOnce(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "nostr poll error: %v\n", err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (e *NostrExtension) pollOnce(ctx context.Context) error {
+	queryURL := fmt.Sprintf("%s/events?author=%s&kinds=1&limit=20", e.baseURL, e.pubkey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, queryURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("query failed: %s: %s", resp.Status, string(body))
+	}
+
+	var events []struct {
+		ID        string  `json:"id"`
+		Pubkey    string  `json:"pubkey"`
+		Kind      int     `json:"kind"`
+		Content   string  `json:"content"`
+		CreatedAt int64   `json:"created_at"`
+		Tags      [][]any `json:"tags"`
+	}
+	if err := json.Unmarshal(body, &events); err != nil {
+		return err
+	}
+
+	for _, event := range events {
+		if event.Kind != 1 {
+			continue
+		}
+		if event.Pubkey == e.pubkey {
+			continue
+		}
+		if e.seenIDs[event.ID] {
+			continue
+		}
+		e.seenIDs[event.ID] = true
+
+		text := strings.TrimSpace(event.Content)
+		if text == "" {
+			continue
+		}
+
+		input := map[string]any{
+			"action":  "message",
+			"channel": "nostr",
+			"chat_id": e.pubkey,
+			"text":    text,
+			"user_id": event.Pubkey,
+		}
+		data, _ := json.Marshal(input)
+		fmt.Println(string(data))
+
+		var response map[string]any
+		if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+			return fmt.Errorf("failed to read response: %w", err)
+		}
+
+		if reply, ok := response["text"].(string); ok && reply != "" {
+			if err := e.sendNote(ctx, event.Pubkey, reply); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (e *NostrExtension) sendNote(ctx context.Context, targetPubkey, text string) error {
+	note := map[string]any{
+		"pubkey":     e.pubkey,
+		"kind":       1,
+		"content":    text,
+		"created_at": time.Now().Unix(),
+		"tags":       [][]string{{"p", targetPubkey}},
+	}
+	body, _ := json.Marshal(note)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.baseURL+"/events", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("publish failed: %s: %s", resp.Status, string(respBody))
+	}
+
+	fmt.Fprintf(os.Stderr, "nostr note published to %s\n", targetPubkey)
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewNostrExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/signal/anyclaw.extension.json
+++ b/extensions/signal/anyclaw.extension.json
@@ -5,7 +5,6 @@
   "description": "Signal messaging channel adapter for AnyClaw",
   "kind": "channel",
   "channels": ["signal"],
-  "entrypoint": "signal_adapter.go",
   "permissions": ["net:out"],
   "config_schema": {
     "type": "object",

--- a/extensions/signal/anyclaw.extension.json
+++ b/extensions/signal/anyclaw.extension.json
@@ -1,0 +1,25 @@
+{
+  "id": "signal",
+  "name": "Signal Channel",
+  "version": "1.0.0",
+  "description": "Signal messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["signal"],
+  "entrypoint": "signal_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "signal_url": {
+        "type": "string",
+        "description": "Signal REST API URL (signal-cli)",
+        "default": "http://localhost:8080"
+      },
+      "number": {
+        "type": "string",
+        "description": "Signal phone number with country code"
+      }
+    },
+    "required": ["number"]
+  }
+}

--- a/extensions/slack/anyclaw.extension.json
+++ b/extensions/slack/anyclaw.extension.json
@@ -1,0 +1,31 @@
+{
+  "id": "slack",
+  "name": "Slack Channel",
+  "version": "1.0.0",
+  "description": "Slack messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["slack"],
+  "entrypoint": "slack_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "bot_token": {
+        "type": "string",
+        "description": "Slack Bot OAuth token",
+        "sensitive": true
+      },
+      "app_token": {
+        "type": "string",
+        "description": "Slack App-level token for Socket Mode",
+        "sensitive": true
+      },
+      "signing_secret": {
+        "type": "string",
+        "description": "Slack signing secret for webhook verification",
+        "sensitive": true
+      }
+    },
+    "required": ["bot_token"]
+  }
+}

--- a/extensions/slack/anyclaw.extension.json
+++ b/extensions/slack/anyclaw.extension.json
@@ -5,7 +5,6 @@
   "description": "Slack messaging channel adapter for AnyClaw",
   "kind": "channel",
   "channels": ["slack"],
-  "entrypoint": "slack_adapter.go",
   "permissions": ["net:out"],
   "config_schema": {
     "type": "object",

--- a/extensions/synology-chat/anyclaw.extension.json
+++ b/extensions/synology-chat/anyclaw.extension.json
@@ -1,0 +1,30 @@
+{
+  "id": "synology-chat",
+  "name": "Synology Chat Channel",
+  "version": "1.0.0",
+  "description": "Synology Chat messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["synology-chat"],
+  "entrypoint": "synology_chat_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "server_url": {
+        "type": "string",
+        "description": "Synology Chat server URL (e.g. https://synology.example.com:5000)"
+      },
+      "api_token": {
+        "type": "string",
+        "description": "Synology Chat bot API token",
+        "sensitive": true
+      },
+      "poll_interval": {
+        "type": "integer",
+        "description": "Poll interval in seconds",
+        "default": 5
+      }
+    },
+    "required": ["server_url", "api_token"]
+  }
+}

--- a/extensions/synology-chat/synology_chat_adapter.go
+++ b/extensions/synology-chat/synology_chat_adapter.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	ServerURL    string `json:"server_url"`
+	APIToken     string `json:"api_token"`
+	PollInterval int    `json:"poll_interval"`
+}
+
+type SynologyChatExtension struct {
+	config      Config
+	client      *http.Client
+	baseURL     string
+	lastMessage int64
+}
+
+func NewSynologyChatExtension(cfg Config) *SynologyChatExtension {
+	return &SynologyChatExtension{
+		config:  cfg,
+		client:  &http.Client{Timeout: 20 * time.Second},
+		baseURL: strings.TrimRight(cfg.ServerURL, "/"),
+	}
+}
+
+func (e *SynologyChatExtension) Run(ctx context.Context) error {
+	interval := time.Duration(e.config.PollInterval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := e.pollOnce(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "synology-chat poll error: %v\n", err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (e *SynologyChatExtension) pollOnce(ctx context.Context) error {
+	params := url.Values{}
+	params.Set("token", e.config.APIToken)
+	params.Set("method", "get_message")
+	if e.lastMessage > 0 {
+		params.Set("last_id", strconv.FormatInt(e.lastMessage, 10))
+	}
+
+	u := fmt.Sprintf("%s/entrypoint.cgi?%s", e.baseURL, params.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var payload struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Messages []struct {
+				ID       int64  `json:"id"`
+				UserID   string `json:"user_id"`
+				Username string `json:"username"`
+				ChatID   string `json:"chat_id"`
+				Text     string `json:"text"`
+			} `json:"messages"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return err
+	}
+	if !payload.Success {
+		return fmt.Errorf("synology-chat get_message returned success=false")
+	}
+
+	for _, msg := range payload.Data.Messages {
+		if msg.ID <= e.lastMessage {
+			continue
+		}
+		e.lastMessage = msg.ID
+
+		text := strings.TrimSpace(msg.Text)
+		if text == "" {
+			continue
+		}
+
+		input := map[string]any{
+			"action":   "message",
+			"channel":  "synology-chat",
+			"chat_id":  msg.ChatID,
+			"text":     text,
+			"user_id":  msg.UserID,
+			"username": msg.Username,
+		}
+		data, _ := json.Marshal(input)
+		fmt.Println(string(data))
+
+		var response map[string]any
+		if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+			return fmt.Errorf("failed to read response: %w", err)
+		}
+		if reply, ok := response["text"].(string); ok && reply != "" {
+			if err := e.sendMessage(ctx, msg.ChatID, reply); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e *SynologyChatExtension) sendMessage(ctx context.Context, chatID string, text string) error {
+	form := url.Values{}
+	form.Set("token", e.config.APIToken)
+	form.Set("method", "post_message")
+	form.Set("payload", fmt.Sprintf(`{"text":%s,"chat_id":%s}`, strconv.Quote(text), strconv.Quote(chatID)))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/entrypoint.cgi", e.baseURL), bytes.NewBufferString(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Success bool `json:"success"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+	if !result.Success {
+		return fmt.Errorf("synology-chat post_message returned success=false")
+	}
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewSynologyChatExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/telegram/anyclaw.extension.json
+++ b/extensions/telegram/anyclaw.extension.json
@@ -1,0 +1,30 @@
+{
+  "id": "telegram",
+  "name": "Telegram Channel",
+  "version": "1.0.0",
+  "description": "Telegram messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["telegram"],
+  "entrypoint": "telegram_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "bot_token": {
+        "type": "string",
+        "description": "Telegram Bot API token",
+        "sensitive": true
+      },
+      "chat_id": {
+        "type": "string",
+        "description": "Optional: restrict to specific chat ID"
+      },
+      "poll_every": {
+        "type": "integer",
+        "description": "Polling interval in seconds",
+        "default": 3
+      }
+    },
+    "required": ["bot_token"]
+  }
+}

--- a/extensions/telegram/telegram_adapter.go
+++ b/extensions/telegram/telegram_adapter.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	BotToken  string `json:"bot_token"`
+	ChatID    string `json:"chat_id,omitempty"`
+	PollEvery int    `json:"poll_every"`
+}
+
+type TelegramExtension struct {
+	config  Config
+	client  *http.Client
+	offset  int64
+	baseURL string
+}
+
+func NewTelegramExtension(cfg Config) *TelegramExtension {
+	return &TelegramExtension{
+		config:  cfg,
+		client:  &http.Client{Timeout: 20 * time.Second},
+		baseURL: "https://api.telegram.org/bot" + cfg.BotToken,
+	}
+}
+
+func (e *TelegramExtension) Run(ctx context.Context) error {
+	interval := time.Duration(e.config.PollEvery) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := e.pollOnce(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "telegram poll error: %v\n", err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (e *TelegramExtension) pollOnce(ctx context.Context) error {
+	u := fmt.Sprintf("%s/getUpdates?timeout=1&offset=%d", e.baseURL, e.offset)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var payload struct {
+		OK     bool `json:"ok"`
+		Result []struct {
+			UpdateID int64 `json:"update_id"`
+			Message  struct {
+				Text string `json:"text"`
+				Chat struct {
+					ID int64 `json:"id"`
+				} `json:"chat"`
+				From struct {
+					Username string `json:"username"`
+				} `json:"from"`
+			} `json:"message"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return err
+	}
+
+	for _, update := range payload.Result {
+		e.offset = update.UpdateID + 1
+		chatID := strconv.FormatInt(update.Message.Chat.ID, 10)
+		if strings.TrimSpace(e.config.ChatID) != "" && chatID != strings.TrimSpace(e.config.ChatID) {
+			continue
+		}
+		text := strings.TrimSpace(update.Message.Text)
+		if text == "" {
+			continue
+		}
+
+		// Send message to AnyClaw core via stdin/stdout JSON protocol
+		input := map[string]any{
+			"action":    "message",
+			"channel":   "telegram",
+			"chat_id":   chatID,
+			"text":      text,
+			"username":  update.Message.From.Username,
+			"update_id": update.UpdateID,
+		}
+		data, _ := json.Marshal(input)
+		fmt.Println(string(data))
+
+		// Read response from stdin
+		var response map[string]any
+		if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+			return fmt.Errorf("failed to read response: %w", err)
+		}
+		if reply, ok := response["text"].(string); ok && reply != "" {
+			if err := e.sendMessage(ctx, chatID, reply); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e *TelegramExtension) sendMessage(ctx context.Context, chatID string, text string) error {
+	values := url.Values{}
+	values.Set("chat_id", chatID)
+	values.Set("text", text)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.baseURL+"/sendMessage", strings.NewReader(values.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("telegram send failed: %s", resp.Status)
+	}
+	return nil
+}
+
+func main() {
+	// Read config from environment
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewTelegramExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Handle shutdown
+	go func() {
+		// Simple signal handling could be added here
+		<-ctx.Done()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/tlon/anyclaw.extension.json
+++ b/extensions/tlon/anyclaw.extension.json
@@ -1,0 +1,34 @@
+{
+  "id": "tlon",
+  "name": "Tlon/Urbit Channel",
+  "version": "1.0.0",
+  "description": "Tlon/Urbit messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["tlon"],
+  "entrypoint": "tlon_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "ship_url": {
+        "type": "string",
+        "description": "Urbit ship URL (e.g. https://my-ship.urbit.org)"
+      },
+      "ship_code": {
+        "type": "string",
+        "description": "Urbit ship access code",
+        "sensitive": true
+      },
+      "ship_name": {
+        "type": "string",
+        "description": "Urbit ship name (~ship-name)"
+      },
+      "poll_interval": {
+        "type": "integer",
+        "description": "Poll interval in seconds",
+        "default": 10
+      }
+    },
+    "required": ["ship_url", "ship_code", "ship_name"]
+  }
+}

--- a/extensions/tlon/tlon_adapter.go
+++ b/extensions/tlon/tlon_adapter.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"os"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	ShipURL      string `json:"ship_url"`
+	ShipCode     string `json:"ship_code"`
+	ShipName     string `json:"ship_name"`
+	PollInterval int    `json:"poll_interval"`
+}
+
+type TlonExtension struct {
+	config   Config
+	client   *http.Client
+	baseURL  string
+	shipName string
+	seenMsgs map[string]bool
+}
+
+func NewTlonExtension(cfg Config) *TlonExtension {
+	baseURL := strings.TrimRight(cfg.ShipURL, "/")
+	jar, _ := cookiejar.New(nil)
+	return &TlonExtension{
+		config:   cfg,
+		client:   &http.Client{Timeout: 30 * time.Second, Jar: jar},
+		baseURL:  baseURL,
+		shipName: cfg.ShipName,
+		seenMsgs: make(map[string]bool),
+	}
+}
+
+func (e *TlonExtension) Run(ctx context.Context) error {
+	if err := e.login(ctx); err != nil {
+		return fmt.Errorf("login failed: %w", err)
+	}
+
+	interval := time.Duration(e.config.PollInterval) * time.Second
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	fmt.Fprintf(os.Stderr, "tlon adapter started, ship=%s, url=%s\n", e.shipName, e.baseURL)
+
+	for {
+		if err := e.pollOnce(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "tlon poll error: %v\n", err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (e *TlonExtension) login(ctx context.Context) error {
+	body := strings.NewReader("password=" + e.config.ShipCode)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.baseURL+"/~/login", body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("login failed: %s", resp.Status)
+	}
+
+	fmt.Fprintf(os.Stderr, "tlon logged in to %s\n", e.shipName)
+	return nil
+}
+
+func (e *TlonExtension) pollOnce(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.baseURL+"/~/scry/channel.json", nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("scry failed: %s: %s", resp.Status, string(body))
+	}
+
+	var channels []struct {
+		ID       string `json:"id"`
+		Path     string `json:"path"`
+		Messages []struct {
+			ID      string `json:"id"`
+			Author  string `json:"author"`
+			Content string `json:"content"`
+			Time    int64  `json:"time"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &channels); err != nil {
+		return err
+	}
+
+	for _, ch := range channels {
+		for _, msg := range ch.Messages {
+			if e.seenMsgs[msg.ID] {
+				continue
+			}
+			e.seenMsgs[msg.ID] = true
+
+			text := strings.TrimSpace(msg.Content)
+			if text == "" {
+				continue
+			}
+
+			input := map[string]any{
+				"action":  "message",
+				"channel": "tlon",
+				"chat_id": ch.Path,
+				"text":    text,
+				"user_id": msg.Author,
+			}
+			data, _ := json.Marshal(input)
+			fmt.Println(string(data))
+
+			var response map[string]any
+			if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+				return fmt.Errorf("failed to read response: %w", err)
+			}
+
+			if reply, ok := response["text"].(string); ok && reply != "" {
+				if err := e.sendMessage(ctx, ch.Path, reply); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (e *TlonExtension) sendMessage(ctx context.Context, chatPath, text string) error {
+	payload := map[string]any{
+		"action": "poke",
+		"app":    "chat-hook",
+		"mark":   "json",
+		"body": map[string]any{
+			"path":    chatPath,
+			"content": text,
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.baseURL+"/~/channel/0", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("send message failed: %s: %s", resp.Status, string(respBody))
+	}
+
+	fmt.Fprintf(os.Stderr, "tlon message sent to %s\n", chatPath)
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewTlonExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/twitch/anyclaw.extension.json
+++ b/extensions/twitch/anyclaw.extension.json
@@ -1,0 +1,34 @@
+{
+  "id": "twitch",
+  "name": "Twitch Channel",
+  "version": "1.0.0",
+  "description": "Twitch chat messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["twitch"],
+  "entrypoint": "twitch_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "channel": {
+        "type": "string",
+        "description": "Twitch channel name to monitor"
+      },
+      "oauth_token": {
+        "type": "string",
+        "description": "Twitch IRC OAuth token",
+        "sensitive": true
+      },
+      "client_id": {
+        "type": "string",
+        "description": "Twitch API client ID"
+      },
+      "client_secret": {
+        "type": "string",
+        "description": "Twitch API client secret",
+        "sensitive": true
+      }
+    },
+    "required": ["channel", "oauth_token"]
+  }
+}

--- a/extensions/twitch/twitch_adapter.go
+++ b/extensions/twitch/twitch_adapter.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	Channel      string `json:"channel"`
+	OAuthToken   string `json:"oauth_token"`
+	ClientID     string `json:"client_id,omitempty"`
+	ClientSecret string `json:"client_secret,omitempty"`
+}
+
+type TwitchAdapter struct {
+	config Config
+	conn   net.Conn
+	reader *bufio.Reader
+}
+
+func NewTwitchAdapter(cfg Config) *TwitchAdapter {
+	return &TwitchAdapter{config: cfg}
+}
+
+func (a *TwitchAdapter) connect(ctx context.Context) error {
+	dialer := net.Dialer{Timeout: 15 * time.Second}
+	conn, err := dialer.DialContext(ctx, "tcp", "irc.chat.twitch.tv:6667")
+	if err != nil {
+		return fmt.Errorf("failed to connect to twitch irc: %w", err)
+	}
+	a.conn = conn
+	a.reader = bufio.NewReader(conn)
+	return nil
+}
+
+func (a *TwitchAdapter) sendLine(line string) error {
+	_, err := fmt.Fprint(a.conn, line+"\r\n")
+	return err
+}
+
+func (a *TwitchAdapter) authenticate() error {
+	token := a.config.OAuthToken
+	if !strings.HasPrefix(token, "oauth:") {
+		token = "oauth:" + token
+	}
+	if err := a.sendLine("PASS " + token); err != nil {
+		return err
+	}
+	nick := strings.ToLower(a.config.Channel)
+	if err := a.sendLine("NICK " + nick); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *TwitchAdapter) joinChannel() error {
+	channel := strings.ToLower(a.config.Channel)
+	if !strings.HasPrefix(channel, "#") {
+		channel = "#" + channel
+	}
+	return a.sendLine("JOIN " + channel)
+}
+
+var privmsgRegex = regexp.MustCompile(`^:(\w+)!\w+@\w+\.tmi\.twitch\.tv PRIVMSG #(\w+) :(.+)$`)
+var tagsRegex = regexp.MustCompile(`^@(.+) :(\w+)!\w+@\w+\.tmi\.twitch\.tv PRIVMSG #(\w+) :(.+)$`)
+
+func parseMessage(line string) (displayName, username, channel, text string, ok bool) {
+	if matches := tagsRegex.FindStringSubmatch(line); matches != nil {
+		tags := matches[1]
+		username = strings.ToLower(matches[2])
+		channel = matches[3]
+		text = matches[4]
+
+		displayName = username
+		if dm := regexp.MustCompile(`display-name=([^;]*)`).FindStringSubmatch(tags); dm != nil {
+			if dm[1] != "" {
+				displayName = dm[1]
+			}
+		}
+		return displayName, username, channel, text, true
+	}
+
+	if matches := privmsgRegex.FindStringSubmatch(line); matches != nil {
+		username = strings.ToLower(matches[1])
+		channel = matches[2]
+		text = matches[3]
+		return username, username, channel, text, true
+	}
+
+	return "", "", "", "", false
+}
+
+func (a *TwitchAdapter) handlePing(line string) bool {
+	if strings.HasPrefix(line, "PING") {
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) == 2 {
+			a.sendLine("PONG " + parts[1])
+		} else {
+			a.sendLine("PONG")
+		}
+		return true
+	}
+	return false
+}
+
+func (a *TwitchAdapter) sendMessage(channel, text string) error {
+	channelName := channel
+	if strings.HasPrefix(channelName, "#") {
+		channelName = channelName[1:]
+	}
+	lines := strings.Split(text, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if err := a.sendLine("PRIVMSG #" + strings.ToLower(channelName) + " :" + line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *TwitchAdapter) Run(ctx context.Context) error {
+	if err := a.connect(ctx); err != nil {
+		return err
+	}
+	defer a.conn.Close()
+
+	if err := a.authenticate(); err != nil {
+		return err
+	}
+
+	if err := a.joinChannel(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "twitch: connected and joined #%s\n", a.config.Channel)
+
+	go func() {
+		<-ctx.Done()
+		a.conn.Close()
+	}()
+
+	scanner := bufio.NewScanner(a.reader)
+	scanner.Buffer(make([]byte, 4096), 65536)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		line = strings.TrimSuffix(line, "\r")
+
+		if line == "" {
+			continue
+		}
+
+		if a.handlePing(line) {
+			continue
+		}
+
+		displayName, username, channel, text, ok := parseMessage(line)
+		if !ok {
+			continue
+		}
+
+		input := map[string]any{
+			"action":       "message",
+			"channel":      "twitch",
+			"chat_id":      channel,
+			"text":         text,
+			"user_id":      username,
+			"display_name": displayName,
+		}
+		data, err := json.Marshal(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "twitch: marshal error: %v\n", err)
+			continue
+		}
+		fmt.Println(string(data))
+
+		var response map[string]any
+		if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+			fmt.Fprintf(os.Stderr, "twitch: read response error: %v\n", err)
+			continue
+		}
+
+		if reply, ok := response["text"].(string); ok && reply != "" {
+			if err := a.sendMessage(channel, reply); err != nil {
+				fmt.Fprintf(os.Stderr, "twitch: send reply error: %v\n", err)
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("twitch: scanner error: %w", err)
+	}
+
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	if cfg.Channel == "" || cfg.OAuthToken == "" {
+		fmt.Fprintln(os.Stderr, "channel and oauth_token are required")
+		os.Exit(1)
+	}
+
+	adapter := NewTwitchAdapter(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := adapter.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/wechat/anyclaw.extension.json
+++ b/extensions/wechat/anyclaw.extension.json
@@ -1,0 +1,35 @@
+{
+  "id": "wechat",
+  "name": "WeChat Channel",
+  "version": "1.0.0",
+  "description": "WeChat messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["wechat"],
+  "entrypoint": "wechat_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "app_id": {
+        "type": "string",
+        "description": "WeChat App ID"
+      },
+      "app_secret": {
+        "type": "string",
+        "description": "WeChat App Secret",
+        "sensitive": true
+      },
+      "token": {
+        "type": "string",
+        "description": "WeChat webhook token",
+        "sensitive": true
+      },
+      "encoding_aes_key": {
+        "type": "string",
+        "description": "WeChat message encoding AES key",
+        "sensitive": true
+      }
+    },
+    "required": ["app_id", "app_secret"]
+  }
+}

--- a/extensions/wechat/anyclaw.extension.json
+++ b/extensions/wechat/anyclaw.extension.json
@@ -30,6 +30,6 @@
         "sensitive": true
       }
     },
-    "required": ["app_id", "app_secret"]
+    "required": ["app_id", "app_secret", "token"]
   }
 }

--- a/extensions/wechat/wechat_adapter.go
+++ b/extensions/wechat/wechat_adapter.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/sha1"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -78,7 +79,7 @@ func (e *WeChatExtension) handleWebhook(w http.ResponseWriter, r *http.Request) 
 	nonce := query.Get("nonce")
 	echoStr := query.Get("echostr")
 
-	if echoStr != "" {
+	if r.Method == http.MethodGet && echoStr != "" {
 		if e.verifySignature(signature, timestamp, nonce) {
 			w.Write([]byte(echoStr))
 		} else {
@@ -89,6 +90,10 @@ func (e *WeChatExtension) handleWebhook(w http.ResponseWriter, r *http.Request) 
 
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !e.verifySignature(signature, timestamp, nonce) {
+		http.Error(w, "invalid signature", http.StatusForbidden)
 		return
 	}
 
@@ -209,15 +214,18 @@ func (e *WeChatExtension) parseXMLMessage(xml string) *wechatMessage {
 }
 
 func (e *WeChatExtension) verifySignature(signature, timestamp, nonce string) bool {
-	if e.config.Token == "" {
-		return true
+	if strings.TrimSpace(e.config.Token) == "" ||
+		strings.TrimSpace(signature) == "" ||
+		strings.TrimSpace(timestamp) == "" ||
+		strings.TrimSpace(nonce) == "" {
+		return false
 	}
 	arr := []string{e.config.Token, timestamp, nonce}
 	sort.Strings(arr)
 	combined := strings.Join(arr, "")
 	h := sha1.Sum([]byte(combined))
 	computed := fmt.Sprintf("%x", h)
-	return computed == signature
+	return subtle.ConstantTimeCompare([]byte(computed), []byte(signature)) == 1
 }
 
 func (e *WeChatExtension) getAccessToken() (string, error) {

--- a/extensions/wechat/wechat_adapter.go
+++ b/extensions/wechat/wechat_adapter.go
@@ -1,0 +1,348 @@
+package main
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type Config struct {
+	AppID          string `json:"app_id"`
+	AppSecret      string `json:"app_secret"`
+	Token          string `json:"token,omitempty"`
+	EncodingAESKey string `json:"encoding_aes_key,omitempty"`
+	Port           int    `json:"port"`
+}
+
+type WeChatExtension struct {
+	config      Config
+	client      *http.Client
+	accessToken string
+	tokenMu     sync.RWMutex
+	tokenExpire time.Time
+}
+
+func NewWeChatExtension(cfg Config) *WeChatExtension {
+	if cfg.Port <= 0 {
+		cfg.Port = 8080
+	}
+	return &WeChatExtension{
+		config: cfg,
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (e *WeChatExtension) Run(ctx context.Context) error {
+	go e.refreshTokenLoop(ctx)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/wechat", e.handleWebhook)
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", e.config.Port),
+		Handler: mux,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		fmt.Fprintf(os.Stderr, "wechat webhook listening on :%d\n", e.config.Port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (e *WeChatExtension) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	signature := query.Get("signature")
+	timestamp := query.Get("timestamp")
+	nonce := query.Get("nonce")
+	echoStr := query.Get("echostr")
+
+	if echoStr != "" {
+		if e.verifySignature(signature, timestamp, nonce) {
+			w.Write([]byte(echoStr))
+		} else {
+			http.Error(w, "invalid signature", http.StatusForbidden)
+		}
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	msg := e.parseMessage(body)
+	if msg == nil {
+		w.Write([]byte("success"))
+		return
+	}
+
+	if msg.MsgType != "text" || msg.Content == "" {
+		w.Write([]byte("success"))
+		return
+	}
+
+	input := map[string]any{
+		"action":   "message",
+		"channel":  "wechat",
+		"chat_id":  msg.FromUserName,
+		"text":     msg.Content,
+		"user_id":  msg.FromUserName,
+		"msg_id":   msg.MsgID,
+		"msg_type": msg.MsgType,
+	}
+	data, _ := json.Marshal(input)
+	fmt.Println(string(data))
+
+	var response map[string]any
+	if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read response: %v\n", err)
+		w.Write([]byte("success"))
+		return
+	}
+
+	if reply, ok := response["text"].(string); ok && reply != "" {
+		if err := e.sendTextMessage(msg.FromUserName, reply); err != nil {
+			fmt.Fprintf(os.Stderr, "wechat send message error: %v\n", err)
+		}
+	}
+
+	w.Write([]byte("success"))
+}
+
+type wechatMessage struct {
+	ToUserName   string `json:"ToUserName"`
+	FromUserName string `json:"FromUserName"`
+	CreateTime   int64  `json:"CreateTime"`
+	MsgType      string `json:"MsgType"`
+	Content      string `json:"Content"`
+	MsgID        string `json:"MsgId"`
+}
+
+func (e *WeChatExtension) parseMessage(body []byte) *wechatMessage {
+	contentType := ""
+	if strings.Contains(string(body), "<xml>") {
+		contentType = "xml"
+	} else {
+		contentType = "json"
+	}
+
+	if contentType == "json" {
+		var msg wechatMessage
+		if err := json.Unmarshal(body, &msg); err != nil {
+			return nil
+		}
+		return &msg
+	}
+
+	return e.parseXMLMessage(string(body))
+}
+
+func (e *WeChatExtension) parseXMLMessage(xml string) *wechatMessage {
+	msg := &wechatMessage{}
+
+	fields := map[string]*string{
+		"ToUserName":   &msg.ToUserName,
+		"FromUserName": &msg.FromUserName,
+		"MsgType":      &msg.MsgType,
+		"Content":      &msg.Content,
+		"MsgId":        &msg.MsgID,
+	}
+
+	for tag, ptr := range fields {
+		open := "<" + tag + ">"
+		close := "</" + tag + ">"
+		start := strings.Index(xml, open)
+		if start == -1 {
+			continue
+		}
+		start += len(open)
+		end := strings.Index(xml[start:], close)
+		if end == -1 {
+			continue
+		}
+		*ptr = xml[start : start+end]
+	}
+
+	if msg.CreateTime == 0 {
+		open := "<CreateTime>"
+		close := "</CreateTime>"
+		start := strings.Index(xml, open)
+		if start != -1 {
+			start += len(open)
+			end := strings.Index(xml[start:], close)
+			if end != -1 {
+				fmt.Sscanf(xml[start:start+end], "%d", &msg.CreateTime)
+			}
+		}
+	}
+
+	return msg
+}
+
+func (e *WeChatExtension) verifySignature(signature, timestamp, nonce string) bool {
+	if e.config.Token == "" {
+		return true
+	}
+	arr := []string{e.config.Token, timestamp, nonce}
+	sort.Strings(arr)
+	combined := strings.Join(arr, "")
+	h := sha1.Sum([]byte(combined))
+	computed := fmt.Sprintf("%x", h)
+	return computed == signature
+}
+
+func (e *WeChatExtension) getAccessToken() (string, error) {
+	e.tokenMu.RLock()
+	if e.accessToken != "" && time.Now().Before(e.tokenExpire) {
+		token := e.accessToken
+		e.tokenMu.RUnlock()
+		return token, nil
+	}
+	e.tokenMu.RUnlock()
+
+	e.tokenMu.Lock()
+	defer e.tokenMu.Unlock()
+
+	if e.accessToken != "" && time.Now().Before(e.tokenExpire) {
+		return e.accessToken, nil
+	}
+
+	u := fmt.Sprintf("https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid=%s&secret=%s",
+		e.config.AppID, e.config.AppSecret)
+
+	resp, err := e.client.Get(u)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		ErrCode     int    `json:"errcode"`
+		ErrMsg      string `json:"errmsg"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	if result.ErrCode != 0 {
+		return "", fmt.Errorf("wechat token error: %d %s", result.ErrCode, result.ErrMsg)
+	}
+
+	e.accessToken = result.AccessToken
+	e.tokenExpire = time.Now().Add(time.Duration(result.ExpiresIn-300) * time.Second)
+	return e.accessToken, nil
+}
+
+func (e *WeChatExtension) refreshTokenLoop(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Minute)
+	defer ticker.Stop()
+
+	e.getAccessToken()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			e.getAccessToken()
+		}
+	}
+}
+
+func (e *WeChatExtension) sendTextMessage(openID, text string) error {
+	token, err := e.getAccessToken()
+	if err != nil {
+		return err
+	}
+
+	u := fmt.Sprintf("https://api.weixin.qq.com/cgi-bin/message/custom/send?access_token=%s", token)
+
+	payload := map[string]any{
+		"touser":  openID,
+		"msgtype": "text",
+		"text": map[string]string{
+			"content": text,
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	resp, err := e.client.Post(u, "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		ErrCode int    `json:"errcode"`
+		ErrMsg  string `json:"errmsg"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+
+	if result.ErrCode != 0 {
+		return fmt.Errorf("wechat send error: %d %s", result.ErrCode, result.ErrMsg)
+	}
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewWeChatExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/wechat/wechat_adapter.go
+++ b/extensions/wechat/wechat_adapter.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1"
 	"crypto/subtle"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
@@ -144,12 +145,12 @@ func (e *WeChatExtension) handleWebhook(w http.ResponseWriter, r *http.Request) 
 }
 
 type wechatMessage struct {
-	ToUserName   string `json:"ToUserName"`
-	FromUserName string `json:"FromUserName"`
-	CreateTime   int64  `json:"CreateTime"`
-	MsgType      string `json:"MsgType"`
-	Content      string `json:"Content"`
-	MsgID        string `json:"MsgId"`
+	ToUserName   string `json:"ToUserName" xml:"ToUserName"`
+	FromUserName string `json:"FromUserName" xml:"FromUserName"`
+	CreateTime   int64  `json:"CreateTime" xml:"CreateTime"`
+	MsgType      string `json:"MsgType" xml:"MsgType"`
+	Content      string `json:"Content" xml:"Content"`
+	MsgID        string `json:"MsgId" xml:"MsgId"`
 }
 
 func (e *WeChatExtension) parseMessage(body []byte) *wechatMessage {
@@ -171,46 +172,12 @@ func (e *WeChatExtension) parseMessage(body []byte) *wechatMessage {
 	return e.parseXMLMessage(string(body))
 }
 
-func (e *WeChatExtension) parseXMLMessage(xml string) *wechatMessage {
-	msg := &wechatMessage{}
-
-	fields := map[string]*string{
-		"ToUserName":   &msg.ToUserName,
-		"FromUserName": &msg.FromUserName,
-		"MsgType":      &msg.MsgType,
-		"Content":      &msg.Content,
-		"MsgId":        &msg.MsgID,
+func (e *WeChatExtension) parseXMLMessage(rawXML string) *wechatMessage {
+	var msg wechatMessage
+	if err := xml.Unmarshal([]byte(rawXML), &msg); err != nil {
+		return nil
 	}
-
-	for tag, ptr := range fields {
-		open := "<" + tag + ">"
-		close := "</" + tag + ">"
-		start := strings.Index(xml, open)
-		if start == -1 {
-			continue
-		}
-		start += len(open)
-		end := strings.Index(xml[start:], close)
-		if end == -1 {
-			continue
-		}
-		*ptr = xml[start : start+end]
-	}
-
-	if msg.CreateTime == 0 {
-		open := "<CreateTime>"
-		close := "</CreateTime>"
-		start := strings.Index(xml, open)
-		if start != -1 {
-			start += len(open)
-			end := strings.Index(xml[start:], close)
-			if end != -1 {
-				fmt.Sscanf(xml[start:start+end], "%d", &msg.CreateTime)
-			}
-		}
-	}
-
-	return msg
+	return &msg
 }
 
 func (e *WeChatExtension) verifySignature(signature, timestamp, nonce string) bool {

--- a/extensions/wechat/wechat_adapter_test.go
+++ b/extensions/wechat/wechat_adapter_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestHandleWebhookRejectsUnsignedPost(t *testing.T) {
+	ext := NewWeChatExtension(Config{Token: "secret"})
+	req := httptest.NewRequest(http.MethodPost, "/wechat", strings.NewReader(`<xml></xml>`))
+	rec := httptest.NewRecorder()
+
+	ext.handleWebhook(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected unsigned POST to be forbidden, got %d", rec.Code)
+	}
+}
+
+func TestHandleWebhookAcceptsSignedPost(t *testing.T) {
+	token := "secret"
+	timestamp := "1710000000"
+	nonce := "nonce"
+	signature := wechatTestSignature(token, timestamp, nonce)
+	ext := NewWeChatExtension(Config{Token: token})
+	req := httptest.NewRequest(
+		http.MethodPost,
+		fmt.Sprintf("/wechat?signature=%s&timestamp=%s&nonce=%s", signature, timestamp, nonce),
+		strings.NewReader(`<xml><MsgType>image</MsgType></xml>`),
+	)
+	rec := httptest.NewRecorder()
+
+	ext.handleWebhook(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected signed POST to be accepted, got %d", rec.Code)
+	}
+	if strings.TrimSpace(rec.Body.String()) != "success" {
+		t.Fatalf("expected success response, got %q", rec.Body.String())
+	}
+}
+
+func wechatTestSignature(token, timestamp, nonce string) string {
+	parts := []string{token, timestamp, nonce}
+	sort.Strings(parts)
+	sum := sha1.Sum([]byte(strings.Join(parts, "")))
+	return fmt.Sprintf("%x", sum)
+}

--- a/extensions/wechat/wechat_adapter_test.go
+++ b/extensions/wechat/wechat_adapter_test.go
@@ -45,6 +45,32 @@ func TestHandleWebhookAcceptsSignedPost(t *testing.T) {
 	}
 }
 
+func TestParseXMLMessageStripsCDATA(t *testing.T) {
+	ext := NewWeChatExtension(Config{})
+
+	msg := ext.parseXMLMessage(`<xml>
+<ToUserName><![CDATA[to-user]]></ToUserName>
+<FromUserName><![CDATA[from-user]]></FromUserName>
+<CreateTime>1710000000</CreateTime>
+<MsgType><![CDATA[text]]></MsgType>
+<Content><![CDATA[hello <world> & friends]]></Content>
+<MsgId>12345</MsgId>
+</xml>`)
+
+	if msg == nil {
+		t.Fatal("expected parsed WeChat message")
+	}
+	if msg.FromUserName != "from-user" {
+		t.Fatalf("expected FromUserName without CDATA, got %q", msg.FromUserName)
+	}
+	if msg.Content != "hello <world> & friends" {
+		t.Fatalf("expected Content without CDATA, got %q", msg.Content)
+	}
+	if msg.MsgType != "text" || msg.MsgID != "12345" || msg.CreateTime != 1710000000 {
+		t.Fatalf("unexpected parsed message: %#v", msg)
+	}
+}
+
 func wechatTestSignature(token, timestamp, nonce string) string {
 	parts := []string{token, timestamp, nonce}
 	sort.Strings(parts)

--- a/extensions/whatsapp/anyclaw.extension.json
+++ b/extensions/whatsapp/anyclaw.extension.json
@@ -5,7 +5,6 @@
   "description": "WhatsApp messaging channel adapter for AnyClaw",
   "kind": "channel",
   "channels": ["whatsapp"],
-  "entrypoint": "whatsapp_adapter.go",
   "permissions": ["net:out"],
   "config_schema": {
     "type": "object",

--- a/extensions/whatsapp/anyclaw.extension.json
+++ b/extensions/whatsapp/anyclaw.extension.json
@@ -1,0 +1,35 @@
+{
+  "id": "whatsapp",
+  "name": "WhatsApp Channel",
+  "version": "1.0.0",
+  "description": "WhatsApp messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["whatsapp"],
+  "entrypoint": "whatsapp_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "access_token": {
+        "type": "string",
+        "description": "WhatsApp Cloud API access token",
+        "sensitive": true
+      },
+      "phone_number_id": {
+        "type": "string",
+        "description": "WhatsApp phone number ID"
+      },
+      "verify_token": {
+        "type": "string",
+        "description": "Webhook verification token",
+        "sensitive": true
+      },
+      "app_secret": {
+        "type": "string",
+        "description": "Facebook app secret for webhook validation",
+        "sensitive": true
+      }
+    },
+    "required": ["access_token", "phone_number_id"]
+  }
+}

--- a/extensions/zalo/anyclaw.extension.json
+++ b/extensions/zalo/anyclaw.extension.json
@@ -1,0 +1,34 @@
+{
+  "id": "zalo",
+  "name": "Zalo Channel",
+  "version": "1.0.0",
+  "description": "Zalo messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["zalo"],
+  "entrypoint": "zalo_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "app_id": {
+        "type": "string",
+        "description": "Zalo Official Account App ID"
+      },
+      "secret_key": {
+        "type": "string",
+        "description": "Zalo Official Account Secret Key",
+        "sensitive": true
+      },
+      "oa_id": {
+        "type": "string",
+        "description": "Zalo Official Account ID"
+      },
+      "webhook_token": {
+        "type": "string",
+        "description": "Webhook verification token",
+        "sensitive": true
+      }
+    },
+    "required": ["app_id", "secret_key", "oa_id"]
+  }
+}

--- a/extensions/zalo/anyclaw.extension.json
+++ b/extensions/zalo/anyclaw.extension.json
@@ -29,6 +29,6 @@
         "sensitive": true
       }
     },
-    "required": ["app_id", "secret_key", "oa_id"]
+    "required": ["app_id", "secret_key", "oa_id", "webhook_token"]
   }
 }

--- a/extensions/zalo/zalo_adapter.go
+++ b/extensions/zalo/zalo_adapter.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type Config struct {
+	AppID        string `json:"app_id"`
+	SecretKey    string `json:"secret_key"`
+	OaID         string `json:"oa_id"`
+	WebhookToken string `json:"webhook_token,omitempty"`
+	Port         int    `json:"port"`
+}
+
+type ZaloExtension struct {
+	config      Config
+	client      *http.Client
+	accessToken string
+	tokenMu     sync.RWMutex
+	tokenExpire time.Time
+}
+
+func NewZaloExtension(cfg Config) *ZaloExtension {
+	if cfg.Port <= 0 {
+		cfg.Port = 8080
+	}
+	return &ZaloExtension{
+		config: cfg,
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (e *ZaloExtension) Run(ctx context.Context) error {
+	go e.refreshTokenLoop(ctx)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/zalo", e.handleWebhook)
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", e.config.Port),
+		Handler: mux,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		fmt.Fprintf(os.Stderr, "zalo webhook listening on :%d\n", e.config.Port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (e *ZaloExtension) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		e.handleVerification(w, r)
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var rawEvent map[string]any
+	if err := json.Unmarshal(body, &rawEvent); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	if e.config.WebhookToken != "" {
+		if !e.verifyWebhookSignature(rawEvent, r) {
+			http.Error(w, "invalid signature", http.StatusForbidden)
+			return
+		}
+	}
+
+	eventType, _ := rawEvent["event"].(string)
+	if eventType != "user_send_msg" {
+		w.Write([]byte("success"))
+		return
+	}
+
+	message, _ := rawEvent["message"].(map[string]any)
+	if message == nil {
+		w.Write([]byte("success"))
+		return
+	}
+
+	msgType, _ := message["msg_type"].(string)
+	if msgType != "text" {
+		w.Write([]byte("success"))
+		return
+	}
+
+	text, _ := message["text"].(string)
+	if text == "" {
+		w.Write([]byte("success"))
+		return
+	}
+
+	sender, _ := rawEvent["sender"].(map[string]any)
+	senderID, _ := sender["id"].(string)
+	if senderID == "" {
+		if fromUser, ok := rawEvent["from_user"].(map[string]any); ok {
+			senderID, _ = fromUser["id"].(string)
+		}
+	}
+	if senderID == "" {
+		senderID, _ = rawEvent["user_id"].(string)
+	}
+
+	chatID := senderID
+	if chatID == "" {
+		chatID, _ = rawEvent["conversation_id"].(string)
+	}
+
+	input := map[string]any{
+		"action":   "message",
+		"channel":  "zalo",
+		"chat_id":  chatID,
+		"text":     text,
+		"user_id":  senderID,
+		"msg_type": msgType,
+	}
+	data, _ := json.Marshal(input)
+	fmt.Println(string(data))
+
+	var response map[string]any
+	if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read response: %v\n", err)
+		w.Write([]byte("success"))
+		return
+	}
+
+	if reply, ok := response["text"].(string); ok && reply != "" {
+		if err := e.sendTextMessage(senderID, reply); err != nil {
+			fmt.Fprintf(os.Stderr, "zalo send message error: %v\n", err)
+		}
+	}
+
+	w.Write([]byte("success"))
+}
+
+func (e *ZaloExtension) handleVerification(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	verifyToken := query.Get("verify_token")
+	echoStr := query.Get("echostr")
+
+	if e.config.WebhookToken != "" && verifyToken != e.config.WebhookToken {
+		http.Error(w, "invalid verify_token", http.StatusForbidden)
+		return
+	}
+
+	if echoStr != "" {
+		w.Write([]byte(echoStr))
+		return
+	}
+
+	w.Write([]byte("verified"))
+}
+
+func (e *ZaloExtension) verifyWebhookSignature(rawEvent map[string]any, r *http.Request) bool {
+	query := r.URL.Query()
+	sig := query.Get("sig")
+	if sig == "" {
+		return true
+	}
+
+	timestamp := query.Get("timestamp")
+	body, _ := json.Marshal(rawEvent)
+
+	h := sha256.New()
+	h.Write([]byte(timestamp + e.config.WebhookToken + string(body)))
+	computed := fmt.Sprintf("%x", h.Sum(nil))
+
+	return strings.EqualFold(computed, sig)
+}
+
+func (e *ZaloExtension) getAccessToken() (string, error) {
+	e.tokenMu.RLock()
+	if e.accessToken != "" && time.Now().Before(e.tokenExpire) {
+		token := e.accessToken
+		e.tokenMu.RUnlock()
+		return token, nil
+	}
+	e.tokenMu.RUnlock()
+
+	e.tokenMu.Lock()
+	defer e.tokenMu.Unlock()
+
+	if e.accessToken != "" && time.Now().Before(e.tokenExpire) {
+		return e.accessToken, nil
+	}
+
+	u := "https://oauth.zalo.me/v4/oa/access_token"
+	payload := map[string]string{
+		"app_id":     e.config.AppID,
+		"secret_key": e.config.SecretKey,
+		"grant_type": "client_credentials",
+	}
+	body, _ := json.Marshal(payload)
+
+	resp, err := e.client.Post(u, "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		ErrCode     int    `json:"error"`
+		ErrMsg      string `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	if result.ErrCode != 0 {
+		return "", fmt.Errorf("zalo token error: %d %s", result.ErrCode, result.ErrMsg)
+	}
+
+	e.accessToken = result.AccessToken
+	e.tokenExpire = time.Now().Add(time.Duration(result.ExpiresIn-300) * time.Second)
+	return e.accessToken, nil
+}
+
+func (e *ZaloExtension) refreshTokenLoop(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Minute)
+	defer ticker.Stop()
+
+	e.getAccessToken()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			e.getAccessToken()
+		}
+	}
+}
+
+func (e *ZaloExtension) sendTextMessage(userID, text string) error {
+	token, err := e.getAccessToken()
+	if err != nil {
+		return err
+	}
+
+	u := fmt.Sprintf("https://openapi.zalo.me/v2.0/oa/message?access_token=%s", token)
+
+	payload := map[string]any{
+		"recipient": map[string]string{
+			"user_id": userID,
+		},
+		"message": map[string]any{
+			"text": text,
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequest(http.MethodPost, u, strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		ErrCode int    `json:"error"`
+		ErrMsg  string `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+
+	if result.ErrCode != 0 {
+		return fmt.Errorf("zalo send error: %d %s", result.ErrCode, result.ErrMsg)
+	}
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewZaloExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/extensions/zalo/zalo_adapter.go
+++ b/extensions/zalo/zalo_adapter.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -189,18 +190,18 @@ func (e *ZaloExtension) handleVerification(w http.ResponseWriter, r *http.Reques
 func (e *ZaloExtension) verifyWebhookSignature(rawEvent map[string]any, r *http.Request) bool {
 	query := r.URL.Query()
 	sig := query.Get("sig")
-	if sig == "" {
-		return true
+	timestamp := query.Get("timestamp")
+	if strings.TrimSpace(sig) == "" || strings.TrimSpace(timestamp) == "" || strings.TrimSpace(e.config.WebhookToken) == "" {
+		return false
 	}
 
-	timestamp := query.Get("timestamp")
 	body, _ := json.Marshal(rawEvent)
 
 	h := sha256.New()
 	h.Write([]byte(timestamp + e.config.WebhookToken + string(body)))
 	computed := fmt.Sprintf("%x", h.Sum(nil))
 
-	return strings.EqualFold(computed, sig)
+	return subtle.ConstantTimeCompare([]byte(strings.ToLower(computed)), []byte(strings.ToLower(sig))) == 1
 }
 
 func (e *ZaloExtension) getAccessToken() (string, error) {

--- a/extensions/zalo/zalo_adapter_test.go
+++ b/extensions/zalo/zalo_adapter_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestVerifyWebhookSignatureRejectsMissingSignature(t *testing.T) {
+	ext := NewZaloExtension(Config{WebhookToken: "secret"})
+	req := httptest.NewRequest(http.MethodPost, "/zalo?timestamp=1710000000", nil)
+
+	if ext.verifyWebhookSignature(map[string]any{"event": "user_send_msg"}, req) {
+		t.Fatal("expected missing signature to be rejected")
+	}
+}
+
+func TestVerifyWebhookSignatureAcceptsValidSignature(t *testing.T) {
+	token := "secret"
+	timestamp := "1710000000"
+	event := map[string]any{"event": "user_send_msg"}
+	signature := zaloTestSignature(token, timestamp, event)
+	ext := NewZaloExtension(Config{WebhookToken: token})
+	req := httptest.NewRequest(
+		http.MethodPost,
+		fmt.Sprintf("/zalo?timestamp=%s&sig=%s", timestamp, signature),
+		nil,
+	)
+
+	if !ext.verifyWebhookSignature(event, req) {
+		t.Fatal("expected valid signature to be accepted")
+	}
+}
+
+func TestHandleWebhookRejectsUnsignedPostWhenTokenConfigured(t *testing.T) {
+	ext := NewZaloExtension(Config{WebhookToken: "secret"})
+	req := httptest.NewRequest(http.MethodPost, "/zalo?timestamp=1710000000", strings.NewReader(`{"event":"user_send_msg"}`))
+	rec := httptest.NewRecorder()
+
+	ext.handleWebhook(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected unsigned POST to be forbidden, got %d", rec.Code)
+	}
+}
+
+func zaloTestSignature(token, timestamp string, event map[string]any) string {
+	body, _ := json.Marshal(event)
+	sum := sha256.Sum256([]byte(timestamp + token + string(body)))
+	return fmt.Sprintf("%x", sum)
+}

--- a/extensions/zalouser/anyclaw.extension.json
+++ b/extensions/zalouser/anyclaw.extension.json
@@ -1,0 +1,30 @@
+{
+  "id": "zalouser",
+  "name": "Zalo Personal Channel",
+  "version": "1.0.0",
+  "description": "Zalo personal account messaging channel adapter for AnyClaw",
+  "kind": "channel",
+  "channels": ["zalouser"],
+  "entrypoint": "zalouser_adapter.go",
+  "permissions": ["net:out"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "cookie": {
+        "type": "string",
+        "description": "Zalo web session cookie",
+        "sensitive": true
+      },
+      "imei": {
+        "type": "string",
+        "description": "Device IMEI for Zalo API"
+      },
+      "poll_interval": {
+        "type": "integer",
+        "description": "Poll interval in seconds",
+        "default": 10
+      }
+    },
+    "required": ["cookie", "imei"]
+  }
+}

--- a/extensions/zalouser/zalouser_adapter.go
+++ b/extensions/zalouser/zalouser_adapter.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Config holds the Zalo personal account configuration.
+type Config struct {
+	Cookie       string `json:"cookie"`
+	IMEI         string `json:"imei"`
+	PollInterval int    `json:"poll_interval"`
+}
+
+// ZaloExtension implements a polling-based adapter for Zalo personal accounts.
+// NOTE: Zalo's internal web API is undocumented. All endpoints below are
+// reverse-engineered placeholders and may break without notice.
+type ZaloExtension struct {
+	config  Config
+	client  *http.Client
+	baseURL string
+	// Last seen message timestamp to avoid duplicates.
+	lastTS int64
+}
+
+func NewZaloExtension(cfg Config) *ZaloExtension {
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 10
+	}
+	return &ZaloExtension{
+		config: cfg,
+		client: &http.Client{Timeout: 15 * time.Second},
+		// Placeholder base URL — the real Zalo web API lives behind
+		// https://tt-ml.zalo.me and similar internal endpoints.
+		baseURL: "https://tt-ml.zalo.me/api",
+	}
+}
+
+// Run starts the polling loop.
+func (e *ZaloExtension) Run(ctx context.Context) error {
+	interval := time.Duration(e.config.PollInterval) * time.Second
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// Initial poll
+	if err := e.pollOnce(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "zalouser poll error: %v\n", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := e.pollOnce(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "zalouser poll error: %v\n", err)
+			}
+		}
+	}
+}
+
+// pollOnce fetches new conversations/messages from Zalo.
+//
+// Placeholder API flow (reverse-engineered, not officially documented):
+//
+//	GET /api/message/getpoll?imei=<imei>
+//	Headers: Cookie: <session-cookie>
+//
+// Expected response (speculative):
+//
+//	{
+//	  "data": {
+//	    "conversations": [
+//	      {
+//	        "id": "12345",
+//	        "last_message": {
+//	          "text": "Hello",
+//	          "sender_id": "67890",
+//	          "sender_name": "Nguyen Van A",
+//	          "timestamp": 1700000000
+//	        }
+//	      }
+//	    ]
+//	  }
+//	}
+func (e *ZaloExtension) pollOnce(ctx context.Context) error {
+	// Build the poll URL with IMEI parameter.
+	// NOTE: The exact query parameter names and response shape are unknown.
+	u := fmt.Sprintf("%s/message/getpoll?imei=%s&t=%d",
+		e.baseURL, e.config.IMEI, time.Now().UnixMilli())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+
+	// Attach the session cookie for authentication.
+	req.Header.Set("Cookie", e.config.Cookie)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("zalouser poll returned %s: %s", resp.Status, string(body))
+	}
+
+	var payload struct {
+		Data struct {
+			Conversations []struct {
+				ID          string `json:"id"`
+				LastMessage struct {
+					Text       string `json:"text"`
+					SenderID   string `json:"sender_id"`
+					SenderName string `json:"sender_name"`
+					Timestamp  int64  `json:"timestamp"`
+				} `json:"last_message"`
+			} `json:"conversations"`
+		} `json:"data"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return err
+	}
+
+	for _, conv := range payload.Data.Conversations {
+		msg := conv.LastMessage
+		if msg.Text == "" {
+			continue
+		}
+		// Skip messages we have already seen.
+		if msg.Timestamp <= e.lastTS {
+			continue
+		}
+		e.lastTS = msg.Timestamp
+
+		// Emit message to AnyClaw core via stdout.
+		out := map[string]any{
+			"action":      "message",
+			"channel":     "zalouser",
+			"chat_id":     conv.ID,
+			"text":        msg.Text,
+			"user_id":     msg.SenderID,
+			"sender_name": msg.SenderName,
+		}
+		data, _ := json.Marshal(out)
+		fmt.Println(string(data))
+
+		// Read reply from AnyClaw core via stdin.
+		var response map[string]any
+		if err := json.NewDecoder(os.Stdin).Decode(&response); err != nil {
+			fmt.Fprintf(os.Stderr, "zalouser failed to read response: %v\n", err)
+			continue
+		}
+
+		if reply, ok := response["text"].(string); ok && reply != "" {
+			if err := e.sendMessage(ctx, conv.ID, reply); err != nil {
+				fmt.Fprintf(os.Stderr, "zalouser send error: %v\n", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// sendMessage delivers a text reply to a Zalo conversation.
+//
+// Placeholder API call (reverse-engineered, not officially documented):
+//
+//	POST /api/message/send
+//	Headers: Cookie: <session-cookie>, Content-Type: application/json
+//	Body: {"to_id": "<chat_id>", "message": "<text>", "imei": "<imei>"}
+func (e *ZaloExtension) sendMessage(ctx context.Context, chatID string, text string) error {
+	u := fmt.Sprintf("%s/message/send", e.baseURL)
+
+	payload := map[string]string{
+		"to_id":   chatID,
+		"message": text,
+		"imei":    e.config.IMEI,
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Cookie", e.config.Cookie)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("zalouser send failed: %s: %s", resp.Status, string(respBody))
+	}
+
+	return nil
+}
+
+func main() {
+	configJSON := os.Getenv("ANYCLAW_EXTENSION_CONFIG")
+	if configJSON == "" {
+		fmt.Fprintln(os.Stderr, "missing ANYCLAW_EXTENSION_CONFIG")
+		os.Exit(1)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ext := NewZaloExtension(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	if err := ext.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "extension error: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## 概要

补充一批 channel extension manifest 和 adapter 示例，为后续多渠道接入提供扩展目录基础。

## 本次变更

- 新增 BlueBubbles、Feishu、Google Chat、iMessage、Line、Matrix、Mattermost、MS Teams 等 channel extension
- 新增 Telegram、WeChat、Zalo、Twitch、Nostr、Nextcloud Talk 等 channel adapter 示例
- 新增对应 `anyclaw.extension.json`
- 只新增 `extensions/*` 文件，不修改现有 extension core

## 验证

已执行：

- `go test ./extensions/...`
- 校验所有 `extensions/**/anyclaw.extension.json` 可正常解析
- `git diff --cached --check`
