### PR TITLE
feat(extensions): add creative CLI adapters

### DIFF
--- a/pkg/extensions/adapters/cli/adapters/audacity/audacity.go
+++ b/pkg/extensions/adapters/cli/adapters/audacity/audacity.go
@@ -1,0 +1,96 @@
+package audacity
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Client struct {
+	soxPath string
+}
+
+type Config struct {
+	SoxPath string
+}
+
+func NewClient(cfg Config) *Client {
+	soxPath := cfg.SoxPath
+	if soxPath == "" {
+		soxPath = "sox"
+	}
+
+	return &Client{
+		soxPath: soxPath,
+	}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.info(ctx)
+	}
+
+	switch args[0] {
+	case "info", "version":
+		return c.info(ctx)
+	case "convert":
+		return c.convert(ctx, args[1:])
+	case "trim":
+		return c.trim(ctx, args[1:])
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) info(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"--version"})
+}
+
+func (c *Client) convert(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("usage: audacity convert <input> <output>")
+	}
+
+	input := args[0]
+	output := args[1]
+	format := strings.TrimPrefix(strings.ToLower(filepath.Ext(output)), ".")
+	if format == "" {
+		return "", fmt.Errorf("output file must include an extension")
+	}
+
+	_, err := c.run(ctx, []string{input, "-t", format, output})
+	if err != nil {
+		return "", fmt.Errorf("conversion failed: %w", err)
+	}
+
+	return fmt.Sprintf("Converted %s to %s", input, output), nil
+}
+
+func (c *Client) trim(ctx context.Context, args []string) (string, error) {
+	if len(args) < 3 {
+		return "", fmt.Errorf("usage: audacity trim <input> <output> <duration>")
+	}
+
+	input := args[0]
+	output := args[1]
+	duration := args[2]
+
+	_, err := c.run(ctx, []string{input, output, "trim", "0", duration})
+	if err != nil {
+		return "", fmt.Errorf("trim failed: %w", err)
+	}
+
+	return fmt.Sprintf("Trimmed %s to %s seconds", output, duration), nil
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.soxPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}

--- a/pkg/extensions/adapters/cli/adapters/blender/blender.go
+++ b/pkg/extensions/adapters/cli/adapters/blender/blender.go
@@ -1,0 +1,239 @@
+package blender
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Client struct {
+	blenderPath string
+	workspace   string
+}
+
+type Config struct {
+	BlenderPath string
+	Workspace   string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.BlenderPath
+	if path == "" {
+		path = "blender"
+	}
+	workspace := cfg.Workspace
+	if workspace == "" {
+		workspace = "."
+	}
+
+	return &Client{
+		blenderPath: path,
+		workspace:   workspace,
+	}
+}
+
+type Scene struct {
+	Name        string       `json:"name"`
+	Objects     []Object     `json:"objects"`
+	Collections []Collection `json:"collections"`
+}
+
+type Object struct {
+	Name     string    `json:"name"`
+	Type     string    `json:"type"`
+	Location []float64 `json:"location"`
+	Rotation []float64 `json:"rotation"`
+	Scale    []float64 `json:"scale"`
+}
+
+type Collection struct {
+	Name     string   `json:"name"`
+	Children []string `json:"children,omitempty"`
+}
+
+type RenderResult struct {
+	OutputPath string `json:"output_path"`
+	Width      int    `json:"width"`
+	Height     int    `json:"height"`
+	Engine     string `json:"engine"`
+	Duration   string `json:"duration"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.listScenes(ctx)
+	}
+
+	cmd := args[0]
+	switch cmd {
+	case "list", "ls":
+		return c.listScenes(ctx)
+	case "scene", "new":
+		return c.createScene(ctx, args[1:])
+	case "object", "add":
+		return c.addObject(ctx, args[1:])
+	case "render", "export":
+		return c.render(ctx, args[1:])
+	case "info":
+		return c.info(ctx)
+	default:
+		return c.runPython(ctx, strings.Join(args, " "))
+	}
+}
+
+func (c *Client) listScenes(ctx context.Context) (string, error) {
+	script := `
+import bpy
+for scene in bpy.data.scenes:
+    print(scene.name)
+`
+	return c.runScript(ctx, script)
+}
+
+func (c *Client) createScene(ctx context.Context, args []string) (string, error) {
+	name := "NewScene"
+	if len(args) > 0 {
+		name = args[0]
+	}
+
+	script := fmt.Sprintf(`
+import bpy
+scene = bpy.data.scenes.new(name="%s")
+bpy.context.window.scene = scene
+print("Created scene:", "%s")
+`, name, name)
+
+	out, err := c.runScript(ctx, script)
+	if err != nil {
+		return "", err
+	}
+	return out + "\nScene created: " + name, nil
+}
+
+func (c *Client) addObject(ctx context.Context, args []string) (string, error) {
+	objType := "cube"
+	objName := "Object"
+	if len(args) > 0 {
+		objType = args[0]
+	}
+	if len(args) > 1 {
+		objName = args[1]
+	}
+
+	script := fmt.Sprintf(`
+import bpy
+obj_type = "%s"
+name = "%s"
+if obj_type == "cube":
+    bpy.ops.mesh.primitive_cube_add(size=2, location=(0, 0, 0))
+    obj = bpy.context.active_object
+elif obj_type == "sphere":
+    bpy.ops.mesh.primitive_uv_sphere_add(radius=1, location=(0, 0, 0))
+    obj = bpy.context.active_object
+elif obj_type == "plane":
+    bpy.ops.mesh.primitive_plane_add(size=2, location=(0, 0, 0))
+    obj = bpy.context.active_object
+elif obj_type == "cylinder":
+    bpy.ops.mesh.primitive_cylinder_add(radius=1, depth=2, location=(0, 0, 0))
+    obj = bpy.context.active_object
+elif obj_type == "cone":
+    bpy.ops.mesh.primitive_cone_add(radius1=1, depth=2, location=(0, 0, 0))
+    obj = bpy.context.active_object
+else:
+    bpy.ops.mesh.primitive_cube_add(size=2, location=(0, 0, 0))
+    obj = bpy.context.active_object
+
+obj.name = name
+print("Added object:", name, "type:", obj_type)
+`, objType, objName)
+
+	return c.runScript(ctx, script)
+}
+
+func (c *Client) render(ctx context.Context, args []string) (string, error) {
+	outputPath := "render.png"
+	format := "PNG"
+	if len(args) > 0 {
+		outputPath = args[0]
+	}
+	if len(args) > 1 {
+		format = args[1]
+	}
+
+	absPath, _ := filepath.Abs(outputPath)
+
+	script := fmt.Sprintf(`
+import bpy
+scene = bpy.context.scene
+scene.render.filepath = "%s"
+scene.render.image_settings.file_format = "%s"
+bpy.ops.render.render(write=True)
+print("Rendered to:", "%s")
+`, outputPath, format, absPath)
+
+	_, err := c.runScript(ctx, script)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Rendered: %s", absPath), nil
+}
+
+func (c *Client) info(ctx context.Context) (string, error) {
+	script := `
+import bpy
+scene = bpy.context.scene
+print("Scene:", scene.name)
+print("Objects:", len(bpy.data.objects))
+print("Collections:", len(bpy.data.collections))
+for obj in bpy.data.objects[:5]:
+    print(" -", obj.name, "type:", obj.type)
+`
+	return c.runScript(ctx, script)
+}
+
+func (c *Client) runPython(ctx context.Context, code string) (string, error) {
+	script := code
+	return c.runScript(ctx, script)
+}
+
+func (c *Client) runScript(ctx context.Context, script string) (string, error) {
+	tmpfile, err := os.CreateTemp("", "blender_*.py")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.WriteString(script); err != nil {
+		return "", err
+	}
+	tmpfile.Close()
+
+	cmd := exec.CommandContext(ctx, c.blenderPath, "--background", "--python", tmpfile.Name())
+	cmd.Dir = c.workspace
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return string(output), err
+	}
+
+	lines := strings.Split(string(output), "\n")
+	var result []string
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "Read prefs:") &&
+			!strings.HasPrefix(line, "found bundled Python:") &&
+			!strings.HasPrefix(line, "Warning:") {
+			result = append(result, line)
+		}
+	}
+
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.blenderPath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/blender/blender.go
+++ b/pkg/extensions/adapters/cli/adapters/blender/blender.go
@@ -2,6 +2,7 @@ package blender
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -101,9 +102,10 @@ func (c *Client) createScene(ctx context.Context, args []string) (string, error)
 
 	script := fmt.Sprintf(`
 import bpy
-scene = bpy.data.scenes.new(name="%s")
-print("Created scene:", "%s")
-`, name, name)
+scene_name = %s
+scene = bpy.data.scenes.new(name=scene_name)
+print("Created scene:", scene_name)
+`, pyString(name))
 
 	out, err := c.runScript(ctx, script)
 	if err != nil {
@@ -124,8 +126,8 @@ func (c *Client) addObject(ctx context.Context, args []string) (string, error) {
 
 	script := fmt.Sprintf(`
 import bpy
-obj_type = "%s"
-name = "%s"
+obj_type = %s
+name = %s
 if obj_type == "cube":
     bpy.ops.mesh.primitive_cube_add(size=2, location=(0, 0, 0))
     obj = bpy.context.active_object
@@ -147,7 +149,7 @@ else:
 
 obj.name = name
 print("Added object:", name, "type:", obj_type)
-`, objType, objName)
+`, pyString(objType), pyString(objName))
 
 	return c.runScript(ctx, script)
 }
@@ -167,11 +169,11 @@ func (c *Client) render(ctx context.Context, args []string) (string, error) {
 	script := fmt.Sprintf(`
 import bpy
 scene = bpy.context.scene
-scene.render.filepath = "%s"
-scene.render.image_settings.file_format = "%s"
+scene.render.filepath = %s
+scene.render.image_settings.file_format = %s
 bpy.ops.render.render(write=True)
-print("Rendered to:", "%s")
-`, outputPath, format, absPath)
+print("Rendered to:", %s)
+`, pyString(outputPath), pyString(format), pyString(absPath))
 
 	_, err := c.runScript(ctx, script)
 	if err != nil {
@@ -197,6 +199,14 @@ for obj in bpy.data.objects[:5]:
 func (c *Client) runPython(ctx context.Context, code string) (string, error) {
 	script := code
 	return c.runScript(ctx, script)
+}
+
+func pyString(value string) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return `""`
+	}
+	return string(data)
 }
 
 func (c *Client) runScript(ctx context.Context, script string) (string, error) {

--- a/pkg/extensions/adapters/cli/adapters/blender/blender.go
+++ b/pkg/extensions/adapters/cli/adapters/blender/blender.go
@@ -102,7 +102,6 @@ func (c *Client) createScene(ctx context.Context, args []string) (string, error)
 	script := fmt.Sprintf(`
 import bpy
 scene = bpy.data.scenes.new(name="%s")
-bpy.context.window.scene = scene
 print("Created scene:", "%s")
 `, name, name)
 

--- a/pkg/extensions/adapters/cli/adapters/blender/blender_test.go
+++ b/pkg/extensions/adapters/cli/adapters/blender/blender_test.go
@@ -24,6 +24,10 @@ func TestMain(m *testing.M) {
 					fmt.Fprint(os.Stderr, "background mode has no bpy.context.window")
 					os.Exit(1)
 				}
+				if strings.Contains(string(script), `name = "bad"`) || strings.Contains(string(script), `print("pwned")`) {
+					fmt.Fprint(os.Stderr, "script contains unescaped object name")
+					os.Exit(1)
+				}
 				fmt.Println("Created scene: TestScene")
 				os.Exit(0)
 			}
