### PR TITLE
fix(tools): handle nil sandbox manager

### DIFF
--- a/pkg/capability/tools/builtins.go
+++ b/pkg/capability/tools/builtins.go
@@ -292,18 +292,16 @@ func RunCommandToolWithPolicy(ctx context.Context, input map[string]any, opts Bu
 		return shellCommandWithShell(cmdCtx, command, shellName)
 	}
 	applyDir := true
-	if opts.Sandbox != nil {
-		sandboxCwd, factory, err := opts.Sandbox.ResolveExecution(ctx, cwd)
-		if err != nil {
-			return "", err
-		}
-		if factory != nil {
-			commandFactory = factory
-			applyDir = false
-		}
-		if sandboxCwd != "" {
-			resolvedCwd = sandboxCwd
-		}
+	sandboxCwd, factory, err := opts.Sandbox.ResolveExecution(ctx, cwd)
+	if err != nil {
+		return "", err
+	}
+	if factory != nil {
+		commandFactory = factory
+		applyDir = false
+	}
+	if sandboxCwd != "" {
+		resolvedCwd = sandboxCwd
 	}
 
 	cmd, err := commandFactory(ctx, cmdStr)

--- a/pkg/capability/tools/builtins_test.go
+++ b/pkg/capability/tools/builtins_test.go
@@ -128,6 +128,48 @@ func TestRunCommandToolWithPolicyBlocksOutsideWorkingDirCwd(t *testing.T) {
 	}
 }
 
+func TestRunCommandToolWithPolicyNilSandboxUsesRequestedCwd(t *testing.T) {
+	workspace := t.TempDir()
+	requestedCwd := filepath.Join(workspace, "requested")
+	if err := os.MkdirAll(requestedCwd, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	_, err := RunCommandToolWithPolicy(context.Background(), map[string]any{
+		"command": "echo ok > marker.txt",
+		"cwd":     requestedCwd,
+	}, BuiltinOptions{
+		WorkingDir:      workspace,
+		ExecutionMode:   "host-reviewed",
+		PermissionLevel: "full",
+	})
+	if err != nil {
+		t.Fatalf("RunCommandToolWithPolicy: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(requestedCwd, "marker.txt")); err != nil {
+		t.Fatalf("expected command to run in requested cwd: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, "marker.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected command to avoid working dir fallback, got %v", err)
+	}
+}
+
+func TestRunCommandToolWithPolicyNilSandboxAllowsEmptyCwd(t *testing.T) {
+	output, err := RunCommandToolWithPolicy(context.Background(), map[string]any{
+		"command": "echo ok",
+	}, BuiltinOptions{
+		ExecutionMode:   "host-reviewed",
+		PermissionLevel: "full",
+	})
+	if err != nil {
+		t.Fatalf("RunCommandToolWithPolicy: %v", err)
+	}
+	if !strings.Contains(output, "ok") {
+		t.Fatalf("expected command output, got %q", output)
+	}
+}
+
 func TestEnsureDesktopAllowedRequiresHostReviewed(t *testing.T) {
 	err := ensureDesktopAllowed("desktop_click", BuiltinOptions{ExecutionMode: "sandbox", PermissionLevel: "limited"}, false)
 	if err == nil {

--- a/pkg/capability/tools/sandbox.go
+++ b/pkg/capability/tools/sandbox.go
@@ -49,7 +49,10 @@ func (m *SandboxManager) Enabled() bool {
 }
 
 func (m *SandboxManager) ResolveExecution(ctx context.Context, requestedCwd string) (string, func(context.Context, string) (*exec.Cmd, error), error) {
-	if m == nil || !m.config.Enabled {
+	if m == nil {
+		return strings.TrimSpace(requestedCwd), nil, nil
+	}
+	if !m.config.Enabled {
 		cwd := strings.TrimSpace(requestedCwd)
 		if cwd == "" {
 			cwd = m.workingDir

--- a/pkg/capability/tools/sandbox_test.go
+++ b/pkg/capability/tools/sandbox_test.go
@@ -1,0 +1,36 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSandboxManagerResolveExecutionNilManagerUsesRequestedCwd(t *testing.T) {
+	var manager *SandboxManager
+
+	cwd, factory, err := manager.ResolveExecution(context.Background(), "workspace")
+	if err != nil {
+		t.Fatalf("ResolveExecution returned error: %v", err)
+	}
+	if cwd != "workspace" {
+		t.Fatalf("expected requested cwd, got %q", cwd)
+	}
+	if factory != nil {
+		t.Fatal("expected nil command factory without a sandbox manager")
+	}
+}
+
+func TestSandboxManagerResolveExecutionNilManagerAllowsEmptyCwd(t *testing.T) {
+	var manager *SandboxManager
+
+	cwd, factory, err := manager.ResolveExecution(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ResolveExecution returned error: %v", err)
+	}
+	if cwd != "" {
+		t.Fatalf("expected empty cwd without a manager fallback, got %q", cwd)
+	}
+	if factory != nil {
+		t.Fatal("expected nil command factory without a sandbox manager")
+	}
+}


### PR DESCRIPTION
## Summary
- Prevent `SandboxManager.ResolveExecution` from panicking when called on a nil manager
- Preserve requested cwd fallback when no sandbox manager is available
- Add regression tests for nil manager behavior

## Verification
- go test ./pkg/capability/tools
- git diff --check origin/main..HEAD
