### PR TITLE
fix: route provider setup requests through gateway

### DIFF
--- a/pkg/gateway/gateway_control_plane_provider_health.go
+++ b/pkg/gateway/gateway_control_plane_provider_health.go
@@ -76,27 +76,27 @@ func activeProviderTest(ctx context.Context, provider config.ProviderProfile) pr
 		return providerHealth{
 			OK:         true,
 			Status:     "reachable",
-			Message:    fmt.Sprintf("Endpoint responded with HTTP %d.", resp.StatusCode),
+			Message:    fmt.Sprintf("连接成功，接口已响应（HTTP %d）。", resp.StatusCode),
 			HTTPStatus: resp.StatusCode,
 		}
 	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return providerHealth{
 			Status:     "auth_error",
-			Message:    fmt.Sprintf("Endpoint reached but authorization failed with HTTP %d.", resp.StatusCode),
+			Message:    fmt.Sprintf("接口已连通，但 API Key 无效或没有权限（HTTP %d）。", resp.StatusCode),
 			HTTPStatus: resp.StatusCode,
 		}
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		return providerHealth{
 			Status:     "endpoint_not_found",
-			Message:    "Endpoint returned HTTP 404. Check whether Base URL already contains the correct API path.",
+			Message:    "接口地址返回 404，请检查是否多填或少填了 API 路径。",
 			HTTPStatus: resp.StatusCode,
 		}
 	}
 	return providerHealth{
 		Status:     "error",
-		Message:    fmt.Sprintf("Endpoint responded with HTTP %d.", resp.StatusCode),
+		Message:    fmt.Sprintf("接口已响应，但返回了 HTTP %d。", resp.StatusCode),
 		HTTPStatus: resp.StatusCode,
 	}
 }

--- a/pkg/gateway/gateway_permissions_test.go
+++ b/pkg/gateway/gateway_permissions_test.go
@@ -100,6 +100,28 @@ func TestGatewayMutablePlatformRoutesRequireWritePermission(t *testing.T) {
 	}
 }
 
+func TestGatewayRoutesAllowLocalControlUICORSPreflight(t *testing.T) {
+	_, mux := newPermissionRouteServer(t, nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/providers", nil)
+	req.Header.Set("Origin", "http://127.0.0.1:4173")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "content-type")
+	req.Header.Set("Access-Control-Request-Private-Network", "true")
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("OPTIONS /providers = %d, want 204; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://127.0.0.1:4173" {
+		t.Fatalf("unexpected CORS allow origin %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Private-Network"); got != "true" {
+		t.Fatalf("unexpected private network CORS header %q", got)
+	}
+}
+
 func TestGatewayAuthUserMutationsRequireUserWritePermission(t *testing.T) {
 	_, mux := newPermissionRouteServer(t, []config.SecurityUser{
 		{

--- a/pkg/gateway/gateway_store_health_test.go
+++ b/pkg/gateway/gateway_store_health_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	agentstore "github.com/1024XEngineer/anyclaw/pkg/capability/catalogs"
@@ -123,24 +124,24 @@ func TestGatewayStoreAndProviderHealth(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		}))
 		defer successSrv.Close()
-		if got := activeProviderTest(context.Background(), config.ProviderProfile{Enabled: config.BoolPtr(true), Provider: "compatible", APIKey: "key", BaseURL: successSrv.URL}); got.Status != "reachable" {
-			t.Fatalf("reachable provider status = %q", got.Status)
+		if got := activeProviderTest(context.Background(), config.ProviderProfile{Enabled: config.BoolPtr(true), Provider: "compatible", APIKey: "key", BaseURL: successSrv.URL}); got.Status != "reachable" || !strings.Contains(got.Message, "连接成功") {
+			t.Fatalf("reachable provider health = %+v", got)
 		}
 
 		authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusUnauthorized)
 		}))
 		defer authSrv.Close()
-		if got := activeProviderTest(context.Background(), config.ProviderProfile{Enabled: config.BoolPtr(true), Provider: "compatible", APIKey: "key", BaseURL: authSrv.URL}); got.Status != "auth_error" {
-			t.Fatalf("auth provider status = %q", got.Status)
+		if got := activeProviderTest(context.Background(), config.ProviderProfile{Enabled: config.BoolPtr(true), Provider: "compatible", APIKey: "key", BaseURL: authSrv.URL}); got.Status != "auth_error" || !strings.Contains(got.Message, "API Key") {
+			t.Fatalf("auth provider health = %+v", got)
 		}
 
 		notFoundSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 		}))
 		defer notFoundSrv.Close()