@@ -48,6 +52,19 @@ func TestCreateSceneWorksInBackgroundMode(t *testing.T) {
 	}
 	if !strings.Contains(out, "Scene created: TestScene") {
 		t.Fatalf("expected create scene confirmation, got %q", out)
+	}
+}
+
+func TestAddObjectQuotesPythonStrings(t *testing.T) {
+	t.Setenv("ANYCLAW_BLENDER_ADAPTER_HELPER", "1")
+	client := NewClient(Config{
+		BlenderPath: fakeBlenderPath(t),
+		Workspace:   t.TempDir(),
+	})
+
+	out, err := client.Run(context.Background(), []string{"object", "cube", "bad\"\nprint(\"pwned\")\n"})
+	if err != nil {
+		t.Fatalf("add object returned error: %v; output: %s", err, out)
 	}
 }
 

--- a/pkg/extensions/adapters/cli/adapters/blender/blender_test.go
+++ b/pkg/extensions/adapters/cli/adapters/blender/blender_test.go
@@ -1,0 +1,85 @@
+package blender
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("ANYCLAW_BLENDER_ADAPTER_HELPER") == "1" {
+		args := os.Args[1:]
+		for i, arg := range args {
+			if arg == "--python" && i+1 < len(args) {
+				script, err := os.ReadFile(args[i+1])
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "read script: %v", err)
+					os.Exit(1)
+				}
+				if strings.Contains(string(script), "bpy.context.window.scene") {
+					fmt.Fprint(os.Stderr, "background mode has no bpy.context.window")
+					os.Exit(1)
+				}
+				fmt.Println("Created scene: TestScene")
+				os.Exit(0)
+			}
+		}
+		fmt.Fprint(os.Stderr, "missing --python script")
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestCreateSceneWorksInBackgroundMode(t *testing.T) {
+	t.Setenv("ANYCLAW_BLENDER_ADAPTER_HELPER", "1")
+	client := NewClient(Config{
+		BlenderPath: fakeBlenderPath(t),
+		Workspace:   t.TempDir(),
+	})
+
+	out, err := client.Run(context.Background(), []string{"scene", "TestScene"})
+	if err != nil {
+		t.Fatalf("create scene returned error: %v; output: %s", err, out)
+	}
+	if !strings.Contains(out, "Scene created: TestScene") {
+		t.Fatalf("expected create scene confirmation, got %q", out)
+	}
+}
+
+func fakeBlenderPath(t *testing.T) string {
+	t.Helper()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "blender-helper.exe")
+	copyExecutable(t, exe, path)
+	return path
+}
+
+func copyExecutable(t *testing.T, src, dst string) {
+	t.Helper()
+
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open source executable: %v", err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("create helper executable: %v", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		t.Fatalf("copy helper executable: %v", err)
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/comfyui/comfyui.go
+++ b/pkg/extensions/adapters/cli/adapters/comfyui/comfyui.go
@@ -1,0 +1,169 @@
+package comfyui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+type Config struct {
+	BaseURL string
+}
+
+func NewClient(cfg Config) *Client {
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "http://localhost:8188"
+	}
+
+	return &Client{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Minute,
+		},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.history(ctx)
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "queue":
+		return c.queue(ctx)
+	case "history":
+		return c.history(ctx)
+	case "prompt":
+		return c.prompt(ctx, subArgs)
+	case "interrupt":
+		return c.interrupt(ctx)
+	case "check":
+		return c.check(ctx, subArgs)
+	case "seed":
+		return c.seed(ctx, subArgs)
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (c *Client) queue(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/queue", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) history(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/history", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) prompt(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("prompt JSON required")
+	}
+
+	workflow := args[0]
+
+	reqBody := map[string]any{"prompt": workflow}
+	body, _ := json.Marshal(reqBody)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/prompt", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) interrupt(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/interrupt", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	return "Interrupted", nil
+}
+
+func (c *Client) check(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("prompt_id required")
+	}
+	promptID := args[0]
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/history/"+promptID, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) seed(ctx context.Context, args []string) (string, error) {
+	return fmt.Sprintf("Use 'prompt' with seed parameter in workflow JSON"), nil
+}
+
+func (c *Client) IsRunning(ctx context.Context) bool {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/system_stats", nil)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode < 300
+}

