### PR TITLE
feat(cmd): add claw bridge CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,10 +53,10 @@ gateway.log
 gateway.err
 anyclaw-final
 anyclaw-test
-anyclaw
-anyclaw.exe
-anyclaw-run.exe
-anyclaw-run.exe~
+/anyclaw
+/anyclaw.exe
+/anyclaw-run.exe
+/anyclaw-run.exe~
 
 # UI generated files
 ui/*.tsbuildinfo

--- a/cmd/anyclaw/claw_cli.go
+++ b/cmd/anyclaw/claw_cli.go
@@ -60,7 +60,7 @@ func runClawStatus(args []string) error {
 		return err
 	}
 
-	root, ok := clawbridge.DiscoverRoot(start)
+	root, ok := discoverClawRoot(start, strings.TrimSpace(*rootFlag) != "" || strings.TrimSpace(*workspaceFlag) != "")
 	if !ok {
 		if *jsonFlag {
 			return writePrettyJSON(map[string]any{"available": false})
@@ -153,11 +153,18 @@ func resolveClawRoot(root string, workspace string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	discovered, ok := clawbridge.DiscoverRoot(start)
+	discovered, ok := discoverClawRoot(start, strings.TrimSpace(root) != "" || strings.TrimSpace(workspace) != "")
 	if !ok {
 		return "", fmt.Errorf("claw-code-main reference not found; set %s or pass --root", clawbridge.EnvRoot)
 	}
 	return discovered, nil
+}
+
+func discoverClawRoot(start string, explicitStart bool) (string, bool) {
+	if explicitStart {
+		return clawbridge.DiscoverRootFromStart(start)
+	}
+	return clawbridge.DiscoverRoot(start)
 }
 
 func printClawLookupJSON(summary *clawbridge.Summary, section string, family string, limit int) error {

--- a/cmd/anyclaw/claw_cli.go
+++ b/cmd/anyclaw/claw_cli.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/1024XEngineer/anyclaw/pkg/clawbridge"
+)
+
+func runClawCommand(args []string) error {
+	if len(args) == 0 {
+		printClawUsage()
+		return nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(args[0])) {
+	case "status":
+		return runClawStatus(args[1:])
+	case "summary":
+		return runClawSummary(args[1:])
+	case "lookup":
+		return runClawLookup(args[1:])
+	case "help", "-h", "--help":
+		printClawUsage()
+		return nil
+	default:
+		printClawUsage()
+		return fmt.Errorf("unknown claw command: %s", args[0])
+	}
+}
+
+func printClawUsage() {
+	fmt.Print(`AnyClaw claw commands:
+
+Usage:
+  anyclaw claw status [--json]
+  anyclaw claw summary [--json] [--limit 6]
+  anyclaw claw lookup [--section summary|commands|tools|subsystems] [--family <name>] [--limit 6]
+
+Flags:
+  --root <path>       Explicit claw-code-main root
+  --workspace <path>  Start discovery from this workspace
+`)
+}
+
+func runClawStatus(args []string) error {
+	fs := flag.NewFlagSet("claw status", flag.ContinueOnError)
+	fs.SetOutput(os.Stdout)
+	rootFlag := fs.String("root", "", "explicit claw-code-main root")
+	workspaceFlag := fs.String("workspace", "", "workspace path used for discovery")
+	jsonFlag := fs.Bool("json", false, "output JSON")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	start, err := resolveClawStart(*rootFlag, *workspaceFlag)
+	if err != nil {
+		return err
+	}
+
+	root, ok := clawbridge.DiscoverRoot(start)
+	if !ok {
+		if *jsonFlag {
+			return writePrettyJSON(map[string]any{"available": false})
+		}
+		printInfo("claw-code-main bridge: unavailable")
+		return nil
+	}
+
+	summary, err := clawbridge.Load(root)
+	if err != nil {
+		return err
+	}
+	if *jsonFlag {
+		return writePrettyJSON(map[string]any{
+			"available":       true,
+			"root":            summary.Root,
+			"commands_count":  summary.CommandsCount,
+			"tools_count":     summary.ToolsCount,
+			"subsystem_count": len(summary.Subsystems),
+		})
+	}
+
+	printSuccess("claw-code-main bridge: available")
+	fmt.Println(clawbridge.HumanSummary(summary))
+	return nil
+}
+
+func runClawSummary(args []string) error {
+	fs := flag.NewFlagSet("claw summary", flag.ContinueOnError)
+	fs.SetOutput(os.Stdout)
+	rootFlag := fs.String("root", "", "explicit claw-code-main root")
+	workspaceFlag := fs.String("workspace", "", "workspace path used for discovery")
+	jsonFlag := fs.Bool("json", false, "output JSON")
+	limitFlag := fs.Int("limit", 6, "maximum items to show")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	root, err := resolveClawRoot(*rootFlag, *workspaceFlag)
+	if err != nil {
+		return err
+	}
+	summary, err := clawbridge.Load(root)
+	if err != nil {
+		return err
+	}
+	if *jsonFlag {
+		return printClawLookupJSON(summary, "summary", "", *limitFlag)
+	}
+
+	fmt.Println(clawbridge.HumanSummary(summary))
+	return nil
+}
+
+func runClawLookup(args []string) error {
+	fs := flag.NewFlagSet("claw lookup", flag.ContinueOnError)
+	fs.SetOutput(os.Stdout)
+	rootFlag := fs.String("root", "", "explicit claw-code-main root")
+	workspaceFlag := fs.String("workspace", "", "workspace path used for discovery")
+	sectionFlag := fs.String("section", "summary", "summary, commands, tools, or subsystems")
+	familyFlag := fs.String("family", "", "family or subsystem name")
+	limitFlag := fs.Int("limit", 6, "maximum items to show")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	root, err := resolveClawRoot(*rootFlag, *workspaceFlag)
+	if err != nil {
+		return err
+	}
+	summary, err := clawbridge.Load(root)
+	if err != nil {
+		return err
+	}
+	return printClawLookupJSON(summary, *sectionFlag, *familyFlag, *limitFlag)
+}
+
+func resolveClawStart(root string, workspace string) (string, error) {
+	if strings.TrimSpace(root) != "" {
+		return strings.TrimSpace(root), nil
+	}
+	if strings.TrimSpace(workspace) != "" {
+		return strings.TrimSpace(workspace), nil
+	}
+	return os.Getwd()
+}
+
+func resolveClawRoot(root string, workspace string) (string, error) {
+	start, err := resolveClawStart(root, workspace)
+	if err != nil {
+		return "", err
+	}
+	discovered, ok := clawbridge.DiscoverRoot(start)
+	if !ok {
+		return "", fmt.Errorf("claw-code-main reference not found; set %s or pass --root", clawbridge.EnvRoot)
+	}
+	return discovered, nil
+}
+
+func printClawLookupJSON(summary *clawbridge.Summary, section string, family string, limit int) error {
+	rendered, err := clawbridge.RenderJSON(summary, section, family, limit)
+	if err != nil {
+		return err
+	}
+	fmt.Println(rendered)
+	return nil
+}

--- a/cmd/anyclaw/claw_cli_test.go
+++ b/cmd/anyclaw/claw_cli_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunAnyClawCLIRoutesClawCommand(t *testing.T) {
+	stdout, _, err := captureCLIOutput(t, func() error {
+		return runAnyClawCLI([]string{"claw"})
+	})
+	if err != nil {
+		t.Fatalf("runAnyClawCLI claw: %v", err)
+	}
+	if !strings.Contains(stdout, "AnyClaw claw commands:") {
+		t.Fatalf("expected claw usage output, got %q", stdout)
+	}
+}
+
+func TestRunClawStatusLoadsBridgeRoot(t *testing.T) {
+	root := writeClawBridgeFixture(t)
+
+	stdout, _, err := captureCLIOutput(t, func() error {
+		return runClawCommand([]string{"status", "--root", root})
+	})
+	if err != nil {
+		t.Fatalf("runClawCommand status: %v", err)
+	}
+	for _, want := range []string{
+		"claw-code-main bridge: available",
+		"commands: 2 snapshot entries",
+		"tools: 1 snapshot entries",
+		"subsystems: 1 mirrored areas",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected %q in output, got %q", want, stdout)
+		}
+	}
+}
+
+func TestRunClawLookupPrintsJSON(t *testing.T) {
+	root := writeClawBridgeFixture(t)
+
+	stdout, _, err := captureCLIOutput(t, func() error {
+		return runClawCommand([]string{"lookup", "--root", root, "--section", "commands", "--family", "agents"})
+	})
+	if err != nil {
+		t.Fatalf("runClawCommand lookup: %v", err)
+	}
+	if !strings.Contains(stdout, `"section": "commands"`) || !strings.Contains(stdout, `"name": "agents"`) {
+		t.Fatalf("expected command family JSON, got %q", stdout)
+	}
+}
+
+func writeClawBridgeFixture(t *testing.T) string {
+	t.Helper()
+
+	root := filepath.Join(t.TempDir(), "claw-code-main")
+	refDir := filepath.Join(root, "src", "reference_data")
+	subsystemsDir := filepath.Join(refDir, "subsystems")
+	if err := os.MkdirAll(subsystemsDir, 0o755); err != nil {
+		t.Fatalf("mkdir fixture: %v", err)
+	}
+
+	writeClawJSON(t, filepath.Join(refDir, "commands_snapshot.json"), []map[string]string{
+		{"name": "agents", "source_hint": "commands/agents/index.ts"},
+		{"name": "tasks", "source_hint": "commands/tasks/index.ts"},
+	})
+	writeClawJSON(t, filepath.Join(refDir, "tools_snapshot.json"), []map[string]string{
+		{"name": "AgentTool", "source_hint": "tools/AgentTool/index.ts"},
+	})
+	writeClawJSON(t, filepath.Join(subsystemsDir, "cli.json"), map[string]any{
+		"archive_name": "cli",
+		"module_count": 7,
+		"sample_files": []string{"cli/handlers/agents.ts"},
+	})
+
+	return root
+}
+
+func writeClawJSON(t *testing.T, path string, value any) {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write fixture %s: %v", path, err)
+	}
+}

--- a/cmd/anyclaw/claw_cli_test.go
+++ b/cmd/anyclaw/claw_cli_test.go
@@ -55,10 +55,58 @@ func TestRunClawLookupPrintsJSON(t *testing.T) {
 	}
 }
 
+func TestRunClawStatusRootFlagOverridesEnvRoot(t *testing.T) {
+	envRoot := writeNamedClawBridgeFixture(t, "env")
+	explicitRoot := writeNamedClawBridgeFixture(t, "explicit")
+	t.Setenv("ANYCLAW_CLAW_CODE_ROOT", envRoot)
+
+	stdout, _, err := captureCLIOutput(t, func() error {
+		return runClawCommand([]string{"status", "--root", explicitRoot})
+	})
+	if err != nil {
+		t.Fatalf("runClawCommand status: %v", err)
+	}
+	if !strings.Contains(stdout, explicitRoot) {
+		t.Fatalf("expected explicit root %q in output, got %q", explicitRoot, stdout)
+	}
+	if strings.Contains(stdout, envRoot) {
+		t.Fatalf("expected env root %q to be ignored, got %q", envRoot, stdout)
+	}
+}
+
+func TestRunClawSummaryWorkspaceFlagOverridesEnvRoot(t *testing.T) {
+	envRoot := writeNamedClawBridgeFixture(t, "env")
+	workspaceRoot := writeNamedClawBridgeFixture(t, "workspace-parent")
+	workspace := filepath.Join(filepath.Dir(workspaceRoot), "anyclaw", "workflows", "default")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	t.Setenv("ANYCLAW_CLAW_CODE_ROOT", envRoot)
+
+	stdout, _, err := captureCLIOutput(t, func() error {
+		return runClawCommand([]string{"summary", "--workspace", workspace})
+	})
+	if err != nil {
+		t.Fatalf("runClawCommand summary: %v", err)
+	}
+	if !strings.Contains(stdout, workspaceRoot) {
+		t.Fatalf("expected workspace-discovered root %q in output, got %q", workspaceRoot, stdout)
+	}
+	if strings.Contains(stdout, envRoot) {
+		t.Fatalf("expected env root %q to be ignored, got %q", envRoot, stdout)
+	}
+}
+
 func writeClawBridgeFixture(t *testing.T) string {
 	t.Helper()
 
-	root := filepath.Join(t.TempDir(), "claw-code-main")
+	return writeNamedClawBridgeFixture(t, "claw-code-main")
+}
+
+func writeNamedClawBridgeFixture(t *testing.T, name string) string {
+	t.Helper()
+
+	root := filepath.Join(t.TempDir(), name, "claw-code-main")
 	refDir := filepath.Join(root, "src", "reference_data")
 	subsystemsDir := filepath.Join(refDir, "subsystems")
 	if err := os.MkdirAll(subsystemsDir, 0o755); err != nil {

--- a/cmd/anyclaw/main.go
+++ b/cmd/anyclaw/main.go
@@ -38,6 +38,8 @@ func runAnyClawCLI(args []string) error {
 		return runPluginCommand(args[1:])
 	case "channels":
 		return runChannelsCommand(args[1:])
+	case "claw":
+		return runClawCommand(args[1:])
 	case "status":
 		return runStatusCommand(args[1:])
 	case "health":
@@ -69,6 +71,7 @@ Usage:
   anyclaw clihub <subcommand>         Run CLI Hub commands
   anyclaw plugin <subcommand>         Run plugin management commands
   anyclaw channels <subcommand>       Run channels management commands
+  anyclaw claw <subcommand>           Inspect claw-code-main bridge reference data
   anyclaw status [options]            Show gateway runtime status
   anyclaw health [options]            Show gateway health summary
   anyclaw sessions [options]          List recent sessions

--- a/pkg/clawbridge/bridge.go
+++ b/pkg/clawbridge/bridge.go
@@ -56,7 +56,10 @@ func DiscoverRoot(start string) (string, bool) {
 			return root, true
 		}
 	}
+	return DiscoverRootFromStart(start)
+}
 
+func DiscoverRootFromStart(start string) (string, bool) {
 	start = strings.TrimSpace(start)
 	if start == "" {
 		return "", false

--- a/pkg/clawbridge/bridge_test.go
+++ b/pkg/clawbridge/bridge_test.go
@@ -50,6 +50,22 @@ func TestDiscoverRootPrefersEnvOverride(t *testing.T) {
 	}
 }
 
+func TestDiscoverRootFromStartIgnoresEnvOverride(t *testing.T) {
+	envRoot := filepath.Join(t.TempDir(), "env", "claw-code-main")
+	if err := writeFixtureBridge(envRoot); err != nil {
+		t.Fatalf("writeFixtureBridge env: %v", err)
+	}
+	explicitRoot := filepath.Join(t.TempDir(), "explicit", "claw-code-main")
+	if err := writeFixtureBridge(explicitRoot); err != nil {
+		t.Fatalf("writeFixtureBridge explicit: %v", err)
+	}
+
+	t.Setenv(EnvRoot, envRoot)
+	if discovered, ok := DiscoverRootFromStart(explicitRoot); !ok || discovered != explicitRoot {
+		t.Fatalf("expected explicit root %q, got %q ok=%v", explicitRoot, discovered, ok)
+	}
+}
+
 func TestLookupAndRenderJSON(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "claw-code-main")
 	if err := writeFixtureBridge(root); err != nil {


### PR DESCRIPTION
## Summary
- Add `anyclaw claw` CLI commands for claw-code-main bridge status, summary, and lookup
- Wire the command into the root CLI help and dispatcher
- Add CLI tests covering routing, status, and lookup output
- Scope `.gitignore` binary ignores to repo-root files so `cmd/anyclaw/*` sources are not ignored

## Verification
- go test ./cmd/anyclaw
- go test ./pkg/clawbridge
- git diff --check origin/main..HEAD
