### PR TITLE
chore(scripts): add desktop helper scripts

### DIFF
--- a/scripts/build-desktop.ps1
+++ b/scripts/build-desktop.ps1
@@ -1,0 +1,188 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$projectDir = Join-Path $repoRoot "cmd/anyclaw-desktop"
+
+function Invoke-ExternalCommand {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Description,
+
+    [Parameter(Mandatory = $true)]
+    [scriptblock]$Command
+  )
+
+  & $Command
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Description failed with exit code $LASTEXITCODE."
+  }
+}
+
+function Get-GoBinDirectory {
+  $goBin = (& go env GOBIN).Trim()
+  if (-not [string]::IsNullOrWhiteSpace($goBin)) {
+    return $goBin
+  }
+
+  $goPath = (& go env GOPATH).Trim()
+  if ([string]::IsNullOrWhiteSpace($goPath)) {
+    throw "Unable to resolve GOPATH from 'go env GOPATH'."
+  }
+
+  return (Join-Path $goPath "bin")
+}
+
+function Clear-BrokenProxyOverrides {
+  $proxyVars = @("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "GIT_HTTP_PROXY", "GIT_HTTPS_PROXY")
+  $brokenProxyValues = @(
+    "http://127.0.0.1:9",
+    "https://127.0.0.1:9",
+    "socks5://127.0.0.1:9"
+  )
+  $snapshot = @{}
+
+  foreach ($name in $proxyVars) {
+    $current = [Environment]::GetEnvironmentVariable($name, "Process")
+    if ([string]::IsNullOrWhiteSpace($current)) {
+      continue
+    }
+
+    $normalized = $current.Trim().ToLowerInvariant()
+    if ($brokenProxyValues -contains $normalized) {
+      $snapshot[$name] = $current
+      Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+    }
+  }
+
+  return $snapshot
+}
+
+function Restore-ProcessVariables {
+  param(
+    [hashtable]$Snapshot
+  )
+
+  if ($null -eq $Snapshot) {
+    return
+  }
+
+  foreach ($name in $Snapshot.Keys) {
+    Set-Item "Env:$name" $Snapshot[$name]
+  }
+}
+
+function Invoke-WithSafeGoEnvironment {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Description,
+
+    [Parameter(Mandatory = $true)]
+    [scriptblock]$Command
+  )
+
+  $proxySnapshot = Clear-BrokenProxyOverrides
+  $originalGoProxy = [Environment]::GetEnvironmentVariable("GOPROXY", "Process")
+
+  try {
+    $proxyCandidates = New-Object System.Collections.Generic.List[string]
+    foreach ($candidate in @(
+      (& go env GOPROXY).Trim(),
+      "https://proxy.golang.org,direct",
+      "https://goproxy.cn,direct",
+      "direct"
+    )) {
+      if (-not [string]::IsNullOrWhiteSpace($candidate) -and -not $proxyCandidates.Contains($candidate)) {
+        $proxyCandidates.Add($candidate)
+      }
+    }
+
+    $lastError = $null
+    foreach ($candidate in $proxyCandidates) {
+      $env:GOPROXY = $candidate
+      Write-Host "$Description with GOPROXY=$candidate"
+      try {
+        Invoke-ExternalCommand -Description $Description -Command $Command
+      }
+      catch {
+        $lastError = $_
+        continue
+      }
+      return
+    }
+
+    if ($lastError -ne $null) {
+      throw $lastError.Exception
+    }
+    throw "$Description failed for all configured GOPROXY values."
+  }
+  finally {
+    if ($null -ne $originalGoProxy) {
+      $env:GOPROXY = $originalGoProxy
+    }
+    else {
+      Remove-Item Env:GOPROXY -ErrorAction SilentlyContinue
+    }
+    Restore-ProcessVariables -Snapshot $proxySnapshot
+  }
+}
+
+function Ensure-WailsBinary {
+  $wailsBinary = Join-Path (Get-GoBinDirectory) "wails.exe"
+  if (Test-Path $wailsBinary) {
+    return $wailsBinary
+  }
+
+  Invoke-WithSafeGoEnvironment -Description "Installing Wails CLI" -Command {
+    go install github.com/wailsapp/wails/v2/cmd/wails@v2.11.0
+  }
+
+  if (-not (Test-Path $wailsBinary)) {
+    throw "Wails CLI was not installed at '$wailsBinary'."
+  }
+
+  return $wailsBinary
+}
+
+if (-not (Get-Command go -ErrorAction SilentlyContinue)) {
+  throw "Go was not found in PATH."
+}
+if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+  throw "npm was not found in PATH."
+}
+
+$wailsBinary = Ensure-WailsBinary
+
+Push-Location $projectDir
+try {
+  Invoke-WithSafeGoEnvironment -Description "Running wails build" -Command {
+    & $wailsBinary build
+  }
+
+  $binDir = Join-Path $projectDir "build\\bin"
+  if (-not (Test-Path $binDir)) {
+    throw "Desktop build output not found: $binDir"
+  }
+
+  $runtimeFolders = @("dist", "skills", "plugins", "workflows")
+  foreach ($name in $runtimeFolders) {
+    $source = Join-Path $repoRoot $name
+    $target = Join-Path $binDir $name
+    if (-not (Test-Path $source)) {
+      continue
+    }
+    if (Test-Path $target) {
+      Remove-Item -LiteralPath $target -Recurse -Force
+    }
+    Copy-Item -LiteralPath $source -Destination $target -Recurse -Force
+  }
+
+  $configPath = Join-Path $repoRoot "anyclaw.json"
+  if (Test-Path $configPath) {
+    Copy-Item -LiteralPath $configPath -Destination (Join-Path $binDir "anyclaw.json") -Force
+  }
+
+  Write-Host "Desktop build ready:" (Join-Path $projectDir "build\\bin")
+}
+finally {
+  Pop-Location
+}