-		if got := activeProviderTest(context.Background(), config.ProviderProfile{Enabled: config.BoolPtr(true), Provider: "compatible", APIKey: "key", BaseURL: notFoundSrv.URL}); got.Status != "endpoint_not_found" {
-			t.Fatalf("404 provider status = %q", got.Status)
+		if got := activeProviderTest(context.Background(), config.ProviderProfile{Enabled: config.BoolPtr(true), Provider: "compatible", APIKey: "key", BaseURL: notFoundSrv.URL}); got.Status != "endpoint_not_found" || !strings.Contains(got.Message, "404") {
+			t.Fatalf("404 provider health = %+v", got)
 		}
 
 		if got := activeProviderTest(context.Background(), config.ProviderProfile{Enabled: config.BoolPtr(true), Provider: "compatible", APIKey: "key"}); got.Status != "ready" {

--- a/pkg/gateway/governance/service.go
+++ b/pkg/gateway/governance/service.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
+	"strings"
 
 	gatewayauth "github.com/1024XEngineer/anyclaw/pkg/gateway/auth"
 	gatewaymiddleware "github.com/1024XEngineer/anyclaw/pkg/gateway/middleware"
@@ -26,9 +28,9 @@ func (s Service) Wrap(path string, next http.HandlerFunc) http.HandlerFunc {
 		next = s.RateLimit.Wrap(next)
 	}
 	if s.Auth != nil {
-		return s.Auth.Wrap(path, next)
+		next = s.Auth.Wrap(path, next)
 	}
-	return next
+	return withLocalCORS(next)
 }
 
 // RequirePermission checks a single named permission before invoking the next handler.
@@ -107,4 +109,58 @@ func writeJSON(w http.ResponseWriter, statusCode int, value any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	_ = json.NewEncoder(w).Encode(value)
+}
+
+func withLocalCORS(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if allowLocalCORS(w, r) && r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next(w, r)
+	}
+}
+
+func allowLocalCORS(w http.ResponseWriter, r *http.Request) bool {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if !isLocalControlOrigin(origin) {
+		return false
+	}
+
+	header := w.Header()
+	header.Set("Access-Control-Allow-Origin", origin)
+	header.Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS")
+	header.Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept")
+	header.Set("Access-Control-Max-Age", "600")
+	if strings.EqualFold(r.Header.Get("Access-Control-Request-Private-Network"), "true") {
+		header.Set("Access-Control-Allow-Private-Network", "true")
+	}
+	header.Add("Vary", "Origin")
+	return true
+}
+
+func isLocalControlOrigin(origin string) bool {
+	if origin == "" {
+		return false
+	}
+	if origin == "null" {
+		return true
+	}
+
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+
+	switch parsed.Scheme {
+	case "http", "https", "wails":
+	default:
+		return false
+	}
+
+	host := strings.Trim(strings.ToLower(parsed.Hostname()), "[]")
+	return host == "localhost" ||
+		host == "127.0.0.1" ||
+		host == "::1" ||
+		strings.HasSuffix(host, ".localhost")
 }

