### PR TITLE
feat(gateway): expand role permissions and sync job cancellation

### DIFF
--- a/pkg/gateway/auth/access.go
+++ b/pkg/gateway/auth/access.go
@@ -5,8 +5,8 @@ import "github.com/1024XEngineer/anyclaw/pkg/config"
 func BuiltinRoleTemplates() []config.SecurityRole {
 	return []config.SecurityRole{
 		{Name: "admin", Description: "Full platform access", Permissions: []string{"*"}},
-		{Name: "operator", Description: "Operate sessions, runtimes, and workspace resources", Permissions: []string{"status.read", "chat.send", "tasks.read", "tasks.write", "approvals.read", "approvals.write", "sessions.read", "sessions.write", "memory.read", "runtimes.read", "runtimes.write", "events.read", "tools.read", "resources.read", "resources.write"}},
-		{Name: "viewer", Description: "Read-only governance and monitoring", Permissions: []string{"status.read", "sessions.read", "events.read", "audit.read", "plugins.read", "channels.read", "routing.read", "runtimes.read", "resources.read"}},
+		{Name: "operator", Description: "Operate sessions, runtimes, and workspace resources", Permissions: []string{"status.read", "chat.send", "tasks.read", "tasks.write", "approvals.read", "approvals.write", "sessions.read", "sessions.write", "memory.read", "runtimes.read", "runtimes.write", "events.read", "tools.read", "resources.read", "resources.write", "jobs.read", "jobs.write", "cron.read", "cron.write", "market.read", "mcp.read", "nodes.read"}},
+		{Name: "viewer", Description: "Read-only governance and monitoring", Permissions: []string{"status.read", "tasks.read", "sessions.read", "events.read", "audit.read", "plugins.read", "channels.read", "routing.read", "runtimes.read", "resources.read", "jobs.read", "cron.read", "market.read", "mcp.read", "nodes.read"}},
 	}
 }
 
@@ -28,7 +28,7 @@ func resolveRolePermissions(cfg *config.SecurityConfig, roleName string) []strin
 	}
 	switch roleName {
 	case "viewer":
-		return []string{"status.read", "sessions.read", "events.read", "audit.read", "plugins.read", "channels.read", "routing.read", "runtimes.read", "resources.read"}
+		return []string{"status.read", "tasks.read", "sessions.read", "events.read", "audit.read", "plugins.read", "channels.read", "routing.read", "runtimes.read", "resources.read", "jobs.read", "cron.read", "market.read", "mcp.read", "nodes.read"}
 	default:
 		return nil
 	}

--- a/pkg/gateway/auth/access.go
+++ b/pkg/gateway/auth/access.go
@@ -5,7 +5,7 @@ import "github.com/1024XEngineer/anyclaw/pkg/config"
 func BuiltinRoleTemplates() []config.SecurityRole {
 	return []config.SecurityRole{
 		{Name: "admin", Description: "Full platform access", Permissions: []string{"*"}},
-		{Name: "operator", Description: "Operate sessions, runtimes, and workspace resources", Permissions: []string{"status.read", "chat.send", "tasks.read", "tasks.write", "approvals.read", "approvals.write", "sessions.read", "sessions.write", "memory.read", "runtimes.read", "runtimes.write", "events.read", "tools.read", "resources.read", "resources.write", "jobs.read", "jobs.write", "cron.read", "cron.write", "market.read", "mcp.read", "nodes.read"}},
+		{Name: "operator", Description: "Operate sessions, runtimes, and workspace resources", Permissions: []string{"status.read", "chat.send", "tasks.read", "tasks.write", "approvals.read", "approvals.write", "sessions.read", "sessions.write", "memory.read", "runtimes.read", "runtimes.write", "events.read", "tools.read", "resources.read", "resources.write", "jobs.read", "jobs.write", "cron.read", "cron.write", "market.read", "market.write", "mcp.read", "mcp.write", "nodes.read", "nodes.write"}},
 		{Name: "viewer", Description: "Read-only governance and monitoring", Permissions: []string{"status.read", "tasks.read", "sessions.read", "events.read", "audit.read", "plugins.read", "channels.read", "routing.read", "runtimes.read", "resources.read", "jobs.read", "cron.read", "market.read", "mcp.read", "nodes.read"}},
 	}
 }