--- a/scripts/build-desktop.ps1
+++ b/scripts/build-desktop.ps1
@@ -1,7 +1,9 @@
 $ErrorActionPreference = "Stop"
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
-$projectDir = Join-Path $repoRoot "cmd/anyclaw-desktop"
+$desktopProjectCandidates = @(
+  (Join-Path $repoRoot "cmd/anyclaw-desktop")
+)
 
 function Invoke-ExternalCommand {
   param(
@@ -30,6 +32,23 @@ function Get-GoBinDirectory {
   }
 
   return (Join-Path $goPath "bin")
+}
+
+function Resolve-DesktopProjectDirectory {
+  foreach ($candidate in $desktopProjectCandidates) {
+    if (Test-Path -LiteralPath $candidate -PathType Container) {
+      return $candidate
+    }
+  }
+
+  $relativeCandidates = $desktopProjectCandidates |
+    ForEach-Object { Resolve-Path -LiteralPath $_ -Relative -ErrorAction SilentlyContinue } |
+    Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  if ($relativeCandidates.Count -eq 0) {
+    $relativeCandidates = @("cmd/anyclaw-desktop")
+  }
+
+  throw "Desktop app project not found. Expected one of: $($relativeCandidates -join ', '). Add the desktop app project before running this optional Wails build helper."
 }
 
 function Clear-BrokenProxyOverrides {
@@ -142,6 +161,8 @@ function Ensure-WailsBinary {
 
   return $wailsBinary
 }
+
+$projectDir = Resolve-DesktopProjectDirectory
 
 if (-not (Get-Command go -ErrorAction SilentlyContinue)) {
   throw "Go was not found in PATH."

--- a/scripts/ui.mjs
+++ b/scripts/ui.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const uiDir = path.join(repoRoot, "ui");
+
+const ACTION_TO_SCRIPT = {
+  dev: "dev",
+  build: "build",
+  preview: "preview",
+  test: "test",
+};
+
+function usage() {
+  process.stderr.write("Usage: node scripts/ui.mjs <install|dev|build|preview|test> [...args]\n");
+}
+
+function which(cmd) {
+  const pathKey = process.platform === "win32" ? "Path" : "PATH";
+  const entries = (process.env[pathKey] ?? process.env.PATH ?? "").split(path.delimiter).filter(Boolean);
+  const exts =
+    process.platform === "win32"
+      ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean)
+      : [""];
+  for (const entry of entries) {
+    for (const ext of exts) {
+      const candidate = path.join(entry, process.platform === "win32" ? `${cmd}${ext}` : cmd);
+      try {
+        if (fs.existsSync(candidate)) {
+          return candidate;
+        }
+      } catch {
+        // ignore path access errors
+      }
+    }
+  }
+  return null;
+}
+
+function isWindowsBatchCommand(cmd) {
+  return process.platform === "win32" && [".cmd", ".bat", ".com"].includes(path.extname(cmd).toLowerCase());
+}
+
+function quoteWindowsCmdArg(value) {
+  const input = String(value);
+  if (input.length === 0) {
+    return '""';
+  }
+  if (!/[ \t"&()^<>|]/.test(input)) {
+    return input;
+  }
+  return `"${input.replace(/"/g, '""')}"`;
+}
+
+function quotePowerShellArg(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function commandInvocation(cmd, args) {
+  if (!isWindowsBatchCommand(cmd)) {
+    return { command: cmd, args, shell: false };
+  }
+
+  const powershell = which("powershell") || "powershell.exe";
+  const inner = [`& ${quotePowerShellArg(cmd)}`, ...args.map(quotePowerShellArg)].join(" ");
+  return {
+    command: powershell,
+    args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", inner],
+    shell: false,
+  };
+}
+
+function run(cmd, args) {
+  const invocation = commandInvocation(cmd, args);
+  const child = spawn(invocation.command, invocation.args, {
+    cwd: uiDir,
+    stdio: "inherit",
+    env: process.env,
+    shell: invocation.shell,
+  });
+  child.on("error", (err) => {
+    console.error(`Failed to launch ${cmd}:`, err);
+    process.exit(1);
+  });
+  child.on("exit", (code) => {
+    process.exit(code ?? 1);
+  });
+}
+
+function runSync(cmd, args, env = process.env) {
+  const invocation = commandInvocation(cmd, args);
+  const result = spawnSync(invocation.command, invocation.args, {
+    cwd: uiDir,
+    stdio: "inherit",
+    env,
+    shell: invocation.shell,
+  });
+  if (result.error) {
+    console.error(`Failed to launch ${cmd}:`, result.error);
+    process.exit(1);
+  }
+  if ((result.status ?? 1) !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function hasDeps(kind) {
+  if (!fs.existsSync(path.join(uiDir, "node_modules", "vite"))) {
+    return false;
+  }
+  if (kind === "test") {
+    if (!fs.existsSync(path.join(uiDir, "node_modules", "vitest"))) {
+      return false;
+    }
+    if (!fs.existsSync(path.join(uiDir, "node_modules", "jsdom"))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function main() {
+  const [action, ...rest] = process.argv.slice(2);
+  if (!action) {
+    usage();
+    process.exit(2);
+  }
+
+  const pnpm = which("pnpm");
+  const corepack = which("corepack");
+  const pkgRunner = pnpm
+    ? { bin: pnpm, prefixArgs: [] }
+    : corepack
+      ? { bin: corepack, prefixArgs: ["pnpm"] }
+      : null;
+
+  if (!pkgRunner) {
+    console.error("Missing pnpm/corepack. Please install Node.js with corepack support or pnpm and retry.");
+    process.exit(1);
+  }
+
+  if (action === "install") {
+    run(pkgRunner.bin, [...pkgRunner.prefixArgs, "install", ...rest]);
+    return;
+  }
+
+  const script = ACTION_TO_SCRIPT[action];
+  if (!script) {
+    usage();
+    process.exit(2);
+  }
+
+  if (!hasDeps(action)) {
+    runSync(pkgRunner.bin, [...pkgRunner.prefixArgs, "install"], process.env);
+  }
+
+  run(pkgRunner.bin, [...pkgRunner.prefixArgs, "run", script, ...rest]);
+}
+
+main();


### PR DESCRIPTION
## 概要

补充桌面构建与控制 UI 辅助脚本，为本地 desktop shell 构建、Wails 安装检查以及前端控制界面生成提供统一入口。

## 本次变更

- 新增 `scripts/build-desktop.ps1`
  - 检查 Go、Node、Wails 等桌面构建依赖
  - 支持代理环境下安装 Wails CLI
  - 提供桌面壳构建入口
- 新增 `scripts/ui.mjs`
  - 生成/更新控制 UI 相关资源
  - 支持 web approval flow 所需的 UI 辅助流程

## 影响

这条 PR 只新增脚本文件，不修改运行时代码或 extension 实现逻辑。