--- a/pkg/gateway/governance/service_test.go
+++ b/pkg/gateway/governance/service_test.go
@@ -1,0 +1,142 @@
+package governance
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/anyclaw/pkg/config"
+	gatewayauth "github.com/1024XEngineer/anyclaw/pkg/gateway/auth"
+)
+
+func TestWrapHandlesLocalCORSPreflight(t *testing.T) {
+	called := false
+	handler := Service{}.Wrap("/providers", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/providers", nil)
+	req.Header.Set("Origin", "http://127.0.0.1:4173")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "content-type")
+	req.Header.Set("Access-Control-Request-Private-Network", "true")
+	handler.ServeHTTP(rec, req)
+
+	if called {
+		t.Fatal("expected CORS preflight to skip wrapped handler")
+	}
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("OPTIONS /providers = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://127.0.0.1:4173" {
+		t.Fatalf("unexpected allow origin %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Private-Network"); got != "true" {
+		t.Fatalf("unexpected private network header %q", got)
+	}
+	if got := rec.Header().Get("Vary"); !strings.Contains(got, "Origin") {
+		t.Fatalf("expected Vary to include Origin, got %q", got)
+	}
+}
+
+func TestWrapLetsLocalCORSPreflightBypassAuth(t *testing.T) {
+	called := false
+	handler := Service{
+		Auth: gatewayauth.NewMiddleware(&config.SecurityConfig{APIToken: "secret"}),
+	}.Wrap("/providers", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/providers", nil)
+	req.Header.Set("Origin", "http://localhost:4173")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	handler.ServeHTTP(rec, req)
+
+	if called {
+		t.Fatal("expected authenticated route preflight to skip wrapped handler")
+	}
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("authenticated OPTIONS /providers = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+	if got := rec.Header().Get("WWW-Authenticate"); got != "" {
+		t.Fatalf("expected preflight to bypass auth challenge, got %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:4173" {
+		t.Fatalf("unexpected allow origin %q", got)
+	}
+}
+
+func TestWrapAddsLocalCORSHeadersAndPassesThroughNonPreflight(t *testing.T) {
+	handler := Service{}.Wrap("/providers", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/providers", nil)
+	req.Header.Set("Origin", "http://ui.localhost:4173")
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("GET /providers = %d, want %d", rec.Code, http.StatusAccepted)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://ui.localhost:4173" {
+		t.Fatalf("unexpected allow origin %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, http.MethodPost) {
+		t.Fatalf("expected allow methods to include POST, got %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Headers"); !strings.Contains(got, "Content-Type") {
+		t.Fatalf("expected allow headers to include Content-Type, got %q", got)
+	}
+}
+
+func TestWrapDoesNotAddCORSHeadersForRemoteOrigin(t *testing.T) {
+	called := false
+	handler := Service{}.Wrap("/providers", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/providers", nil)
+	req.Header.Set("Origin", "https://example.com")
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Fatal("expected remote-origin OPTIONS request to reach wrapped handler")
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("unexpected allow origin %q", got)
+	}
+}
+
+func TestIsLocalControlOrigin(t *testing.T) {
+	tests := []struct {
+		origin string
+		want   bool
+	}{
+		{origin: "", want: false},
+		{origin: ":", want: false},
+		{origin: "null", want: true},
+		{origin: "http://localhost:4173", want: true},
+		{origin: "https://127.0.0.1", want: true},
+		{origin: "wails://localhost", want: true},
+		{origin: "http://[::1]:4173", want: true},
+		{origin: "http://ui.localhost:4173", want: true},
+		{origin: "ftp://localhost", want: false},
+		{origin: "https://example.com", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.origin, func(t *testing.T) {
+			if got := isLocalControlOrigin(tt.origin); got != tt.want {
+				t.Fatalf("isLocalControlOrigin(%q) = %v, want %v", tt.origin, got, tt.want)
+			}
+		})
+	}
+}

--- a/ui/src/features/api/client.ts
+++ b/ui/src/features/api/client.ts
@@ -1,0 +1,156 @@
+const DEFAULT_GATEWAY_ORIGIN = "http://127.0.0.1:18789";
+
+type ImportMetaWithEnv = ImportMeta & {
+  env?: Record<string, string | undefined>;
+};
+
+function trimTrailingSlash(value: string) {
+  return value.trim().replace(/\/+$/, "");
+}
+
+function safeJsonParse(value: string) {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function configuredGatewayOrigin() {
+  const globalOrigin =
+    typeof globalThis !== "undefined"
+      ? (globalThis as { __ANYCLAW_API_ORIGIN__?: string }).__ANYCLAW_API_ORIGIN__
+      : undefined;
+  const metaOrigin =
+    typeof document !== "undefined"
+      ? document.querySelector<HTMLMetaElement>('meta[name="anyclaw-api-origin"]')?.content
+      : undefined;
+  const envOrigin = (import.meta as ImportMetaWithEnv).env?.VITE_ANYCLAW_API_ORIGIN;
+  const origin = trimTrailingSlash(globalOrigin || metaOrigin || envOrigin || DEFAULT_GATEWAY_ORIGIN);
+
+  try {
+    return new URL(origin).origin;
+  } catch {
+    return DEFAULT_GATEWAY_ORIGIN;
+  }
+}
+
+function inputURL(input: RequestInfo | URL) {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  if (typeof Request !== "undefined" && input instanceof Request) return input.url;
+  return "";
+}
+
+function isRootRelativePath(value: string) {
+  return value.startsWith("/") && !value.startsWith("//");
+}
+
+function canUseSameOriginAPI() {
+  if (typeof window === "undefined") return true;
+  return window.location.protocol === "http:" || window.location.protocol === "https:";
+}
+
+function currentOriginLooksLikeGateway(gatewayOrigin: string) {
+  if (typeof window === "undefined") return true;
+  if (!canUseSameOriginAPI()) return false;
+  if (window.location.origin === gatewayOrigin) return true;
+
+  try {
+    const gatewayURL = new URL(gatewayOrigin);
+    return window.location.port !== "" && window.location.port === gatewayURL.port;
+  } catch {
+    return false;
+  }
+}
+
+function gatewayURL(path: string) {
+  return new URL(path, configuredGatewayOrigin()).toString();
+}
+
+function resolveAPIInput(input: RequestInfo | URL): RequestInfo | URL {
+  const url = inputURL(input);
+  if (!isRootRelativePath(url) || canUseSameOriginAPI()) {
+    return input;
+  }
+  return gatewayURL(url);
+}
+
+function canRetryViaGateway(input: RequestInfo | URL) {
+  const url = inputURL(input);
+  return isRootRelativePath(url) && !currentOriginLooksLikeGateway(configuredGatewayOrigin());
+}
+
+function shouldRetryResponseViaGateway(input: RequestInfo | URL, response: Response) {
+  if (!canRetryViaGateway(input)) {
+    return false;
+  }
+  if (response.status === 404 || response.status === 405) {
+    return true;
+  }
+
+  const contentType = response.headers.get("Content-Type") ?? "";
+  return response.ok && contentType.toLowerCase().includes("text/html");
+}
+
+function gatewayNetworkError(input: RequestInfo | URL, cause: unknown) {
+  const target = isRootRelativePath(inputURL(input)) ? gatewayURL(inputURL(input)) : inputURL(input);
+  const detail = cause instanceof Error && cause.message ? ` 原始错误：${cause.message}` : "";
+  return new Error(`无法连接本地 AnyClaw 网关（${target}）。请确认桌面端或 gateway 已启动。${detail}`);
+}
+
+export async function apiFetch(input: RequestInfo | URL, init?: RequestInit) {
+  try {
+    const response = await fetch(resolveAPIInput(input), init);
+    if (shouldRetryResponseViaGateway(input, response)) {
+      return await fetch(gatewayURL(inputURL(input)), init);
+    }
+    return response;
+  } catch (error) {
+    if (!canRetryViaGateway(input)) {
+      throw gatewayNetworkError(input, error);
+    }
+
+    try {
+      return await fetch(gatewayURL(inputURL(input)), init);
+    } catch (retryError) {
+      throw gatewayNetworkError(input, retryError);
+    }
+  }
+}
+
+export async function requestJSON<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
+  const response = await apiFetch(input, {
+    ...init,
+    headers: {
+      Accept: "application/json",
+      ...(init?.body ? { "Content-Type": "application/json" } : null),
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  const raw = await response.text();
+  const payload = raw ? safeJsonParse(raw) : null;
+
+  if (!response.ok) {
+    const message =
+      payload && typeof payload === "object" && "error" in payload && typeof payload.error === "string"
+        ? payload.error
+        : raw.trim() || `请求失败 (${response.status})`;
+    throw new Error(message);
+  }
+
+  return payload as T;
+}
+
+export async function fetchJSONOrNull<T>(input: RequestInfo | URL): Promise<T | null> {
+  try {
+    const response = await apiFetch(input, {
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) return null;
+    return (await response.json()) as T;
+  } catch {
+    return null;
+  }
+}

--- a/ui/src/features/model-settings/ModelSettingsModal.test.tsx
+++ b/ui/src/features/model-settings/ModelSettingsModal.test.tsx
@@ -27,6 +27,34 @@ describe("ModelSettingsModal", () => {
     vi.restoreAllMocks();
   });
 
+  it("uses user-facing API protocol fields when creating a custom model", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+
+      if (url === "/providers" && method === "GET") {
+        return jsonResponse([]);
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithClient(<ModelSettingsModal onClose={vi.fn()} />);
+
+    await screen.findByText("自定义大模型");
+
+    expect(screen.getByText("接口地址")).toBeInTheDocument();
+    expect(screen.getByText("API 协议类型")).toBeInTheDocument();
+    expect(screen.getByText("API Key")).toBeInTheDocument();
+    expect(screen.getByText("模型名称")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "API 协议类型" })).toHaveTextContent("OpenAI 兼容协议");
+    expect(screen.getByRole("combobox", { name: "API 协议类型" })).toHaveTextContent("Anthropic 兼容协议");
+    expect(screen.queryByText("运行时")).not.toBeInTheDocument();
+    expect(screen.queryByText("Base URL")).not.toBeInTheDocument();
+  });
+
   it("keeps provider selection separate from setting the default provider", async () => {
     const providers = [
       {

--- a/ui/src/features/model-settings/ModelSettingsModal.test.tsx
+++ b/ui/src/features/model-settings/ModelSettingsModal.test.tsx
@@ -56,6 +56,48 @@ describe("ModelSettingsModal", () => {
     expect(screen.queryByText("Base URL")).not.toBeInTheDocument();
   });
 
+  it("shows a friendly success message for provider connection tests", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+
+      if (url === "/providers" && method === "GET") {
+        return jsonResponse([]);
+      }
+
+      if (url === "/providers/test" && method === "POST") {
+        return jsonResponse({
+          http_status: 200,
+          message: "Endpoint responded with HTTP 200.",
+          ok: true,
+          status: "reachable",
+        });
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithClient(<ModelSettingsModal onClose={vi.fn()} />);
+
+    await screen.findByText("自定义大模型");
+
+    fireEvent.change(screen.getByPlaceholderText("请输入模型的显示名称"), {
+      target: { value: "我的模型" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("例如 gpt-4o-mini"), {
+      target: { value: "gpt-4o-mini" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("请输入 API Key"), {
+      target: { value: "test-key" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /测试连接/i }));
+
+    expect(await screen.findByText("连接成功，接口已响应（HTTP 200）。")).toBeInTheDocument();
+    expect(screen.queryByText("Endpoint responded with HTTP 200.")).not.toBeInTheDocument();
+  });
+
   it("keeps provider selection separate from setting the default provider", async () => {
     const providers = [
       {

--- a/ui/src/features/model-settings/ModelSettingsModal.test.tsx
+++ b/ui/src/features/model-settings/ModelSettingsModal.test.tsx
@@ -51,6 +51,7 @@ describe("ModelSettingsModal", () => {
     expect(screen.getByText("模型名称")).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "API 协议类型" })).toHaveTextContent("OpenAI 兼容协议");
     expect(screen.getByRole("combobox", { name: "API 协议类型" })).toHaveTextContent("Anthropic 兼容协议");
+    expect(screen.queryByText("通义千问兼容协议")).not.toBeInTheDocument();
     expect(screen.queryByText("运行时")).not.toBeInTheDocument();
     expect(screen.queryByText("Base URL")).not.toBeInTheDocument();
   });

--- a/ui/src/features/model-settings/ModelSettingsModal.tsx
+++ b/ui/src/features/model-settings/ModelSettingsModal.tsx
@@ -17,7 +17,7 @@ type ModelSettingsModalProps = {
   onClose: () => void;
 };
 
-type ProviderRuntime = "compatible" | "ollama" | "qwen";
+type ProviderRuntime = "anthropic" | "compatible" | "ollama" | "qwen";
 
 type ProviderHealth = {
   http_status?: number;
@@ -65,58 +65,69 @@ type NoticeState =
 const NEW_PROVIDER_ID = "__new_provider__";
 
 function normalizeRuntime(value?: string): ProviderRuntime {
-  const runtime = value?.trim().toLowerCase();
+  const runtime = value?.trim().toLowerCase() ?? "";
+  if (runtime === "anthropic" || runtime.includes("claude")) return "anthropic";
   if (runtime === "ollama") return "ollama";
-  if (runtime === "qwen") return "qwen";
+  if (runtime === "qwen" || runtime === "dashscope") return "qwen";
   return "compatible";
 }
 
 function runtimeLabel(runtime: ProviderRuntime) {
   switch (runtime) {
+    case "anthropic":
+      return "Anthropic 兼容协议";
     case "ollama":
-      return "Ollama";
+      return "Ollama 本地接口";
     case "qwen":
-      return "通义千问";
+      return "通义千问兼容协议";
     default:
-      return "兼容接口";
+      return "OpenAI 兼容协议";
   }
 }
 
 function runtimeModelPlaceholder(runtime: ProviderRuntime) {
   switch (runtime) {
+    case "anthropic":
+      return "例如 claude-3-5-sonnet";
     case "ollama":
       return "例如 llama3.2";
     case "qwen":
       return "例如 qwen-max";
     default:
-      return "例如 gpt-5.4";
+      return "例如 gpt-4o-mini";
   }
 }
 
 function runtimeBaseUrlPlaceholder(runtime: ProviderRuntime) {
   switch (runtime) {
+    case "anthropic":
+      return "请输入 API 基础地址，例如 https://api.anthropic.com/v1";
     case "ollama":
-      return "例如 http://127.0.0.1:11434";
+      return "请输入 API 基础地址，例如 http://127.0.0.1:11434/v1";
     case "qwen":
-      return "例如 https://dashscope.aliyuncs.com/compatible-mode/v1";
+      return "请输入 API 基础地址，例如 https://dashscope.aliyuncs.com/compatible-mode/v1";
     default:
-      return "例如 https://api.openai.com/v1";
+      return "请输入 API 基础地址，例如 https://api.openai.com/v1";
   }
 }
 
 function runtimeDescription(runtime: ProviderRuntime) {
   switch (runtime) {
+    case "anthropic":
+      return "适用于 Claude / Anthropic Messages API 接口。";
     case "ollama":
       return "适合本地模型，通常不需要 API Key。";
     case "qwen":
-      return "适合阿里云百炼兼容模式接入。";
+      return "适用于阿里云百炼兼容模式接入。";
     default:
-      return "适合 OpenAI、OpenRouter、火山方舟等兼容接口。";
+      return "适用于 OpenAI、OpenRouter、火山方舟等采用 chat/completions 的接口。";
   }
 }
 
 function runtimeToType(runtime: ProviderRuntime) {
   switch (runtime) {
+    case "anthropic":
+      return "anthropic";
     case "ollama":
       return "ollama";
     case "qwen":
@@ -175,8 +186,8 @@ function buildPayload(draft: ProviderDraft) {
 }
 
 function validateDraft(draft: ProviderDraft) {
-  if (draft.name.trim() === "") return "请填写配置名称";
-  if (draft.model.trim() === "") return "请填写模型名称";
+  if (draft.name.trim() === "") return "请填写模型名称";
+  if (draft.model.trim() === "") return "请填写调用模型";
   if (draft.runtime !== "ollama" && draft.apiKey.trim() === "" && !draft.hasStoredApiKey) {
     return "请填写 API Key";
   }
@@ -231,7 +242,7 @@ function resolveTestFeedback(result: ProviderHealth | null) {
     return {
       message:
         result.message ||
-        `服务可达，但返回了 HTTP ${httpStatus}。请确认 Base URL 和接口路径是否正确。`,
+        `服务可达，但返回了 HTTP ${httpStatus}。请确认接口地址和 API 协议类型是否正确。`,
       tone: "warning" as const,
     };
   }
@@ -395,8 +406,8 @@ export function ModelSettingsModal({ onClose }: ModelSettingsModalProps) {
       model: draft.model.trim() || "placeholder-model",
     });
 
-    if (validationMessage === "请填写模型名称") {
-      setNotice({ kind: "error", message: "测试前请先填写模型名称" });
+    if (validationMessage === "请填写调用模型") {
+      setNotice({ kind: "error", message: "测试前请先填写调用模型" });
       return;
     }
 
@@ -519,7 +530,7 @@ export function ModelSettingsModal({ onClose }: ModelSettingsModalProps) {
               <div>
                 <div className="flex items-center gap-2">
                   <div className="text-[22px] font-semibold tracking-[-0.03em] text-[#111827]">
-                    {isCreating ? "新建模型配置" : draft.name || "模型配置"}
+                    {isCreating ? "自定义大模型" : draft.name || "模型配置"}
                   </div>
                   {!isCreating && selectedProvider?.is_default ? (
                     <span className="rounded-full bg-[#eef2ff] px-3 py-1 text-xs font-medium text-[#3b5bcc]">
@@ -578,40 +589,7 @@ export function ModelSettingsModal({ onClose }: ModelSettingsModalProps) {
           <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 lg:px-8 lg:py-7">
             <div className="grid gap-6 xl:grid-cols-2">
               <div>
-                <FieldLabel label="配置名称" />
-                <input
-                  className="h-12 w-full rounded-[16px] border border-[#dbe1ea] bg-white px-4 text-sm text-[#111827] outline-none transition-colors duration-150 placeholder:text-[#98a2b3] focus:border-[#98a2b3]"
-                  onChange={(event) => updateDraft("name", event.target.value)}
-                  placeholder="例如 我的 OpenAI 接口"
-                  value={draft.name}
-                />
-              </div>
-
-              <div>
-                <FieldLabel label="运行时" />
-                <select
-                  className="h-12 w-full rounded-[16px] border border-[#dbe1ea] bg-white px-4 text-sm text-[#111827] outline-none transition-colors duration-150 focus:border-[#98a2b3]"
-                  onChange={(event) => updateDraft("runtime", event.target.value as ProviderRuntime)}
-                  value={draft.runtime}
-                >
-                  <option value="compatible">兼容接口</option>
-                  <option value="qwen">通义千问</option>
-                  <option value="ollama">Ollama</option>
-                </select>
-              </div>
-
-              <div>
-                <FieldLabel label="模型名称" />
-                <input
-                  className="h-12 w-full rounded-[16px] border border-[#dbe1ea] bg-white px-4 text-sm text-[#111827] outline-none transition-colors duration-150 placeholder:text-[#98a2b3] focus:border-[#98a2b3]"
-                  onChange={(event) => updateDraft("model", event.target.value)}
-                  placeholder={runtimeModelPlaceholder(draft.runtime)}
-                  value={draft.model}
-                />
-              </div>
-
-              <div>
-                <FieldLabel hint="可留空" label="Base URL" />
+                <FieldLabel label="接口地址" />
                 <input
                   className="h-12 w-full rounded-[16px] border border-[#dbe1ea] bg-white px-4 text-sm text-[#111827] outline-none transition-colors duration-150 placeholder:text-[#98a2b3] focus:border-[#98a2b3]"
                   onChange={(event) => updateDraft("baseUrl", event.target.value)}
@@ -620,13 +598,28 @@ export function ModelSettingsModal({ onClose }: ModelSettingsModalProps) {
                 />
               </div>
 
+              <div>
+                <FieldLabel label="API 协议类型" />
+                <select
+                  aria-label="API 协议类型"
+                  className="h-12 w-full rounded-[16px] border border-[#dbe1ea] bg-white px-4 text-sm text-[#111827] outline-none transition-colors duration-150 focus:border-[#98a2b3]"
+                  onChange={(event) => updateDraft("runtime", event.target.value as ProviderRuntime)}
+                  value={draft.runtime}
+                >
+                  <option value="compatible">OpenAI 兼容协议</option>
+                  <option value="anthropic">Anthropic 兼容协议</option>
+                  <option value="qwen">通义千问兼容协议</option>
+                  <option value="ollama">Ollama 本地接口</option>
+                </select>
+              </div>
+
               <div className="xl:col-span-2">
                 <FieldLabel hint={requiresApiKey ? "必填" : "本地模型通常不需要"} label="API Key" />
                 <div className="relative">
                   <input
                     className="h-12 w-full rounded-[16px] border border-[#dbe1ea] bg-white px-4 pr-12 text-sm text-[#111827] outline-none transition-colors duration-150 placeholder:text-[#98a2b3] focus:border-[#98a2b3]"
                     onChange={(event) => updateDraft("apiKey", event.target.value)}
-                    placeholder={requiresApiKey ? "输入你的 API Key" : "如有需要可填写"}
+                    placeholder={requiresApiKey ? "请输入 API Key" : "如有需要可填写"}
                     type={secretVisible ? "text" : "password"}
                     value={draft.apiKey}
                   />
@@ -643,6 +636,26 @@ export function ModelSettingsModal({ onClose }: ModelSettingsModalProps) {
                 {draft.hasStoredApiKey && draft.apiKeyPreview && draft.apiKey.trim() === "" ? (
                   <div className="mt-2 text-xs text-[#667085]">已保存密钥：{draft.apiKeyPreview}</div>
                 ) : null}
+              </div>
+
+              <div>
+                <FieldLabel label="模型名称" />
+                <input
+                  className="h-12 w-full rounded-[16px] border border-[#dbe1ea] bg-white px-4 text-sm text-[#111827] outline-none transition-colors duration-150 placeholder:text-[#98a2b3] focus:border-[#98a2b3]"
+                  onChange={(event) => updateDraft("name", event.target.value)}
+                  placeholder="请输入模型的显示名称"
+                  value={draft.name}
+                />
+              </div>
+
+              <div>
+                <FieldLabel hint="实际发送给 API 的模型名" label="调用模型" />
+                <input
+                  className="h-12 w-full rounded-[16px] border border-[#dbe1ea] bg-white px-4 text-sm text-[#111827] outline-none transition-colors duration-150 placeholder:text-[#98a2b3] focus:border-[#98a2b3]"
+                  onChange={(event) => updateDraft("model", event.target.value)}
+                  placeholder={runtimeModelPlaceholder(draft.runtime)}
+                  value={draft.model}
+                />
               </div>
             </div>
           </div>

--- a/ui/src/features/model-settings/ModelSettingsModal.tsx
+++ b/ui/src/features/model-settings/ModelSettingsModal.tsx
@@ -17,7 +17,7 @@ type ModelSettingsModalProps = {
   onClose: () => void;
 };
 
-type ProviderRuntime = "anthropic" | "compatible" | "ollama" | "qwen";
+type ProviderRuntime = "anthropic" | "compatible" | "ollama";
 
 type ProviderHealth = {
   http_status?: number;
@@ -68,7 +68,6 @@ function normalizeRuntime(value?: string): ProviderRuntime {
   const runtime = value?.trim().toLowerCase() ?? "";
   if (runtime === "anthropic" || runtime.includes("claude")) return "anthropic";
   if (runtime === "ollama") return "ollama";
-  if (runtime === "qwen" || runtime === "dashscope") return "qwen";
   return "compatible";
 }
 
@@ -78,8 +77,6 @@ function runtimeLabel(runtime: ProviderRuntime) {
       return "Anthropic 兼容协议";
     case "ollama":
       return "Ollama 本地接口";
-    case "qwen":
-      return "通义千问兼容协议";
     default:
       return "OpenAI 兼容协议";
   }
@@ -91,8 +88,6 @@ function runtimeModelPlaceholder(runtime: ProviderRuntime) {
       return "例如 claude-3-5-sonnet";
     case "ollama":
       return "例如 llama3.2";
-    case "qwen":
-      return "例如 qwen-max";
     default:
       return "例如 gpt-4o-mini";
   }
@@ -104,8 +99,6 @@ function runtimeBaseUrlPlaceholder(runtime: ProviderRuntime) {
       return "请输入 API 基础地址，例如 https://api.anthropic.com/v1";
     case "ollama":
       return "请输入 API 基础地址，例如 http://127.0.0.1:11434/v1";
-    case "qwen":
-      return "请输入 API 基础地址，例如 https://dashscope.aliyuncs.com/compatible-mode/v1";
     default:
       return "请输入 API 基础地址，例如 https://api.openai.com/v1";
   }
@@ -117,10 +110,8 @@ function runtimeDescription(runtime: ProviderRuntime) {
       return "适用于 Claude / Anthropic Messages API 接口。";
     case "ollama":
       return "适合本地模型，通常不需要 API Key。";
-    case "qwen":
-      return "适用于阿里云百炼兼容模式接入。";
     default:
-      return "适用于 OpenAI、OpenRouter、火山方舟等采用 chat/completions 的接口。";
+      return "适用于 OpenAI、通义千问百炼、OpenRouter、火山方舟等采用 chat/completions 的接口。";
   }
 }
 
@@ -130,8 +121,6 @@ function runtimeToType(runtime: ProviderRuntime) {
       return "anthropic";
     case "ollama":
       return "ollama";
-    case "qwen":
-      return "qwen";
     default:
       return "openai-compatible";
   }
@@ -608,7 +597,6 @@ export function ModelSettingsModal({ onClose }: ModelSettingsModalProps) {
                 >
                   <option value="compatible">OpenAI 兼容协议</option>
                   <option value="anthropic">Anthropic 兼容协议</option>
-                  <option value="qwen">通义千问兼容协议</option>
                   <option value="ollama">Ollama 本地接口</option>
                 </select>
               </div>

--- a/ui/src/features/model-settings/ModelSettingsModal.tsx
+++ b/ui/src/features/model-settings/ModelSettingsModal.tsx
@@ -11,6 +11,8 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
+import { requestJSON } from "@/features/api/client";
+
 type ModelSettingsModalProps = {
   onClose: () => void;
 };
@@ -61,38 +63,6 @@ type NoticeState =
   | null;
 
 const NEW_PROVIDER_ID = "__new_provider__";
-
-function safeJsonParse(value: string) {
-  try {
-    return JSON.parse(value) as unknown;
-  } catch {
-    return null;
-  }
-}
-
-async function requestJSON<T>(input: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(input, {
-    ...init,
-    headers: {
-      Accept: "application/json",
-      ...(init?.body ? { "Content-Type": "application/json" } : null),
-      ...(init?.headers ?? {}),
-    },
-  });
-
-  const raw = await response.text();
-  const payload = raw ? safeJsonParse(raw) : null;
-
-  if (!response.ok) {
-    const message =
-      payload && typeof payload === "object" && "error" in payload && typeof payload.error === "string"
-        ? payload.error
-        : `请求失败 (${response.status})`;
-    throw new Error(message);
-  }
-
-  return payload as T;
-}
 
 function normalizeRuntime(value?: string): ProviderRuntime {
   const runtime = value?.trim().toLowerCase();

--- a/ui/src/features/model-settings/ModelSettingsModal.tsx
+++ b/ui/src/features/model-settings/ModelSettingsModal.tsx
@@ -219,10 +219,12 @@ function resolveTestFeedback(result: ProviderHealth | null) {
 
   const httpStatus = result.http_status;
   const isHealthyHttp = httpStatus === undefined || (httpStatus >= 200 && httpStatus < 300);
+  const fallbackMessage = result.message?.trim() ?? "";
+  const friendlyMessage = resolveProviderHealthMessage(result);
 
   if (result.ok && isHealthyHttp) {
     return {
-      message: result.message || "连接测试已完成",
+      message: friendlyMessage || "连接成功，接口已响应。",
       tone: "success" as const,
     };
   }
@@ -230,16 +232,54 @@ function resolveTestFeedback(result: ProviderHealth | null) {
   if (result.ok && httpStatus !== undefined) {
     return {
       message:
-        result.message ||
+        friendlyMessage ||
         `服务可达，但返回了 HTTP ${httpStatus}。请确认接口地址和 API 协议类型是否正确。`,
       tone: "warning" as const,
     };
   }
 
   return {
-    message: result.message || "连接测试失败",
+    message: friendlyMessage || fallbackMessage || "连接测试失败",
     tone: "error" as const,
   };
+}
+
+function resolveProviderHealthMessage(result: ProviderHealth) {
+  const raw = result.message?.trim() ?? "";
+  const status = result.status?.trim().toLowerCase() ?? "";
+  const httpStatus = result.http_status;
+
+  if (status === "reachable" && result.ok) {
+    return httpStatus ? `连接成功，接口已响应（HTTP ${httpStatus}）。` : "连接成功，接口已响应。";
+  }
+  if (status === "ready" && result.ok) {
+    return raw || "配置已就绪，可以使用。";
+  }
+  if (status === "auth_error") {
+    return httpStatus
+      ? `接口已连通，但 API Key 无效或没有权限（HTTP ${httpStatus}）。`
+      : "接口已连通，但 API Key 无效或没有权限。";
+  }
+  if (status === "endpoint_not_found") {
+    return "接口地址返回 404，请检查是否多填或少填了 API 路径。";
+  }
+  if (status === "invalid_base_url") {
+    return "接口地址格式不正确，请检查后再试。";
+  }
+  if (status === "missing_key") {
+    return "请填写 API Key 后再测试连接。";
+  }
+  if (status === "disabled") {
+    return "这个模型配置已停用，请启用后再测试。";
+  }
+  if (/^Endpoint responded with HTTP 2\d\d\.?$/i.test(raw)) {
+    return httpStatus ? `连接成功，接口已响应（HTTP ${httpStatus}）。` : "连接成功，接口已响应。";
+  }
+  if (/^Endpoint responded with HTTP \d+\.?$/i.test(raw) && httpStatus) {
+    return `接口已响应，但返回了 HTTP ${httpStatus}。`;
+  }
+
+  return raw;
 }
 
 function FieldLabel({ hint, label }: { hint?: string; label: string }) {

--- a/ui/src/features/workspace/useWorkspaceOverview.ts
+++ b/ui/src/features/workspace/useWorkspaceOverview.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { fetchJSONOrNull } from "@/features/api/client";
 import { workspaceSnapshot } from "@/generated/workspaceSnapshot.generated";
 import { normalizeSkillDescription } from "@/features/workspace/skillDescription";
 
@@ -298,26 +299,14 @@ function compactText(value: string, fallback: string) {
   return text === "" ? fallback : text;
 }
 
-async function fetchJSON<T>(input: string): Promise<T | null> {
-  try {
-    const response = await fetch(input, {
-      headers: { Accept: "application/json" },
-    });
-    if (!response.ok) return null;
-    return (await response.json()) as T;
-  } catch {
-    return null;
-  }
-}
-
 async function fetchLivePayload(): Promise<LivePayload> {
   const [status, providers, agents, skills, channels, runtimes] = await Promise.all([
-    fetchJSON<LiveStatus>("/status"),
-    fetchJSON<LiveProvider[]>("/providers"),
-    fetchJSON<LiveAgent[]>("/agents"),
-    fetchJSON<LiveSkill[]>("/skills"),
-    fetchJSON<LiveChannel[]>("/channels"),
-    fetchJSON<LiveRuntime[]>("/runtimes"),
+    fetchJSONOrNull<LiveStatus>("/status"),
+    fetchJSONOrNull<LiveProvider[]>("/providers"),
+    fetchJSONOrNull<LiveAgent[]>("/agents"),
+    fetchJSONOrNull<LiveSkill[]>("/skills"),
+    fetchJSONOrNull<LiveChannel[]>("/channels"),
+    fetchJSONOrNull<LiveRuntime[]>("/runtimes"),
   ]);
 
   return {


### PR DESCRIPTION
## 变更说明

- 修复控制台添加/保存模型供应商时，请求在跨端口、桌面壳或静态预览环境下可能出现 `Failed to fetch` 的问题。
- 新增统一的控制台 API 请求客户端，支持本地 gateway 地址兜底与更友好的连接失败提示。
- 为 gateway 增加本地控制台 UI 的 CORS 预检支持，避免 `OPTIONS /providers` 被拦截。
- 优化自定义大模型配置表单文案，将“运行时 / Base URL”等偏实现的说法改为“API 协议类型 / 接口地址”等用户更容易理解的表达。
- 将通义千问百炼归入 `OpenAI 兼容协议`，不再作为单独协议类型展示。
- 优化模型连接测试提示，例如成功时显示“连接成功，接口已响应（HTTP 200）”。

## 验证

- `npm run ui:test`
- `npm run ui:build`
- `go test ./pkg/gateway`
- `go test ./pkg/gateway/governance`