--- a/pkg/gateway/auth/access_test.go
+++ b/pkg/gateway/auth/access_test.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+)
+
+func TestBuiltinOperatorCanUseMutablePlatformRoutes(t *testing.T) {
+	permissions := ResolveRolePermissions(&config.SecurityConfig{}, "operator")
+	for _, permission := range []string{"market.write", "mcp.write", "nodes.write"} {
+		if !slices.Contains(permissions, permission) {
+			t.Fatalf("builtin operator missing %q in %v", permission, permissions)
+		}
+	}
+}
+
+func TestBuiltinViewerDoesNotGetPlatformWritePermissions(t *testing.T) {
+	permissions := ResolveRolePermissions(&config.SecurityConfig{}, "viewer")
+	for _, permission := range []string{"market.write", "mcp.write", "nodes.write"} {
+		if slices.Contains(permissions, permission) {
+			t.Fatalf("builtin viewer unexpectedly has %q in %v", permission, permissions)
+		}
+	}
+}

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	openaicompat "github.com/1024XEngineer/anyclaw/pkg/api/openai"
@@ -55,6 +56,7 @@ type Server struct {
 	plugins        *plugin.Registry
 	ingressPlugins []plugin.IngressRunner
 	jobQueue       chan func()
+	jobCancelMu    sync.RWMutex
 	jobCancel      map[string]bool
 	jobMaxAttempts int
 	webhooks       *webhookext.Handler

--- a/pkg/gateway/gateway_audit_jobs_api.go
+++ b/pkg/gateway/gateway_audit_jobs_api.go
@@ -67,7 +67,7 @@ func (s *Server) handleCancelJob(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "job is not cancellable"})
 		return
 	}
-	s.jobCancel[job.ID] = true
+	s.markJobCancelled(job.ID)
 	job.Status = "cancelled"
 	job.CompletedAt = time.Now().UTC().Format(time.RFC3339)
 	job.Cancellable = false

