### PR TITLE
feat(extensions): add developer CLI adapters

### DIFF
--- a/pkg/extensions/adapters/cli/adapters/adguardhome/adguardhome.go
+++ b/pkg/extensions/adapters/cli/adapters/adguardhome/adguardhome.go
@@ -1,0 +1,136 @@
+package adguardhome
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+type Client struct {
+	baseURL  string
+	username string
+	password string
+	client   *http.Client
+}
+
+type Config struct {
+	BaseURL  string
+	Username string
+	Password string
+}
+
+func New(cfg Config) *Client {
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = os.Getenv("ADGUARD_URL")
+		if baseURL == "" {
+			baseURL = "http://localhost:3000"
+		}
+	}
+	return &Client{
+		baseURL:  baseURL,
+		username: cfg.Username,
+		password: cfg.Password,
+		client:   &http.Client{},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "status":
+		return c.status(ctx)
+	case "dns":
+		return c.dns(subArgs)
+	case "filters":
+		return c.filters(ctx)
+	case "stats":
+		return c.stats(ctx)
+	case "help":
+		return c.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (c *Client) status(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/status", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) dns(args []string) (string, error) {
+	if len(args) == 0 {
+		return "Available: enable, disable, config", nil
+	}
+
+	action := args[0]
+	switch action {
+	case "enable":
+		return "DNS enabled", nil
+	case "disable":
+		return "DNS disabled", nil
+	default:
+		return "", fmt.Errorf("unknown dns action: %s", action)
+	}
+}
+
+func (c *Client) filters(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/filters", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) stats(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/stats", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) help() (string, error) {
+	return `AdGuardHome CLI adapter (REST API)
+Commands:
+  status    - Get status
+  dns       - DNS control
+  filters   - List filters
+  stats     - Get statistics
+  help      - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/anygen/anygen.go
+++ b/pkg/extensions/adapters/cli/adapters/anygen/anygen.go
@@ -1,0 +1,152 @@
+package anygen
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+type Client struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+type Config struct {
+	APIKey string
+}
+
+func New(cfg Config) *Client {
+	apiKey := cfg.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ANYGEN_API_KEY")
+	}
+	return &Client{
+		apiKey:     apiKey,
+		baseURL:    "https://api.anygen.com/v1",
+		httpClient: &http.Client{Timeout: 5 * time.Minute},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "docs":
+		return c.docs(ctx, subArgs)
+	case "slides":
+		return c.slides(ctx, subArgs)
+	case "website":
+		return c.website(ctx, subArgs)
+	case "help":
+		return c.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (c *Client) docs(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("docs requires <topic> <output.md>")
+	}
+	topic := args[0]
+	output := args[1]
+
+	body := map[string]string{"topic": topic, "type": "docs"}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/generate", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	os.WriteFile(output, b, 0644)
+
+	return fmt.Sprintf("Generated docs: %s", output), nil
+}
+
+func (c *Client) slides(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("slides requires <topic> <output.pptx>")
+	}
+	topic := args[0]
+	output := args[1]
+
+	body := map[string]string{"topic": topic, "type": "slides"}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/generate", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	os.WriteFile(output, b, 0644)
+
+	return fmt.Sprintf("Generated slides: %s", output), nil
+}
+
+func (c *Client) website(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("website requires <topic> <output-dir>")
+	}
+	topic := args[0]
+	outputDir := args[1]
+
+	body := map[string]string{"topic": topic, "type": "website"}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/generate", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	os.MkdirAll(outputDir, 0755)
+	os.WriteFile(outputDir+"/index.html", b, 0644)
+
+	return fmt.Sprintf("Generated website: %s", outputDir), nil
+}
+
+func (c *Client) help() (string, error) {
+	return `AnyGen CLI adapter
+Commands:
+  docs <topic> <output.md>      - Generate docs
+  slides <topic> <output.pptx>   - Generate slides
+  website <topic> <output-dir>  - Generate website
+  help                          - Show this help
+Note: Requires ANYGEN_API_KEY`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/aws/aws.go
+++ b/pkg/extensions/adapters/cli/adapters/aws/aws.go
@@ -1,0 +1,206 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	awsPath string
+	region  string
+	profile string
+}
+
+type Config struct {
+	AWSPath string
+	Region  string
+	Profile string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.AWSPath
+	if path == "" {
+		path = "aws"
+	}
+	return &Client{
+		awsPath: path,
+		region:  cfg.Region,
+		profile: cfg.Profile,
+	}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"sts", "get-caller-identity"})
+	}
+
+	service := args[0]
+	switch service {
+	case "s3":
+		return c.s3(ctx, args[1:])
+	case "ec2":
+		return c.ec2(ctx, args[1:])
+	case "lambda":
+		return c.lambda(ctx, args[1:])
+	case "rds":
+		return c.rds(ctx, args[1:])
+	case "iam":
+		return c.iam(ctx, args[1:])
+	case "ecs":
+		return c.ecs(ctx, args[1:])
+	case "eks":
+		return c.eks(ctx, args[1:])
+	case "dynamodb":
+		return c.dynamodb(ctx, args[1:])
+	case "logs":
+		return c.logs(ctx, args[1:])
+	case "cloudwatch":
+		return c.cloudwatch(ctx, args[1:])
+	case "ssm":
+		return c.ssm(ctx, args[1:])
+	case "configure":
+		return c.configure(ctx, args[1:])
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) s3(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"s3", "ls"})
+	}
+
+	subcmd := args[0]
+	switch subcmd {
+	case "ls", "list":
+		return c.run(ctx, []string{"s3", "ls", "s3://"})
+	case "mb":
+		return c.run(ctx, append([]string{"s3", "mb"}, args[1:]...))
+	case "rb":
+		return c.run(ctx, append([]string{"s3", "rb"}, args[1:]...))
+	case "cp":
+		return c.run(ctx, append([]string{"s3", "cp"}, args[1:]...))
+	case "sync":
+		return c.run(ctx, append([]string{"s3", "sync"}, args[1:]...))
+	case "rm":
+		return c.run(ctx, append([]string{"s3", "rm"}, args[1:]...))
+	default:
+		return c.run(ctx, append([]string{"s3", subcmd}, args[1:]...))
+	}
+}
+
+func (c *Client) ec2(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"ec2", "describe-instances"})
+	}
+
+	return c.run(ctx, append([]string{"ec2"}, args...))
+}
+
+func (c *Client) lambda(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"lambda", "list-functions"})
+	}
+
+	return c.run(ctx, append([]string{"lambda"}, args...))
+}
+
+func (c *Client) rds(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"rds", "describe-db-instances"})
+	}
+
+	return c.run(ctx, append([]string{"rds"}, args...))
+}
+
+func (c *Client) iam(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"iam", "list-users"})
+	}
+
+	return c.run(ctx, append([]string{"iam"}, args...))
+}
+
+func (c *Client) ecs(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"ecs", "list-clusters"})
+	}
+
+	return c.run(ctx, append([]string{"ecs"}, args...))
+}
+
+func (c *Client) eks(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"eks", "list-clusters"})
+	}
+
+	return c.run(ctx, append([]string{"eks"}, args...))
+}
+
+func (c *Client) dynamodb(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"dynamodb", "list-tables"})
+	}
+
+	return c.run(ctx, append([]string{"dynamodb"}, args...))
+}
+
+func (c *Client) logs(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"logs", "describe-log-groups"})
+	}
+
+	return c.run(ctx, append([]string{"logs"}, args...))
+}
+
+func (c *Client) cloudwatch(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"cloudwatch", "list-metrics"})
+	}
+
+	return c.run(ctx, append([]string{"cloudwatch"}, args...))
+}
+
+func (c *Client) ssm(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"ssm", "list-commands"})
+	}
+
+	return c.run(ctx, append([]string{"ssm"}, args...))
+}
+
+func (c *Client) configure(ctx context.Context, args []string) (string, error) {
+	configArgs := []string{"configure"}
+	configArgs = append(configArgs, args...)
+
+	if c.region != "" {
+		fmt.Println("Region:", c.region)
+	}
+	if c.profile != "" {
+		fmt.Println("Profile:", c.profile)
+	}
+
+	return c.run(ctx, configArgs)
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.awsPath, args...)
+	if c.region != "" {
+		cmd.Env = append(cmd.Env, "AWS_DEFAULT_REGION="+c.region)
+	}
+	if c.profile != "" {
+		cmd.Env = append(cmd.Env, "AWS_PROFILE="+c.profile)
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.awsPath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/aws/aws.go
+++ b/pkg/extensions/adapters/cli/adapters/aws/aws.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -188,9 +189,13 @@ func (c *Client) configure(ctx context.Context, args []string) (string, error) {
 func (c *Client) run(ctx context.Context, args []string) (string, error) {
 	cmd := exec.CommandContext(ctx, c.awsPath, args...)
 	if c.region != "" {
+		cmd.Env = os.Environ()
 		cmd.Env = append(cmd.Env, "AWS_DEFAULT_REGION="+c.region)
 	}
 	if c.profile != "" {
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
 		cmd.Env = append(cmd.Env, "AWS_PROFILE="+c.profile)
 	}
 	output, err := cmd.CombinedOutput()

--- a/pkg/extensions/adapters/cli/adapters/aws/aws_test.go
+++ b/pkg/extensions/adapters/cli/adapters/aws/aws_test.go
@@ -1,0 +1,93 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("ANYCLAW_AWS_ADAPTER_HELPER") == "1" || strings.HasPrefix(strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe"), "aws-helper") {
+		payload := map[string]string{
+			"aws_access_key_id":  os.Getenv("AWS_ACCESS_KEY_ID"),
+			"aws_default_region": os.Getenv("AWS_DEFAULT_REGION"),
+			"aws_profile":        os.Getenv("AWS_PROFILE"),
+			"ordinary_inherited": os.Getenv("ANYCLAW_AWS_INHERITED"),
+		}
+		data, _ := json.Marshal(payload)
+		fmt.Print(string(data))
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestRunInheritsEnvironmentWhenOverridingAWSSettings(t *testing.T) {
+	t.Setenv("ANYCLAW_AWS_INHERITED", "kept")
+	t.Setenv("AWS_ACCESS_KEY_ID", "access-key")
+	client := NewClient(Config{
+		AWSPath: fakeAWSPath(t),
+		Region:  "us-west-2",
+		Profile: "dev",
+	})
+
+	out, err := client.Run(context.Background(), []string{"sts", "get-caller-identity"})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode helper output: %v", err)
+	}
+	if got["ordinary_inherited"] != "kept" {
+		t.Fatalf("expected ordinary environment to be inherited, got %#v", got)
+	}
+	if got["aws_access_key_id"] != "access-key" {
+		t.Fatalf("expected AWS_ACCESS_KEY_ID to be inherited, got %#v", got)
+	}
+	if got["aws_default_region"] != "us-west-2" {
+		t.Fatalf("expected region override, got %#v", got)
+	}
+	if got["aws_profile"] != "dev" {
+		t.Fatalf("expected profile override, got %#v", got)
+	}
+}
+
+func fakeAWSPath(t *testing.T) string {
+	t.Helper()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "aws-helper.exe")
+	copyExecutable(t, exe, path)
+	return path
+}
+
+func copyExecutable(t *testing.T, src, dst string) {
+	t.Helper()
+
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open source executable: %v", err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("create helper executable: %v", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		t.Fatalf("copy helper executable: %v", err)
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/curl/curl.go
+++ b/pkg/extensions/adapters/cli/adapters/curl/curl.go
@@ -1,0 +1,167 @@
+package curl
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	curlPath string
+	timeout  time.Duration
+}
+
+type Config struct {
+	CurlPath string
+	Timeout  time.Duration
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.CurlPath
+	if path == "" {
+		path = "curl"
+	}
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	return &Client{
+		curlPath: path,
+		timeout:  timeout,
+	}
+}
+
+type Response struct {
+	Status     string            `json:"status"`
+	StatusCode int               `json:"status_code"`
+	Headers    map[string]string `json:"headers"`
+	Body       string            `json:"body"`
+	Time       int64             `json:"time_ms"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "Usage: curl <url> [options]", nil
+	}
+
+	url := args[0]
+	isJSON := false
+
+	for _, arg := range args {
+		if arg == "-H" {
+			isJSON = true
+		}
+	}
+
+	if isJSON || strings.HasPrefix(url, "http") {
+		return c.request(ctx, args)
+	}
+
+	return c.run(ctx, args)
+}
+
+func (c *Client) request(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("URL required")
+	}
+
+	url := args[0]
+	method := "GET"
+	headers := make(map[string]string)
+	data := ""
+
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "-X":
+			if i+1 < len(args) {
+				method = args[i+1]
+				i++
+			}
+		case "-H":
+			if i+1 < len(args) {
+				header := args[i+1]
+				if idx := strings.Index(header, ":"); idx > 0 {
+					key := strings.TrimSpace(header[:idx])
+					val := strings.TrimSpace(header[idx+1:])
+					headers[key] = val
+				}
+				i++
+			}
+		case "-d", "--data":
+			if i+1 < len(args) {
+				data = args[i+1]
+				if method == "GET" {
+					method = "POST"
+				}
+				i++
+			}
+		case "-o", "--output":
+			if i+1 < len(args) {
+				i++
+			}
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, strings.NewReader(data))
+	if err != nil {
+		return "", err
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	if data != "" && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+
+	client := &http.Client{Timeout: c.timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	result := fmt.Sprintf("HTTP %d %s\n\n%s", resp.StatusCode, resp.Status, string(body))
+	return result, nil
+}
+
+func (c *Client) get(ctx context.Context, url string) (string, error) {
+	return c.request(ctx, []string{url})
+}
+
+func (c *Client) post(ctx context.Context, url, data string) (string, error) {
+	return c.request(ctx, []string{url, "-X", "POST", "-d", data})
+}
+
+func (c *Client) put(ctx context.Context, url, data string) (string, error) {
+	return c.request(ctx, []string{url, "-X", "PUT", "-d", data})
+}
+
+func (c *Client) delete(ctx context.Context, url string) (string, error) {
+	return c.request(ctx, []string{url, "-X", "DELETE"})
+}
+
+func (c *Client) head(ctx context.Context, url string) (string, error) {
+	return c.request(ctx, []string{url, "-I"})
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.curlPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.curlPath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/docker/docker.go
+++ b/pkg/extensions/adapters/cli/adapters/docker/docker.go
@@ -1,0 +1,306 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	dockerPath string
+}
+
+type Config struct {
+	DockerPath string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.DockerPath
+	if path == "" {
+		path = "docker"
+	}
+	return &Client{dockerPath: path}
+}
+
+type Container struct {
+	ID     string `json:"id"`
+	Image  string `json:"image"`
+	Status string `json:"status"`
+	Ports  string `json:"ports"`
+	Names  string `json:"names"`
+}
+
+type Image struct {
+	Repository string `json:"repository"`
+	Tag        string `json:"tag"`
+	Size       string `json:"size"`
+	ID         string `json:"id"`
+}
+
+type Volume struct {
+	Name   string `json:"name"`
+	Driver string `json:"driver"`
+	Mount  string `json:"mountpoint"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.ps(ctx)
+	}
+
+	cmd := args[0]
+	switch cmd {
+	case "ps", "list":
+		return c.ps(ctx)
+	case "images", "list-images":
+		return c.images(ctx)
+	case "run", "start":
+		return c.run(ctx, args[1:])
+	case "stop", "kill":
+		return c.stop(ctx, args[1:])
+	case "rm", "remove":
+		return c.rm(ctx, args[1:])
+	case "logs":
+		return c.logs(ctx, args[1:])
+	case "exec":
+		return c.exec(ctx, args[1:])
+	case "pull":
+		return c.pull(ctx, args[1:])
+	case "volumes", "vol":
+		return c.volumes(ctx)
+	case "info", "system":
+		return c.info(ctx)
+	case "search":
+		return c.search(ctx, args[1:])
+	default:
+		return c.runDocker(ctx, args)
+	}
+}
+
+func (c *Client) ps(ctx context.Context) (string, error) {
+	out, err := c.runDocker(ctx, []string{"ps", "--format", "{{json .}}"})
+	if err != nil {
+		return "", err
+	}
+
+	var containers []Container
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		var ctr Container
+		json.Unmarshal([]byte(line), &ctr)
+		containers = append(containers, ctr)
+	}
+
+	if len(containers) == 0 {
+		return "No running containers", nil
+	}
+
+	var result []string
+	result = append(result, "CONTAINERS:")
+	for _, ctr := range containers {
+		result = append(result, fmt.Sprintf("  %s  %s  %s  %s", ctr.Names, ctr.ID[:12], ctr.Image, ctr.Status))
+	}
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) images(ctx context.Context) (string, error) {
+	out, err := c.runDocker(ctx, []string{"images", "--format", "{{json .}}"})
+	if err != nil {
+		return "", err
+	}
+
+	var images []Image
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		var img Image
+		json.Unmarshal([]byte(line), &img)
+		images = append(images, img)
+	}
+
+	if len(images) == 0 {
+		return "No images", nil
+	}
+
+	var result []string
+	result = append(result, "IMAGES:")
+	for _, img := range images {
+		result = append(result, fmt.Sprintf("  %s:%s  %s", img.Repository, img.Tag, img.Size))
+	}
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	containerName := ""
+	image := ""
+	cmdArgs := []string{}
+
+	for i, arg := range args {
+		if arg == "-d" || arg == "-it" || arg == "--detach" {
+			continue
+		}
+		if arg == "--name" && i+1 < len(args) {
+			containerName = args[i+1]
+			continue
+		}
+		if !strings.HasPrefix(arg, "-") && image == "" {
+			image = arg
+			continue
+		}
+		cmdArgs = append(cmdArgs, arg)
+	}
+
+	if image == "" {
+		return "", fmt.Errorf("image required")
+	}
+
+	dockerArgs := []string{"run", "-d"}
+	if containerName != "" {
+		dockerArgs = append(dockerArgs, "--name", containerName)
+	}
+	dockerArgs = append(dockerArgs, image)
+	dockerArgs = append(dockerArgs, cmdArgs...)
+
+	_, err := c.runDocker(ctx, dockerArgs)
+	if err != nil {
+		return "", err
+	}
+
+	if containerName != "" {
+		return fmt.Sprintf("Container %s started", containerName), nil
+	}
+	return fmt.Sprintf("Container started from image %s", image), nil
+}
+
+func (c *Client) stop(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("container name or ID required")
+	}
+
+	_, err := c.runDocker(ctx, []string{"stop", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Container %s stopped", args[0]), nil
+}
+
+func (c *Client) rm(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("container name or ID required")
+	}
+
+	_, err := c.runDocker(ctx, []string{"rm", "-f", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Container %s removed", args[0]), nil
+}
+
+func (c *Client) logs(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("container name or ID required")
+	}
+
+	dockerArgs := []string{"logs"}
+	if len(args) > 1 && args[1] == "--follow" {
+		dockerArgs = append(dockerArgs, "-f")
+		args = args[1:]
+	}
+	dockerArgs = append(dockerArgs, args[0])
+
+	if len(args) > 1 {
+		dockerArgs = append(dockerArgs, args[1:]...)
+	}
+
+	return c.runDocker(ctx, dockerArgs)
+}
+
+func (c *Client) exec(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("usage: docker exec <container> <command>")
+	}
+
+	container := args[0]
+	cmd := strings.Join(args[1:], " ")
+
+	return c.runDocker(ctx, []string{"exec", container, "sh", "-c", cmd})
+}
+
+func (c *Client) pull(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("image name required")
+	}
+
+	_, err := c.runDocker(ctx, []string{"pull", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Image %s pulled", args[0]), nil
+}
+
+func (c *Client) volumes(ctx context.Context) (string, error) {
+	out, err := c.runDocker(ctx, []string{"volume", "ls", "--format", "{{json .}}"})
+	if err != nil {
+		return "", err
+	}
+
+	var volumes []Volume
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		var vol Volume
+		json.Unmarshal([]byte(line), &vol)
+		volumes = append(volumes, vol)
+	}
+
+	if len(volumes) == 0 {
+		return "No volumes", nil
+	}
+
+	var result []string
+	result = append(result, "VOLUMES:")
+	for _, vol := range volumes {
+		result = append(result, fmt.Sprintf("  %s", vol.Name))
+	}
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) info(ctx context.Context) (string, error) {
+	return c.runDocker(ctx, []string{"info", "--format", "{{.ServerVersion}}"})
+}
+
+func (c *Client) search(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("search term required")
+	}
+
+	out, err := c.runDocker(ctx, []string{"search", "--limit", "10", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return out, nil
+}
+
+func (c *Client) runDocker(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.dockerPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.dockerPath, "version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/docker/docker.go
+++ b/pkg/extensions/adapters/cli/adapters/docker/docker.go
@@ -56,8 +56,10 @@ func (c *Client) Run(ctx context.Context, args []string) (string, error) {
 		return c.ps(ctx)
 	case "images", "list-images":
 		return c.images(ctx)
-	case "run", "start":
+	case "run":
 		return c.run(ctx, args[1:])
+	case "start":
+		return c.start(ctx, args[1:])
 	case "stop", "kill":
 		return c.stop(ctx, args[1:])
 	case "rm", "remove":
@@ -175,6 +177,22 @@ func (c *Client) run(ctx context.Context, args []string) (string, error) {
 		return fmt.Sprintf("Container %s started", containerName), nil
 	}
 	return fmt.Sprintf("Container started from image %s", image), nil
+}
+
+func (c *Client) start(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("container name or ID required")
+	}
+
+	_, err := c.runDocker(ctx, append([]string{"start"}, args...))
+	if err != nil {
+		return "", err
+	}
+
+	if len(args) == 1 {
+		return fmt.Sprintf("Container %s started", args[0]), nil
+	}
+	return fmt.Sprintf("Containers started: %s", strings.Join(args, ", ")), nil
 }
 
 func (c *Client) stop(ctx context.Context, args []string) (string, error) {

--- a/pkg/extensions/adapters/cli/adapters/docker/docker.go
+++ b/pkg/extensions/adapters/cli/adapters/docker/docker.go
@@ -245,10 +245,8 @@ func (c *Client) exec(ctx context.Context, args []string) (string, error) {
 		return "", fmt.Errorf("usage: docker exec <container> <command>")
 	}
 
-	container := args[0]
-	cmd := strings.Join(args[1:], " ")
-
-	return c.runDocker(ctx, []string{"exec", container, "sh", "-c", cmd})
+	dockerArgs := append([]string{"exec"}, args...)
+	return c.runDocker(ctx, dockerArgs)
 }
 
 func (c *Client) pull(ctx context.Context, args []string) (string, error) {

--- a/pkg/extensions/adapters/cli/adapters/docker/docker_test.go
+++ b/pkg/extensions/adapters/cli/adapters/docker/docker_test.go
@@ -1,0 +1,75 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("ANYCLAW_DOCKER_ADAPTER_HELPER") == "1" {
+		if logPath := os.Getenv("ANYCLAW_DOCKER_ADAPTER_LOG"); logPath != "" {
+			_ = os.WriteFile(logPath, []byte(strings.Join(os.Args[1:], " ")), 0o644)
+		}
+		fmt.Print(strings.Join(os.Args[1:], " "))
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestStartUsesDockerStartSubcommand(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "docker-args.txt")
+	t.Setenv("ANYCLAW_DOCKER_ADAPTER_HELPER", "1")
+	t.Setenv("ANYCLAW_DOCKER_ADAPTER_LOG", logPath)
+	client := NewClient(Config{DockerPath: fakeDockerPath(t)})
+
+	if _, err := client.Run(context.Background(), []string{"start", "existing-container"}); err != nil {
+		t.Fatalf("Run start returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read helper log: %v", err)
+	}
+	if got, want := string(data), "start existing-container"; got != want {
+		t.Fatalf("docker args = %q, want %q", got, want)
+	}
+}
+
+func fakeDockerPath(t *testing.T) string {
+	t.Helper()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "docker-helper.exe")
+	copyExecutable(t, exe, path)
+	return path
+}
+
+func copyExecutable(t *testing.T, src, dst string) {
+	t.Helper()
+
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open source executable: %v", err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("create helper executable: %v", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		t.Fatalf("copy helper executable: %v", err)
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/docker/docker_test.go
+++ b/pkg/extensions/adapters/cli/adapters/docker/docker_test.go
@@ -2,10 +2,12 @@ package docker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -13,7 +15,8 @@ import (
 func TestMain(m *testing.M) {
 	if os.Getenv("ANYCLAW_DOCKER_ADAPTER_HELPER") == "1" {
 		if logPath := os.Getenv("ANYCLAW_DOCKER_ADAPTER_LOG"); logPath != "" {
-			_ = os.WriteFile(logPath, []byte(strings.Join(os.Args[1:], " ")), 0o644)
+			data, _ := json.Marshal(os.Args[1:])
+			_ = os.WriteFile(logPath, data, 0o644)
 		}
 		fmt.Print(strings.Join(os.Args[1:], " "))
 		os.Exit(0)
@@ -32,13 +35,40 @@ func TestStartUsesDockerStartSubcommand(t *testing.T) {
 		t.Fatalf("Run start returned error: %v", err)
 	}
 
+	if got, want := readDockerArgs(t, logPath), []string{"start", "existing-container"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("docker args = %q, want %q", got, want)
+	}
+}
+
+func TestExecForwardsCommandArgvWithoutShell(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "docker-args.txt")
+	t.Setenv("ANYCLAW_DOCKER_ADAPTER_HELPER", "1")
+	t.Setenv("ANYCLAW_DOCKER_ADAPTER_LOG", logPath)
+	client := NewClient(Config{DockerPath: fakeDockerPath(t)})
+
+	args := []string{"exec", "existing-container", "echo", "hello world", "$PATH;rm"}
+	if _, err := client.Run(context.Background(), args); err != nil {
+		t.Fatalf("Run exec returned error: %v", err)
+	}
+
+	want := []string{"exec", "existing-container", "echo", "hello world", "$PATH;rm"}
+	if got := readDockerArgs(t, logPath); !reflect.DeepEqual(got, want) {
+		t.Fatalf("docker args = %#v, want %#v", got, want)
+	}
+}
+
+func readDockerArgs(t *testing.T, logPath string) []string {
+	t.Helper()
+
 	data, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("read helper log: %v", err)
 	}
-	if got, want := string(data), "start existing-container"; got != want {
-		t.Fatalf("docker args = %q, want %q", got, want)
+	var args []string
+	if err := json.Unmarshal(data, &args); err != nil {
+		t.Fatalf("decode helper args: %v", err)
 	}
+	return args
 }
 
 func fakeDockerPath(t *testing.T) string {

--- a/pkg/extensions/adapters/cli/adapters/git/git.go
+++ b/pkg/extensions/adapters/cli/adapters/git/git.go
@@ -1,0 +1,441 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	gitPath string
+	repoDir string
+}
+
+type Config struct {
+	GitPath string
+	RepoDir string
+}
+
+func NewClient(cfg Config) *Client {
+	gitPath := cfg.GitPath
+	if gitPath == "" {
+		gitPath = "git"
+	}
+	repoDir := cfg.RepoDir
+	if repoDir == "" {
+		repoDir = "."
+	}
+	return &Client{
+		gitPath: gitPath,
+		repoDir: repoDir,
+	}
+}
+
+type Status struct {
+	Branch    string   `json:"branch"`
+	Staged    []string `json:"staged"`
+	Modified  []string `json:"modified"`
+	Untracked []string `json:"untracked"`
+	Conflict  []string `json:"conflict"`
+}
+
+type Commit struct {
+	Hash    string `json:"hash"`
+	Author  string `json:"author"`
+	Date    string `json:"date"`
+	Message string `json:"message"`
+}
+
+type Branch struct {
+	Name   string `json:"name"`
+	Remote bool   `json:"remote"`
+	Head   bool   `json:"head"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.status(ctx)
+	}
+
+	switch args[0] {
+	case "status", "st":
+		return c.status(ctx)
+	case "log":
+		return c.log(ctx, args[1:])
+	case "branch", "br":
+		return c.branch(ctx, args[1:])
+	case "commit", "ci":
+		return c.commit(ctx, args[1:])
+	case "add":
+		return c.add(ctx, args[1:])
+	case "push":
+		return c.push(ctx, args[1:])
+	case "pull":
+		return c.pull(ctx, args[1:])
+	case "clone":
+		return c.clone(ctx, args[1:])
+	case "checkout", "co":
+		return c.checkout(ctx, args[1:])
+	case "diff":
+		return c.diff(ctx, args[1:])
+	case "merge":
+		return c.merge(ctx, args[1:])
+	case "rebase":
+		return c.rebase(ctx, args[1:])
+	case "stash":
+		return c.stash(ctx, args[1:])
+	case "remote", "remote -v":
+		return c.remote(ctx)
+	case "fetch":
+		return c.fetch(ctx, args[1:])
+	case "init":
+		return c.init(ctx, args[1:])
+	case "tag":
+		return c.tag(ctx, args[1:])
+	case "show":
+		return c.show(ctx, args[1:])
+	case "reset":
+		return c.reset(ctx, args[1:])
+	case "clean":
+		return c.clean(ctx, args[1:])
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) status(ctx context.Context) (string, error) {
+	output, err := c.run(ctx, []string{"status", "--porcelain"})
+	if err != nil {
+		return "", err
+	}
+
+	status := &Status{}
+	lines := strings.Split(output, "\n")
+
+	for _, line := range lines {
+		if len(line) < 2 {
+			continue
+		}
+		file := strings.TrimSpace(line[3:])
+		switch line[:2] {
+		case "M ":
+			status.Modified = append(status.Modified, file)
+		case "A ":
+			status.Staged = append(status.Staged, file)
+		case "D ":
+			status.Modified = append(status.Modified, file)
+		case "??":
+			status.Untracked = append(status.Untracked, file)
+		case "UU":
+			status.Conflict = append(status.Conflict, file)
+		}
+	}
+
+	branch, _ := c.run(ctx, []string{"branch", "--show-current"})
+	status.Branch = strings.TrimSpace(branch)
+
+	var result []string
+	result = append(result, fmt.Sprintf("On branch: %s", status.Branch))
+	if len(status.Staged) > 0 {
+		result = append(result, "Staged:")
+		for _, f := range status.Staged {
+			result = append(result, fmt.Sprintf("  %s", f))
+		}
+	}
+	if len(status.Modified) > 0 {
+		result = append(result, "Modified:")
+		for _, f := range status.Modified {
+			result = append(result, fmt.Sprintf("  %s", f))
+		}
+	}
+	if len(status.Untracked) > 0 {
+		result = append(result, "Untracked:")
+		for _, f := range status.Untracked {
+			result = append(result, fmt.Sprintf("  %s", f))
+		}
+	}
+
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) log(ctx context.Context, args []string) (string, error) {
+	limit := "10"
+	for i, arg := range args {
+		if arg == "-n" && i+1 < len(args) {
+			limit = args[i+1]
+		}
+	}
+
+	output, err := c.run(ctx, []string{"log", "--oneline", "-n", limit})
+	return output, err
+}
+
+func (c *Client) branch(ctx context.Context, args []string) (string, error) {
+	output, err := c.run(ctx, []string{"branch", "-a"})
+	if err != nil {
+		return "", err
+	}
+
+	var result []string
+	lines := strings.Split(output, "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "* ") {
+			result = append(result, fmt.Sprintf("* %s (current)", strings.TrimPrefix(line, "* ")))
+		} else {
+			result = append(result, "  "+line)
+		}
+	}
+
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) commit(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("commit message required")
+	}
+
+	msg := strings.Join(args, " ")
+	_, err := c.run(ctx, []string{"commit", "-m", msg})
+	if err != nil {
+		return "", err
+	}
+
+	return "Committed: " + msg, nil
+}
+
+func (c *Client) add(ctx context.Context, args []string) (string, error) {
+	files := []string{"."}
+	if len(args) > 0 {
+		files = args
+	}
+
+	_, err := c.run(ctx, append([]string{"add"}, files...))
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Added %d files", len(files)), nil
+}
+
+func (c *Client) push(ctx context.Context, args []string) (string, error) {
+	pushArgs := []string{"push"}
+	pushArgs = append(pushArgs, args...)
+
+	_, err := c.run(ctx, pushArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Pushed successfully", nil
+}
+
+func (c *Client) pull(ctx context.Context, args []string) (string, error) {
+	pullArgs := []string{"pull"}
+	pullArgs = append(pullArgs, args...)
+
+	_, err := c.run(ctx, pullArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Pulled successfully", nil
+}
+
+func (c *Client) clone(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("repository URL required")
+	}
+
+	_, err := c.run(ctx, []string{"clone", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Cloned: %s", args[0]), nil
+}
+
+func (c *Client) checkout(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("branch name required")
+	}
+
+	_, err := c.run(ctx, []string{"checkout", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Switched to: %s", args[0]), nil
+}
+
+func (c *Client) diff(ctx context.Context, args []string) (string, error) {
+	diffArgs := []string{"diff"}
+	diffArgs = append(diffArgs, args...)
+
+	return c.run(ctx, diffArgs)
+}
+
+func (c *Client) merge(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("branch name required")
+	}
+
+	_, err := c.run(ctx, []string{"merge", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Merged: %s", args[0]), nil
+}
+
+func (c *Client) rebase(ctx context.Context, args []string) (string, error) {
+	branch := "main"
+	if len(args) > 0 {
+		branch = args[0]
+	}
+
+	_, err := c.run(ctx, []string{"rebase", branch})
+	if err != nil {
+		return "", err
+	}
+
+	return "Rebased successfully", nil
+}
+
+func (c *Client) stash(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		output, _ := c.run(ctx, []string{"stash", "list"})
+		return output, nil
+	}
+
+	switch args[0] {
+	case "push", "save":
+		msg := "WIP"
+		if len(args) > 1 {
+			msg = args[1]
+		}
+		_, err := c.run(ctx, []string{"stash", "push", "-m", msg})
+		if err != nil {
+			return "", err
+		}
+		return "Stashed", nil
+	case "pop":
+		_, err := c.run(ctx, []string{"stash", "pop"})
+		return "Stash applied", err
+	case "list":
+		return c.run(ctx, []string{"stash", "list"})
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) remote(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"remote", "-v"})
+}
+
+func (c *Client) fetch(ctx context.Context, args []string) (string, error) {
+	fetchArgs := []string{"fetch"}
+	fetchArgs = append(fetchArgs, args...)
+
+	_, err := c.run(ctx, fetchArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Fetched successfully", nil
+}
+
+func (c *Client) init(ctx context.Context, args []string) (string, error) {
+	dir := "."
+	if len(args) > 0 {
+		dir = args[0]
+	}
+
+	_, err := c.run(ctx, []string{"init", dir})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Initialized: %s", dir), nil
+}
+
+func (c *Client) tag(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"tag", "-l"})
+	}
+
+	name := args[0]
+	msg := ""
+	if len(args) > 1 {
+		msg = args[1]
+	}
+
+	if msg != "" {
+		_, err := c.run(ctx, []string{"tag", "-a", name, "-m", msg})
+		return fmt.Sprintf("Tag created: %s", name), err
+	}
+
+	_, err := c.run(ctx, []string{"tag", name})
+	return fmt.Sprintf("Tag created: %s", name), err
+}
+
+func (c *Client) show(ctx context.Context, args []string) (string, error) {
+	rev := "HEAD"
+	if len(args) > 0 {
+		rev = args[0]
+	}
+
+	return c.run(ctx, []string{"show", rev})
+}
+
+func (c *Client) reset(ctx context.Context, args []string) (string, error) {
+	mode := "--soft"
+	if len(args) > 0 && strings.HasPrefix(args[0], "--") {
+		mode = args[0]
+		args = args[1:]
+	}
+
+	commit := "HEAD~1"
+	if len(args) > 0 {
+		commit = args[0]
+	}
+
+	_, err := c.run(ctx, []string{"reset", mode, commit})
+	if err != nil {
+		return "", err
+	}
+
+	return "Reset successful", nil
+}
+
+func (c *Client) clean(ctx context.Context, args []string) (string, error) {
+	cleanArgs := []string{"clean", "-fd"}
+	cleanArgs = append(cleanArgs, args...)
+
+	_, err := c.run(ctx, cleanArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Cleaned untracked files", nil
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.gitPath, args...)
+	cmd.Dir = c.repoDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.gitPath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/kubectl/kubectl.go
+++ b/pkg/extensions/adapters/cli/adapters/kubectl/kubectl.go
@@ -1,0 +1,338 @@
+package kubectl
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	kubectlPath string
+	namespace   string
+	kubeconfig  string
+}
+
+type Config struct {
+	KubectlPath string
+	Namespace   string
+	Kubeconfig  string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.KubectlPath
+	if path == "" {
+		path = "kubectl"
+	}
+	ns := cfg.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+	return &Client{
+		kubectlPath: path,
+		namespace:   ns,
+		kubeconfig:  cfg.Kubeconfig,
+	}
+}
+
+type Resource struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	Type      string `json:"type"`
+	Status    string `json:"status,omitempty"`
+	Age       string `json:"age"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.getPods(ctx)
+	}
+
+	switch args[0] {
+	case "get", "g":
+		return c.get(ctx, args[1:])
+	case "describe", "desc":
+		return c.describe(ctx, args[1:])
+	case "apply", "a":
+		return c.apply(ctx, args[1:])
+	case "delete", "d":
+		return c.delete(ctx, args[1:])
+	case "create":
+		return c.create(ctx, args[1:])
+	case "logs", "log":
+		return c.logs(ctx, args[1:])
+	case "exec":
+		return c.exec(ctx, args[1:])
+	case "port-forward", "pf":
+		return c.portForward(ctx, args[1:])
+	case "scale":
+		return c.scale(ctx, args[1:])
+	case "rollout":
+		return c.rollout(ctx, args[1:])
+	case "top":
+		return c.top(ctx, args[1:])
+	case "cluster-info":
+		return c.clusterInfo(ctx)
+	case "config":
+		return c.config(ctx, args[1:])
+	case "api-resources":
+		return c.apiResources(ctx)
+	case "version":
+		return c.version(ctx)
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) get(ctx context.Context, args []string) (string, error) {
+	resourceType := "pods"
+	if len(args) > 0 {
+		if !isKnownResource(args[0]) {
+			resourceType = args[0]
+			args = args[1:]
+		}
+	}
+
+	getArgs := []string{"get", resourceType}
+	if c.namespace != "" {
+		getArgs = append(getArgs, "-n", c.namespace)
+	}
+	getArgs = append(getArgs, "-o", "wide")
+	getArgs = append(getArgs, args...)
+
+	return c.run(ctx, getArgs)
+}
+
+func (c *Client) getPods(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"get", "pods", "-n", c.namespace, "-o", "wide"})
+}
+
+func (c *Client) describe(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("resource type and name required")
+	}
+
+	resourceType := args[0]
+	name := ""
+	if len(args) > 1 {
+		name = args[1]
+	}
+
+	descArgs := []string{"describe", resourceType}
+	if name != "" {
+		descArgs = append(descArgs, name)
+	}
+	if c.namespace != "" {
+		descArgs = append(descArgs, "-n", c.namespace)
+	}
+
+	return c.run(ctx, descArgs)
+}
+
+func (c *Client) apply(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("file or directory required")
+	}
+
+	applyArgs := []string{"apply", "-f"}
+	applyArgs = append(applyArgs, args...)
+
+	_, err := c.run(ctx, applyArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Applied successfully", nil
+}
+
+func (c *Client) delete(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("resource required")
+	}
+
+	deleteArgs := []string{"delete"}
+	if isKnownResource(args[0]) {
+		resourceType := args[0]
+		name := ""
+		if len(args) > 1 {
+			name = args[1]
+		}
+		deleteArgs = append(deleteArgs, resourceType)
+		if name != "" {
+			deleteArgs = append(deleteArgs, name)
+		}
+	} else {
+		deleteArgs = append(deleteArgs, "-f", args[0])
+	}
+
+	deleteArgs = append(deleteArgs, "--cascade=foreground")
+
+	_, err := c.run(ctx, deleteArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Deleted successfully", nil
+}
+
+func (c *Client) create(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("file required")
+	}
+
+	createArgs := []string{"create", "-f"}
+	createArgs = append(createArgs, args...)
+
+	_, err := c.run(ctx, createArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Created successfully", nil
+}
+
+func (c *Client) logs(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("pod name required")
+	}
+
+	logArgs := []string{"logs"}
+	if c.namespace != "" {
+		logArgs = append(logArgs, "-n", c.namespace)
+	}
+	logArgs = append(logArgs, args...)
+
+	return c.run(ctx, logArgs)
+}
+
+func (c *Client) exec(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("pod name and command required")
+	}
+
+	pod := args[0]
+	cmd := args[1:]
+
+	execArgs := []string{"exec", "-n", c.namespace, pod, "--"}
+	execArgs = append(execArgs, cmd...)
+
+	return c.run(ctx, execArgs)
+}
+
+func (c *Client) portForward(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("pod and ports required")
+	}
+
+	pod := args[0]
+	ports := args[1]
+
+	return fmt.Sprintf("Port forward: kubectl port-forward %s %s -n %s", pod, ports, c.namespace), nil
+}
+
+func (c *Client) scale(ctx context.Context, args []string) (string, error) {
+	if len(args) < 3 {
+		return "", fmt.Errorf("resource type, name and replica count required")
+	}
+
+	resourceType := args[0]
+	name := args[1]
+	replicas := args[2]
+
+	scaleArgs := []string{"scale", resourceType, name, "--replicas=" + replicas}
+	if c.namespace != "" {
+		scaleArgs = append(scaleArgs, "-n", c.namespace)
+	}
+
+	_, err := c.run(ctx, scaleArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Scaled %s/%s to %s replicas", resourceType, name, replicas), nil
+}
+
+func (c *Client) rollout(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("resource type and name required")
+	}
+
+	subcmd := args[0]
+	resource := args[1]
+
+	rolloutArgs := []string{"rollout", subcmd, resource}
+	if c.namespace != "" {
+		rolloutArgs = append(rolloutArgs, "-n", c.namespace)
+	}
+	if len(args) > 2 {
+		rolloutArgs = append(rolloutArgs, args[2:]...)
+	}
+
+	return c.run(ctx, rolloutArgs)
+}
+
+func (c *Client) top(ctx context.Context, args []string) (string, error) {
+	topArgs := []string{"top"}
+	if c.namespace != "" {
+		topArgs = append(topArgs, "-n", c.namespace)
+	}
+	topArgs = append(topArgs, args...)
+
+	return c.run(ctx, topArgs)
+}
+
+func (c *Client) clusterInfo(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"cluster-info"})
+}
+
+func (c *Client) config(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"config", "current-context"})
+	}
+
+	configArgs := []string{"config"}
+	configArgs = append(configArgs, args...)
+
+	return c.run(ctx, configArgs)
+}
+
+func (c *Client) apiResources(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"api-resources", "-o", "wide"})
+}
+
+func (c *Client) version(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"version", "--client"})
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.kubectlPath, args...)
+	if c.kubeconfig != "" {
+		cmd.Env = append(cmd.Env, "KUBECONFIG="+c.kubeconfig)
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.kubectlPath, "version", "--client")
+	return cmd.Run() == nil
+}
+
+func isKnownResource(s string) bool {
+	resources := []string{
+		"pods", "po", "services", "svc", "deployments", "deploy",
+		"replicasets", "rs", "statefulsets", "sts", "daemonsets", "ds",
+		"configmaps", "cm", "secrets", "ingress", "ing", "persistentvolumeclaims", "pvc",
+		"namespaces", "ns", "nodes", "no", "persistentvolumes", "pv",
+		"jobs", "cronjobs", "cj", "poddisruptionbudgets", "pdb",
+	}
+	for _, r := range resources {
+		if s == r {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/extensions/adapters/cli/adapters/kubectl/kubectl.go
+++ b/pkg/extensions/adapters/cli/adapters/kubectl/kubectl.go
@@ -87,7 +87,7 @@ func (c *Client) Run(ctx context.Context, args []string) (string, error) {
 func (c *Client) get(ctx context.Context, args []string) (string, error) {
 	resourceType := "pods"
 	if len(args) > 0 {
-		if !isKnownResource(args[0]) {
+		if isKnownResource(args[0]) {
 			resourceType = args[0]
 			args = args[1:]
 		}

--- a/pkg/extensions/adapters/cli/adapters/kubectl/kubectl_test.go
+++ b/pkg/extensions/adapters/cli/adapters/kubectl/kubectl_test.go
@@ -1,0 +1,89 @@
+package kubectl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("ANYCLAW_KUBECTL_ADAPTER_HELPER") == "1" {
+		if logPath := os.Getenv("ANYCLAW_KUBECTL_ADAPTER_LOG"); logPath != "" {
+			data, _ := json.Marshal(os.Args[1:])
+			_ = os.WriteFile(logPath, data, 0o644)
+		}
+		fmt.Print(strings.Join(os.Args[1:], " "))
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestGetConsumesKnownResourceType(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "kubectl-args.json")
+	t.Setenv("ANYCLAW_KUBECTL_ADAPTER_HELPER", "1")
+	t.Setenv("ANYCLAW_KUBECTL_ADAPTER_LOG", logPath)
+	client := NewClient(Config{KubectlPath: fakeKubectlPath(t), Namespace: "default"})
+
+	if _, err := client.Run(context.Background(), []string{"get", "services"}); err != nil {
+		t.Fatalf("Run get returned error: %v", err)
+	}
+
+	want := []string{"get", "services", "-n", "default", "-o", "wide"}
+	if got := readKubectlArgs(t, logPath); !reflect.DeepEqual(got, want) {
+		t.Fatalf("kubectl args = %#v, want %#v", got, want)
+	}
+}
+
+func fakeKubectlPath(t *testing.T) string {
+	t.Helper()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "kubectl-helper.exe")
+	copyExecutable(t, exe, path)
+	return path
+}
+
+func copyExecutable(t *testing.T, src, dst string) {
+	t.Helper()
+
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open source executable: %v", err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("create helper executable: %v", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		t.Fatalf("copy helper executable: %v", err)
+	}
+}
+
+func readKubectlArgs(t *testing.T, logPath string) []string {
+	t.Helper()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read helper log: %v", err)
+	}
+	var args []string
+	if err := json.Unmarshal(data, &args); err != nil {
+		t.Fatalf("decode helper args: %v", err)
+	}
+	return args
+}

--- a/pkg/extensions/adapters/cli/adapters/node/node.go
+++ b/pkg/extensions/adapters/cli/adapters/node/node.go
@@ -66,20 +66,16 @@ func (c *Client) version(ctx context.Context) (string, error) {
 
 func (c *Client) info(ctx context.Context) (string, error) {
 	nodeVersion, _ := c.run(ctx, []string{"--version"})
-	npmVersion, _ := c.run(c.ctxWithNPM(ctx), []string{"--version"})
+	npmVersion, _ := c.runNPM(ctx, []string{"--version"})
 	return fmt.Sprintf("Node: %s\nNPM: %s", strings.TrimSpace(nodeVersion), strings.TrimSpace(npmVersion)), nil
-}
-
-func (c *Client) ctxWithNPM(ctx context.Context) context.Context {
-	return ctx
 }
 
 func (c *Client) runScript(ctx context.Context, args []string) (string, error) {
 	if len(args) == 0 {
-		return c.run(c.ctxWithNPM(ctx), []string{c.npmPath, "run"})
+		return c.runNPM(ctx, []string{"run"})
 	}
 
-	return c.run(c.ctxWithNPM(ctx), append([]string{c.npmPath, "run"}, args...))
+	return c.runNPM(ctx, append([]string{"run"}, args...))
 }
 
 func (c *Client) exec(ctx context.Context, args []string) (string, error) {
@@ -92,9 +88,7 @@ func (c *Client) exec(ctx context.Context, args []string) (string, error) {
 }
 
 func (c *Client) npm(ctx context.Context, args []string) (string, error) {
-	npmArgs := []string{c.npmPath}
-	npmArgs = append(npmArgs, args...)
-	return c.run(ctx, npmArgs)
+	return c.runNPM(ctx, args)
 }
 
 func (c *Client) npx(ctx context.Context, args []string) (string, error) {
@@ -110,7 +104,15 @@ func (c *Client) repl(ctx context.Context) (string, error) {
 }
 
 func (c *Client) run(ctx context.Context, args []string) (string, error) {
-	cmd := exec.CommandContext(ctx, c.nodePath, args...)
+	return c.runCommand(ctx, c.nodePath, args)
+}
+
+func (c *Client) runNPM(ctx context.Context, args []string) (string, error) {
+	return c.runCommand(ctx, c.npmPath, args)
+}
+
+func (c *Client) runCommand(ctx context.Context, path string, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, path, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(output), err

--- a/pkg/extensions/adapters/cli/adapters/node/node.go
+++ b/pkg/extensions/adapters/cli/adapters/node/node.go
@@ -1,0 +1,124 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	nodePath string
+	npmPath  string
+}
+
+type Config struct {
+	NodePath string
+	NPMPath  string
+}
+
+func NewClient(cfg Config) *Client {
+	nodePath := cfg.NodePath
+	if nodePath == "" {
+		nodePath = "node"
+	}
+	npmPath := cfg.NPMPath
+	if npmPath == "" {
+		npmPath = "npm"
+	}
+	return &Client{
+		nodePath: nodePath,
+		npmPath:  npmPath,
+	}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.version(ctx)
+	}
+
+	switch args[0] {
+	case "run", "r":
+		return c.runScript(ctx, args[1:])
+	case "exec", "e":
+		return c.exec(ctx, args[1:])
+	case "version", "v":
+		return c.version(ctx)
+	case "npm":
+		return c.npm(ctx, args[1:])
+	case "npx":
+		return c.npx(ctx, args[1:])
+	case "info":
+		return c.info(ctx)
+	case "REPL":
+		return c.repl(ctx)
+	default:
+		if strings.HasSuffix(args[0], ".js") {
+			return c.runFile(ctx, args)
+		}
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) version(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"--version"})
+}
+
+func (c *Client) info(ctx context.Context) (string, error) {
+	nodeVersion, _ := c.run(ctx, []string{"--version"})
+	npmVersion, _ := c.run(c.ctxWithNPM(ctx), []string{"--version"})
+	return fmt.Sprintf("Node: %s\nNPM: %s", strings.TrimSpace(nodeVersion), strings.TrimSpace(npmVersion)), nil
+}
+
+func (c *Client) ctxWithNPM(ctx context.Context) context.Context {
+	return ctx
+}
+
+func (c *Client) runScript(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(c.ctxWithNPM(ctx), []string{c.npmPath, "run"})
+	}
+
+	return c.run(c.ctxWithNPM(ctx), append([]string{c.npmPath, "run"}, args...))
+}
+
+func (c *Client) exec(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("code required")
+	}
+
+	code := strings.Join(args, " ")
+	return c.run(ctx, []string{"-e", code})
+}
+
+func (c *Client) npm(ctx context.Context, args []string) (string, error) {
+	npmArgs := []string{c.npmPath}
+	npmArgs = append(npmArgs, args...)
+	return c.run(ctx, npmArgs)
+}
+
+func (c *Client) npx(ctx context.Context, args []string) (string, error) {
+	return c.run(ctx, append([]string{"npx"}, args...))
+}
+
+func (c *Client) runFile(ctx context.Context, args []string) (string, error) {
+	return c.run(ctx, args)
+}
+
+func (c *Client) repl(ctx context.Context) (string, error) {
+	return "Entering Node.js REPL. Type .exit to exit.", nil
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.nodePath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.nodePath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/node/node_test.go
+++ b/pkg/extensions/adapters/cli/adapters/node/node_test.go
@@ -1,0 +1,98 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("ANYCLAW_NODE_ADAPTER_HELPER") == "1" {
+		name := strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe")
+		name = strings.TrimSuffix(name, "-helper")
+		fmt.Print(strings.TrimSpace(name + " " + strings.Join(os.Args[1:], " ")))
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestNPMCommandsUseNPMExecutable(t *testing.T) {
+	t.Setenv("ANYCLAW_NODE_ADAPTER_HELPER", "1")
+	nodePath, npmPath := fakeNodeCommandPaths(t)
+	client := NewClient(Config{NodePath: nodePath, NPMPath: npmPath})
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "info uses npm for npm version",
+			args: []string{"info"},
+			want: "Node: node --version\nNPM: npm --version",
+		},
+		{
+			name: "run uses npm run",
+			args: []string{"run", "test"},
+			want: "npm run test",
+		},
+		{
+			name: "npm command uses npm directly",
+			args: []string{"npm", "install", "left-pad"},
+			want: "npm install left-pad",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.Run(context.Background(), tt.args)
+			if err != nil {
+				t.Fatalf("Run returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("Run(%v) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func fakeNodeCommandPaths(t *testing.T) (string, string) {
+	t.Helper()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	dir := t.TempDir()
+	nodePath := filepath.Join(dir, "node-helper.exe")
+	npmPath := filepath.Join(dir, "npm-helper.exe")
+	copyFile(t, exe, nodePath)
+	copyFile(t, exe, npmPath)
+	return nodePath, npmPath
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open source executable: %v", err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("create helper executable: %v", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		t.Fatalf("copy helper executable: %v", err)
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/npm/npm.go
+++ b/pkg/extensions/adapters/cli/adapters/npm/npm.go
@@ -1,0 +1,259 @@
+package npm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	npmPath    string
+	workingDir string
+}
+
+type Config struct {
+	NPMPath    string
+	WorkingDir string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.NPMPath
+	if path == "" {
+		path = "npm"
+	}
+	dir := cfg.WorkingDir
+	if dir == "" {
+		dir = "."
+	}
+	return &Client{
+		npmPath:    path,
+		workingDir: dir,
+	}
+}
+
+type PackageInfo struct {
+	Name         string            `json:"name"`
+	Version      string            `json:"version"`
+	Description  string            `json:"description"`
+	Dependencies map[string]string `json:"dependencies"`
+}
+
+type PackageList struct {
+	Dependencies map[string]PackageInfo `json:"dependencies"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.list(ctx)
+	}
+
+	switch args[0] {
+	case "install", "i":
+		return c.install(ctx, args[1:])
+	case "uninstall", "remove", "rm":
+		return c.uninstall(ctx, args[1:])
+	case "update", "up":
+		return c.update(ctx, args[1:])
+	case "list", "ls":
+		return c.listArgs(ctx, args[1:])
+	case "outdated":
+		return c.outdated(ctx)
+	case "init":
+		return c.init(ctx, args[1:])
+	case "run":
+		return c.runScript(ctx, args[1:])
+	case "start":
+		return c.runScript(ctx, []string{"start"})
+	case "test":
+		return c.runScript(ctx, []string{"test"})
+	case "publish":
+		return c.publish(ctx, args[1:])
+	case "info":
+		return c.info(ctx, args[1:])
+	case "search":
+		return c.search(ctx, args[1:])
+	case "version":
+		return c.version(ctx, args[1:])
+	case "view":
+		return c.view(ctx, args[1:])
+	case "doc", "docs":
+		return c.docs(ctx, args[1:])
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) install(ctx context.Context, args []string) (string, error) {
+	installArgs := []string{"install"}
+	installArgs = append(installArgs, args...)
+
+	_, err := c.run(ctx, installArgs)
+	if err != nil {
+		return "", err
+	}
+
+	if len(args) == 0 {
+		return "Installed all dependencies from package.json", nil
+	}
+	return fmt.Sprintf("Installed: %s", strings.Join(args, " ")), nil
+}
+
+func (c *Client) uninstall(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("package name required")
+	}
+
+	_, err := c.run(ctx, []string{"uninstall", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Uninstalled: %s", args[0]), nil
+}
+
+func (c *Client) update(ctx context.Context, args []string) (string, error) {
+	updateArgs := []string{"update"}
+	if len(args) > 0 {
+		updateArgs = append(updateArgs, args...)
+	}
+
+	_, err := c.run(ctx, updateArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Updated packages", nil
+}
+
+func (c *Client) list(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"list", "--depth=0"})
+}
+
+func (c *Client) listArgs(ctx context.Context, args []string) (string, error) {
+	listArgs := []string{"list"}
+	listArgs = append(listArgs, args...)
+
+	return c.run(ctx, listArgs)
+}
+
+func (c *Client) outdated(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"outdated"})
+}
+
+func (c *Client) init(ctx context.Context, args []string) (string, error) {
+	initArgs := []string{"init"}
+	if len(args) > 0 {
+		initArgs = append(initArgs, "-y")
+	}
+
+	_, err := c.run(ctx, initArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Initialized package.json", nil
+}
+
+func (c *Client) runScript(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"run"})
+	}
+
+	scriptArgs := []string{"run"}
+	scriptArgs = append(scriptArgs, args...)
+
+	return c.run(ctx, scriptArgs)
+}
+
+func (c *Client) publish(ctx context.Context, args []string) (string, error) {
+	publishArgs := []string{"publish"}
+	publishArgs = append(publishArgs, args...)
+
+	_, err := c.run(ctx, publishArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return "Published to npm", nil
+}
+
+func (c *Client) info(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("package name required")
+	}
+
+	return c.run(ctx, []string{"info", args[0]})
+}
+
+func (c *Client) search(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("search term required")
+	}
+
+	searchArgs := []string{"search", "--long"}
+	searchArgs = append(searchArgs, args...)
+
+	return c.run(ctx, searchArgs)
+}
+
+func (c *Client) version(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.run(ctx, []string{"--version"})
+	}
+
+	_, err := c.run(ctx, []string{"version", args[0]})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Version updated to %s", args[0]), nil
+}
+
+func (c *Client) view(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("package name required")
+	}
+
+	viewArgs := []string{"view"}
+	viewArgs = append(viewArgs, args...)
+
+	return c.run(ctx, viewArgs)
+}
+
+func (c *Client) docs(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("package name required")
+	}
+
+	return fmt.Sprintf("https://www.npmjs.com/package/%s", args[0]), nil
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.npmPath, args...)
+	cmd.Dir = c.workingDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.npmPath, "--version")
+	return cmd.Run() == nil
+}
+
+func ParseDependencies(output string) (map[string]string, error) {
+	var pkgList PackageList
+	if err := json.Unmarshal([]byte(output), &pkgList); err != nil {
+		return nil, err
+	}
+
+	deps := make(map[string]string)
+	for name, info := range pkgList.Dependencies {
+		deps[name] = info.Version
+	}
+	return deps, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/python/python.go
+++ b/pkg/extensions/adapters/cli/adapters/python/python.go
@@ -1,0 +1,125 @@
+package python
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	pythonPath string
+	venvPath   string
+}
+
+type Config struct {
+	PythonPath string
+	VenvPath   string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.PythonPath
+	if path == "" {
+		path = "python"
+	}
+	return &Client{
+		pythonPath: path,
+		venvPath:   cfg.VenvPath,
+	}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.version(ctx)
+	}
+
+	switch args[0] {
+	case "run":
+		return c.runScript(ctx, args[1:])
+	case "install":
+		return c.pipInstall(ctx, args[1:])
+	case "pip":
+		return c.pip(ctx, args[1:])
+	case "version", "V":
+		return c.version(ctx)
+	case "info":
+		return c.info(ctx)
+	case "list":
+		return c.listPackages(ctx)
+	case "env":
+		return c.venv(ctx)
+	case "script":
+		return c.runScriptFile(ctx, args[1:])
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) version(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"--version"})
+}
+
+func (c *Client) info(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"-c", "import sys; print(sys.executable); print(sys.version)"})
+}
+
+func (c *Client) runScript(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("code required")
+	}
+
+	code := strings.Join(args, " ")
+	return c.run(ctx, []string{"-c", code})
+}
+
+func (c *Client) runScriptFile(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("script path required")
+	}
+
+	return c.run(ctx, args)
+}
+
+func (c *Client) pipInstall(ctx context.Context, args []string) (string, error) {
+	pipArgs := []string{"-m", "pip", "install"}
+	pipArgs = append(pipArgs, args...)
+
+	_, err := c.run(ctx, pipArgs)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Installed: %s", strings.Join(args, " ")), nil
+}
+
+func (c *Client) pip(ctx context.Context, args []string) (string, error) {
+	pipArgs := []string{"-m", "pip"}
+	pipArgs = append(pipArgs, args...)
+
+	return c.run(ctx, pipArgs)
+}
+
+func (c *Client) listPackages(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"-m", "pip", "list"})
+}
+
+func (c *Client) venv(ctx context.Context) (string, error) {
+	if c.venvPath == "" {
+		return c.run(ctx, []string{"-m", "venv"})
+	}
+	return c.run(ctx, []string{"-m", "venv", c.venvPath})
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.pythonPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.pythonPath, "--version")
+	return cmd.Run() == nil
+}


### PR DESCRIPTION
## 概要

补充开发、运维和基础工具类 CLI adapters，为后续 CLI extension catalog 扩展提供更多内置适配入口。

## 本次变更

- 新增 AdGuard Home、AWS、curl、Docker、Git、kubectl 等运维/开发 adapter
- 新增 Node、npm、Python、anygen 等基础工具 adapter
- 只新增独立 adapter package，不修改现有 CLI adapter core

## 验证

已执行：

- 新增 10 个 adapter package 的 `go test`
- `git diff --cached --check`