--- a/pkg/extensions/adapters/cli/adapters/drawio/drawio.go
+++ b/pkg/extensions/adapters/cli/adapters/drawio/drawio.go
@@ -1,0 +1,79 @@
+package drawio
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Adapter struct {
+	drawioPath string
+}
+
+type Config struct {
+	DrawioPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.DrawioPath
+	if path == "" {
+		path = "drawio"
+	}
+	return &Adapter{drawioPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "drawio"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "export":
+		return a.export(subArgs)
+	case "convert":
+		return a.convert(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) export(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("export requires <input.drawio> <output.pdf/png/svg>")
+	}
+	input := args[0]
+	output := args[1]
+
+	ext := strings.ToLower(filepath.Ext(output))
+	format := strings.TrimPrefix(ext, ".")
+
+	cmd := exec.Command(a.drawioPath, "--export", "--output", output, "--format", format, input)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("export failed: %w", err)
+	}
+
+	return fmt.Sprintf("Exported to %s", output), nil
+}
+
+func (a *Adapter) convert(args []string) (string, error) {
+	return a.export(args)
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Draw.io CLI adapter
+Commands:
+  export <input.drawio> <output.pdf/png/svg> - Export diagram
+  convert <input> <output>                   - Convert (alias)
+  help                                       - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/ffmpeg/ffmpeg.go
+++ b/pkg/extensions/adapters/cli/adapters/ffmpeg/ffmpeg.go
@@ -1,0 +1,173 @@
+package ffmpeg
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Client struct {
+	ffmpegPath  string
+	ffprobePath string
+}
+
+type Config struct {
+	FFmpegPath  string
+	FFProbePath string
+}
+
+func NewClient(cfg Config) *Client {
+	ffmpeg := cfg.FFmpegPath
+	if ffmpeg == "" {
+		ffmpeg = "ffmpeg"
+	}
+	ffprobe := cfg.FFProbePath
+	if ffprobe == "" {
+		ffprobe = "ffprobe"
+	}
+	return &Client{
+		ffmpegPath:  ffmpeg,
+		ffprobePath: ffprobe,
+	}
+}
+
+type Stream struct {
+	Index   int    `json:"index"`
+	Type    string `json:"codec_type"`
+	Codec   string `json:"codec_name"`
+	Width   int    `json:"width"`
+	Height  int    `json:"height"`
+	FPS     string `json:"r_frame_rate"`
+	Bitrate string `json:"bit_rate"`
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.probeMedia(ctx)
+	}
+
+	switch args[0] {
+	case "info", "probe":
+		return c.probeMediaArgs(ctx, args[1:])
+	case "convert", "transcode":
+		return c.convertMedia(ctx, args[1:])
+	case "thumbnail", "screenshot":
+		return c.thumbnailMedia(ctx, args[1:])
+	case "version":
+		return c.run(ctx, []string{"-version"})
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) probeMedia(ctx context.Context) (string, error) {
+	return c.run(ctx, []string{"-version"})
+}
+
+func (c *Client) probeMediaArgs(ctx context.Context, args []string) (string, error) {
+	input := "input.mp4"
+	if len(args) > 0 {
+		input = args[0]
+	}
+
+	output, err := c.runFFProbe(ctx, []string{"-v", "quiet", "-print_format", "json", "-show_format", "-show_streams", input})
+	if err != nil {
+		return "", err
+	}
+
+	var result []string
+	result = append(result, fmt.Sprintf("File: %s", input))
+	result = append(result, output[:min(500, len(output))])
+	return strings.Join(result, "\n"), nil
+}
+
+func (c *Client) convertMedia(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("usage: ffmpeg convert <input> <output>")
+	}
+
+	input := args[0]
+	output := args[1]
+
+	_, err := c.run(ctx, []string{"-i", input, "-y", output})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Converted: %s -> %s", input, output), nil
+}
+
+func (c *Client) thumbnailMedia(ctx context.Context, args []string) (string, error) {
+	input := "input.mp4"
+	output := "thumb.jpg"
+	time := "00:00:01"
+
+	for i, arg := range args {
+		if arg == "-i" && i+1 < len(args) {
+			input = args[i+1]
+		}
+		if arg == "-o" && i+1 < len(args) {
+			output = args[i+1]
+		}
+		if arg == "-t" && i+1 < len(args) {
+			time = args[i+1]
+		}
+	}
+
+	_, err := c.run(ctx, []string{"-i", input, "-ss", time, "-vframes", "1", "-y", output})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Thumbnail: %s at %s", output, time), nil
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.ffmpegPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) runFFProbe(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.ffprobePath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.ffmpegPath, "-version")
+	return cmd.Run() == nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func getExt(filename string) string {
+	ext := filepath.Ext(filename)
+	return strings.ToLower(ext)
+}
+
+func audioCodec(ext string) string {
+	switch ext {
+	case ".mp3":
+		return "libmp3lame"
+	case ".wav":
+		return "pcm_s16le"
+	case ".aac", ".m4a":
+		return "aac"
+	default:
+		return "copy"
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/freecad/freecad.go
+++ b/pkg/extensions/adapters/cli/adapters/freecad/freecad.go
@@ -1,0 +1,109 @@
+package freecad
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type Adapter struct {
+	freecadPath string
+}
+
+type Config struct {
+	FreecadPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.FreecadPath
+	if path == "" {
+		path = "FreeCAD"
+	}
+	return &Adapter{freecadPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "freecad"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "info":
+		return a.info()
+	case "open":
+		return a.open(subArgs)
+	case "macro":
+		return a.macro(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) info() (string, error) {
+	cmd := exec.Command(a.freecadPath, "--version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("freecad not found: %w", err)
+	}
+	return string(output), nil
+}
+
+func (a *Adapter) open(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("open requires <file.fcstd1> [file.fcstd2...]")
+	}
+
+	for _, f := range args {
+		if _, err := os.Stat(f); os.IsNotExist(err) {
+			return "", fmt.Errorf("file not found: %s", f)
+		}
+	}
+
+	cmd := exec.Command(a.freecadPath, "--background", args[0])
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Opened %d files", len(args)), nil
+}
+
+func (a *Adapter) macro(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("macro requires <file.fcstd> <macro.py>")
+	}
+	model := args[0]
+	script := args[1]
+
+	if _, err := os.Stat(script); os.IsNotExist(err) {
+		return "", fmt.Errorf("script not found: %s", script)
+	}
+
+	cmd := exec.Command(a.freecadPath, "--background", "--python-script", script, model)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("macro failed: %s", string(output))
+	}
+
+	return "Macro executed", nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `FreeCAD CLI adapter (258 commands: Part, Sketcher, PartDesign, Assembly, Mesh, TechDraw, Draft, FEM, CAM)
+Commands:
+  info                   - Show FreeCAD version
+  open <file.fcstd...>  - Open model file(s)
+  macro <file> <script> - Run Python script on model
+  help                   - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/freecad/freecad.go
+++ b/pkg/extensions/adapters/cli/adapters/freecad/freecad.go
@@ -69,7 +69,8 @@ func (a *Adapter) open(args []string) (string, error) {
 		}
 	}
 
-	cmd := exec.Command(a.freecadPath, "--background", args[0])
+	cmdArgs := append([]string{"--background"}, args...)
+	cmd := exec.Command(a.freecadPath, cmdArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/pkg/extensions/adapters/cli/adapters/freecad/freecad_test.go
+++ b/pkg/extensions/adapters/cli/adapters/freecad/freecad_test.go
@@ -1,0 +1,100 @@
+package freecad
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("ANYCLAW_FREECAD_ADAPTER_HELPER") == "1" {
+		if logPath := os.Getenv("ANYCLAW_FREECAD_ADAPTER_LOG"); logPath != "" {
+			data, _ := json.Marshal(os.Args[1:])
+			_ = os.WriteFile(logPath, data, 0o644)
+		}
+		fmt.Print(strings.Join(os.Args[1:], " "))
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestOpenPassesAllFilesToFreeCAD(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.FCStd")
+	second := filepath.Join(dir, "second.FCStd")
+	writeFile(t, first)
+	writeFile(t, second)
+	logPath := filepath.Join(dir, "freecad-args.json")
+	t.Setenv("ANYCLAW_FREECAD_ADAPTER_HELPER", "1")
+	t.Setenv("ANYCLAW_FREECAD_ADAPTER_LOG", logPath)
+	adapter := New(Config{FreecadPath: fakeFreeCADPath(t)})
+
+	if _, err := adapter.Execute(context.Background(), []string{"open", first, second}); err != nil {
+		t.Fatalf("open returned error: %v", err)
+	}
+
+	want := []string{"--background", first, second}
+	if got := readFreeCADArgs(t, logPath); !reflect.DeepEqual(got, want) {
+		t.Fatalf("freecad args = %#v, want %#v", got, want)
+	}
+}
+
+func fakeFreeCADPath(t *testing.T) string {
+	t.Helper()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "freecad-helper.exe")
+	copyExecutable(t, exe, path)
+	return path
+}
+
+func copyExecutable(t *testing.T, src, dst string) {
+	t.Helper()
+
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open source executable: %v", err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("create helper executable: %v", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		t.Fatalf("copy helper executable: %v", err)
+	}
+}
+
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("model"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func readFreeCADArgs(t *testing.T, logPath string) []string {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read helper log: %v", err)
+	}
+	var args []string
+	if err := json.Unmarshal(data, &args); err != nil {
+		t.Fatalf("decode helper args: %v", err)
+	}
+	return args
+}

--- a/pkg/extensions/adapters/cli/adapters/gimp/gimp.go
+++ b/pkg/extensions/adapters/cli/adapters/gimp/gimp.go
@@ -1,0 +1,110 @@
+package gimp
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	gimpPath string
+}
+
+type Config struct {
+	GimpPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.GimpPath
+	if path == "" {
+		path = "gimp"
+	}
+	return &Adapter{gimpPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "gimp"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "convert":
+		return a.convert(subArgs)
+	case "resize":
+		return a.resize(subArgs)
+	case "crop":
+		return a.crop(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) convert(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("convert requires <input> <output>")
+	}
+	input := args[0]
+	output := args[1]
+
+	script := fmt.Sprintf("(gimp-file-load RUN-NONINTERACTIVE \"%s\" \"%s\") (gimp-file-save RUN-NONINTERACTIVE (car (gimp-image-get-active-layer 1)) (car (gimp-image-get-active-drawable 1)) \"%s\" \"%s\") (gimp-quit 1)", input, input, output, output)
+
+	cmd := exec.Command(a.gimpPath, "-i", "-b", script)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("conversion failed: %w", err)
+	}
+
+	return fmt.Sprintf("Converted to %s", output), nil
+}
+
+func (a *Adapter) resize(args []string) (string, error) {
+	if len(args) < 3 {
+		return "", fmt.Errorf("resize requires <input> <width> <height>")
+	}
+	input := args[0]
+	width := args[1]
+	height := args[2]
+
+	script := fmt.Sprintf("(gimp-file-load RUN-NONINTERACTIVE \"%s\" \"%s\") (gimp-image-scale 1 %s %s) (gimp-file-save RUN-NONINTERACTIVE (car (gimp-image-get-active-layer 1)) (car (gimp-image-get-active-drawable 1)) \"%s\" \"%s\") (gimp-quit 1)", input, input, width, height, input, input)
+
+	cmd := exec.Command(a.gimpPath, "-i", "-b", script)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("resize failed: %w", err)
+	}
+
+	return fmt.Sprintf("Resized to %sx%s", width, height), nil
+}
+
+func (a *Adapter) crop(args []string) (string, error) {
+	if len(args) < 5 {
+		return "", fmt.Errorf("crop requires <input> <x> <y> <width> <height>")
+	}
+	input := args[0]
+	x, y, w, h := args[1], args[2], args[3], args[4]
+
+	script := fmt.Sprintf("(gimp-file-load RUN-NONINTERACTIVE \"%s\" \"%s\") (gimp-image-crop 1 %s %s %s %s) (gimp-file-save RUN-NONINTERACTIVE (car (gimp-image-get-active-layer 1)) (car (gimp-image-get-active-drawable 1)) \"%s\" \"%s\") (gimp-quit 1)", input, input, w, h, x, y, input, input)
+
+	cmd := exec.Command(a.gimpPath, "-i", "-b", script)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("crop failed: %w", err)
+	}
+
+	return "Cropped successfully", nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `GIMP CLI adapter (batch mode)
+Commands:
+  convert <input> <output>           - Convert format
+  resize <input> <width> <height>   - Resize image
+  crop <input> <x> <y> <w> <h>      - Crop image
+  help                               - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/inkscape/inkscape.go
+++ b/pkg/extensions/adapters/cli/adapters/inkscape/inkscape.go
@@ -1,0 +1,74 @@
+package inkscape
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	inkscapePath string
+}
+
+type Config struct {
+	InkscapePath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.InkscapePath
+	if path == "" {
+		path = "inkscape"
+	}
+	return &Adapter{inkscapePath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "inkscape"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "export":
+		return a.export(subArgs)
+	case "convert":
+		return a.convert(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) export(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("export requires <input.svg> <output.png/pdf/eps>")
+	}
+	input := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.inkscapePath, "--export-filename", output, input)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("export failed: %w", err)
+	}
+
+	return fmt.Sprintf("Exported to %s", output), nil
+}
+
+func (a *Adapter) convert(args []string) (string, error) {
+	return a.export(args)
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Inkscape CLI adapter
+Commands:
+  export <input.svg> <output.png/pdf/eps> - Export to format
+  convert <input> <output>               - Convert (alias)
+  help                                    - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/kdenlive/kdenlive.go
+++ b/pkg/extensions/adapters/cli/adapters/kdenlive/kdenlive.go
@@ -1,0 +1,79 @@
+package kdenlive
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	meltPath string
+}
+
+type Config struct {
+	MeltPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.MeltPath
+	if path == "" {
+		path = "melt"
+	}
+	return &Adapter{meltPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "kdenlive"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "render":
+		return a.render(subArgs)
+	case "info":
+		return a.info(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) render(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("render requires <profile> <output>")
+	}
+	profile := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.meltPath, profile, "-", "out", output)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("render failed: %w", err)
+	}
+
+	return fmt.Sprintf("Rendered to %s", output), nil
+}
+
+func (a *Adapter) info(args []string) (string, error) {
+	cmd := exec.Command(a.meltPath, "-query", "profiles")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Kdenlive CLI adapter (via melt)
+Commands:
+  render <profile> <output> - Render video
+  info                      - List profiles
+  help                      - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/krita/krita.go
+++ b/pkg/extensions/adapters/cli/adapters/krita/krita.go
@@ -1,0 +1,67 @@
+package krita
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	kritaPath string
+}
+
+type Config struct {
+	KritaPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.KritaPath
+	if path == "" {
+		path = "krita"
+	}
+	return &Adapter{kritaPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "krita"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "export":
+		return a.export(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) export(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("export requires <input.kra> <output.png>")
+	}
+	input := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.kritaPath, "--export", "--export-filename", output, input)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("export failed: %w", err)
+	}
+
+	return fmt.Sprintf("Exported to %s", output), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Krita CLI adapter
+Commands:
+  export <input.kra> <output.png> - Export to format
+  help                           - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/libreoffice/libreoffice.go
+++ b/pkg/extensions/adapters/cli/adapters/libreoffice/libreoffice.go
@@ -1,0 +1,142 @@
+package libreoffice
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Client struct {
+	sofficePath string
+}
+
+type Config struct {
+	SofficePath string
+}
+
+func NewClient(cfg Config) *Client {
+	path := cfg.SofficePath
+	if path == "" {
+		path = "soffice"
+	}
+	return &Client{sofficePath: path}
+}
+
+func (c *Client) Run(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "LibreOffice available. Use: convert, pdf, view", nil
+	}
+
+	switch args[0] {
+	case "convert":
+		return c.convert(ctx, args[1:])
+	case "pdf":
+		return c.toPDF(ctx, args[1:])
+	case "view":
+		return c.view(ctx, args[1:])
+	case "headless":
+		return c.headless(ctx, args[1:])
+	default:
+		return c.run(ctx, args)
+	}
+}
+
+func (c *Client) convert(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("usage: libreoffice convert <input> <output>")
+	}
+
+	input := args[0]
+	output := args[1]
+
+	inputAbs, _ := filepath.Abs(input)
+	outputAbs, _ := filepath.Abs(output)
+
+	_, err := c.run(ctx, []string{
+		"--headless",
+		"--convert-to",
+		filepath.Ext(output)[1:],
+		"--outdir",
+		filepath.Dir(outputAbs),
+		inputAbs,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Converted: %s -> %s", input, output), nil
+}
+
+func (c *Client) toPDF(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("usage: libreoffice pdf <input> [output]")
+	}
+
+	input := args[0]
+	var output string
+	if len(args) > 1 {
+		output = args[1]
+	} else {
+		ext := filepath.Ext(input)
+		output = strings.TrimSuffix(input, ext) + ".pdf"
+	}
+
+	inputAbs, _ := filepath.Abs(input)
+	outputAbs, _ := filepath.Abs(output)
+
+	_, err := c.run(ctx, []string{
+		"--headless",
+		"--convert-to",
+		"pdf",
+		"--outdir",
+		filepath.Dir(outputAbs),
+		inputAbs,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("PDF created: %s", output), nil
+}
+
+func (c *Client) view(ctx context.Context, args []string) (string, error) {
+	if len(args) < 1 {
+		return "", fmt.Errorf("usage: libreoffice view <file>")
+	}
+
+	input := args[0]
+	inputAbs, _ := filepath.Abs(input)
+
+	_, err := c.run(ctx, []string{
+		"--view",
+		inputAbs,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Opened: %s", input), nil
+}
+
+func (c *Client) headless(ctx context.Context, args []string) (string, error) {
+	headlessArgs := []string{"--headless"}
+	headlessArgs = append(headlessArgs, args...)
+
+	return c.run(ctx, headlessArgs)
+}
+
+func (c *Client) run(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.sofficePath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) IsInstalled(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, c.sofficePath, "--version")
+	return cmd.Run() == nil
+}

--- a/pkg/extensions/adapters/cli/adapters/libreoffice/libreoffice.go
+++ b/pkg/extensions/adapters/cli/adapters/libreoffice/libreoffice.go
@@ -3,6 +3,7 @@ package libreoffice
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -65,6 +66,9 @@ func (c *Client) convert(ctx context.Context, args []string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if err := moveConvertedOutput(inputAbs, outputAbs, filepath.Ext(output)[1:]); err != nil {
+		return "", err
+	}
 
 	return fmt.Sprintf("Converted: %s -> %s", input, output), nil
 }
@@ -95,6 +99,9 @@ func (c *Client) toPDF(ctx context.Context, args []string) (string, error) {
 		inputAbs,
 	})
 	if err != nil {
+		return "", err
+	}
+	if err := moveConvertedOutput(inputAbs, outputAbs, "pdf"); err != nil {
 		return "", err
 	}
 
@@ -134,6 +141,26 @@ func (c *Client) run(ctx context.Context, args []string) (string, error) {
 		return string(output), err
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+func moveConvertedOutput(inputAbs, outputAbs, format string) error {
+	generated := filepath.Join(
+		filepath.Dir(outputAbs),
+		strings.TrimSuffix(filepath.Base(inputAbs), filepath.Ext(inputAbs))+"."+format,
+	)
+	if filepath.Clean(generated) == filepath.Clean(outputAbs) {
+		return nil
+	}
+	if _, err := os.Stat(generated); err != nil {
+		return fmt.Errorf("converted output not found: %s: %w", generated, err)
+	}
+	if err := os.Remove(outputAbs); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove existing output %s: %w", outputAbs, err)
+	}
+	if err := os.Rename(generated, outputAbs); err != nil {
+		return fmt.Errorf("rename converted output %s to %s: %w", generated, outputAbs, err)
+	}
+	return nil
 }
 
 func (c *Client) IsInstalled(ctx context.Context) bool {

--- a/pkg/extensions/adapters/cli/adapters/libreoffice/libreoffice_test.go
+++ b/pkg/extensions/adapters/cli/adapters/libreoffice/libreoffice_test.go
@@ -1,0 +1,140 @@
+package libreoffice
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("ANYCLAW_LIBREOFFICE_ADAPTER_HELPER") == "1" {
+		args := os.Args[1:]
+		format := ""
+		outDir := ""
+		input := ""
+		for i := 0; i < len(args); i++ {
+			switch args[i] {
+			case "--convert-to":
+				if i+1 < len(args) {
+					format = args[i+1]
+					i++
+				}
+			case "--outdir":
+				if i+1 < len(args) {
+					outDir = args[i+1]
+					i++
+				}
+			default:
+				input = args[i]
+			}
+		}
+		if format == "" || outDir == "" || input == "" {
+			fmt.Fprintf(os.Stderr, "missing conversion args: %v", args)
+			os.Exit(1)
+		}
+		name := strings.TrimSuffix(filepath.Base(input), filepath.Ext(input)) + "." + format
+		if err := os.WriteFile(filepath.Join(outDir, name), []byte("converted"), 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "write output: %v", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestConvertRenamesLibreOfficeDerivedOutput(t *testing.T) {
+	dir := t.TempDir()
+	input := filepath.Join(dir, "foo.docx")
+	output := filepath.Join(dir, "custom", "bar.pdf")
+	if err := os.MkdirAll(filepath.Dir(output), 0o755); err != nil {
+		t.Fatalf("mkdir output dir: %v", err)
+	}
+	writeFile(t, input)
+	t.Setenv("ANYCLAW_LIBREOFFICE_ADAPTER_HELPER", "1")
+	client := NewClient(Config{SofficePath: fakeSofficePath(t)})
+
+	if _, err := client.Run(context.Background(), []string{"convert", input, output}); err != nil {
+		t.Fatalf("convert returned error: %v", err)
+	}
+
+	assertFileExists(t, output)
+	assertFileMissing(t, filepath.Join(filepath.Dir(output), "foo.pdf"))
+}
+
+func TestToPDFRenamesLibreOfficeDerivedOutput(t *testing.T) {
+	dir := t.TempDir()
+	input := filepath.Join(dir, "foo.odt")
+	output := filepath.Join(dir, "custom", "bar.pdf")
+	if err := os.MkdirAll(filepath.Dir(output), 0o755); err != nil {
+		t.Fatalf("mkdir output dir: %v", err)
+	}
+	writeFile(t, input)
+	t.Setenv("ANYCLAW_LIBREOFFICE_ADAPTER_HELPER", "1")
+	client := NewClient(Config{SofficePath: fakeSofficePath(t)})
+
+	if _, err := client.Run(context.Background(), []string{"pdf", input, output}); err != nil {
+		t.Fatalf("pdf returned error: %v", err)
+	}
+
+	assertFileExists(t, output)
+	assertFileMissing(t, filepath.Join(filepath.Dir(output), "foo.pdf"))
+}
+
+func fakeSofficePath(t *testing.T) string {
+	t.Helper()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "soffice-helper.exe")
+	copyExecutable(t, exe, path)
+	return path
+}
+
+func copyExecutable(t *testing.T, src, dst string) {
+	t.Helper()
+
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open source executable: %v", err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("create helper executable: %v", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		t.Fatalf("copy helper executable: %v", err)
+	}
+}
+
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("document"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file %s to exist: %v", path, err)
+	}
+}
+
+func assertFileMissing(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected file %s to be absent, stat err=%v", path, err)
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/mermaid/mermaid.go
+++ b/pkg/extensions/adapters/cli/adapters/mermaid/mermaid.go
@@ -1,0 +1,110 @@
+package mermaid
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Adapter struct{}
+
+func New() *Adapter {
+	return &Adapter{}
+}
+
+func (a *Adapter) Name() string {
+	return "mermaid"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "render":
+		return a.render(subArgs)
+	case "serve":
+		return a.serve(subArgs)
+	case "validate":
+		return a.validate(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) render(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("render requires <input.mmd> <output.png/pdf/svg>")
+	}
+	input := args[0]
+	output := args[1]
+
+	ext := strings.ToLower(filepath.Ext(output))
+	format := strings.TrimPrefix(ext, ".")
+
+	outputDir := filepath.Dir(output)
+	if outputDir == "." {
+		outputDir = "./dist"
+		os.MkdirAll(outputDir, 0755)
+	}
+
+	cmd := exec.Command("npx", "-y", "@mermaid-js/mermaid-cli", "-i", input, "-o", outputDir, "-t", format)
+	cmd.Dir = filepath.Dir(input)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("render failed: %s", string(out))
+	}
+
+	return fmt.Sprintf("Rendered to %s", output), nil
+}
+
+func (a *Adapter) serve(args []string) (string, error) {
+	port := "8080"
+	if len(args) > 0 {
+		port = args[0]
+	}
+
+	cmd := exec.Command("npx", "-y", "mermaid", "-p", port)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Mermaid server started on port %s", port), nil
+}
+
+func (a *Adapter) validate(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("validate requires <input.mmd>")
+	}
+	input := args[0]
+
+	cmd := exec.Command("npx", "-y", "@mermaid-js/mermaid-cli", "-i", input, "-o", "/dev/null")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("validation failed: %s", string(output))
+	}
+
+	return "Valid Mermaid diagram", nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Mermaid CLI adapter
+Commands:
+  render <input.mmd> <output>  - Render diagram to file
+  serve [port]                - Start local server
+  validate <input.mmd>        - Validate diagram syntax
+  help                        - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/mermaid/mermaid.go
+++ b/pkg/extensions/adapters/cli/adapters/mermaid/mermaid.go
@@ -52,12 +52,13 @@ func (a *Adapter) render(args []string) (string, error) {
 	format := strings.TrimPrefix(ext, ".")
 
 	outputDir := filepath.Dir(output)
-	if outputDir == "." {
-		outputDir = "./dist"
-		os.MkdirAll(outputDir, 0755)
+	if outputDir != "." {
+		if err := os.MkdirAll(outputDir, 0o755); err != nil {
+			return "", err
+		}
 	}
 
-	cmd := exec.Command("npx", "-y", "@mermaid-js/mermaid-cli", "-i", input, "-o", outputDir, "-t", format)
+	cmd := exec.Command("npx", "-y", "@mermaid-js/mermaid-cli", "-i", input, "-o", output, "-t", format)
 	cmd.Dir = filepath.Dir(input)
 
 	out, err := cmd.CombinedOutput()

--- a/pkg/extensions/adapters/cli/adapters/mermaid/mermaid_test.go
+++ b/pkg/extensions/adapters/cli/adapters/mermaid/mermaid_test.go
@@ -1,0 +1,97 @@
+package mermaid
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("ANYCLAW_MERMAID_ADAPTER_HELPER") == "1" {
+		output := ""
+		args := os.Args[1:]
+		for i := 0; i < len(args); i++ {
+			if args[i] == "-o" && i+1 < len(args) {
+				output = args[i+1]
+				i++
+			}
+		}
+		expected := os.Getenv("ANYCLAW_MERMAID_EXPECT_OUTPUT")
+		if output != expected {
+			fmt.Fprintf(os.Stderr, "expected -o %q, got %q; args=%v", expected, output, args)
+			os.Exit(1)
+		}
+		if err := os.MkdirAll(filepath.Dir(output), 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "mkdir output dir: %v", err)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(output, []byte("rendered"), 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "write output: %v", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestRenderPassesOutputFilePathToMermaidCLI(t *testing.T) {
+	dir := t.TempDir()
+	input := filepath.Join(dir, "in.mmd")
+	output := filepath.Join(dir, "custom", "out.png")
+	if err := os.WriteFile(input, []byte("graph TD; A-->B;"), 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	t.Setenv("ANYCLAW_MERMAID_ADAPTER_HELPER", "1")
+	t.Setenv("ANYCLAW_MERMAID_EXPECT_OUTPUT", output)
+	t.Setenv("PATH", fakeNpxDir(t)+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if _, err := New().Execute(context.Background(), []string{"render", input, output}); err != nil {
+		t.Fatalf("render returned error: %v", err)
+	}
+	if _, err := os.Stat(output); err != nil {
+		t.Fatalf("expected output %s to exist: %v", output, err)
+	}
+}
+
+func fakeNpxDir(t *testing.T) string {
+	t.Helper()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	dir := t.TempDir()
+	name := "npx"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	copyExecutable(t, exe, filepath.Join(dir, name))
+	return dir
+}
+
+func copyExecutable(t *testing.T, src, dst string) {
+	t.Helper()
+
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open source executable: %v", err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("create helper executable: %v", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		t.Fatalf("copy helper executable: %v", err)
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/mubu/mubu.go
+++ b/pkg/extensions/adapters/cli/adapters/mubu/mubu.go
@@ -1,0 +1,107 @@
+package mubu
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Adapter struct {
+	dataDir string
+}
+
+type Config struct {
+	DataDir string
+}
+
+func New(cfg Config) *Adapter {
+	dir := cfg.DataDir
+	if dir == "" {
+		home, _ := os.UserHomeDir()
+		dir = filepath.Join(home, "Library", "Application Support", "Mubu")
+	}
+	return &Adapter{dataDir: dir}
+}
+
+func (a *Adapter) Name() string {
+	return "mubu"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.list()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "list":
+		return a.list()
+	case "documents":
+		return a.documents()
+	case "search":
+		return a.search(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) list() (string, error) {
+	entries, err := os.ReadDir(a.dataDir)
+	if err != nil {
+		return "", fmt.Errorf("cannot read mubu data: %w", err)
+	}
+
+	var result []string
+	for _, e := range entries {
+		if e.IsDir() {
+			result = append(result, e.Name())
+		}
+	}
+	if len(result) == 0 {
+		return "No documents found", nil
+	}
+	return strings.Join(result, "\n"), nil
+}
+
+func (a *Adapter) documents() (string, error) {
+	return a.list()
+}
+
+func (a *Adapter) search(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("search requires <query>")
+	}
+	query := strings.Join(args, " ")
+
+	entries, err := os.ReadDir(a.dataDir)
+	if err != nil {
+		return "", err
+	}
+
+	var result []string
+	for _, e := range entries {
+		if e.IsDir() && strings.Contains(strings.ToLower(e.Name()), strings.ToLower(query)) {
+			result = append(result, e.Name())
+		}
+	}
+
+	if len(result) == 0 {
+		return fmt.Sprintf("No documents matching '%s'", query), nil
+	}
+	return strings.Join(result, "\n"), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Mubu CLI adapter (knowledge management)
+Commands:
+  list                    - List documents
+  documents               - List documents (alias)
+  search <query>          - Search documents
+  help                    - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/musescore/musescore.go
+++ b/pkg/extensions/adapters/cli/adapters/musescore/musescore.go
@@ -1,0 +1,112 @@
+package musescore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Adapter struct {
+	mscorePath string
+}
+
+type Config struct {
+	MscorePath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.MscorePath
+	if path == "" {
+		path = "mscore"
+	}
+	return &Adapter{mscorePath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "musescore"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "convert":
+		return a.convert(subArgs)
+	case "export":
+		return a.export(subArgs)
+	case "info":
+		return a.info(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) convert(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("convert requires <input.mscz> <output.pdf/mp3/midi>")
+	}
+	input := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.mscorePath, "-o", output, input)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("conversion failed: %w", err)
+	}
+
+	return fmt.Sprintf("Converted %s to %s", input, output), nil
+}
+
+func (a *Adapter) export(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("export requires <input.mscz> <format>")
+	}
+	input := args[0]
+	format := args[1]
+
+	ext := "." + format
+	output := strings.TrimSuffix(filepath.Base(input), filepath.Ext(input)) + ext
+
+	cmd := exec.Command(a.mscorePath, "-o", output, input)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("export failed: %w", err)
+	}
+
+	return fmt.Sprintf("Exported to %s", output), nil
+}
+
+func (a *Adapter) info(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("info requires <input.mscz>")
+	}
+	input := args[0]
+
+	cmd := exec.Command(a.mscorePath, "-i", input)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("info failed: %w", err)
+	}
+
+	return string(output), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `MuseScore CLI adapter
+Commands:
+  convert <input.mscz> <output.pdf/mp3/midi>  - Convert score
+  export <input.mscz> <format>               - Export to format
+  info <input.mscz>                           - Show score info
+  help                                        - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/notebooklm/notebooklm.go
+++ b/pkg/extensions/adapters/cli/adapters/notebooklm/notebooklm.go
@@ -115,11 +115,11 @@ func (c *Client) createNotebook(ctx context.Context, name string) (string, error
 }
 
 func (c *Client) source(ctx context.Context, args []string) (string, error) {
-	if len(args) < 2 {
+	if len(args) < 3 || args[0] != "add" {
 		return "", fmt.Errorf("source add <notebook_id> <url/file>")
 	}
-	notebookID := args[0]
-	source := args[1]
+	notebookID := args[1]
+	source := args[2]
 
 	body := map[string]string{"source": source}
 	jsonBody, _ := json.Marshal(body)

--- a/pkg/extensions/adapters/cli/adapters/notebooklm/notebooklm.go
+++ b/pkg/extensions/adapters/cli/adapters/notebooklm/notebooklm.go
@@ -1,0 +1,204 @@
+package notebooklm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+type Client struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+type Config struct {
+	APIKey string
+}
+
+func New(cfg Config) *Client {
+	apiKey := cfg.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("NOTEBOOKLM_API_KEY")
+	}
+	return &Client{
+		apiKey:     apiKey,
+		baseURL:    "https://notebooklm.google.com/api/v1",
+		httpClient: &http.Client{Timeout: 5 * time.Minute},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "notebook":
+		return c.notebook(ctx, subArgs)
+	case "source":
+		return c.source(ctx, subArgs)
+	case "chat":
+		return c.chat(ctx, subArgs)
+	case "download":
+		return c.download(ctx, subArgs)
+	case "help":
+		return c.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (c *Client) notebook(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "Available: list, create, delete", nil
+	}
+
+	action := args[0]
+	switch action {
+	case "list":
+		return c.listNotebooks(ctx)
+	case "create":
+		if len(args) < 2 {
+			return "", fmt.Errorf("create requires <name>")
+		}
+		return c.createNotebook(ctx, args[1])
+	default:
+		return "", fmt.Errorf("unknown notebook action: %s", action)
+	}
+}
+
+func (c *Client) listNotebooks(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/notebooks", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) createNotebook(ctx context.Context, name string) (string, error) {
+	body := map[string]string{"name": name}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/notebooks", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) source(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("source add <notebook_id> <url/file>")
+	}
+	notebookID := args[0]
+	source := args[1]
+
+	body := map[string]string{"source": source}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/notebooks/"+notebookID+"/sources", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) chat(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("chat <notebook_id> <message>")
+	}
+	notebookID := args[0]
+	message := args[1]
+
+	body := map[string]string{"message": message}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/notebooks/"+notebookID+"/chat", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) download(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("download <notebook_id> <output.zip>")
+	}
+	notebookID := args[0]
+	output := args[1]
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/notebooks/"+notebookID+"/export", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	os.WriteFile(output, b, 0644)
+
+	return fmt.Sprintf("Downloaded to %s", output), nil
+}
+
+func (c *Client) help() (string, error) {
+	return `NotebookLM CLI adapter
+Commands:
+  notebook list                           - List notebooks
+  notebook create <name>                 - Create notebook
+  source add <notebook_id> <url>        - Add source
+  chat <notebook_id> <message>          - Send chat
+  download <notebook_id> <output.zip>   - Export
+  help                                    - Show this help
+Note: Requires NOTEBOOKLM_API_KEY`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/notebooklm/notebooklm_test.go
+++ b/pkg/extensions/adapters/cli/adapters/notebooklm/notebooklm_test.go
@@ -1,0 +1,39 @@
+package notebooklm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSourceAddUsesDocumentedNotebookIDAndSource(t *testing.T) {
+	const notebookID = "nb-1"
+	const sourceURL = "https://example.com/source"
+
+	var gotPath string
+	var gotBody map[string]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	client := New(Config{APIKey: "test-key"})
+	client.baseURL = server.URL
+	client.httpClient = server.Client()
+
+	if _, err := client.Execute(context.Background(), []string{"source", "add", notebookID, sourceURL}); err != nil {
+		t.Fatalf("source add returned error: %v", err)
+	}
+	if gotPath != "/notebooks/"+notebookID+"/sources" {
+		t.Fatalf("expected source request for notebook %q, got path %q", notebookID, gotPath)
+	}
+	if gotBody["source"] != sourceURL {
+		t.Fatalf("expected source %q, got body %#v", sourceURL, gotBody)
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/novita/novita.go
+++ b/pkg/extensions/adapters/cli/adapters/novita/novita.go
@@ -1,0 +1,153 @@
+package novita
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+type Config struct {
+	APIKey string
+}
+
+func New(cfg Config) *Client {
+	apiKey := cfg.APIKey
+	if apiKey == "" {
+		apiKey = "novita"
+	}
+	return &Client{
+		apiKey:     apiKey,
+		baseURL:    "https://api.novita.ai/v1",
+		httpClient: &http.Client{Timeout: 5 * time.Minute},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "chat":
+		return c.chat(ctx, subArgs)
+	case "models":
+		return c.models(ctx)
+	case "help":
+		return c.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+type ChatRequest struct {
+	Model       string    `json:"model"`
+	Messages    []Message `json:"messages"`
+	Stream      bool      `json:"stream,omitempty"`
+	MaxTokens   int       `json:"max_tokens,omitempty"`
+	Temperature float64   `json:"temperature,omitempty"`
+}
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ChatResponse struct {
+	ID      string   `json:"id"`
+	Choices []Choice `json:"choices"`
+	Usage   Usage    `json:"usage"`
+}
+
+type Choice struct {
+	Message Message `json:"message"`
+	Index   int     `json:"index"`
+}
+
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+func (c *Client) chat(ctx context.Context, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("chat requires <model> <prompt>")
+	}
+	model := args[0]
+	prompt := strings.Join(args[1:], " ")
+
+	body := ChatRequest{
+		Model: model,
+		Messages: []Message{
+			{Role: "user", Content: prompt},
+		},
+		MaxTokens: 1024,
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+
+	var result ChatResponse
+	if err := json.Unmarshal(b, &result); err != nil {
+		return string(b), err
+	}
+
+	if len(result.Choices) > 0 {
+		return result.Choices[0].Message.Content, nil
+	}
+	return "", fmt.Errorf("no response")
+}
+
+func (c *Client) models(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/models", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) help() (string, error) {
+	return `Novita AI CLI adapter (OpenAI-compatible API)
+Models: deepseek, glm, minimax, qwen, and more
+Commands:
+  chat <model> <prompt>  - Send chat request
+  models                  - List available models
+  help                    - Show this help
+Note: Requires NOVITA_API_KEY`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/novita/novita.go
+++ b/pkg/extensions/adapters/cli/adapters/novita/novita.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 )
@@ -24,7 +25,7 @@ type Config struct {
 func New(cfg Config) *Client {
 	apiKey := cfg.APIKey
 	if apiKey == "" {
-		apiKey = "novita"
+		apiKey = os.Getenv("NOVITA_API_KEY")
 	}
 	return &Client{
 		apiKey:     apiKey,
@@ -87,6 +88,9 @@ func (c *Client) chat(ctx context.Context, args []string) (string, error) {
 	if len(args) < 2 {
 		return "", fmt.Errorf("chat requires <model> <prompt>")
 	}
+	if err := c.requireAPIKey(); err != nil {
+		return "", err
+	}
 	model := args[0]
 	prompt := strings.Join(args[1:], " ")
 
@@ -126,6 +130,10 @@ func (c *Client) chat(ctx context.Context, args []string) (string, error) {
 }
 
 func (c *Client) models(ctx context.Context) (string, error) {
+	if err := c.requireAPIKey(); err != nil {
+		return "", err
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/models", nil)
 	if err != nil {
 		return "", err
@@ -140,6 +148,13 @@ func (c *Client) models(ctx context.Context) (string, error) {
 
 	b, _ := io.ReadAll(resp.Body)
 	return string(b), nil
+}
+
+func (c *Client) requireAPIKey() error {
+	if strings.TrimSpace(c.apiKey) == "" {
+		return fmt.Errorf("NOVITA_API_KEY is required")
+	}
+	return nil
 }
 
 func (c *Client) help() (string, error) {

--- a/pkg/extensions/adapters/cli/adapters/novita/novita_test.go
+++ b/pkg/extensions/adapters/cli/adapters/novita/novita_test.go
@@ -1,0 +1,42 @@
+package novita
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewReadsAPIKeyFromEnvironment(t *testing.T) {
+	t.Setenv("NOVITA_API_KEY", "env-key")
+
+	client := New(Config{})
+
+	if client.apiKey != "env-key" {
+		t.Fatalf("expected API key from NOVITA_API_KEY, got %q", client.apiKey)
+	}
+}
+
+func TestModelsRequiresAPIKeyBeforeRequest(t *testing.T) {
+	t.Setenv("NOVITA_API_KEY", "")
+
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+
+	client := New(Config{})
+	client.baseURL = server.URL
+	client.httpClient = server.Client()
+
+	_, err := client.Execute(context.Background(), []string{"models"})
+	if err == nil || !strings.Contains(err.Error(), "NOVITA_API_KEY") {
+		t.Fatalf("expected missing NOVITA_API_KEY error, got %v", err)
+	}
+	if called {
+		t.Fatal("expected no remote request without API key")
+	}
+}

--- a/pkg/extensions/adapters/cli/adapters/obsstudio/obsstudio.go
+++ b/pkg/extensions/adapters/cli/adapters/obsstudio/obsstudio.go
@@ -1,0 +1,110 @@
+package obsstudio
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	obsPath string
+}
+
+type Config struct {
+	ObsPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.ObsPath
+	if path == "" {
+		path = "obs"
+	}
+	return &Adapter{obsPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "obs-studio"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "start":
+		return a.start(subArgs)
+	case "stop":
+		return a.stop()
+	case "scene":
+		return a.scene(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) start(args []string) (string, error) {
+	mode := "recording"
+	if len(args) > 0 {
+		mode = args[0]
+	}
+
+	cmd := exec.Command(a.obsPath, "--start"+mode)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Started %s", mode), nil
+}
+
+func (a *Adapter) stop() (string, error) {
+	cmd := exec.Command(a.obsPath, "--stop")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	return "Stopped", nil
+}
+
+func (a *Adapter) scene(args []string) (string, error) {
+	if len(args) == 0 {
+		return "Available: list, switch <name>", nil
+	}
+
+	action := args[0]
+	switch action {
+	case "list":
+		cmd := exec.Command(a.obsPath, "--scene-list")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return "", err
+		}
+		return string(output), nil
+	case "switch":
+		if len(args) < 2 {
+			return "", fmt.Errorf("switch requires <scene_name>")
+		}
+		cmd := exec.Command(a.obsPath, "--scene-switch", args[1])
+		if err := cmd.Run(); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Switched to %s", args[1]), nil
+	default:
+		return "", fmt.Errorf("unknown scene action: %s", action)
+	}
+}
+
+func (a *Adapter) help() (string, error) {
+	return `OBS Studio CLI adapter
+Commands:
+  start [recording/streaming] - Start recording/streaming
+  stop                         - Stop
+  scene list                   - List scenes
+  scene switch <name>          - Switch scene
+  help                         - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/renderdoc/renderdoc.go
+++ b/pkg/extensions/adapters/cli/adapters/renderdoc/renderdoc.go
@@ -1,0 +1,84 @@
+package renderdoc
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	renderdocPath string
+}
+
+type Config struct {
+	RenderdocPath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.RenderdocPath
+	if path == "" {
+		path = "renderdoc"
+	}
+	return &Adapter{renderdocPath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "renderdoc"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "capture":
+		return a.capture(subArgs)
+	case "info":
+		return a.info(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) capture(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("capture requires <executable> <output.rdc>")
+	}
+	exe := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.renderdocPath, "--capture", "--exe", exe, "--output", output)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("capture failed: %w", err)
+	}
+
+	return fmt.Sprintf("Captured to %s", output), nil
+}
+
+func (a *Adapter) info(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("info requires <capture.rdc>")
+	}
+	input := args[0]
+
+	cmd := exec.Command(a.renderdocPath, "--info", input)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `RenderDoc CLI adapter (GPU frame capture)
+Commands:
+  capture <exe> <output.rdc> - Capture frames
+  info <capture.rdc>         - Show capture info
+  help                       - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/rms/rms.go
+++ b/pkg/extensions/adapters/cli/adapters/rms/rms.go
@@ -1,0 +1,137 @@
+package rms
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+type Client struct {
+	apiToken string
+	baseURL  string
+	client   *http.Client
+}
+
+type Config struct {
+	APIToken string
+}
+
+func New(cfg Config) *Client {
+	token := cfg.APIToken
+	if token == "" {
+		token = os.Getenv("RMS_API_TOKEN")
+	}
+	return &Client{
+		apiToken: token,
+		baseURL:  "https://rms.teltonika-networks.com/api/v1",
+		client:   &http.Client{},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "devices":
+		return c.devices(ctx)
+	case "info":
+		return c.info(subArgs)
+	case "status":
+		return c.status(subArgs)
+	case "help":
+		return c.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+type Device struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	IP       string `json:"ip"`
+	Model    string `json:"model"`
+	Firmware string `json:"firmware"`
+}
+
+func (c *Client) devices(ctx context.Context) (string, error) {
+	if c.apiToken == "" {
+		return "", fmt.Errorf("RMS_API_TOKEN not configured")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/devices", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Token "+c.apiToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) info(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("info requires <device_id>")
+	}
+	deviceID := args[0]
+
+	req, err := http.NewRequest(http.MethodGet, c.baseURL+"/devices/"+deviceID, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Token "+c.apiToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) status(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("status requires <device_id>")
+	}
+	deviceID := args[0]
+
+	req, err := http.NewRequest(http.MethodGet, c.baseURL+"/devices/"+deviceID+"/status", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Token "+c.apiToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) help() (string, error) {
+	return `Teltonika RMS CLI adapter
+Commands:
+  devices                - List all devices
+  info <device_id>       - Get device info
+  status <device_id>    - Get device status
+  help                  - Show this help
+Note: Requires RMS_API_TOKEN`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/shotcut/shotcut.go
+++ b/pkg/extensions/adapters/cli/adapters/shotcut/shotcut.go
@@ -1,0 +1,91 @@
+package shotcut
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	meltPath   string
+	ffmpegPath string
+}
+
+type Config struct {
+	MeltPath   string
+	FfmpegPath string
+}
+
+func New(cfg Config) *Adapter {
+	meltPath := cfg.MeltPath
+	if meltPath == "" {
+		meltPath = "melt"
+	}
+	ffmpegPath := cfg.FfmpegPath
+	if ffmpegPath == "" {
+		ffmpegPath = "ffmpeg"
+	}
+	return &Adapter{meltPath: meltPath, ffmpegPath: ffmpegPath}
+}
+
+func (a *Adapter) Name() string {
+	return "shotcut"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "render":
+		return a.render(subArgs)
+	case "convert":
+		return a.convert(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) render(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("render requires <input> <output>")
+	}
+	input := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.meltPath, input, "-", "out", output)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("render failed: %w", err)
+	}
+
+	return fmt.Sprintf("Rendered to %s", output), nil
+}
+
+func (a *Adapter) convert(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("convert requires <input> <output>")
+	}
+	input := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.ffmpegPath, "-i", input, "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "aac", "-b:a", "128k", output)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("convert failed: %w", err)
+	}
+
+	return fmt.Sprintf("Converted to %s", output), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Shotcut CLI adapter (via melt/ffmpeg)
+Commands:
+  render <input> <output> - Render video (melt)
+  convert <input> <output> - Convert format (ffmpeg)
+  help                    - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/sketch/sketch.go
+++ b/pkg/extensions/adapters/cli/adapters/sketch/sketch.go
@@ -1,0 +1,85 @@
+package sketch
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type Adapter struct {
+	nodePath string
+}
+
+type Config struct {
+	NodePath string
+}
+
+func New(cfg Config) *Adapter {
+	path := cfg.NodePath
+	if path == "" {
+		path = "node"
+	}
+	return &Adapter{nodePath: path}
+}
+
+func (a *Adapter) Name() string {
+	return "sketch"
+}
+
+func (a *Adapter) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return a.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "create":
+		return a.create(subArgs)
+	case "export":
+		return a.export(subArgs)
+	case "help":
+		return a.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func (a *Adapter) create(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("create requires <output.sketch> <json-spec>")
+	}
+	output := args[0]
+	spec := args[1]
+
+	cmd := exec.Command(a.nodePath, "sketch-cli", "create", "-o", output, spec)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("create failed: %w", err)
+	}
+
+	return fmt.Sprintf("Created %s", output), nil
+}
+
+func (a *Adapter) export(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("export requires <input.sketch> <output.pdf/png>")
+	}
+	input := args[0]
+	output := args[1]
+
+	cmd := exec.Command(a.nodePath, "sketch-cli", "export", "-o", output, input)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("export failed: %w", err)
+	}
+
+	return fmt.Sprintf("Exported to %s", output), nil
+}
+
+func (a *Adapter) help() (string, error) {
+	return `Sketch CLI adapter (via sketch-constructor)
+Commands:
+  create <output.sketch> <spec.json> - Create sketch file
+  export <input.sketch> <output>      - Export to format
+  help                               - Show this help`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/zoom/zoom.go
+++ b/pkg/extensions/adapters/cli/adapters/zoom/zoom.go
@@ -1,0 +1,172 @@
+package zoom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type Client struct {
+	apiKey    string
+	apiSecret string
+	baseURL   string
+	token     string
+	client    *http.Client
+}
+
+type Config struct {
+	APIKey    string
+	APISecret string
+	AccountID string
+	Token     string
+}
+
+func New(cfg Config) *Client {
+	token := cfg.Token
+	if token == "" {
+		token = os.Getenv("ZOOM_TOKEN")
+	}
+	return &Client{
+		apiKey:    cfg.APIKey,
+		apiSecret: cfg.APISecret,
+		baseURL:   "https://api.zoom.us/v2",
+		token:     token,
+		client:    &http.Client{},
+	}
+}
+
+func (c *Client) Execute(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return c.help()
+	}
+
+	cmd := args[0]
+	subArgs := args[1:]
+
+	switch cmd {
+	case "meetings":
+		return c.meetings(subArgs)
+	case "list":
+		return c.list(subArgs)
+	case "create":
+		if len(subArgs) < 1 {
+			return "", fmt.Errorf("create requires <topic>")
+		}
+		return c.createMeeting(subArgs[0], subArgs[1:])
+	case "join":
+		return c.join(subArgs)
+	case "help":
+		return c.help()
+	default:
+		return "", fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+type Meeting struct {
+	ID        int64  `json:"id"`
+	Topic     string `json:"topic"`
+	StartTime string `json:"start_time"`
+	Duration  int    `json:"duration"`
+	JoinURL   string `json:"join_url"`
+}
+
+func (c *Client) meetings(args []string) (string, error) {
+	if len(args) == 0 {
+		return c.listMeetings()
+	}
+
+	action := args[0]
+	switch action {
+	case "list":
+		return c.listMeetings()
+	case "create":
+		if len(args) < 2 {
+			return "", fmt.Errorf("create requires <topic> [duration]")
+		}
+		return c.createMeeting(args[1], args[2:])
+	default:
+		return "", fmt.Errorf("unknown meeting action: %s", action)
+	}
+}
+
+func (c *Client) listMeetings() (string, error) {
+	if c.token == "" {
+		return "", fmt.Errorf("ZOOM_TOKEN not configured")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, c.baseURL+"/users/me/meetings", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) createMeeting(topic string, args []string) (string, error) {
+	if c.token == "" {
+		return "", fmt.Errorf("ZOOM_TOKEN not configured")
+	}
+
+	duration := 60
+	if len(args) > 0 {
+		fmt.Sscanf(args[0], "%d", &duration)
+	}
+
+	body := map[string]any{
+		"topic":    topic,
+		"type":     2,
+		"duration": duration,
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/users/me/meetings", strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	return string(b), nil
+}
+
+func (c *Client) list(args []string) (string, error) {
+	return c.listMeetings()
+}
+
+func (c *Client) join(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("join requires <meeting_id>")
+	}
+	meetingID := args[0]
+	return fmt.Sprintf("Join at: https://zoom.us/j/%s", meetingID), nil
+}
+
+func (c *Client) help() (string, error) {
+	return `Zoom CLI adapter (REST API)
+Commands:
+  meetings list              - List upcoming meetings
+  meetings create <topic>    - Create instant meeting
+  list                       - List meetings (alias)
+  join <meeting_id>          - Get join URL
+  help                       - Show this help
+Note: Requires ZOOM_TOKEN environment variable`, nil
+}

--- a/pkg/extensions/adapters/cli/adapters/zotero/zotero.go
+++ b/pkg/extensions/adapters/cli/adapters/zotero/zotero.go
@@ -1,0 +1,349 @@
+package zotero
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	httpClient  *http.Client
+	apiKey      string
+	userID      string
+	baseURL     string
+	libraryPath string
+}
+
+type Config struct {
+	APIKey      string
+	UserID      string
+	LibraryPath string
+}
+
+func NewClient(cfg Config) *Client {
+	baseURL := "https://api.zotero.org"
+	if cfg.UserID == "" {
+		cfg.UserID = os.Getenv("ZOTERO_USER_ID")
+	}
+	if cfg.APIKey == "" {
+		cfg.APIKey = os.Getenv("ZOTERO_API_KEY")
+	}
+	if cfg.LibraryPath == "" {
+		cfg.LibraryPath = os.Getenv("ZOTERO_LIBRARY_PATH")
+	}
+
+	return &Client{
+		httpClient:  &http.Client{Timeout: 30 * time.Second},
+		apiKey:      cfg.APIKey,
+		userID:      cfg.UserID,
+		baseURL:     baseURL,
+		libraryPath: cfg.LibraryPath,
+	}
+}
+
+type Item struct {
+	Key          string         `json:"key"`
+	Version      int            `json:"version"`
+	Library      map[string]any `json:"library"`
+	Parent       string         `json:"parent,omitempty"`
+	ItemType     string         `json:"itemType"`
+	Title        string         `json:"title"`
+	Creators     []Creator      `json:"creators,omitempty"`
+	Tags         []Tag          `json:"tags,omitempty"`
+	Collections  []string       `json:"collections,omitempty"`
+	Date         string         `json:"date,omitempty"`
+	URL          string         `json:"url,omitempty"`
+	AbstractNote string         `json:"abstractNote,omitempty"`
+	Extra        string         `json:"extra,omitempty"`
+	Metadata     map[string]any `json:"metadata,omitempty"`
+}
+
+type Creator struct {
+	CreatorType string `json:"creatorType"`
+	FirstName   string `json:"firstName"`
+	LastName    string `json:"lastName"`
+	Name        string `json:"name,omitempty"`
+}
+
+type Tag struct {
+	Tag  string `json:"tag"`
+	Type int    `json:"type"`
+}
+
+type Collection struct {
+	Key      string   `json:"key"`
+	Name     string   `json:"name"`
+	Parent   string   `json:"parent,omitempty"`
+	Children []string `json:"children,omitempty"`
+}
+
+type SearchResult struct {
+	Items   []Item `json:"items"`
+	Total   int    `json:"total"`
+	Library string `json:"library"`
+}
+
+func (c *Client) ListItems(ctx context.Context, collectionKey string, limit int) ([]Item, error) {
+	url := fmt.Sprintf("%s/users/%s/items", c.baseURL, c.userID)
+	if collectionKey != "" {
+		url = fmt.Sprintf("%s/users/%s/collections/%s/items", c.baseURL, c.userID, collectionKey)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Zotero-API-Key", c.apiKey)
+	req.Header.Set("Zotero-API-Version", "3")
+	if limit > 0 {
+		req.Header.Set("Limit", strconv.Itoa(limit))
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("zotero error: %s", string(b))
+	}
+
+	var items []Item
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return nil, err
+	}
+
+	return items, nil
+}
+
+func (c *Client) GetItem(ctx context.Context, itemKey string) (*Item, error) {
+	url := fmt.Sprintf("%s/users/%s/items/%s", c.baseURL, c.userID, itemKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Zotero-API-Key", c.apiKey)
+	req.Header.Set("Zotero-API-Version", "3")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("zotero error: %s", string(b))
+	}
+
+	var items []Item
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return nil, err
+	}
+
+	if len(items) == 0 {
+		return nil, fmt.Errorf("item not found")
+	}
+
+	return &items[0], nil
+}
+
+func (c *Client) Search(ctx context.Context, query string, itemType string, limit int) ([]Item, error) {
+	url := fmt.Sprintf("%s/users/%s/items", c.baseURL, c.userID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	q := req.URL.Query()
+	q.Add("q", query)
+	if itemType != "" {
+		q.Add("itemType", itemType)
+	}
+	if limit > 0 {
+		q.Add("limit", strconv.Itoa(limit))
+	}
+	req.URL.RawQuery = q.Encode()
+
+	req.Header.Set("Zotero-API-Key", c.apiKey)
+	req.Header.Set("Zotero-API-Version", "3")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("zotero error: %s", string(b))
+	}
+
+	var items []Item
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return nil, err
+	}
+
+	return items, nil
+}
+
+func (c *Client) ListCollections(ctx context.Context) ([]Collection, error) {
+	url := fmt.Sprintf("%s/users/%s/collections", c.baseURL, c.userID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Zotero-API-Key", c.apiKey)
+	req.Header.Set("Zotero-API-Version", "3")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("zotero error: %s", string(b))
+	}
+
+	var collections []Collection
+	if err := json.NewDecoder(resp.Body).Decode(&collections); err != nil {
+		return nil, err
+	}
+
+	return collections, nil
+}
+
+func (c *Client) CreateCollection(ctx context.Context, name string, parentKey string) (*Collection, error) {
+	url := fmt.Sprintf("%s/users/%s/collections", c.baseURL, c.userID)
+
+	body, _ := json.Marshal(map[string]any{
+		"name":   name,
+		"parent": parentKey,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(body)))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Zotero-API-Key", c.apiKey)
+	req.Header.Set("Zotero-API-Version", "3")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("zotero error: %s", string(b))
+	}
+
+	var collection Collection
+	if err := json.NewDecoder(resp.Body).Decode(&collection); err != nil {
+		return nil, err
+	}
+
+	return &collection, nil
+}
+
+func (c *Client) AttachFile(ctx context.Context, itemKey string, filePath string) error {
+	if c.libraryPath == "" {
+		return fmt.Errorf("library path not configured")
+	}
+
+	if _, err := os.Stat(filePath); err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/users/%s/items/%s/attachments", c.baseURL, c.userID, itemKey)
+
+	filename := filepath.Base(filePath)
+	body, _ := json.Marshal(map[string]any{
+		"filename": filename,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Zotero-API-Key", c.apiKey)
+	req.Header.Set("Zotero-API-Version", "3")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("zotero error: %s", string(b))
+	}
+
+	return nil
+}
+
+func (c *Client) Export(itemKey string, format string) (string, error) {
+	url := fmt.Sprintf("%s/users/%s/items/%s?format=%s", c.baseURL, c.userID, itemKey, format)
+
+	cmd := exec.Command("curl", "-s", "-H", "Zotero-API-Key: "+c.apiKey, url)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
+}
+
+func (c *Client) IsConfigured() bool {
+	return c.apiKey != "" && c.userID != ""
+}
+
+func FormatItem(item *Item) string {
+	var parts []string
+
+	if item.Title != "" {
+		parts = append(parts, item.Title)
+	}
+
+	for _, c := range item.Creators {
+		if c.Name != "" {
+			parts = append(parts, c.Name)
+		} else {
+			parts = append(parts, c.LastName+", "+c.FirstName)
+		}
+	}
+
+	if item.Date != "" {
+		parts = append(parts, "("+item.Date+")")
+	}
+
+	if item.URL != "" {
+		parts = append(parts, item.URL)
+	}
+
+	return strings.Join(parts, " - ")
+}


### PR DESCRIPTION
## 概要

补充创作、媒体和生产力类 CLI adapters，为图像、音视频、文档、设计和知识工具集成提供基础适配入口。

## 本次变更

- 新增 Audacity、Blender、ComfyUI、FFmpeg、GIMP、Krita、Inkscape 等创作/媒体 adapter
- 新增 LibreOffice、Mermaid、MuseScore、NotebookLM、Zotero 等生产力 adapter
- 新增 OBS Studio、RenderDoc、Shotcut、Sketch、Zoom 等工具 adapter
- 只新增独立 adapter package，不修改现有 CLI adapter core

## 验证

已执行：

- 新增 23 个 adapter package 的 `go test`
- `git diff --cached --check`