--- a/pkg/gateway/gateway_http_helpers.go
+++ b/pkg/gateway/gateway_http_helpers.go
@@ -67,7 +67,24 @@ func (s *Server) startWorkers(ctx context.Context) {
 }
 
 func (s *Server) shouldCancelJob(id string) bool {
+	if s == nil {
+		return false
+	}
+	s.jobCancelMu.RLock()
+	defer s.jobCancelMu.RUnlock()
 	return s.jobCancel[id]
+}
+
+func (s *Server) markJobCancelled(id string) {
+	if s == nil {
+		return
+	}
+	s.jobCancelMu.Lock()
+	defer s.jobCancelMu.Unlock()
+	if s.jobCancel == nil {
+		s.jobCancel = map[string]bool{}
+	}
+	s.jobCancel[id] = true
 }
 
 func (s *Server) wrap(path string, next http.HandlerFunc) http.HandlerFunc {

--- a/pkg/gateway/gateway_permissions_test.go
+++ b/pkg/gateway/gateway_permissions_test.go
@@ -1,0 +1,137 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	"github.com/1024XEngineer/anyclaw/pkg/state"
+)
+
+func newBearerRequest(method string, target string, token string, body string) *http.Request {
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	return req
+}
+
+func newPermissionRouteServer(t *testing.T, users []config.SecurityUser) (*Server, *http.ServeMux) {
+	t.Helper()
+	server := New(newTestMainRuntime(t))
+	if err := server.ensureDefaultWorkspace(); err != nil {
+		t.Fatalf("ensure default workspace: %v", err)
+	}
+	server.mainRuntime.Config.Security.Users = users
+	mux := http.NewServeMux()
+	server.registerGatewayRoutes(mux)
+	return server, mux
+}
+
+func TestGatewayRoutesUseMethodSpecificTaskPermissions(t *testing.T) {
+	_, mux := newPermissionRouteServer(t, []config.SecurityUser{{
+		Name:                "task-reader",
+		Token:               "task-read-token",
+		PermissionOverrides: []string{"tasks.read"},
+	}})
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, newBearerRequest(http.MethodGet, "/tasks", "task-read-token", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /tasks with tasks.read = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, newBearerRequest(http.MethodPost, "/tasks", "task-read-token", `{"input":"hello"}`))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("POST /tasks without tasks.write = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGatewayJobMutationRoutesRequireWritePermission(t *testing.T) {
+	server, mux := newPermissionRouteServer(t, []config.SecurityUser{{
+		Name:                "job-reader",
+		Token:               "job-read-token",
+		PermissionOverrides: []string{"jobs.read"},
+	}})
+	if err := server.store.AppendJob(&state.Job{ID: "queued-job", Kind: "noop", Status: "queued", Cancellable: true}); err != nil {
+		t.Fatalf("append job: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, newBearerRequest(http.MethodGet, "/jobs", "job-read-token", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /jobs with jobs.read = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, newBearerRequest(http.MethodPost, "/jobs/cancel", "job-read-token", `{"job_id":"queued-job"}`))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("POST /jobs/cancel without jobs.write = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGatewayMutablePlatformRoutesRequireWritePermission(t *testing.T) {
+	_, mux := newPermissionRouteServer(t, []config.SecurityUser{{
+		Name:  "platform-reader",
+		Token: "platform-read-token",
+		PermissionOverrides: []string{
+			"market.read",
+			"mcp.read",
+			"nodes.read",
+		},
+	}})
+
+	for _, tc := range []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{method: http.MethodPost, path: "/market/plugins/demo/install"},
+		{method: http.MethodPost, path: "/mcp/servers/demo/connect"},
+		{method: http.MethodDelete, path: "/nodes/demo"},
+	} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, newBearerRequest(tc.method, tc.path, "platform-read-token", tc.body))
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("%s %s without write permission = %d, want 403; body=%s", tc.method, tc.path, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestGatewayCronRoutesInitializeLazilyAndRequireWritePermission(t *testing.T) {
+	cronInitOnce = sync.Once{}
+	cronScheduler = nil
+	defer func() {
+		if cronScheduler != nil {
+			cronScheduler.Stop()
+		}
+		cronInitOnce = sync.Once{}
+		cronScheduler = nil
+	}()
+
+	_, mux := newPermissionRouteServer(t, []config.SecurityUser{{
+		Name:                "cron-reader",
+		Token:               "cron-read-token",
+		PermissionOverrides: []string{"cron.read"},
+	}})
+	if cronScheduler != nil {
+		t.Fatal("expected cron scheduler to remain uninitialized until the first cron request")
+	}
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, newBearerRequest(http.MethodGet, "/cron/?json=1", "cron-read-token", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /cron/?json=1 with cron.read = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if cronScheduler == nil {
+		t.Fatal("expected cron scheduler to initialize lazily on first cron request")
+	}
+
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, newBearerRequest(http.MethodPost, "/cron/", "cron-read-token", `{"name":"hourly","schedule":"@hourly","command":"echo hi"}`))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("POST /cron/ without cron.write = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/gateway/gateway_routes_platform.go
+++ b/pkg/gateway/gateway_routes_platform.go
@@ -5,6 +5,7 @@ import (
 
 	gatewayintake "github.com/1024XEngineer/anyclaw/pkg/gateway/intake"
 	scheduleui "github.com/1024XEngineer/anyclaw/pkg/gateway/transport/scheduleui"
+	runtimeschedule "github.com/1024XEngineer/anyclaw/pkg/runtime/execution/schedule"
 )
 
 func (s *Server) registerGatewayPlatformRoutes(mux *http.ServeMux) {
@@ -14,7 +15,7 @@ func (s *Server) registerGatewayPlatformRoutes(mux *http.ServeMux) {
 	s.registerDiscoveryRoutes(mux)
 	s.registerMCPRoutes(mux)
 	s.registerMarketRoutes(mux)
-	scheduleui.RegisterUIHandler(mux, cronScheduler, "/cron")
+	s.registerCronRoutes(mux)
 }
 
 func (s *Server) registerOpenAIRoutes(mux *http.ServeMux) {
@@ -36,7 +37,10 @@ func (s *Server) registerExtensionRoutes(mux *http.ServeMux) {
 
 func (s *Server) registerNodeRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/nodes", s.wrap("/nodes", requirePermission("nodes.read", s.nodesAPI().HandleList)))
-	mux.HandleFunc("/nodes/", s.wrap("/nodes/", s.nodesAPI().HandleByID))
+	mux.HandleFunc("/nodes/", s.wrap("/nodes/", requirePermissionByMethod(map[string]string{
+		http.MethodDelete: "nodes.write",
+		http.MethodGet:    "nodes.read",
+	}, "nodes.read", s.nodesAPI().HandleByID)))
 	mux.HandleFunc("/nodes/invoke", s.wrap("/nodes/invoke", requirePermission("nodes.write", s.nodesAPI().HandleInvoke)))
 }
 
@@ -51,13 +55,33 @@ func (s *Server) registerMCPRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/mcp/resources", s.wrap("/mcp/resources", requirePermission("mcp.read", s.handleMCPResources)))
 	mux.HandleFunc("/mcp/prompts", s.wrap("/mcp/prompts", requirePermission("mcp.read", s.handleMCPPrompts)))
 	mux.HandleFunc("/mcp/call", s.wrap("/mcp/call", requirePermission("mcp.write", s.handleMCPCall)))
-	mux.HandleFunc("/mcp/servers/", s.wrap("/mcp/servers/", s.handleMCPServerAction))
+	mux.HandleFunc("/mcp/servers/", s.wrap("/mcp/servers/", requirePermissionByMethod(map[string]string{
+		http.MethodGet:  "mcp.read",
+		http.MethodPost: "mcp.write",
+	}, "mcp.read", s.handleMCPServerAction)))
 }
 
 func (s *Server) registerMarketRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/market/search", s.wrap("/market/search", requirePermission("market.read", s.handleMarketSearch)))
 	mux.HandleFunc("/market/plugins", s.wrap("/market/plugins", requirePermission("market.read", s.handleMarketPlugins)))
-	mux.HandleFunc("/market/plugins/", s.wrap("/market/plugins/", s.handleMarketPluginAction))
+	mux.HandleFunc("/market/plugins/", s.wrap("/market/plugins/", requirePermissionByMethod(map[string]string{
+		http.MethodGet:  "market.read",
+		http.MethodPost: "market.write",
+	}, "market.read", s.handleMarketPluginAction)))
 	mux.HandleFunc("/market/installed", s.wrap("/market/installed", requirePermission("market.read", s.handleMarketInstalled)))
 	mux.HandleFunc("/market/categories", s.wrap("/market/categories", requirePermission("market.read", s.handleMarketCategories)))
+}
+
+func (s *Server) registerCronRoutes(mux *http.ServeMux) {
+	scheduleui.RegisterUIHandlerWithProvider(mux, func() *runtimeschedule.Scheduler {
+		s.initCronScheduler()
+		return cronScheduler
+	}, "/cron", func(path string, next http.HandlerFunc) http.HandlerFunc {
+		return s.wrap(path, requirePermissionByMethod(map[string]string{
+			http.MethodDelete: "cron.write",
+			http.MethodGet:    "cron.read",
+			http.MethodPost:   "cron.write",
+			http.MethodPut:    "cron.write",
+		}, "cron.read", next))
+	})
 }

--- a/pkg/gateway/gateway_routes_shared.go
+++ b/pkg/gateway/gateway_routes_shared.go
@@ -63,10 +63,10 @@ func (s *Server) registerRuntimeGovernanceRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/auth/roles", s.wrap("/auth/roles", s.handleRoles))
 	mux.HandleFunc("/auth/roles/impact", s.wrap("/auth/roles/impact", requirePermission("auth.users.read", s.handleRoleImpact)))
 	mux.HandleFunc("/audit", s.wrap("/audit", requirePermission("audit.read", s.handleAudit)))
-	mux.HandleFunc("/jobs", s.wrap("/jobs", requirePermission("audit.read", s.handleJobs)))
-	mux.HandleFunc("/jobs/", s.wrap("/jobs/", requirePermission("audit.read", s.handleJobByID)))
-	mux.HandleFunc("/jobs/retry", s.wrap("/jobs/retry", requirePermission("audit.read", s.handleRetryJob)))
-	mux.HandleFunc("/jobs/cancel", s.wrap("/jobs/cancel", requirePermission("audit.read", s.handleCancelJob)))
+	mux.HandleFunc("/jobs", s.wrap("/jobs", requirePermission("jobs.read", s.handleJobs)))
+	mux.HandleFunc("/jobs/", s.wrap("/jobs/", requirePermission("jobs.read", s.handleJobByID)))
+	mux.HandleFunc("/jobs/retry", s.wrap("/jobs/retry", requirePermission("jobs.write", s.handleRetryJob)))
+	mux.HandleFunc("/jobs/cancel", s.wrap("/jobs/cancel", requirePermission("jobs.write", s.handleCancelJob)))
 	mux.HandleFunc("/config", s.wrap("/config", s.handleConfigAPI))
 	mux.HandleFunc("/memory", s.wrap("/memory", requirePermission("memory.read", requireHierarchyAccess(s.resolveHierarchyFromQuery, s.handleMemory))))
 	mux.HandleFunc("/approvals", s.wrap("/approvals", requirePermission("approvals.read", s.handleApprovals)))
@@ -84,7 +84,10 @@ func (s *Server) registerSessionTaskRoutes(mux *http.ServeMux) {
 	}, "sessions.read", requireHierarchyAccess(s.resolveHierarchyFromSessionPath, s.sessionCommandsAPI().HandleByID))))
 	mux.HandleFunc("/sessions/move", s.wrap("/sessions/move", requirePermission("sessions.write", s.sessionMoveCommandsAPI().HandleSingle)))
 	mux.HandleFunc("/sessions/move-batch", s.wrap("/sessions/move-batch", requirePermission("sessions.write", s.sessionMoveCommandsAPI().HandleBatch)))
-	mux.HandleFunc("/tasks", s.wrap("/tasks", requirePermission("tasks.write", requireHierarchyAccess(s.resolveHierarchyFromQuery, s.taskCommandsAPI().HandleCollection))))
+	mux.HandleFunc("/tasks", s.wrap("/tasks", requirePermissionByMethod(map[string]string{
+		http.MethodGet:  "tasks.read",
+		http.MethodPost: "tasks.write",
+	}, "tasks.read", requireHierarchyAccess(s.resolveHierarchyFromQuery, s.taskCommandsAPI().HandleCollection))))
 	mux.HandleFunc("/tasks/", s.wrap("/tasks/", s.taskCommandsAPI().HandleByID))
 	mux.HandleFunc("/v2/tasks", s.wrap("/v2/tasks", requirePermission("tasks.write", s.handleV2Tasks)))
 	mux.HandleFunc("/v2/tasks/", s.wrap("/v2/tasks/", requirePermission("tasks.read", s.handleV2TaskByID)))

--- a/pkg/gateway/gateway_users_api.go
+++ b/pkg/gateway/gateway_users_api.go
@@ -156,6 +156,16 @@ func allowedSecurityPermissions() map[string]bool {
 		"config.read":     true,
 		"config.write":    true,
 		"audit.read":      true,
+		"jobs.read":       true,
+		"jobs.write":      true,
+		"cron.read":       true,
+		"cron.write":      true,
+		"market.read":     true,
+		"market.write":    true,
+		"mcp.read":        true,
+		"mcp.write":       true,
+		"nodes.read":      true,
+		"nodes.write":     true,
 		"auth.users.read": true,
 	}
 }

--- a/pkg/gateway/transport/scheduleui/ui.go
+++ b/pkg/gateway/transport/scheduleui/ui.go
@@ -12,31 +12,65 @@ import (
 
 // RegisterUIHandler registers the cron web UI and API handlers on the given mux.
 func RegisterUIHandler(mux *http.ServeMux, scheduler *runtimeschedule.Scheduler, prefix string) {
+	RegisterUIHandlerWithProvider(mux, func() *runtimeschedule.Scheduler {
+		return scheduler
+	}, prefix, nil)
+}
+
+type SchedulerProvider func() *runtimeschedule.Scheduler
+type Middleware func(path string, next http.HandlerFunc) http.HandlerFunc
+
+// RegisterUIHandlerWithProvider registers cron UI handlers with optional lazy scheduler lookup and middleware.
+func RegisterUIHandlerWithProvider(mux *http.ServeMux, schedulerProvider SchedulerProvider, prefix string, middleware Middleware) {
 	if !strings.HasSuffix(prefix, "/") {
 		prefix += "/"
 	}
 
-	mux.HandleFunc(prefix, func(w http.ResponseWriter, r *http.Request) {
+	handle := func(path string, handler http.HandlerFunc) {
+		if middleware != nil {
+			handler = middleware(path, handler)
+		}
+		mux.HandleFunc(path, handler)
+	}
+
+	scheduler := func() *runtimeschedule.Scheduler {
+		if schedulerProvider == nil {
+			return nil
+		}
+		return schedulerProvider()
+	}
+
+	handle(prefix, func(w http.ResponseWriter, r *http.Request) {
+		s := scheduler()
+		if s == nil {
+			http.Error(w, "cron scheduler not initialized", http.StatusServiceUnavailable)
+			return
+		}
 		switch r.Method {
 		case http.MethodGet:
 			if r.URL.Query().Get("json") == "1" {
-				serveCronJSON(w, scheduler)
+				serveCronJSON(w, s)
 			} else {
-				serveCronUI(w, scheduler)
+				serveCronUI(w, s)
 			}
 		case http.MethodPost:
-			handleCreateTask(w, r, scheduler)
+			handleCreateTask(w, r, s)
 		default:
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
 	})
 
-	mux.HandleFunc(prefix+"stats", func(w http.ResponseWriter, r *http.Request) {
+	handle(prefix+"stats", func(w http.ResponseWriter, r *http.Request) {
+		s := scheduler()
+		if s == nil {
+			http.Error(w, "cron scheduler not initialized", http.StatusServiceUnavailable)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(scheduler.Stats())
+		_ = json.NewEncoder(w).Encode(s.Stats())
 	})
 
-	mux.HandleFunc(prefix+"validate", func(w http.ResponseWriter, r *http.Request) {
+	handle(prefix+"validate", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -53,7 +87,7 @@ func RegisterUIHandler(mux *http.ServeMux, scheduler *runtimeschedule.Scheduler,
 		_ = json.NewEncoder(w).Encode(resp)
 	})
 
-	mux.HandleFunc(prefix+"next", func(w http.ResponseWriter, r *http.Request) {
+	handle(prefix+"next", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return


### PR DESCRIPTION
Add jobs, cron, market, MCP, node, and task read/write access to builtin operator and viewer roles so governance defaults cover newer platform capabilities. Also guard job cancellation state with a mutex and route cancellation through a helper to avoid concurrent map access issues in the gateway.feat(gateway): expand role permissions and sync job cancellation

Add jobs, cron, market, MCP, node, and task read/write access to builtin operator and viewer roles so governance defaults cover newer platform capabilities. Also guard job cancellation state with a mutex and route cancellation through a helper to avoid concurrent map access issues in the gateway.